### PR TITLE
graphical_issues_in_voltage_level_198

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/library/AdaptedComponentMetadata.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/library/AdaptedComponentMetadata.java
@@ -32,6 +32,8 @@ public class AdaptedComponentMetadata {
 
     private ComponentSize size;
 
+    private boolean allowRotation;
+
     public String getType() {
         return type;
     }
@@ -62,5 +64,13 @@ public class AdaptedComponentMetadata {
 
     public void setAnchorPoints(List<AnchorPoint> anchorPoints) {
         this.anchorPoints = anchorPoints;
+    }
+
+    public boolean isAllowRotation() {
+        return allowRotation;
+    }
+
+    public void setAllowRotation(boolean allowRotation) {
+        this.allowRotation = allowRotation;
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentLibrary.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentLibrary.java
@@ -23,5 +23,7 @@ public interface ComponentLibrary {
 
     ComponentSize getSize(String type);
 
+    boolean isAllowRotation(String type);
+
     String getStyleSheet();
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentMetadata.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentMetadata.java
@@ -30,15 +30,19 @@ public class ComponentMetadata {
 
     private final ComponentSize size;
 
+    private boolean allowRotation;
+
     @JsonCreator
     public ComponentMetadata(@JsonProperty("type") String type,
                              @JsonProperty("id") String id,
                              @JsonProperty("anchorPoints") List<AnchorPoint> anchorPoints,
-                             @JsonProperty("size") ComponentSize size) {
+                             @JsonProperty("size") ComponentSize size,
+                             @JsonProperty("allowRotation") boolean allowRotation) {
         this.type = Objects.requireNonNull(type);
         this.id = id;
         this.anchorPoints = Collections.unmodifiableList(Objects.requireNonNull(anchorPoints));
         this.size = Objects.requireNonNull(size);
+        this.allowRotation = allowRotation;
     }
 
     public String getType() {
@@ -55,5 +59,9 @@ public class ComponentMetadata {
 
     public List<AnchorPoint> getAnchorPoints() {
         return anchorPoints;
+    }
+
+    public boolean isAllowRotation() {
+        return allowRotation;
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentMetadataAdapter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentMetadataAdapter.java
@@ -17,7 +17,8 @@ public class ComponentMetadataAdapter extends XmlAdapter<AdaptedComponentMetadat
 
     @Override
     public ComponentMetadata unmarshal(AdaptedComponentMetadata adapted) {
-        return new ComponentMetadata(adapted.getType(), adapted.getId(), adapted.getAnchorPoints(), adapted.getSize());
+        return new ComponentMetadata(adapted.getType(), adapted.getId(),
+                adapted.getAnchorPoints(), adapted.getSize(), adapted.isAllowRotation());
     }
 
     @Override
@@ -27,6 +28,7 @@ public class ComponentMetadataAdapter extends XmlAdapter<AdaptedComponentMetadat
         adapted.setId(componentMetadata.getId());
         adapted.setSize(componentMetadata.getSize());
         adapted.setAnchorPoints(componentMetadata.getAnchorPoints());
+        adapted.setAllowRotation(componentMetadata.isAllowRotation());
         return adapted;
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ResourcesComponentLibrary.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ResourcesComponentLibrary.java
@@ -77,6 +77,13 @@ public class ResourcesComponentLibrary implements ComponentLibrary {
         return component != null ? component.getMetadata().getSize() : new ComponentSize(0, 0);
     }
 
+    @Override
+    public boolean isAllowRotation(String type) {
+        Objects.requireNonNull(type);
+        Component component = components.get(type);
+        return component != null ? component.getMetadata().isAllowRotation() : true;
+    }
+
     public String getStyleSheet() {
         return styleSheet;
     }

--- a/single-line-diagram-core/src/main/resources/ConvergenceLibrary/capacitor.svg
+++ b/single-line-diagram-core/src/main/resources/ConvergenceLibrary/capacitor.svg
@@ -1,7 +1,8 @@
 <?xml version="1.0" standalone="no"?>
 <svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="12" height="12">
-    <line x1="6" y1="0" x2="6" y2="3"/>
-    <line x1="0" y1="3" x2="12" y2="3"/>
-    <line x1="0" y1="6" x2="12" y2="6"/>
-    <line x1="6" y1="6" x2="6" y2="9"/>
+    <line x1="6" y1="0" x2="6" y2="4.5"/>
+    <line x1="0" y1="4.5" x2="12" y2="4.5"/>
+    <line x1="0" y1="7.5" x2="12" y2="7.5"/>
+    <line x1="6" y1="7.5" x2="6" y2="12"/>
 </svg>
+

--- a/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.xml
+++ b/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.xml
@@ -6,6 +6,7 @@
             <size width="20" height="20" />
             <anchorPoint x="0" y="-10" orientation="VERTICAL"/>
             <anchorPoint x="0" y="10" orientation="VERTICAL"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
     <component>
@@ -14,6 +15,7 @@
             <size width="10" height="10"/>
             <anchorPoint x="0" y="-5" orientation="VERTICAL"/>
             <anchorPoint x="0" y="5" orientation="VERTICAL"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
     <component>
@@ -22,6 +24,7 @@
             <size width="16" height="9"/>
             <anchorPoint x="0" y="-4" orientation="VERTICAL"/>
             <anchorPoint x="0" y="4" orientation="VERTICAL"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
     <component>
@@ -32,6 +35,7 @@
             <anchorPoint x="0" y="6" orientation="VERTICAL"/>
             <anchorPoint x="-6" y="0" orientation="HORIZONTAL"/>
             <anchorPoint x="6" y="0" orientation="HORIZONTAL"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
     <component>
@@ -42,6 +46,7 @@
             <anchorPoint x="0" y="4" orientation="VERTICAL"/>
             <anchorPoint x="-6" y="0" orientation="HORIZONTAL"/>
             <anchorPoint x="6" y="0" orientation="HORIZONTAL"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
     <component>
@@ -51,6 +56,7 @@
             <anchorPoint x="-7" y="-4" orientation="HORIZONTAL"/>
             <anchorPoint x="7" y="-4" orientation="HORIZONTAL"/>
             <anchorPoint x="0" y="6" orientation="VERTICAL"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
     <component>
@@ -59,6 +65,7 @@
             <size width="12" height="12"/>
             <anchorPoint x="0" y="-6" orientation="VERTICAL"/>
             <anchorPoint x="0" y="6" orientation="VERTICAL"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
     <component>
@@ -67,6 +74,7 @@
             <size width="15" height="9"/>
             <anchorPoint x="0" y="-4" orientation="VERTICAL"/>
             <anchorPoint x="0" y="4" orientation="VERTICAL"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
     <component>
@@ -74,6 +82,7 @@
         <metadata type="DISCONNECTOR">
             <size height="8" width="8"/>
             <anchorPoint x="0" y="0" orientation="VERTICAL"/>
+            <allowRotation>false</allowRotation>
         </metadata>
     </component>
     <component>
@@ -81,6 +90,7 @@
         <metadata type="NODE">
             <size height="8" width="8"/>
             <anchorPoint x="0" y="0" orientation="NONE"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
     <component>
@@ -89,6 +99,7 @@
             <size width="15" height="15"/>
             <anchorPoint x="0" y="-6" orientation="VERTICAL"/>
             <anchorPoint x="0" y="6" orientation="VERTICAL"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
     <component>
@@ -97,6 +108,7 @@
             <size width="12" height="12"/>
             <anchorPoint x="0" y="-6" orientation="VERTICAL"/>
             <anchorPoint x="0" y="6" orientation="VERTICAL"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
     <component>
@@ -105,6 +117,7 @@
             <size width="16" height="8"/>
             <anchorPoint x="0" y="-6" orientation="VERTICAL"/>
             <anchorPoint x="0" y="6" orientation="VERTICAL"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
     <component>
@@ -112,6 +125,7 @@
         <metadata type="ARROW">
             <size height="10" width="10"/>
             <anchorPoint x="0" y="0" orientation="VERTICAL"/>
+            <allowRotation>true</allowRotation>
         </metadata>
     </component>
 </components>

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/GraphMetadataTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/GraphMetadataTest.java
@@ -51,7 +51,7 @@ public class GraphMetadataTest {
         metadata.addComponentMetadata(new ComponentMetadata(BREAKER,
                                                             "br1",
                                                             ImmutableList.of(new AnchorPoint(5, 4, AnchorOrientation.NONE)),
-                                                            new ComponentSize(10, 12)));
+                                                            new ComponentSize(10, 12), true));
 
         metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("id1", "vid1", null, BREAKER, null, false, BusCell.Direction.UNDEFINED, false));
         metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("id2", "vid2", null, BUSBAR_SECTION, null, false, BusCell.Direction.UNDEFINED, false));

--- a/single-line-diagram-core/src/test/resources/TestCase1.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase1.svg
@@ -129,25 +129,6 @@
     <line y2="9" x1="16" x2="0" y1="0"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="l_N_LABEL">l</text>
         </g>
-        <g class="DISCONNECTOR d" id="d" transform="translate(41.0,306.0)">
-    <g class="closed" id="d_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="d_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER b" id="b" transform="translate(35.0,145.0)">
-    <g class="closed" id="b_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="b_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="NODE FICT_vl_dFictif" id="FICT_vl_dFictif" transform="translate(41.0,276.0)">
     <circle r="4" cx="4" cy="4"/>
 </g>
@@ -173,6 +154,25 @@
         </g>
         <polyline class="wire wire_vl" points="45.0,165.0,45.0,280.0" id="vl_Wire2"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="vl_Wire3"/>
+        <g class="DISCONNECTOR d" id="d" transform="translate(41.0,306.0)">
+    <g class="closed" id="d_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="d_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER b" id="b" transform="translate(35.0,145.0)">
+    <g class="closed" id="b_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="b_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHorizontal.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHorizontal.svg
@@ -350,309 +350,6 @@
         <g class="LINE line1_ONE" id="line1_ONE" transform="translate(545.0,80.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="line1_ONE_N_LABEL">line1</text>
         </g>
-        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(566.0,356.0)">
-    <g class="closed" id="dsect11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,605.0,350.0)">
-    <g class="closed" id="dtrct11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(616.0,356.0)">
-    <g class="closed" id="dsect12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(566.0,381.0)">
-    <g class="closed" id="dsect21_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect21_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,605.0,375.0)">
-    <g class="closed" id="dtrct21_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct21_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(616.0,381.0)">
-    <g class="closed" id="dsect22_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect22_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(91.0,356.0)">
-    <g class="closed" id="dload1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload1" id="bload1" transform="translate(85.0,195.0)">
-    <g class="closed" id="bload1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(191.0,381.0)">
-    <g class="closed" id="dgen1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen1" id="bgen1" transform="translate(185.0,530.0)">
-    <g class="closed" id="bgen1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(641.0,356.0)">
-    <g class="closed" id="dload2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload2" id="bload2" transform="translate(635.0,195.0)">
-    <g class="closed" id="bload2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(891.0,381.0)">
-    <g class="closed" id="dgen2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen2" id="bgen2" transform="translate(885.0,530.0)">
-    <g class="closed" id="bgen2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(141.0,356.0)">
-    <g class="closed" id="dtrf11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf11" id="btrf11" transform="translate(135.0,195.0)">
-    <g class="closed" id="btrf11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(841.0,356.0)">
-    <g class="closed" id="dtrf12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf12" id="btrf12" transform="translate(835.0,195.0)">
-    <g class="closed" id="btrf12_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf12_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(241.0,381.0)">
-    <g class="closed" id="dtrf13_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf13_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf13" id="btrf13" transform="translate(235.0,530.0)">
-    <g class="closed" id="btrf13_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf13_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(791.0,381.0)">
-    <g class="closed" id="dtrf14_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf14_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf14" id="btrf14" transform="translate(785.0,530.0)">
-    <g class="closed" id="btrf14_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf14_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(291.0,356.0)">
-    <g class="closed" id="dtrf15_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf15_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf15" id="btrf15" transform="translate(285.0,195.0)">
-    <g class="closed" id="btrf15_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf15_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(366.0,356.0)">
-    <g class="closed" id="dtrf16_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf16_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf16" id="btrf16" transform="translate(360.0,236.66666666666669)">
-    <g class="closed" id="btrf16_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf16_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(466.0,381.0)">
-    <g class="closed" id="dtrf17_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf17_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf17" id="btrf17" transform="translate(460.0,488.3333333333333)">
-    <g class="closed" id="btrf17_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf17_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(716.0,356.0)">
-    <g class="closed" id="dtrf18_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf18_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf18" id="btrf18" transform="translate(710.0,236.66666666666669)">
-    <g class="closed" id="btrf18_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf18_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dline11_2" id="dline11_2" transform="translate(541.0,356.0)">
-    <g class="closed" id="dline11_2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dline11_2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bline11_2" id="bline11_2" transform="translate(535.0,195.0)">
-    <g class="closed" id="bline11_2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bline11_2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl1_trf61_fictif" id="FICT_vl1_trf61_fictif" transform="translate(363.0,157.33333333333331)">
     <circle r="4" id="FICT_vl1_trf61_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="FICT_vl1_trf61_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
@@ -1061,6 +758,309 @@
         <polyline class="wire wire_vl1" points="895.0,385.0,895.0,415.0" id="vl1_Wire67"/>
         <polyline class="wire wire_vl1" points="795.0,530.0,795.0,415.0" id="vl1_Wire68"/>
         <polyline class="wire wire_vl1" points="795.0,385.0,795.0,415.0" id="vl1_Wire69"/>
+        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(566.0,356.0)">
+    <g class="closed" id="dsect11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,605.0,350.0)">
+    <g class="closed" id="dtrct11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(616.0,356.0)">
+    <g class="closed" id="dsect12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(566.0,381.0)">
+    <g class="closed" id="dsect21_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect21_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,605.0,375.0)">
+    <g class="closed" id="dtrct21_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct21_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(616.0,381.0)">
+    <g class="closed" id="dsect22_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect22_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(91.0,356.0)">
+    <g class="closed" id="dload1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload1" id="bload1" transform="translate(85.0,195.0)">
+    <g class="closed" id="bload1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(191.0,381.0)">
+    <g class="closed" id="dgen1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen1" id="bgen1" transform="translate(185.0,530.0)">
+    <g class="closed" id="bgen1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(641.0,356.0)">
+    <g class="closed" id="dload2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload2" id="bload2" transform="translate(635.0,195.0)">
+    <g class="closed" id="bload2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(891.0,381.0)">
+    <g class="closed" id="dgen2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen2" id="bgen2" transform="translate(885.0,530.0)">
+    <g class="closed" id="bgen2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(141.0,356.0)">
+    <g class="closed" id="dtrf11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf11" id="btrf11" transform="translate(135.0,195.0)">
+    <g class="closed" id="btrf11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(841.0,356.0)">
+    <g class="closed" id="dtrf12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf12" id="btrf12" transform="translate(835.0,195.0)">
+    <g class="closed" id="btrf12_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf12_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(241.0,381.0)">
+    <g class="closed" id="dtrf13_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf13_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf13" id="btrf13" transform="translate(235.0,530.0)">
+    <g class="closed" id="btrf13_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf13_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(791.0,381.0)">
+    <g class="closed" id="dtrf14_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf14_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf14" id="btrf14" transform="translate(785.0,530.0)">
+    <g class="closed" id="btrf14_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf14_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(291.0,356.0)">
+    <g class="closed" id="dtrf15_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf15_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf15" id="btrf15" transform="translate(285.0,195.0)">
+    <g class="closed" id="btrf15_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf15_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(366.0,356.0)">
+    <g class="closed" id="dtrf16_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf16_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf16" id="btrf16" transform="translate(360.0,236.66666666666669)">
+    <g class="closed" id="btrf16_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf16_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(466.0,381.0)">
+    <g class="closed" id="dtrf17_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf17_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf17" id="btrf17" transform="translate(460.0,488.3333333333333)">
+    <g class="closed" id="btrf17_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf17_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(716.0,356.0)">
+    <g class="closed" id="dtrf18_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf18_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf18" id="btrf18" transform="translate(710.0,236.66666666666669)">
+    <g class="closed" id="btrf18_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf18_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dline11_2" id="dline11_2" transform="translate(541.0,356.0)">
+    <g class="closed" id="dline11_2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dline11_2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bline11_2" id="bline11_2" transform="translate(535.0,195.0)">
+    <g class="closed" id="bline11_2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bline11_2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g class="BUSBAR_SECTION bbs5" id="bbs5" transform="translate(1080.0,360.0)">
             <line y2="0" x1="0" x2="680.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs5_NW_LABEL">bbs5</text>
@@ -1101,205 +1101,6 @@
     <circle r="4" id="trf4_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_TWO_N_LABEL">trf4</text>
         </g>
-        <g class="DISCONNECTOR dscpl1" id="dscpl1" transform="translate(1091.0,356.0)">
-    <g class="closed" id="dscpl1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dscpl1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER ddcpl1" id="ddcpl1" transform="matrix(0.0,1.0,-1.0,0.0,1130.0,310.0)">
-    <g class="closed" id="ddcpl1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="ddcpl1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dscpl2" id="dscpl2" transform="translate(1141.0,381.0)">
-    <g class="closed" id="dscpl2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dscpl2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload3" id="dload3" transform="translate(1191.0,356.0)">
-    <g class="closed" id="dload3_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload3_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload3" id="bload3" transform="translate(1185.0,195.0)">
-    <g class="closed" id="bload3_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload3_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen4" id="dgen4" transform="translate(1291.0,381.0)">
-    <g class="closed" id="dgen4_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen4_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen4" id="bgen4" transform="translate(1285.0,530.0)">
-    <g class="closed" id="bgen4_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen4_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf21" id="dtrf21" transform="translate(1241.0,356.0)">
-    <g class="closed" id="dtrf21_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf21_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf21" id="btrf21" transform="translate(1235.0,195.0)">
-    <g class="closed" id="btrf21_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf21_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf22" id="dtrf22" transform="translate(1691.0,381.0)">
-    <g class="closed" id="dtrf22_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf22_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf22" id="btrf22" transform="translate(1685.0,530.0)">
-    <g class="closed" id="btrf22_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf22_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf23" id="dtrf23" transform="translate(1741.0,381.0)">
-    <g class="closed" id="dtrf23_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf23_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf23" id="btrf23" transform="translate(1735.0,530.0)">
-    <g class="closed" id="btrf23_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf23_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf24" id="dtrf24" transform="translate(1341.0,356.0)">
-    <g class="closed" id="dtrf24_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf24_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf24" id="btrf24" transform="translate(1335.0,195.0)">
-    <g class="closed" id="btrf24_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf24_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf26" id="dtrf26" transform="translate(1516.0,381.0)">
-    <g class="closed" id="dtrf26_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf26_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf26" id="btrf26" transform="translate(1510.0,236.66666666666669)">
-    <g class="closed" id="btrf26_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf26_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf27" id="dtrf27" transform="translate(1416.0,356.0)">
-    <g class="closed" id="dtrf27_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf27_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf27" id="btrf27" transform="translate(1410.0,236.66666666666669)">
-    <g class="closed" id="btrf27_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf27_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf28" id="dtrf28" transform="translate(1616.0,381.0)">
-    <g class="closed" id="dtrf28_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf28_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf28" id="btrf28" transform="translate(1610.0,488.3333333333333)">
-    <g class="closed" id="btrf28_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf28_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl2_trf62_fictif" id="FICT_vl2_trf62_fictif" transform="translate(1513.0,157.33333333333331)">
     <circle r="4" id="FICT_vl2_trf62_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="FICT_vl2_trf62_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
@@ -1608,6 +1409,205 @@
         <polyline class="wire wire_vl2" points="1520.0,385.0,1520.0,330.0" id="vl2_Wire45"/>
         <polyline class="wire wire_vl2" points="1620.0,488.3333333333333,1620.0,415.0" id="vl2_Wire46"/>
         <polyline class="wire wire_vl2" points="1620.0,385.0,1620.0,415.0" id="vl2_Wire47"/>
+        <g class="DISCONNECTOR dscpl1" id="dscpl1" transform="translate(1091.0,356.0)">
+    <g class="closed" id="dscpl1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dscpl1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER ddcpl1" id="ddcpl1" transform="matrix(0.0,1.0,-1.0,0.0,1130.0,310.0)">
+    <g class="closed" id="ddcpl1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="ddcpl1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dscpl2" id="dscpl2" transform="translate(1141.0,381.0)">
+    <g class="closed" id="dscpl2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dscpl2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload3" id="dload3" transform="translate(1191.0,356.0)">
+    <g class="closed" id="dload3_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload3_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload3" id="bload3" transform="translate(1185.0,195.0)">
+    <g class="closed" id="bload3_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload3_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen4" id="dgen4" transform="translate(1291.0,381.0)">
+    <g class="closed" id="dgen4_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen4_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen4" id="bgen4" transform="translate(1285.0,530.0)">
+    <g class="closed" id="bgen4_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen4_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf21" id="dtrf21" transform="translate(1241.0,356.0)">
+    <g class="closed" id="dtrf21_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf21_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf21" id="btrf21" transform="translate(1235.0,195.0)">
+    <g class="closed" id="btrf21_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf21_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf22" id="dtrf22" transform="translate(1691.0,381.0)">
+    <g class="closed" id="dtrf22_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf22_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf22" id="btrf22" transform="translate(1685.0,530.0)">
+    <g class="closed" id="btrf22_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf22_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf23" id="dtrf23" transform="translate(1741.0,381.0)">
+    <g class="closed" id="dtrf23_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf23_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf23" id="btrf23" transform="translate(1735.0,530.0)">
+    <g class="closed" id="btrf23_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf23_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf24" id="dtrf24" transform="translate(1341.0,356.0)">
+    <g class="closed" id="dtrf24_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf24_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf24" id="btrf24" transform="translate(1335.0,195.0)">
+    <g class="closed" id="btrf24_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf24_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf26" id="dtrf26" transform="translate(1516.0,381.0)">
+    <g class="closed" id="dtrf26_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf26_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf26" id="btrf26" transform="translate(1510.0,236.66666666666669)">
+    <g class="closed" id="btrf26_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf26_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf27" id="dtrf27" transform="translate(1416.0,356.0)">
+    <g class="closed" id="dtrf27_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf27_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf27" id="btrf27" transform="translate(1410.0,236.66666666666669)">
+    <g class="closed" id="btrf27_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf27_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf28" id="dtrf28" transform="translate(1616.0,381.0)">
+    <g class="closed" id="dtrf28_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf28_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf28" id="btrf28" transform="translate(1610.0,488.3333333333333)">
+    <g class="closed" id="btrf28_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf28_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g class="BUSBAR_SECTION bbs7" id="bbs7" transform="translate(1930.0,360.0)">
             <line y2="0" x1="0" x2="380.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs7_NW_LABEL">bbs7</text>
@@ -1623,101 +1623,6 @@
     <circle r="4" id="trf5_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
 <text x="-5.0" font-size="8" y="21.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_TWO_S_LABEL">trf5</text>
         </g>
-        <g class="DISCONNECTOR dload4" id="dload4" transform="translate(1941.0,356.0)">
-    <g class="closed" id="dload4_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload4_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload4" id="bload4" transform="translate(1935.0,195.0)">
-    <g class="closed" id="bload4_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload4_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf25" id="dtrf25" transform="translate(1991.0,356.0)">
-    <g class="closed" id="dtrf25_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf25_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf25" id="btrf25" transform="translate(1985.0,505.0)">
-    <g class="closed" id="btrf25_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf25_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf36" id="dtrf36" transform="translate(2066.0,356.0)">
-    <g class="closed" id="dtrf36_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf36_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf36" id="btrf36" transform="translate(2060.0,236.66666666666669)">
-    <g class="closed" id="btrf36_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf36_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf37" id="dtrf37" transform="translate(2166.0,356.0)">
-    <g class="closed" id="dtrf37_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf37_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf37" id="btrf37" transform="translate(2160.0,463.3333333333333)">
-    <g class="closed" id="btrf37_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf37_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf38" id="dtrf38" transform="translate(2266.0,356.0)">
-    <g class="closed" id="dtrf38_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf38_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf38" id="btrf38" transform="translate(2260.0,236.66666666666669)">
-    <g class="closed" id="btrf38_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf38_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl3_trf63_fictif" id="FICT_vl3_trf63_fictif" transform="translate(2063.0,157.33333333333331)">
     <circle r="4" id="FICT_vl3_trf63_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="FICT_vl3_trf63_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
@@ -1926,6 +1831,101 @@
         <polyline class="wire wire_vl3" points="2170.0,360.0,2170.0,390.0" id="vl3_Wire23"/>
         <polyline class="wire wire_vl3" points="2270.0,256.6666666666667,2270.0,330.0" id="vl3_Wire24"/>
         <polyline class="wire wire_vl3" points="2270.0,360.0,2270.0,330.0" id="vl3_Wire25"/>
+        <g class="DISCONNECTOR dload4" id="dload4" transform="translate(1941.0,356.0)">
+    <g class="closed" id="dload4_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload4_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload4" id="bload4" transform="translate(1935.0,195.0)">
+    <g class="closed" id="bload4_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload4_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf25" id="dtrf25" transform="translate(1991.0,356.0)">
+    <g class="closed" id="dtrf25_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf25_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf25" id="btrf25" transform="translate(1985.0,505.0)">
+    <g class="closed" id="btrf25_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf25_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf36" id="dtrf36" transform="translate(2066.0,356.0)">
+    <g class="closed" id="dtrf36_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf36_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf36" id="btrf36" transform="translate(2060.0,236.66666666666669)">
+    <g class="closed" id="btrf36_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf36_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf37" id="dtrf37" transform="translate(2166.0,356.0)">
+    <g class="closed" id="dtrf37_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf37_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf37" id="btrf37" transform="translate(2160.0,463.3333333333333)">
+    <g class="closed" id="btrf37_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf37_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf38" id="dtrf38" transform="translate(2266.0,356.0)">
+    <g class="closed" id="dtrf38_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf38_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf38" id="btrf38" transform="translate(2260.0,236.66666666666669)">
+    <g class="closed" id="btrf38_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf38_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <polyline class="wire wire_vl1" points="145.0,80.0,145.0,50.0,1245.0,50.0,1245.0,80.0" id="vl1_vl2_Wire0"/>
         <polyline class="wire wire_vl1" points="845.0,80.0,845.0,20.0,1040.0,20.0,1040.0,695.0,1695.0,695.0,1695.0,665.0" id="vl1_vl2_Wire1"/>
         <polyline class="wire wire_vl1" points="245.0,665.0,245.0,725.0,1745.0,725.0,1745.0,665.0" id="vl1_vl2_Wire2"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHorizontalNominalVoltageLevel.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHorizontalNominalVoltageLevel.svg
@@ -350,309 +350,6 @@
         <g class="LINE line1_ONE" id="line1_ONE" transform="translate(545.0,80.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="line1_ONE_N_LABEL">line1</text>
         </g>
-        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(566.0,356.0)">
-    <g class="closed" id="dsect11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,605.0,350.0)">
-    <g class="closed" id="dtrct11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(616.0,356.0)">
-    <g class="closed" id="dsect12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(566.0,381.0)">
-    <g class="closed" id="dsect21_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect21_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,605.0,375.0)">
-    <g class="closed" id="dtrct21_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct21_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(616.0,381.0)">
-    <g class="closed" id="dsect22_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect22_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(91.0,356.0)">
-    <g class="closed" id="dload1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload1" id="bload1" transform="translate(85.0,195.0)">
-    <g class="closed" id="bload1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(191.0,381.0)">
-    <g class="closed" id="dgen1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen1" id="bgen1" transform="translate(185.0,530.0)">
-    <g class="closed" id="bgen1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(641.0,356.0)">
-    <g class="closed" id="dload2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload2" id="bload2" transform="translate(635.0,195.0)">
-    <g class="closed" id="bload2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(891.0,381.0)">
-    <g class="closed" id="dgen2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen2" id="bgen2" transform="translate(885.0,530.0)">
-    <g class="closed" id="bgen2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(141.0,356.0)">
-    <g class="closed" id="dtrf11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf11" id="btrf11" transform="translate(135.0,195.0)">
-    <g class="closed" id="btrf11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(841.0,356.0)">
-    <g class="closed" id="dtrf12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf12" id="btrf12" transform="translate(835.0,195.0)">
-    <g class="closed" id="btrf12_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf12_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(241.0,381.0)">
-    <g class="closed" id="dtrf13_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf13_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf13" id="btrf13" transform="translate(235.0,530.0)">
-    <g class="closed" id="btrf13_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf13_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(791.0,381.0)">
-    <g class="closed" id="dtrf14_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf14_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf14" id="btrf14" transform="translate(785.0,530.0)">
-    <g class="closed" id="btrf14_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf14_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(291.0,356.0)">
-    <g class="closed" id="dtrf15_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf15_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf15" id="btrf15" transform="translate(285.0,195.0)">
-    <g class="closed" id="btrf15_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf15_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(366.0,356.0)">
-    <g class="closed" id="dtrf16_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf16_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf16" id="btrf16" transform="translate(360.0,236.66666666666669)">
-    <g class="closed" id="btrf16_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf16_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(466.0,381.0)">
-    <g class="closed" id="dtrf17_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf17_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf17" id="btrf17" transform="translate(460.0,488.3333333333333)">
-    <g class="closed" id="btrf17_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf17_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(716.0,356.0)">
-    <g class="closed" id="dtrf18_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf18_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf18" id="btrf18" transform="translate(710.0,236.66666666666669)">
-    <g class="closed" id="btrf18_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf18_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dline11_2" id="dline11_2" transform="translate(541.0,356.0)">
-    <g class="closed" id="dline11_2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dline11_2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bline11_2" id="bline11_2" transform="translate(535.0,195.0)">
-    <g class="closed" id="bline11_2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bline11_2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl1_trf61_fictif" id="FICT_vl1_trf61_fictif" transform="translate(363.0,157.33333333333331)">
     <circle r="4" id="FICT_vl1_trf61_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4" stroke="rgb(34, 139, 34)"/>
     <circle r="4" id="FICT_vl1_trf61_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4" stroke="rgb(34, 139, 34)"/>
@@ -1061,6 +758,309 @@
         <polyline class="wire wire_vl1" points="895.0,385.0,895.0,415.0" id="vl1_Wire67"/>
         <polyline class="wire wire_vl1" points="795.0,530.0,795.0,415.0" id="vl1_Wire68"/>
         <polyline class="wire wire_vl1" points="795.0,385.0,795.0,415.0" id="vl1_Wire69"/>
+        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(566.0,356.0)">
+    <g class="closed" id="dsect11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,605.0,350.0)">
+    <g class="closed" id="dtrct11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(616.0,356.0)">
+    <g class="closed" id="dsect12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(566.0,381.0)">
+    <g class="closed" id="dsect21_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect21_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,605.0,375.0)">
+    <g class="closed" id="dtrct21_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct21_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(616.0,381.0)">
+    <g class="closed" id="dsect22_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect22_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(91.0,356.0)">
+    <g class="closed" id="dload1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload1" id="bload1" transform="translate(85.0,195.0)">
+    <g class="closed" id="bload1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(191.0,381.0)">
+    <g class="closed" id="dgen1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen1" id="bgen1" transform="translate(185.0,530.0)">
+    <g class="closed" id="bgen1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(641.0,356.0)">
+    <g class="closed" id="dload2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload2" id="bload2" transform="translate(635.0,195.0)">
+    <g class="closed" id="bload2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(891.0,381.0)">
+    <g class="closed" id="dgen2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen2" id="bgen2" transform="translate(885.0,530.0)">
+    <g class="closed" id="bgen2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(141.0,356.0)">
+    <g class="closed" id="dtrf11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf11" id="btrf11" transform="translate(135.0,195.0)">
+    <g class="closed" id="btrf11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(841.0,356.0)">
+    <g class="closed" id="dtrf12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf12" id="btrf12" transform="translate(835.0,195.0)">
+    <g class="closed" id="btrf12_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf12_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(241.0,381.0)">
+    <g class="closed" id="dtrf13_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf13_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf13" id="btrf13" transform="translate(235.0,530.0)">
+    <g class="closed" id="btrf13_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf13_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(791.0,381.0)">
+    <g class="closed" id="dtrf14_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf14_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf14" id="btrf14" transform="translate(785.0,530.0)">
+    <g class="closed" id="btrf14_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf14_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(291.0,356.0)">
+    <g class="closed" id="dtrf15_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf15_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf15" id="btrf15" transform="translate(285.0,195.0)">
+    <g class="closed" id="btrf15_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf15_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(366.0,356.0)">
+    <g class="closed" id="dtrf16_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf16_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf16" id="btrf16" transform="translate(360.0,236.66666666666669)">
+    <g class="closed" id="btrf16_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf16_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(466.0,381.0)">
+    <g class="closed" id="dtrf17_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf17_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf17" id="btrf17" transform="translate(460.0,488.3333333333333)">
+    <g class="closed" id="btrf17_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf17_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(716.0,356.0)">
+    <g class="closed" id="dtrf18_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf18_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf18" id="btrf18" transform="translate(710.0,236.66666666666669)">
+    <g class="closed" id="btrf18_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf18_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dline11_2" id="dline11_2" transform="translate(541.0,356.0)">
+    <g class="closed" id="dline11_2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dline11_2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bline11_2" id="bline11_2" transform="translate(535.0,195.0)">
+    <g class="closed" id="bline11_2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bline11_2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g class="BUSBAR_SECTION bbs5" id="bbs5" transform="translate(1080.0,360.0)">
             <line y2="0" x1="0" x2="680.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs5_NW_LABEL">bbs5</text>
@@ -1101,205 +1101,6 @@
     <circle r="4" id="trf4_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4" stroke="rgb(255, 0, 0)"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_TWO_N_LABEL">trf4</text>
         </g>
-        <g class="DISCONNECTOR dscpl1" id="dscpl1" transform="translate(1091.0,356.0)">
-    <g class="closed" id="dscpl1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dscpl1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER ddcpl1" id="ddcpl1" transform="matrix(0.0,1.0,-1.0,0.0,1130.0,310.0)">
-    <g class="closed" id="ddcpl1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="ddcpl1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dscpl2" id="dscpl2" transform="translate(1141.0,381.0)">
-    <g class="closed" id="dscpl2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dscpl2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload3" id="dload3" transform="translate(1191.0,356.0)">
-    <g class="closed" id="dload3_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload3_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload3" id="bload3" transform="translate(1185.0,195.0)">
-    <g class="closed" id="bload3_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload3_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen4" id="dgen4" transform="translate(1291.0,381.0)">
-    <g class="closed" id="dgen4_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen4_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen4" id="bgen4" transform="translate(1285.0,530.0)">
-    <g class="closed" id="bgen4_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen4_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf21" id="dtrf21" transform="translate(1241.0,356.0)">
-    <g class="closed" id="dtrf21_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf21_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf21" id="btrf21" transform="translate(1235.0,195.0)">
-    <g class="closed" id="btrf21_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf21_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf22" id="dtrf22" transform="translate(1691.0,381.0)">
-    <g class="closed" id="dtrf22_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf22_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf22" id="btrf22" transform="translate(1685.0,530.0)">
-    <g class="closed" id="btrf22_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf22_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf23" id="dtrf23" transform="translate(1741.0,381.0)">
-    <g class="closed" id="dtrf23_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf23_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf23" id="btrf23" transform="translate(1735.0,530.0)">
-    <g class="closed" id="btrf23_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf23_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf24" id="dtrf24" transform="translate(1341.0,356.0)">
-    <g class="closed" id="dtrf24_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf24_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf24" id="btrf24" transform="translate(1335.0,195.0)">
-    <g class="closed" id="btrf24_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf24_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf26" id="dtrf26" transform="translate(1516.0,381.0)">
-    <g class="closed" id="dtrf26_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf26_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf26" id="btrf26" transform="translate(1510.0,236.66666666666669)">
-    <g class="closed" id="btrf26_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf26_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf27" id="dtrf27" transform="translate(1416.0,356.0)">
-    <g class="closed" id="dtrf27_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf27_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf27" id="btrf27" transform="translate(1410.0,236.66666666666669)">
-    <g class="closed" id="btrf27_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf27_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf28" id="dtrf28" transform="translate(1616.0,381.0)">
-    <g class="closed" id="dtrf28_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf28_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf28" id="btrf28" transform="translate(1610.0,488.3333333333333)">
-    <g class="closed" id="btrf28_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf28_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl2_trf62_fictif" id="FICT_vl2_trf62_fictif" transform="translate(1513.0,157.33333333333331)">
     <circle r="4" id="FICT_vl2_trf62_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4" stroke="rgb(255, 0, 0)"/>
     <circle r="4" id="FICT_vl2_trf62_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4" stroke="rgb(34, 139, 34)"/>
@@ -1608,6 +1409,205 @@
         <polyline class="wire wire_vl2" points="1520.0,385.0,1520.0,330.0" id="vl2_Wire45"/>
         <polyline class="wire wire_vl2" points="1620.0,488.3333333333333,1620.0,415.0" id="vl2_Wire46"/>
         <polyline class="wire wire_vl2" points="1620.0,385.0,1620.0,415.0" id="vl2_Wire47"/>
+        <g class="DISCONNECTOR dscpl1" id="dscpl1" transform="translate(1091.0,356.0)">
+    <g class="closed" id="dscpl1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dscpl1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER ddcpl1" id="ddcpl1" transform="matrix(0.0,1.0,-1.0,0.0,1130.0,310.0)">
+    <g class="closed" id="ddcpl1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="ddcpl1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dscpl2" id="dscpl2" transform="translate(1141.0,381.0)">
+    <g class="closed" id="dscpl2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dscpl2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload3" id="dload3" transform="translate(1191.0,356.0)">
+    <g class="closed" id="dload3_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload3_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload3" id="bload3" transform="translate(1185.0,195.0)">
+    <g class="closed" id="bload3_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload3_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen4" id="dgen4" transform="translate(1291.0,381.0)">
+    <g class="closed" id="dgen4_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen4_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen4" id="bgen4" transform="translate(1285.0,530.0)">
+    <g class="closed" id="bgen4_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen4_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf21" id="dtrf21" transform="translate(1241.0,356.0)">
+    <g class="closed" id="dtrf21_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf21_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf21" id="btrf21" transform="translate(1235.0,195.0)">
+    <g class="closed" id="btrf21_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf21_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf22" id="dtrf22" transform="translate(1691.0,381.0)">
+    <g class="closed" id="dtrf22_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf22_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf22" id="btrf22" transform="translate(1685.0,530.0)">
+    <g class="closed" id="btrf22_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf22_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf23" id="dtrf23" transform="translate(1741.0,381.0)">
+    <g class="closed" id="dtrf23_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf23_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf23" id="btrf23" transform="translate(1735.0,530.0)">
+    <g class="closed" id="btrf23_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf23_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf24" id="dtrf24" transform="translate(1341.0,356.0)">
+    <g class="closed" id="dtrf24_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf24_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf24" id="btrf24" transform="translate(1335.0,195.0)">
+    <g class="closed" id="btrf24_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf24_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf26" id="dtrf26" transform="translate(1516.0,381.0)">
+    <g class="closed" id="dtrf26_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf26_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf26" id="btrf26" transform="translate(1510.0,236.66666666666669)">
+    <g class="closed" id="btrf26_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf26_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf27" id="dtrf27" transform="translate(1416.0,356.0)">
+    <g class="closed" id="dtrf27_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf27_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf27" id="btrf27" transform="translate(1410.0,236.66666666666669)">
+    <g class="closed" id="btrf27_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf27_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf28" id="dtrf28" transform="translate(1616.0,381.0)">
+    <g class="closed" id="dtrf28_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf28_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf28" id="btrf28" transform="translate(1610.0,488.3333333333333)">
+    <g class="closed" id="btrf28_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf28_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g class="BUSBAR_SECTION bbs7" id="bbs7" transform="translate(1930.0,360.0)">
             <line y2="0" x1="0" x2="380.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs7_NW_LABEL">bbs7</text>
@@ -1623,101 +1623,6 @@
     <circle r="4" id="trf5_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4" stroke="rgb(255, 0, 0)"/>
 <text x="-5.0" font-size="8" y="21.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_TWO_S_LABEL">trf5</text>
         </g>
-        <g class="DISCONNECTOR dload4" id="dload4" transform="translate(1941.0,356.0)">
-    <g class="closed" id="dload4_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload4_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload4" id="bload4" transform="translate(1935.0,195.0)">
-    <g class="closed" id="bload4_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload4_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf25" id="dtrf25" transform="translate(1991.0,356.0)">
-    <g class="closed" id="dtrf25_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf25_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf25" id="btrf25" transform="translate(1985.0,505.0)">
-    <g class="closed" id="btrf25_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf25_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf36" id="dtrf36" transform="translate(2066.0,356.0)">
-    <g class="closed" id="dtrf36_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf36_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf36" id="btrf36" transform="translate(2060.0,236.66666666666669)">
-    <g class="closed" id="btrf36_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf36_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf37" id="dtrf37" transform="translate(2166.0,356.0)">
-    <g class="closed" id="dtrf37_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf37_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf37" id="btrf37" transform="translate(2160.0,463.3333333333333)">
-    <g class="closed" id="btrf37_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf37_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf38" id="dtrf38" transform="translate(2266.0,356.0)">
-    <g class="closed" id="dtrf38_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf38_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf38" id="btrf38" transform="translate(2260.0,236.66666666666669)">
-    <g class="closed" id="btrf38_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf38_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl3_trf63_fictif" id="FICT_vl3_trf63_fictif" transform="translate(2063.0,157.33333333333331)">
     <circle r="4" id="FICT_vl3_trf63_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4" stroke="rgb(255, 0, 0)"/>
     <circle r="4" id="FICT_vl3_trf63_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4" stroke="rgb(34, 139, 34)"/>
@@ -1926,6 +1831,101 @@
         <polyline class="wire wire_vl3" points="2170.0,360.0,2170.0,390.0" id="vl3_Wire23"/>
         <polyline class="wire wire_vl3" points="2270.0,256.6666666666667,2270.0,330.0" id="vl3_Wire24"/>
         <polyline class="wire wire_vl3" points="2270.0,360.0,2270.0,330.0" id="vl3_Wire25"/>
+        <g class="DISCONNECTOR dload4" id="dload4" transform="translate(1941.0,356.0)">
+    <g class="closed" id="dload4_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload4_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload4" id="bload4" transform="translate(1935.0,195.0)">
+    <g class="closed" id="bload4_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload4_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf25" id="dtrf25" transform="translate(1991.0,356.0)">
+    <g class="closed" id="dtrf25_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf25_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf25" id="btrf25" transform="translate(1985.0,505.0)">
+    <g class="closed" id="btrf25_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf25_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf36" id="dtrf36" transform="translate(2066.0,356.0)">
+    <g class="closed" id="dtrf36_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf36_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf36" id="btrf36" transform="translate(2060.0,236.66666666666669)">
+    <g class="closed" id="btrf36_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf36_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf37" id="dtrf37" transform="translate(2166.0,356.0)">
+    <g class="closed" id="dtrf37_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf37_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf37" id="btrf37" transform="translate(2160.0,463.3333333333333)">
+    <g class="closed" id="btrf37_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf37_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf38" id="dtrf38" transform="translate(2266.0,356.0)">
+    <g class="closed" id="dtrf38_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf38_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf38" id="btrf38" transform="translate(2260.0,236.66666666666669)">
+    <g class="closed" id="btrf38_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf38_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <polyline class="wire wire_vl1" points="145.0,80.0,145.0,50.0,1245.0,50.0,1245.0,80.0" id="vl1_vl2_Wire0"/>
         <polyline class="wire wire_vl1" points="845.0,80.0,845.0,20.0,1040.0,20.0,1040.0,695.0,1695.0,695.0,1695.0,665.0" id="vl1_vl2_Wire1"/>
         <polyline class="wire wire_vl1" points="245.0,665.0,245.0,725.0,1745.0,725.0,1745.0,665.0" id="vl1_vl2_Wire2"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphVertical.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphVertical.svg
@@ -350,309 +350,6 @@
         <g class="LINE line1_ONE" id="line1_ONE" transform="translate(545.0,80.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="line1_ONE_N_LABEL">line1</text>
         </g>
-        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(566.0,356.0)">
-    <g class="closed" id="dsect11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,605.0,350.0)">
-    <g class="closed" id="dtrct11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(616.0,356.0)">
-    <g class="closed" id="dsect12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(566.0,381.0)">
-    <g class="closed" id="dsect21_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect21_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,605.0,375.0)">
-    <g class="closed" id="dtrct21_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct21_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(616.0,381.0)">
-    <g class="closed" id="dsect22_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect22_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(91.0,356.0)">
-    <g class="closed" id="dload1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload1" id="bload1" transform="translate(85.0,195.0)">
-    <g class="closed" id="bload1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(191.0,381.0)">
-    <g class="closed" id="dgen1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen1" id="bgen1" transform="translate(185.0,530.0)">
-    <g class="closed" id="bgen1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(641.0,356.0)">
-    <g class="closed" id="dload2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload2" id="bload2" transform="translate(635.0,195.0)">
-    <g class="closed" id="bload2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(891.0,381.0)">
-    <g class="closed" id="dgen2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen2" id="bgen2" transform="translate(885.0,530.0)">
-    <g class="closed" id="bgen2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(141.0,356.0)">
-    <g class="closed" id="dtrf11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf11" id="btrf11" transform="translate(135.0,195.0)">
-    <g class="closed" id="btrf11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(841.0,356.0)">
-    <g class="closed" id="dtrf12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf12" id="btrf12" transform="translate(835.0,195.0)">
-    <g class="closed" id="btrf12_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf12_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(241.0,381.0)">
-    <g class="closed" id="dtrf13_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf13_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf13" id="btrf13" transform="translate(235.0,530.0)">
-    <g class="closed" id="btrf13_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf13_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(791.0,381.0)">
-    <g class="closed" id="dtrf14_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf14_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf14" id="btrf14" transform="translate(785.0,530.0)">
-    <g class="closed" id="btrf14_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf14_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(291.0,356.0)">
-    <g class="closed" id="dtrf15_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf15_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf15" id="btrf15" transform="translate(285.0,195.0)">
-    <g class="closed" id="btrf15_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf15_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(366.0,356.0)">
-    <g class="closed" id="dtrf16_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf16_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf16" id="btrf16" transform="translate(360.0,236.66666666666669)">
-    <g class="closed" id="btrf16_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf16_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(466.0,381.0)">
-    <g class="closed" id="dtrf17_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf17_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf17" id="btrf17" transform="translate(460.0,488.3333333333333)">
-    <g class="closed" id="btrf17_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf17_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(716.0,356.0)">
-    <g class="closed" id="dtrf18_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf18_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf18" id="btrf18" transform="translate(710.0,236.66666666666669)">
-    <g class="closed" id="btrf18_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf18_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dline11_2" id="dline11_2" transform="translate(541.0,356.0)">
-    <g class="closed" id="dline11_2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dline11_2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bline11_2" id="bline11_2" transform="translate(535.0,195.0)">
-    <g class="closed" id="bline11_2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bline11_2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl1_trf61_fictif" id="FICT_vl1_trf61_fictif" transform="translate(363.0,157.33333333333331)">
     <circle r="4" id="FICT_vl1_trf61_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="FICT_vl1_trf61_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
@@ -1061,6 +758,309 @@
         <polyline class="wire wire_vl1" points="895.0,385.0,895.0,415.0" id="vl1_Wire67"/>
         <polyline class="wire wire_vl1" points="795.0,530.0,795.0,415.0" id="vl1_Wire68"/>
         <polyline class="wire wire_vl1" points="795.0,385.0,795.0,415.0" id="vl1_Wire69"/>
+        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(566.0,356.0)">
+    <g class="closed" id="dsect11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,605.0,350.0)">
+    <g class="closed" id="dtrct11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(616.0,356.0)">
+    <g class="closed" id="dsect12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(566.0,381.0)">
+    <g class="closed" id="dsect21_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect21_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,605.0,375.0)">
+    <g class="closed" id="dtrct21_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct21_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(616.0,381.0)">
+    <g class="closed" id="dsect22_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect22_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(91.0,356.0)">
+    <g class="closed" id="dload1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload1" id="bload1" transform="translate(85.0,195.0)">
+    <g class="closed" id="bload1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(191.0,381.0)">
+    <g class="closed" id="dgen1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen1" id="bgen1" transform="translate(185.0,530.0)">
+    <g class="closed" id="bgen1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(641.0,356.0)">
+    <g class="closed" id="dload2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload2" id="bload2" transform="translate(635.0,195.0)">
+    <g class="closed" id="bload2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(891.0,381.0)">
+    <g class="closed" id="dgen2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen2" id="bgen2" transform="translate(885.0,530.0)">
+    <g class="closed" id="bgen2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(141.0,356.0)">
+    <g class="closed" id="dtrf11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf11" id="btrf11" transform="translate(135.0,195.0)">
+    <g class="closed" id="btrf11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(841.0,356.0)">
+    <g class="closed" id="dtrf12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf12" id="btrf12" transform="translate(835.0,195.0)">
+    <g class="closed" id="btrf12_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf12_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(241.0,381.0)">
+    <g class="closed" id="dtrf13_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf13_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf13" id="btrf13" transform="translate(235.0,530.0)">
+    <g class="closed" id="btrf13_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf13_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(791.0,381.0)">
+    <g class="closed" id="dtrf14_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf14_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf14" id="btrf14" transform="translate(785.0,530.0)">
+    <g class="closed" id="btrf14_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf14_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(291.0,356.0)">
+    <g class="closed" id="dtrf15_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf15_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf15" id="btrf15" transform="translate(285.0,195.0)">
+    <g class="closed" id="btrf15_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf15_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(366.0,356.0)">
+    <g class="closed" id="dtrf16_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf16_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf16" id="btrf16" transform="translate(360.0,236.66666666666669)">
+    <g class="closed" id="btrf16_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf16_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(466.0,381.0)">
+    <g class="closed" id="dtrf17_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf17_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf17" id="btrf17" transform="translate(460.0,488.3333333333333)">
+    <g class="closed" id="btrf17_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf17_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(716.0,356.0)">
+    <g class="closed" id="dtrf18_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf18_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf18" id="btrf18" transform="translate(710.0,236.66666666666669)">
+    <g class="closed" id="btrf18_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf18_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dline11_2" id="dline11_2" transform="translate(541.0,356.0)">
+    <g class="closed" id="dline11_2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dline11_2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bline11_2" id="bline11_2" transform="translate(535.0,195.0)">
+    <g class="closed" id="bline11_2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bline11_2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g class="BUSBAR_SECTION bbs5" id="bbs5" transform="translate(80.0,1050.0)">
             <line y2="0" x1="0" x2="680.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs5_NW_LABEL">bbs5</text>
@@ -1101,205 +1101,6 @@
     <circle r="4" id="trf4_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_TWO_N_LABEL">trf4</text>
         </g>
-        <g class="DISCONNECTOR dscpl1" id="dscpl1" transform="translate(91.0,1046.0)">
-    <g class="closed" id="dscpl1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dscpl1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER ddcpl1" id="ddcpl1" transform="matrix(0.0,1.0,-1.0,0.0,130.0,1000.0)">
-    <g class="closed" id="ddcpl1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="ddcpl1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dscpl2" id="dscpl2" transform="translate(141.0,1071.0)">
-    <g class="closed" id="dscpl2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dscpl2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload3" id="dload3" transform="translate(191.0,1046.0)">
-    <g class="closed" id="dload3_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload3_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload3" id="bload3" transform="translate(185.0,885.0)">
-    <g class="closed" id="bload3_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload3_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen4" id="dgen4" transform="translate(291.0,1071.0)">
-    <g class="closed" id="dgen4_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen4_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen4" id="bgen4" transform="translate(285.0,1220.0)">
-    <g class="closed" id="bgen4_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen4_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf21" id="dtrf21" transform="translate(241.0,1046.0)">
-    <g class="closed" id="dtrf21_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf21_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf21" id="btrf21" transform="translate(235.0,885.0)">
-    <g class="closed" id="btrf21_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf21_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf22" id="dtrf22" transform="translate(691.0,1071.0)">
-    <g class="closed" id="dtrf22_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf22_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf22" id="btrf22" transform="translate(685.0,1220.0)">
-    <g class="closed" id="btrf22_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf22_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf23" id="dtrf23" transform="translate(741.0,1071.0)">
-    <g class="closed" id="dtrf23_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf23_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf23" id="btrf23" transform="translate(735.0,1220.0)">
-    <g class="closed" id="btrf23_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf23_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf24" id="dtrf24" transform="translate(341.0,1046.0)">
-    <g class="closed" id="dtrf24_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf24_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf24" id="btrf24" transform="translate(335.0,885.0)">
-    <g class="closed" id="btrf24_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf24_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf26" id="dtrf26" transform="translate(516.0,1071.0)">
-    <g class="closed" id="dtrf26_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf26_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf26" id="btrf26" transform="translate(510.0,926.6666666666667)">
-    <g class="closed" id="btrf26_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf26_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf27" id="dtrf27" transform="translate(416.0,1046.0)">
-    <g class="closed" id="dtrf27_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf27_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf27" id="btrf27" transform="translate(410.0,926.6666666666667)">
-    <g class="closed" id="btrf27_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf27_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf28" id="dtrf28" transform="translate(616.0,1071.0)">
-    <g class="closed" id="dtrf28_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf28_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf28" id="btrf28" transform="translate(610.0,1178.3333333333333)">
-    <g class="closed" id="btrf28_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf28_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl2_trf62_fictif" id="FICT_vl2_trf62_fictif" transform="translate(513.0,847.3333333333334)">
     <circle r="4" id="FICT_vl2_trf62_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="FICT_vl2_trf62_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
@@ -1608,6 +1409,205 @@
         <polyline class="wire wire_vl2" points="520.0,1075.0,520.0,1020.0" id="vl2_Wire45"/>
         <polyline class="wire wire_vl2" points="620.0,1178.3333333333333,620.0,1105.0" id="vl2_Wire46"/>
         <polyline class="wire wire_vl2" points="620.0,1075.0,620.0,1105.0" id="vl2_Wire47"/>
+        <g class="DISCONNECTOR dscpl1" id="dscpl1" transform="translate(91.0,1046.0)">
+    <g class="closed" id="dscpl1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dscpl1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER ddcpl1" id="ddcpl1" transform="matrix(0.0,1.0,-1.0,0.0,130.0,1000.0)">
+    <g class="closed" id="ddcpl1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="ddcpl1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dscpl2" id="dscpl2" transform="translate(141.0,1071.0)">
+    <g class="closed" id="dscpl2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dscpl2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload3" id="dload3" transform="translate(191.0,1046.0)">
+    <g class="closed" id="dload3_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload3_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload3" id="bload3" transform="translate(185.0,885.0)">
+    <g class="closed" id="bload3_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload3_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen4" id="dgen4" transform="translate(291.0,1071.0)">
+    <g class="closed" id="dgen4_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen4_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen4" id="bgen4" transform="translate(285.0,1220.0)">
+    <g class="closed" id="bgen4_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen4_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf21" id="dtrf21" transform="translate(241.0,1046.0)">
+    <g class="closed" id="dtrf21_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf21_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf21" id="btrf21" transform="translate(235.0,885.0)">
+    <g class="closed" id="btrf21_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf21_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf22" id="dtrf22" transform="translate(691.0,1071.0)">
+    <g class="closed" id="dtrf22_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf22_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf22" id="btrf22" transform="translate(685.0,1220.0)">
+    <g class="closed" id="btrf22_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf22_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf23" id="dtrf23" transform="translate(741.0,1071.0)">
+    <g class="closed" id="dtrf23_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf23_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf23" id="btrf23" transform="translate(735.0,1220.0)">
+    <g class="closed" id="btrf23_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf23_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf24" id="dtrf24" transform="translate(341.0,1046.0)">
+    <g class="closed" id="dtrf24_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf24_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf24" id="btrf24" transform="translate(335.0,885.0)">
+    <g class="closed" id="btrf24_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf24_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf26" id="dtrf26" transform="translate(516.0,1071.0)">
+    <g class="closed" id="dtrf26_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf26_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf26" id="btrf26" transform="translate(510.0,926.6666666666667)">
+    <g class="closed" id="btrf26_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf26_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf27" id="dtrf27" transform="translate(416.0,1046.0)">
+    <g class="closed" id="dtrf27_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf27_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf27" id="btrf27" transform="translate(410.0,926.6666666666667)">
+    <g class="closed" id="btrf27_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf27_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf28" id="dtrf28" transform="translate(616.0,1071.0)">
+    <g class="closed" id="dtrf28_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf28_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf28" id="btrf28" transform="translate(610.0,1178.3333333333333)">
+    <g class="closed" id="btrf28_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf28_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g class="BUSBAR_SECTION bbs7" id="bbs7" transform="translate(80.0,1740.0)">
             <line y2="0" x1="0" x2="380.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs7_NW_LABEL">bbs7</text>
@@ -1623,101 +1623,6 @@
     <circle r="4" id="trf5_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
 <text x="-5.0" font-size="8" y="21.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_TWO_S_LABEL">trf5</text>
         </g>
-        <g class="DISCONNECTOR dload4" id="dload4" transform="translate(91.0,1736.0)">
-    <g class="closed" id="dload4_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload4_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload4" id="bload4" transform="translate(85.0,1575.0)">
-    <g class="closed" id="bload4_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload4_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf25" id="dtrf25" transform="translate(141.0,1736.0)">
-    <g class="closed" id="dtrf25_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf25_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf25" id="btrf25" transform="translate(135.0,1885.0)">
-    <g class="closed" id="btrf25_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf25_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf36" id="dtrf36" transform="translate(216.0,1736.0)">
-    <g class="closed" id="dtrf36_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf36_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf36" id="btrf36" transform="translate(210.0,1616.6666666666667)">
-    <g class="closed" id="btrf36_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf36_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf37" id="dtrf37" transform="translate(316.0,1736.0)">
-    <g class="closed" id="dtrf37_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf37_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf37" id="btrf37" transform="translate(310.0,1843.3333333333333)">
-    <g class="closed" id="btrf37_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf37_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf38" id="dtrf38" transform="translate(416.0,1736.0)">
-    <g class="closed" id="dtrf38_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf38_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf38" id="btrf38" transform="translate(410.0,1616.6666666666667)">
-    <g class="closed" id="btrf38_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf38_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl3_trf63_fictif" id="FICT_vl3_trf63_fictif" transform="translate(213.0,1537.3333333333333)">
     <circle r="4" id="FICT_vl3_trf63_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="FICT_vl3_trf63_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
@@ -1926,6 +1831,101 @@
         <polyline class="wire wire_vl3" points="320.0,1740.0,320.0,1770.0" id="vl3_Wire23"/>
         <polyline class="wire wire_vl3" points="420.0,1636.6666666666667,420.0,1710.0" id="vl3_Wire24"/>
         <polyline class="wire wire_vl3" points="420.0,1740.0,420.0,1710.0" id="vl3_Wire25"/>
+        <g class="DISCONNECTOR dload4" id="dload4" transform="translate(91.0,1736.0)">
+    <g class="closed" id="dload4_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload4_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload4" id="bload4" transform="translate(85.0,1575.0)">
+    <g class="closed" id="bload4_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload4_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf25" id="dtrf25" transform="translate(141.0,1736.0)">
+    <g class="closed" id="dtrf25_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf25_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf25" id="btrf25" transform="translate(135.0,1885.0)">
+    <g class="closed" id="btrf25_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf25_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf36" id="dtrf36" transform="translate(216.0,1736.0)">
+    <g class="closed" id="dtrf36_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf36_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf36" id="btrf36" transform="translate(210.0,1616.6666666666667)">
+    <g class="closed" id="btrf36_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf36_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf37" id="dtrf37" transform="translate(316.0,1736.0)">
+    <g class="closed" id="dtrf37_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf37_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf37" id="btrf37" transform="translate(310.0,1843.3333333333333)">
+    <g class="closed" id="btrf37_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf37_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf38" id="dtrf38" transform="translate(416.0,1736.0)">
+    <g class="closed" id="dtrf38_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf38_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf38" id="btrf38" transform="translate(410.0,1616.6666666666667)">
+    <g class="closed" id="btrf38_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf38_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <polyline class="wire wire_vl1" points="145.0,80.0,145.0,50.0,40.0,50.0,40.0,740.0,245.0,740.0,245.0,770.0" id="vl1_vl2_Wire0"/>
         <polyline class="wire wire_vl1" points="845.0,80.0,845.0,20.0,10.0,20.0,10.0,1385.0,695.0,1385.0,695.0,1355.0" id="vl1_vl2_Wire1"/>
         <polyline class="wire wire_vl1" points="245.0,665.0,245.0,695.0,980.0,695.0,980.0,1415.0,745.0,1415.0,745.0,1355.0" id="vl1_vl2_Wire2"/>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.svg
@@ -199,290 +199,6 @@
     <circle r="4" id="trf5_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_ONE_N_LABEL">trf5</text>
         </g>
-        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(736.0,306.0)">
-    <g class="closed" id="dsect11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,790.0,300.0)">
-    <g class="closed" id="dtrct11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(816.0,306.0)">
-    <g class="closed" id="dsect12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(736.0,331.0)">
-    <g class="closed" id="dsect21_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect21_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,790.0,325.0)">
-    <g class="closed" id="dtrct21_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct21_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(816.0,331.0)">
-    <g class="closed" id="dsect22_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect22_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(56.0,306.0)">
-    <g class="closed" id="dload1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload1" id="bload1" transform="translate(50.0,145.0)">
-    <g class="closed" id="bload1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(216.0,331.0)">
-    <g class="closed" id="dgen1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen1" id="bgen1" transform="translate(210.0,480.0)">
-    <g class="closed" id="bgen1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(856.0,306.0)">
-    <g class="closed" id="dload2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload2" id="bload2" transform="translate(850.0,145.0)">
-    <g class="closed" id="bload2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(1256.0,331.0)">
-    <g class="closed" id="dgen2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen2" id="bgen2" transform="translate(1250.0,480.0)">
-    <g class="closed" id="bgen2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(136.0,306.0)">
-    <g class="closed" id="dtrf11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf11" id="btrf11" transform="translate(130.0,145.0)">
-    <g class="closed" id="btrf11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(1176.0,306.0)">
-    <g class="closed" id="dtrf12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf12" id="btrf12" transform="translate(1170.0,145.0)">
-    <g class="closed" id="btrf12_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf12_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(296.0,331.0)">
-    <g class="closed" id="dtrf13_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf13_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf13" id="btrf13" transform="translate(290.0,480.0)">
-    <g class="closed" id="btrf13_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf13_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(1096.0,331.0)">
-    <g class="closed" id="dtrf14_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf14_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf14" id="btrf14" transform="translate(1090.0,480.0)">
-    <g class="closed" id="btrf14_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf14_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(376.0,306.0)">
-    <g class="closed" id="dtrf15_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf15_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf15" id="btrf15" transform="translate(370.0,145.0)">
-    <g class="closed" id="btrf15_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf15_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(496.0,306.0)">
-    <g class="closed" id="dtrf16_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf16_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf16" id="btrf16" transform="translate(490.0,186.66666666666669)">
-    <g class="closed" id="btrf16_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf16_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(656.0,331.0)">
-    <g class="closed" id="dtrf17_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf17_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf17" id="btrf17" transform="translate(650.0,438.3333333333333)">
-    <g class="closed" id="btrf17_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf17_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(976.0,306.0)">
-    <g class="closed" id="dtrf18_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf18_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf18" id="btrf18" transform="translate(970.0,186.66666666666669)">
-    <g class="closed" id="btrf18_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf18_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl1_trf61_fictif" id="FICT_vl1_trf61_fictif" transform="translate(493.0,107.33333333333334)">
     <circle r="4" id="FICT_vl1_trf61_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="FICT_vl1_trf61_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
@@ -871,6 +587,290 @@
         <polyline class="wire wire_vl1" points="1260.0,335.0,1260.0,365.0" id="vl1_Wire63"/>
         <polyline class="wire wire_vl1" points="1100.0,480.0,1100.0,365.0" id="vl1_Wire64"/>
         <polyline class="wire wire_vl1" points="1100.0,335.0,1100.0,365.0" id="vl1_Wire65"/>
+        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(736.0,306.0)">
+    <g class="closed" id="dsect11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,790.0,300.0)">
+    <g class="closed" id="dtrct11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(816.0,306.0)">
+    <g class="closed" id="dsect12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(736.0,331.0)">
+    <g class="closed" id="dsect21_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect21_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,790.0,325.0)">
+    <g class="closed" id="dtrct21_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct21_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(816.0,331.0)">
+    <g class="closed" id="dsect22_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect22_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(56.0,306.0)">
+    <g class="closed" id="dload1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload1" id="bload1" transform="translate(50.0,145.0)">
+    <g class="closed" id="bload1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(216.0,331.0)">
+    <g class="closed" id="dgen1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen1" id="bgen1" transform="translate(210.0,480.0)">
+    <g class="closed" id="bgen1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(856.0,306.0)">
+    <g class="closed" id="dload2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload2" id="bload2" transform="translate(850.0,145.0)">
+    <g class="closed" id="bload2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(1256.0,331.0)">
+    <g class="closed" id="dgen2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen2" id="bgen2" transform="translate(1250.0,480.0)">
+    <g class="closed" id="bgen2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(136.0,306.0)">
+    <g class="closed" id="dtrf11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf11" id="btrf11" transform="translate(130.0,145.0)">
+    <g class="closed" id="btrf11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(1176.0,306.0)">
+    <g class="closed" id="dtrf12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf12" id="btrf12" transform="translate(1170.0,145.0)">
+    <g class="closed" id="btrf12_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf12_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(296.0,331.0)">
+    <g class="closed" id="dtrf13_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf13_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf13" id="btrf13" transform="translate(290.0,480.0)">
+    <g class="closed" id="btrf13_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf13_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(1096.0,331.0)">
+    <g class="closed" id="dtrf14_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf14_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf14" id="btrf14" transform="translate(1090.0,480.0)">
+    <g class="closed" id="btrf14_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf14_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(376.0,306.0)">
+    <g class="closed" id="dtrf15_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf15_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf15" id="btrf15" transform="translate(370.0,145.0)">
+    <g class="closed" id="btrf15_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf15_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(496.0,306.0)">
+    <g class="closed" id="dtrf16_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf16_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf16" id="btrf16" transform="translate(490.0,186.66666666666669)">
+    <g class="closed" id="btrf16_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf16_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(656.0,331.0)">
+    <g class="closed" id="dtrf17_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf17_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf17" id="btrf17" transform="translate(650.0,438.3333333333333)">
+    <g class="closed" id="btrf17_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf17_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(976.0,306.0)">
+    <g class="closed" id="dtrf18_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf18_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf18" id="btrf18" transform="translate(970.0,186.66666666666669)">
+    <g class="closed" id="btrf18_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf18_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl1">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL1_optimized.svg
@@ -247,96 +247,6 @@
             <use href="#TWO_WINDINGS_TRANSFORMER-WINDING2"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_ONE_N_LABEL">trf5</text>
         </g>
-        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(736.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,790.0,300.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(816.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(736.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,790.0,325.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(816.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(56.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER bload1" id="bload1" transform="translate(50.0,145.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(216.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER bgen1" id="bgen1" transform="translate(210.0,480.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(856.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER bload2" id="bload2" transform="translate(850.0,145.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(1256.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER bgen2" id="bgen2" transform="translate(1250.0,480.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(136.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf11" id="btrf11" transform="translate(130.0,145.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(1176.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf12" id="btrf12" transform="translate(1170.0,145.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(296.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf13" id="btrf13" transform="translate(290.0,480.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(1096.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf14" id="btrf14" transform="translate(1090.0,480.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(376.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf15" id="btrf15" transform="translate(370.0,145.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(496.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf16" id="btrf16" transform="translate(490.0,186.66666666666669)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(656.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf17" id="btrf17" transform="translate(650.0,438.3333333333333)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(976.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf18" id="btrf18" transform="translate(970.0,186.66666666666669)">
-            <use href="#BREAKER-closed"/>
-        </g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl1_trf61_fictif" id="FICT_vl1_trf61_fictif" transform="translate(493.0,107.33333333333334)">
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING1"/>
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING2"/>
@@ -573,6 +483,96 @@
         <polyline class="wire wire_vl1" points="1260.0,335.0,1260.0,365.0" id="vl1_Wire63"/>
         <polyline class="wire wire_vl1" points="1100.0,480.0,1100.0,365.0" id="vl1_Wire64"/>
         <polyline class="wire wire_vl1" points="1100.0,335.0,1100.0,365.0" id="vl1_Wire65"/>
+        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(736.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,790.0,300.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(816.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(736.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,790.0,325.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(816.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(56.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER bload1" id="bload1" transform="translate(50.0,145.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(216.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER bgen1" id="bgen1" transform="translate(210.0,480.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(856.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER bload2" id="bload2" transform="translate(850.0,145.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(1256.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER bgen2" id="bgen2" transform="translate(1250.0,480.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(136.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf11" id="btrf11" transform="translate(130.0,145.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(1176.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf12" id="btrf12" transform="translate(1170.0,145.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(296.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf13" id="btrf13" transform="translate(290.0,480.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(1096.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf14" id="btrf14" transform="translate(1090.0,480.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(376.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf15" id="btrf15" transform="translate(370.0,145.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(496.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf16" id="btrf16" transform="translate(490.0,186.66666666666669)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(656.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf17" id="btrf17" transform="translate(650.0,438.3333333333333)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(976.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf18" id="btrf18" transform="translate(970.0,186.66666666666669)">
+            <use href="#BREAKER-closed"/>
+        </g>
         <g id="LABEL_VL_vl1">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.svg
@@ -172,205 +172,6 @@
     <circle r="4" id="trf4_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_TWO_N_LABEL">trf4</text>
         </g>
-        <g class="DISCONNECTOR dscpl1" id="dscpl1" transform="translate(56.0,306.0)">
-    <g class="closed" id="dscpl1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dscpl1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER ddcpl1" id="ddcpl1" transform="matrix(0.0,1.0,-1.0,0.0,110.0,260.0)">
-    <g class="closed" id="ddcpl1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="ddcpl1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dscpl2" id="dscpl2" transform="translate(136.0,331.0)">
-    <g class="closed" id="dscpl2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dscpl2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload3" id="dload3" transform="translate(216.0,306.0)">
-    <g class="closed" id="dload3_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload3_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload3" id="bload3" transform="translate(210.0,145.0)">
-    <g class="closed" id="bload3_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload3_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen4" id="dgen4" transform="translate(376.0,331.0)">
-    <g class="closed" id="dgen4_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen4_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen4" id="bgen4" transform="translate(370.0,480.0)">
-    <g class="closed" id="bgen4_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen4_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf21" id="dtrf21" transform="translate(296.0,306.0)">
-    <g class="closed" id="dtrf21_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf21_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf21" id="btrf21" transform="translate(290.0,145.0)">
-    <g class="closed" id="btrf21_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf21_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf22" id="dtrf22" transform="translate(1016.0,331.0)">
-    <g class="closed" id="dtrf22_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf22_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf22" id="btrf22" transform="translate(1010.0,480.0)">
-    <g class="closed" id="btrf22_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf22_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf23" id="dtrf23" transform="translate(1096.0,331.0)">
-    <g class="closed" id="dtrf23_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf23_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf23" id="btrf23" transform="translate(1090.0,480.0)">
-    <g class="closed" id="btrf23_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf23_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf24" id="dtrf24" transform="translate(456.0,306.0)">
-    <g class="closed" id="dtrf24_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf24_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf24" id="btrf24" transform="translate(450.0,145.0)">
-    <g class="closed" id="btrf24_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf24_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf26" id="dtrf26" transform="translate(736.0,331.0)">
-    <g class="closed" id="dtrf26_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf26_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf26" id="btrf26" transform="translate(730.0,186.66666666666669)">
-    <g class="closed" id="btrf26_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf26_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf27" id="dtrf27" transform="translate(576.0,306.0)">
-    <g class="closed" id="dtrf27_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf27_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf27" id="btrf27" transform="translate(570.0,186.66666666666669)">
-    <g class="closed" id="btrf27_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf27_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf28" id="dtrf28" transform="translate(896.0,331.0)">
-    <g class="closed" id="dtrf28_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf28_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf28" id="btrf28" transform="translate(890.0,438.3333333333333)">
-    <g class="closed" id="btrf28_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf28_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl2_trf62_fictif" id="FICT_vl2_trf62_fictif" transform="translate(733.0,107.33333333333334)">
     <circle r="4" id="FICT_vl2_trf62_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="FICT_vl2_trf62_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
@@ -682,6 +483,205 @@
         <polyline class="wire wire_vl2" points="740.0,335.0,740.0,280.0" id="vl2_Wire45"/>
         <polyline class="wire wire_vl2" points="900.0,438.3333333333333,900.0,365.0" id="vl2_Wire46"/>
         <polyline class="wire wire_vl2" points="900.0,335.0,900.0,365.0" id="vl2_Wire47"/>
+        <g class="DISCONNECTOR dscpl1" id="dscpl1" transform="translate(56.0,306.0)">
+    <g class="closed" id="dscpl1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dscpl1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER ddcpl1" id="ddcpl1" transform="matrix(0.0,1.0,-1.0,0.0,110.0,260.0)">
+    <g class="closed" id="ddcpl1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="ddcpl1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dscpl2" id="dscpl2" transform="translate(136.0,331.0)">
+    <g class="closed" id="dscpl2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dscpl2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload3" id="dload3" transform="translate(216.0,306.0)">
+    <g class="closed" id="dload3_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload3_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload3" id="bload3" transform="translate(210.0,145.0)">
+    <g class="closed" id="bload3_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload3_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen4" id="dgen4" transform="translate(376.0,331.0)">
+    <g class="closed" id="dgen4_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen4_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen4" id="bgen4" transform="translate(370.0,480.0)">
+    <g class="closed" id="bgen4_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen4_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf21" id="dtrf21" transform="translate(296.0,306.0)">
+    <g class="closed" id="dtrf21_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf21_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf21" id="btrf21" transform="translate(290.0,145.0)">
+    <g class="closed" id="btrf21_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf21_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf22" id="dtrf22" transform="translate(1016.0,331.0)">
+    <g class="closed" id="dtrf22_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf22_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf22" id="btrf22" transform="translate(1010.0,480.0)">
+    <g class="closed" id="btrf22_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf22_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf23" id="dtrf23" transform="translate(1096.0,331.0)">
+    <g class="closed" id="dtrf23_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf23_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf23" id="btrf23" transform="translate(1090.0,480.0)">
+    <g class="closed" id="btrf23_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf23_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf24" id="dtrf24" transform="translate(456.0,306.0)">
+    <g class="closed" id="dtrf24_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf24_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf24" id="btrf24" transform="translate(450.0,145.0)">
+    <g class="closed" id="btrf24_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf24_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf26" id="dtrf26" transform="translate(736.0,331.0)">
+    <g class="closed" id="dtrf26_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf26_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf26" id="btrf26" transform="translate(730.0,186.66666666666669)">
+    <g class="closed" id="btrf26_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf26_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf27" id="dtrf27" transform="translate(576.0,306.0)">
+    <g class="closed" id="dtrf27_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf27_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf27" id="btrf27" transform="translate(570.0,186.66666666666669)">
+    <g class="closed" id="btrf27_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf27_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf28" id="dtrf28" transform="translate(896.0,331.0)">
+    <g class="closed" id="dtrf28_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf28_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf28" id="btrf28" transform="translate(890.0,438.3333333333333)">
+    <g class="closed" id="btrf28_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf28_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl2">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL2_optimized.svg
@@ -224,69 +224,6 @@
             <use href="#TWO_WINDINGS_TRANSFORMER-WINDING2"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_TWO_N_LABEL">trf4</text>
         </g>
-        <g class="DISCONNECTOR dscpl1" id="dscpl1" transform="translate(56.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER ddcpl1" id="ddcpl1" transform="matrix(0.0,1.0,-1.0,0.0,110.0,260.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dscpl2" id="dscpl2" transform="translate(136.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="DISCONNECTOR dload3" id="dload3" transform="translate(216.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER bload3" id="bload3" transform="translate(210.0,145.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dgen4" id="dgen4" transform="translate(376.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER bgen4" id="bgen4" transform="translate(370.0,480.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf21" id="dtrf21" transform="translate(296.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf21" id="btrf21" transform="translate(290.0,145.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf22" id="dtrf22" transform="translate(1016.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf22" id="btrf22" transform="translate(1010.0,480.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf23" id="dtrf23" transform="translate(1096.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf23" id="btrf23" transform="translate(1090.0,480.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf24" id="dtrf24" transform="translate(456.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf24" id="btrf24" transform="translate(450.0,145.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf26" id="dtrf26" transform="translate(736.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf26" id="btrf26" transform="translate(730.0,186.66666666666669)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf27" id="dtrf27" transform="translate(576.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf27" id="btrf27" transform="translate(570.0,186.66666666666669)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf28" id="dtrf28" transform="translate(896.0,331.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf28" id="btrf28" transform="translate(890.0,438.3333333333333)">
-            <use href="#BREAKER-closed"/>
-        </g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl2_trf62_fictif" id="FICT_vl2_trf62_fictif" transform="translate(733.0,107.33333333333334)">
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING1"/>
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING2"/>
@@ -476,6 +413,69 @@
         <polyline class="wire wire_vl2" points="740.0,335.0,740.0,280.0" id="vl2_Wire45"/>
         <polyline class="wire wire_vl2" points="900.0,438.3333333333333,900.0,365.0" id="vl2_Wire46"/>
         <polyline class="wire wire_vl2" points="900.0,335.0,900.0,365.0" id="vl2_Wire47"/>
+        <g class="DISCONNECTOR dscpl1" id="dscpl1" transform="translate(56.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER ddcpl1" id="ddcpl1" transform="matrix(0.0,1.0,-1.0,0.0,110.0,260.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dscpl2" id="dscpl2" transform="translate(136.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="DISCONNECTOR dload3" id="dload3" transform="translate(216.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER bload3" id="bload3" transform="translate(210.0,145.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dgen4" id="dgen4" transform="translate(376.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER bgen4" id="bgen4" transform="translate(370.0,480.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf21" id="dtrf21" transform="translate(296.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf21" id="btrf21" transform="translate(290.0,145.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf22" id="dtrf22" transform="translate(1016.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf22" id="btrf22" transform="translate(1010.0,480.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf23" id="dtrf23" transform="translate(1096.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf23" id="btrf23" transform="translate(1090.0,480.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf24" id="dtrf24" transform="translate(456.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf24" id="btrf24" transform="translate(450.0,145.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf26" id="dtrf26" transform="translate(736.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf26" id="btrf26" transform="translate(730.0,186.66666666666669)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf27" id="dtrf27" transform="translate(576.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf27" id="btrf27" transform="translate(570.0,186.66666666666669)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf28" id="dtrf28" transform="translate(896.0,331.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf28" id="btrf28" transform="translate(890.0,438.3333333333333)">
+            <use href="#BREAKER-closed"/>
+        </g>
         <g id="LABEL_VL_vl2">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL3.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL3.svg
@@ -161,164 +161,12 @@
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs8_NW_LABEL">bbs8</text>
         </g>
         <g class="CAPACITOR self6" id="self6" transform="translate(854.0,584.0)">
-    <line y2="3" x1="6" x2="6" y1="0"/>
-    <line y2="3" x1="0" x2="12" y1="3"/>
-    <line y2="6" x1="0" x2="12" y1="6"/>
-    <line y2="9" x1="6" x2="6" y1="6"/>
+    <line y2="4.5" x1="6" x2="6" y1="0"/>
+    <line y2="4.5" x1="0" x2="12" y1="4.5"/>
+    <line y2="7.5" x1="0" x2="12" y1="7.5"/>
+    <line y2="12" x1="6" x2="6" y1="7.5"/>
 <text x="-5.0" font-size="8" y="25.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="self6_S_LABEL">self6</text>
         </g>
-        <g class="DISCONNECTOR dload4" id="dload4" transform="translate(56.0,306.0)">
-    <g class="closed" id="dload4_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload4_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload4" id="bload4" transform="translate(50.0,145.0)">
-    <g class="closed" id="bload4_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload4_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dself4" id="dself4" transform="translate(136.0,306.0)">
-    <g class="closed" id="dself4_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dself4_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bself4" id="bself4" transform="translate(130.0,455.0)">
-    <g class="closed" id="bself4_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bself4_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf25" id="dtrf25" transform="translate(216.0,306.0)">
-    <g class="closed" id="dtrf25_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf25_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf25" id="btrf25" transform="translate(210.0,455.0)">
-    <g class="closed" id="btrf25_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf25_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf36" id="dtrf36" transform="translate(336.0,306.0)">
-    <g class="closed" id="dtrf36_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf36_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf36" id="btrf36" transform="translate(330.0,186.66666666666669)">
-    <g class="closed" id="btrf36_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf36_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf37" id="dtrf37" transform="translate(496.0,306.0)">
-    <g class="closed" id="dtrf37_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf37_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf37" id="btrf37" transform="translate(490.0,413.3333333333333)">
-    <g class="closed" id="btrf37_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf37_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf38" id="dtrf38" transform="translate(656.0,306.0)">
-    <g class="closed" id="dtrf38_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf38_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf38" id="btrf38" transform="translate(650.0,186.66666666666669)">
-    <g class="closed" id="btrf38_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf38_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dself5" id="dself5" transform="translate(776.0,306.0)">
-    <g class="closed" id="dself5_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dself5_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bself5" id="bself5" transform="translate(770.0,455.0)">
-    <g class="closed" id="bself5_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bself5_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dself6" id="dself6" transform="translate(856.0,306.0)">
-    <g class="closed" id="dself6_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dself6_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bself6" id="bself6" transform="translate(850.0,455.0)">
-    <g class="closed" id="bself6_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bself6_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl3_trf63_fictif" id="FICT_vl3_trf63_fictif" transform="translate(333.0,107.33333333333334)">
     <circle r="4" id="FICT_vl3_trf63_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="FICT_vl3_trf63_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
@@ -596,6 +444,158 @@
         <polyline class="wire wire_vl3" points="780.0,310.0,780.0,340.0" id="vl3_Wire35"/>
         <polyline class="wire wire_vl3" points="860.0,455.0,860.0,340.0" id="vl3_Wire36"/>
         <polyline class="wire wire_vl3" points="860.0,310.0,860.0,340.0" id="vl3_Wire37"/>
+        <g class="DISCONNECTOR dload4" id="dload4" transform="translate(56.0,306.0)">
+    <g class="closed" id="dload4_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload4_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload4" id="bload4" transform="translate(50.0,145.0)">
+    <g class="closed" id="bload4_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload4_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dself4" id="dself4" transform="translate(136.0,306.0)">
+    <g class="closed" id="dself4_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dself4_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bself4" id="bself4" transform="translate(130.0,455.0)">
+    <g class="closed" id="bself4_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bself4_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf25" id="dtrf25" transform="translate(216.0,306.0)">
+    <g class="closed" id="dtrf25_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf25_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf25" id="btrf25" transform="translate(210.0,455.0)">
+    <g class="closed" id="btrf25_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf25_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf36" id="dtrf36" transform="translate(336.0,306.0)">
+    <g class="closed" id="dtrf36_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf36_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf36" id="btrf36" transform="translate(330.0,186.66666666666669)">
+    <g class="closed" id="btrf36_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf36_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf37" id="dtrf37" transform="translate(496.0,306.0)">
+    <g class="closed" id="dtrf37_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf37_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf37" id="btrf37" transform="translate(490.0,413.3333333333333)">
+    <g class="closed" id="btrf37_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf37_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf38" id="dtrf38" transform="translate(656.0,306.0)">
+    <g class="closed" id="dtrf38_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf38_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf38" id="btrf38" transform="translate(650.0,186.66666666666669)">
+    <g class="closed" id="btrf38_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf38_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dself5" id="dself5" transform="translate(776.0,306.0)">
+    <g class="closed" id="dself5_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dself5_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bself5" id="bself5" transform="translate(770.0,455.0)">
+    <g class="closed" id="bself5_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bself5_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dself6" id="dself6" transform="translate(856.0,306.0)">
+    <g class="closed" id="dself6_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dself6_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bself6" id="bself6" transform="translate(850.0,455.0)">
+    <g class="closed" id="bself6_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bself6_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl3">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL3_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL3_optimized.svg
@@ -120,10 +120,10 @@
     <circle r="4" cx="4" cy="4"/>
 </g>
         <g id="CAPACITOR">
-    <line y2="3" x1="6" x2="6" y1="0"/>
-    <line y2="3" x1="0" x2="12" y1="3"/>
-    <line y2="6" x1="0" x2="12" y1="6"/>
-    <line y2="9" x1="6" x2="6" y1="6"/>
+    <line y2="4.5" x1="6" x2="6" y1="0"/>
+    <line y2="4.5" x1="0" x2="12" y1="4.5"/>
+    <line y2="7.5" x1="0" x2="12" y1="7.5"/>
+    <line y2="12" x1="6" x2="6" y1="7.5"/>
 </g>
         <g id="DISCONNECTOR">
     <g class="closed" id="DISCONNECTOR-closed">
@@ -214,54 +214,6 @@
         <g class="CAPACITOR self6" id="self6" transform="translate(854.0,584.0)">
             <use href="#CAPACITOR"/>
             <text x="-5.0" font-size="8" y="25.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="self6_S_LABEL">self6</text>
-        </g>
-        <g class="DISCONNECTOR dload4" id="dload4" transform="translate(56.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER bload4" id="bload4" transform="translate(50.0,145.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dself4" id="dself4" transform="translate(136.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER bself4" id="bself4" transform="translate(130.0,455.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf25" id="dtrf25" transform="translate(216.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf25" id="btrf25" transform="translate(210.0,455.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf36" id="dtrf36" transform="translate(336.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf36" id="btrf36" transform="translate(330.0,186.66666666666669)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf37" id="dtrf37" transform="translate(496.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf37" id="btrf37" transform="translate(490.0,413.3333333333333)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dtrf38" id="dtrf38" transform="translate(656.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER btrf38" id="btrf38" transform="translate(650.0,186.66666666666669)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dself5" id="dself5" transform="translate(776.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER bself5" id="bself5" transform="translate(770.0,455.0)">
-            <use href="#BREAKER-closed"/>
-        </g>
-        <g class="DISCONNECTOR dself6" id="dself6" transform="translate(856.0,306.0)">
-            <use href="#DISCONNECTOR-closed"/>
-        </g>
-        <g class="BREAKER bself6" id="bself6" transform="translate(850.0,455.0)">
-            <use href="#BREAKER-closed"/>
         </g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl3_trf63_fictif" id="FICT_vl3_trf63_fictif" transform="translate(333.0,107.33333333333334)">
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING1"/>
@@ -432,6 +384,54 @@
         <polyline class="wire wire_vl3" points="780.0,310.0,780.0,340.0" id="vl3_Wire35"/>
         <polyline class="wire wire_vl3" points="860.0,455.0,860.0,340.0" id="vl3_Wire36"/>
         <polyline class="wire wire_vl3" points="860.0,310.0,860.0,340.0" id="vl3_Wire37"/>
+        <g class="DISCONNECTOR dload4" id="dload4" transform="translate(56.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER bload4" id="bload4" transform="translate(50.0,145.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dself4" id="dself4" transform="translate(136.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER bself4" id="bself4" transform="translate(130.0,455.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf25" id="dtrf25" transform="translate(216.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf25" id="btrf25" transform="translate(210.0,455.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf36" id="dtrf36" transform="translate(336.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf36" id="btrf36" transform="translate(330.0,186.66666666666669)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf37" id="dtrf37" transform="translate(496.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf37" id="btrf37" transform="translate(490.0,413.3333333333333)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dtrf38" id="dtrf38" transform="translate(656.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER btrf38" id="btrf38" transform="translate(650.0,186.66666666666669)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dself5" id="dself5" transform="translate(776.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER bself5" id="bself5" transform="translate(770.0,455.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR dself6" id="dself6" transform="translate(856.0,306.0)">
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER bself6" id="bself6" transform="translate(850.0,455.0)">
+            <use href="#BREAKER-closed"/>
+        </g>
         <g id="LABEL_VL_vl3">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase1BusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase1BusBreaker.svg
@@ -133,15 +133,6 @@
     <line y2="9" x1="16" x2="0" y1="0"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="l_N_LABEL">l</text>
         </g>
-        <g class="DISCONNECTOR b1_l" id="b1_l" transform="translate(41.0,306.0)">
-    <g class="closed" id="b1_l_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="b1_l_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
         <g class="NODE FICT_vl_b1_lFictif" id="FICT_vl_b1_lFictif" transform="translate(41.0,276.0)">
     <circle r="4" cx="4" cy="4"/>
 </g>
@@ -166,6 +157,15 @@
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="vl_Wire2"/>
+        <g class="DISCONNECTOR b1_l" id="b1_l" transform="translate(41.0,306.0)">
+    <g class="closed" id="b1_l_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="b1_l_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase1inverted.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase1inverted.svg
@@ -129,25 +129,6 @@
             <line y2="0" x1="0" x2="30.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs_NW_LABEL">bbs</text>
         </g>
-        <g class="DISCONNECTOR d" id="d" transform="translate(41.0,306.0)">
-    <g class="closed" id="d_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="d_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER b" id="b" transform="translate(35.0,145.0)">
-    <g class="closed" id="b_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="b_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="NODE FICT_vl_dFictif" id="FICT_vl_dFictif" transform="translate(41.0,276.0)">
     <circle r="4" cx="4" cy="4"/>
 </g>
@@ -173,6 +154,25 @@
         </g>
         <polyline class="wire wire_vl" points="45.0,165.0,45.0,280.0" id="vl_Wire2"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="vl_Wire3"/>
+        <g class="DISCONNECTOR d" id="d" transform="translate(41.0,306.0)">
+    <g class="closed" id="d_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="d_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER b" id="b" transform="translate(35.0,145.0)">
+    <g class="closed" id="b_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="b_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase2StackedCell.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase2StackedCell.svg
@@ -136,6 +136,30 @@
         <g class="NODE FICT_vl_2" id="FICT_vl_2" transform="translate(41.0,276.0)">
     <circle r="4" cx="4" cy="4"/>
 </g>
+        <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="vl_Wire0"/>
+        <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="vl_Wire1"/>
+        <polyline class="wire wire_vl" points="45.0,335.0,45.0,335.0" id="vl_Wire2"/>
+        <polyline class="wire wire_vl" points="45.0,335.0,45.0,280.0" id="vl_Wire3"/>
+        <polyline class="wire wire_vl" points="45.0,280.0,45.0,165.0" id="vl_Wire4"/>
+        <polyline class="wire wire_vl" points="45.0,145.0,45.0,34.0" id="vl_Wire5"/>
+        <g class="ARROW1_l_UP" id="vl_Wire5_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
+     <g class="arrow-up" id="vl_Wire5_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl_Wire5_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        </g>
+        <g class="ARROW2__l_UP" id="vl_Wire5_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
+     <g class="arrow-up" id="vl_Wire5_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl_Wire5_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        </g>
         <g class="DISCONNECTOR d1" id="d1" transform="translate(41.0,306.0)">
     <g class="closed" id="d1_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
@@ -164,30 +188,6 @@
         <line y2="10" x1="5" x2="15" y1="10"/>
     </g>
 </g>
-        <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="vl_Wire0"/>
-        <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="vl_Wire1"/>
-        <polyline class="wire wire_vl" points="45.0,335.0,45.0,335.0" id="vl_Wire2"/>
-        <polyline class="wire wire_vl" points="45.0,335.0,45.0,280.0" id="vl_Wire3"/>
-        <polyline class="wire wire_vl" points="45.0,280.0,45.0,165.0" id="vl_Wire4"/>
-        <polyline class="wire wire_vl" points="45.0,145.0,45.0,34.0" id="vl_Wire5"/>
-        <g class="ARROW1_l_UP" id="vl_Wire5_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
-     <g class="arrow-up" id="vl_Wire5_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl_Wire5_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
-        </g>
-        <g class="ARROW2__l_UP" id="vl_Wire5_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
-     <g class="arrow-up" id="vl_Wire5_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl_Wire5_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
-        </g>
         <g id="LABEL_VL_vl">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase3Coupling.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase3Coupling.svg
@@ -128,6 +128,18 @@
             <line y2="0" x1="0" x2="80.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs2_NW_LABEL">bbs2</text>
         </g>
+        <g class="NODE FICT_vl_d1Fictif" id="FICT_vl_d1Fictif" transform="matrix(0.0,1.0,-1.0,0.0,49.0,266.0)">
+    <circle r="4" cx="4" cy="4"/>
+</g>
+        <g class="NODE FICT_vl_d2Fictif" id="FICT_vl_d2Fictif" transform="matrix(0.0,1.0,-1.0,0.0,99.0,266.0)">
+    <circle r="4" cx="4" cy="4"/>
+</g>
+        <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="vl_Wire0"/>
+        <polyline class="wire wire_vl" points="95.0,335.0,95.0,335.0" id="vl_Wire1"/>
+        <polyline class="wire wire_vl" points="60.0,270.0,45.0,270.0" id="vl_Wire2"/>
+        <polyline class="wire wire_vl" points="45.0,310.0,45.0,270.0" id="vl_Wire3"/>
+        <polyline class="wire wire_vl" points="80.0,270.0,95.0,270.0" id="vl_Wire4"/>
+        <polyline class="wire wire_vl" points="95.0,335.0,95.0,270.0" id="vl_Wire5"/>
         <g class="DISCONNECTOR d1" id="d1" transform="translate(41.0,306.0)">
     <g class="closed" id="d1_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
@@ -156,18 +168,6 @@
         <line y2="8" x1="8" x2="0" y1="0"/>
     </g>
 </g>
-        <g class="NODE FICT_vl_d1Fictif" id="FICT_vl_d1Fictif" transform="matrix(0.0,1.0,-1.0,0.0,49.0,266.0)">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g class="NODE FICT_vl_d2Fictif" id="FICT_vl_d2Fictif" transform="matrix(0.0,1.0,-1.0,0.0,99.0,266.0)">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="vl_Wire0"/>
-        <polyline class="wire wire_vl" points="95.0,335.0,95.0,335.0" id="vl_Wire1"/>
-        <polyline class="wire wire_vl" points="60.0,270.0,45.0,270.0" id="vl_Wire2"/>
-        <polyline class="wire wire_vl" points="45.0,310.0,45.0,270.0" id="vl_Wire3"/>
-        <polyline class="wire wire_vl" points="80.0,270.0,95.0,270.0" id="vl_Wire4"/>
-        <polyline class="wire wire_vl" points="95.0,335.0,95.0,270.0" id="vl_Wire5"/>
         <g id="LABEL_VL_vl">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase4NotParallelel.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase4NotParallelel.svg
@@ -155,103 +155,13 @@
         <g class="NODE FICT_vl_4" id="FICT_vl_4" transform="translate(41.0,276.0)">
     <circle r="4" cx="4" cy="4"/>
 </g>
-        <g class="BREAKER ba" id="ba" transform="translate(35.0,145.0)">
-    <g class="closed" id="ba_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="ba_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR da1" id="da1" transform="translate(41.0,306.0)">
-    <g class="closed" id="da1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="da1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR da2" id="da2" transform="translate(41.0,331.0)">
-    <g class="closed" id="da2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="da2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
         <g class="NODE FICT_vl_6" id="FICT_vl_6" transform="translate(141.0,361.0)">
     <circle r="4" cx="4" cy="4"/>
-</g>
-        <g class="BREAKER bb" id="bb" transform="translate(135.0,480.0)">
-    <g class="closed" id="bb_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bb_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR db1" id="db1" transform="translate(141.0,306.0)">
-    <g class="closed" id="db1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="db1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR db2" id="db2" transform="translate(141.0,331.0)">
-    <g class="closed" id="db2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="db2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR ss1" id="ss1" transform="matrix(0.0,1.0,-1.0,0.0,99.0,306.0)">
-    <g class="closed" id="ss1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="ss1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bc" id="bc" transform="translate(185.0,145.0)">
-    <g class="closed" id="bc_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bc_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dc1" id="dc1" transform="translate(191.0,306.0)">
-    <g class="closed" id="dc1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dc1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
 </g>
         <g class="NODE FICT_vl_dc1Fictif" id="FICT_vl_dc1Fictif" transform="translate(191.0,276.0)">
     <circle r="4" cx="4" cy="4"/>
 </g>
-        <g class="NODE ss1fSwitch0" id="ss1fSwitch0" transform="translate(116.0,306.0)">
-    <circle r="4" cx="4" cy="4"/>
-</g>
         <g class="NODE FICT_vl_ss1fNode0" id="FICT_vl_ss1fNode0" transform="matrix(0.0,1.0,-1.0,0.0,124.0,306.0)">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g class="NODE ss1fSwitch1" id="ss1fSwitch1" transform="translate(66.0,306.0)">
     <circle r="4" cx="4" cy="4"/>
 </g>
         <g class="NODE FICT_vl_ss1fNode1" id="FICT_vl_ss1fNode1" transform="matrix(0.0,1.0,-1.0,0.0,74.0,306.0)">
@@ -333,6 +243,96 @@
         <polyline class="wire wire_vl" points="60.0,310.0,70.0,310.0" id="vl_Wire19"/>
         <polyline class="wire wire_vl" points="70.0,310.0,70.0,310.0" id="vl_Wire20"/>
         <polyline class="wire wire_vl" points="70.0,310.0,95.0,310.0" id="vl_Wire21"/>
+        <g class="BREAKER ba" id="ba" transform="translate(35.0,145.0)">
+    <g class="closed" id="ba_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="ba_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR da1" id="da1" transform="translate(41.0,306.0)">
+    <g class="closed" id="da1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="da1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR da2" id="da2" transform="translate(41.0,331.0)">
+    <g class="closed" id="da2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="da2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bb" id="bb" transform="translate(135.0,480.0)">
+    <g class="closed" id="bb_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bb_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR db1" id="db1" transform="translate(141.0,306.0)">
+    <g class="closed" id="db1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="db1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR db2" id="db2" transform="translate(141.0,331.0)">
+    <g class="closed" id="db2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="db2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR ss1" id="ss1" transform="translate(91.0,306.0)">
+    <g class="closed" id="ss1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="ss1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bc" id="bc" transform="translate(185.0,145.0)">
+    <g class="closed" id="bc_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bc_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dc1" id="dc1" transform="translate(191.0,306.0)">
+    <g class="closed" id="dc1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dc1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="NODE ss1fSwitch0" id="ss1fSwitch0" transform="translate(116.0,306.0)">
+    <circle r="4" cx="4" cy="4"/>
+</g>
+        <g class="NODE ss1fSwitch1" id="ss1fSwitch1" transform="translate(66.0,306.0)">
+    <circle r="4" cx="4" cy="4"/>
+</g>
         <g id="LABEL_VL_vl">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase5ShuntHorizontal.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase5ShuntHorizontal.svg
@@ -136,54 +136,6 @@
     <line y2="9" x1="16" x2="0" y1="0"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="lb_N_LABEL">lb</text>
         </g>
-        <g class="BREAKER ba" id="ba" transform="translate(35.0,186.66666666666669)">
-    <g class="closed" id="ba_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="ba_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR da" id="da" transform="translate(41.0,306.0)">
-    <g class="closed" id="da_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="da_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bb" id="bb" transform="translate(85.0,186.66666666666669)">
-    <g class="closed" id="bb_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bb_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR db" id="db" transform="translate(91.0,306.0)">
-    <g class="closed" id="db_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="db_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bs" id="bs" transform="matrix(0.0,1.0,-1.0,0.0,80.0,103.3333)">
-    <g class="closed" id="bs_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bs_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="NODE FICT_vl_laFictif" id="FICT_vl_laFictif" transform="translate(41.0,109.33333333333334)">
     <circle r="4" cx="4" cy="4"/>
 </g>
@@ -244,6 +196,54 @@
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="vl_Wire9"/>
         <polyline class="wire wire_vl" points="95.0,206.66666666666669,95.0,280.0" id="vl_Wire10"/>
         <polyline class="wire wire_vl" points="95.0,310.0,95.0,280.0" id="vl_Wire11"/>
+        <g class="BREAKER ba" id="ba" transform="translate(35.0,186.66666666666669)">
+    <g class="closed" id="ba_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="ba_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR da" id="da" transform="translate(41.0,306.0)">
+    <g class="closed" id="da_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="da_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bb" id="bb" transform="translate(85.0,186.66666666666669)">
+    <g class="closed" id="bb_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bb_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR db" id="db" transform="translate(91.0,306.0)">
+    <g class="closed" id="db_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="db_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bs" id="bs" transform="matrix(0.0,1.0,-1.0,0.0,80.0,103.3333)">
+    <g class="closed" id="bs_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bs_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase5ShuntVertical.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase5ShuntVertical.svg
@@ -136,56 +136,8 @@
     <line y2="9" x1="16" x2="0" y1="0"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="lb_N_LABEL">lb</text>
         </g>
-        <g class="BREAKER ba" id="ba" transform="translate(35.0,186.66666666666669)">
-    <g class="closed" id="ba_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="ba_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR da" id="da" transform="translate(41.0,306.0)">
-    <g class="closed" id="da_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="da_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
         <g class="NODE FICT_vl_3" id="FICT_vl_3" transform="translate(91.0,276.0)">
     <circle r="4" cx="4" cy="4"/>
-</g>
-        <g class="BREAKER bb" id="bb" transform="translate(85.0,145.0)">
-    <g class="closed" id="bb_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bb_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR db" id="db" transform="translate(91.0,306.0)">
-    <g class="closed" id="db_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="db_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bs" id="bs" transform="translate(60.0,186.66666666666669)">
-    <g class="closed" id="bs_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bs_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
 </g>
         <g class="NODE FICT_vl_laFictif" id="FICT_vl_laFictif" transform="translate(41.0,109.33333333333334)">
     <circle r="4" cx="4" cy="4"/>
@@ -240,6 +192,54 @@
         </g>
         <polyline class="wire wire_vl" points="45.0,206.66666666666669,45.0,280.0" id="vl_Wire9"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="vl_Wire10"/>
+        <g class="BREAKER ba" id="ba" transform="translate(35.0,186.66666666666669)">
+    <g class="closed" id="ba_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="ba_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR da" id="da" transform="translate(41.0,306.0)">
+    <g class="closed" id="da_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="da_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bb" id="bb" transform="translate(85.0,145.0)">
+    <g class="closed" id="bb_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bb_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR db" id="db" transform="translate(91.0,306.0)">
+    <g class="closed" id="db_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="db_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bs" id="bs" transform="translate(60.0,186.66666666666669)">
+    <g class="closed" id="bs_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bs_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase6CouplingNonFlatHorizontal.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase6CouplingNonFlatHorizontal.svg
@@ -137,6 +137,42 @@
             <line y2="0" x1="0" x2="30.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs2.2_NW_LABEL">bbs2.2</text>
         </g>
+        <g class="NODE FICT_vl_d1Fictif" id="FICT_vl_d1Fictif" transform="matrix(0.0,1.0,-1.0,0.0,49.0,266.0)">
+    <circle r="4" cx="4" cy="4"/>
+</g>
+        <g class="NODE FICT_vl_d2Fictif" id="FICT_vl_d2Fictif" transform="matrix(0.0,1.0,-1.0,0.0,149.0,266.0)">
+    <circle r="4" cx="4" cy="4"/>
+</g>
+        <g class="NODE FICT_vl_ds1fNode0" id="FICT_vl_ds1fNode0" transform="matrix(0.0,1.0,-1.0,0.0,74.0,306.0)">
+    <circle r="4" cx="4" cy="4"/>
+</g>
+        <g class="NODE FICT_vl_ds1fNode1" id="FICT_vl_ds1fNode1" transform="matrix(0.0,1.0,-1.0,0.0,124.0,306.0)">
+    <circle r="4" cx="4" cy="4"/>
+</g>
+        <g class="NODE FICT_vl_ds2fNode0" id="FICT_vl_ds2fNode0" transform="matrix(0.0,1.0,-1.0,0.0,74.0,331.0)">
+    <circle r="4" cx="4" cy="4"/>
+</g>
+        <g class="NODE FICT_vl_ds2fNode1" id="FICT_vl_ds2fNode1" transform="matrix(0.0,1.0,-1.0,0.0,124.0,331.0)">
+    <circle r="4" cx="4" cy="4"/>
+</g>
+        <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="vl_Wire0"/>
+        <polyline class="wire wire_vl" points="145.0,335.0,145.0,335.0" id="vl_Wire1"/>
+        <polyline class="wire wire_vl" points="60.0,270.0,45.0,270.0" id="vl_Wire2"/>
+        <polyline class="wire wire_vl" points="45.0,310.0,45.0,270.0" id="vl_Wire3"/>
+        <polyline class="wire wire_vl" points="80.0,270.0,145.0,270.0" id="vl_Wire4"/>
+        <polyline class="wire wire_vl" points="145.0,335.0,145.0,270.0" id="vl_Wire5"/>
+        <polyline class="wire wire_vl" points="60.0,310.0,70.0,310.0" id="vl_Wire6"/>
+        <polyline class="wire wire_vl" points="70.0,310.0,70.0,310.0" id="vl_Wire7"/>
+        <polyline class="wire wire_vl" points="70.0,310.0,95.0,310.0" id="vl_Wire8"/>
+        <polyline class="wire wire_vl" points="130.0,310.0,120.0,310.0" id="vl_Wire9"/>
+        <polyline class="wire wire_vl" points="120.0,310.0,120.0,310.0" id="vl_Wire10"/>
+        <polyline class="wire wire_vl" points="120.0,310.0,95.0,310.0" id="vl_Wire11"/>
+        <polyline class="wire wire_vl" points="60.0,335.0,70.0,335.0" id="vl_Wire12"/>
+        <polyline class="wire wire_vl" points="70.0,335.0,70.0,335.0" id="vl_Wire13"/>
+        <polyline class="wire wire_vl" points="70.0,335.0,95.0,335.0" id="vl_Wire14"/>
+        <polyline class="wire wire_vl" points="130.0,335.0,120.0,335.0" id="vl_Wire15"/>
+        <polyline class="wire wire_vl" points="120.0,335.0,120.0,335.0" id="vl_Wire16"/>
+        <polyline class="wire wire_vl" points="120.0,335.0,95.0,335.0" id="vl_Wire17"/>
         <g class="DISCONNECTOR d1" id="d1" transform="translate(41.0,306.0)">
     <g class="closed" id="d1_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
@@ -165,7 +201,7 @@
         <line y2="8" x1="8" x2="0" y1="0"/>
     </g>
 </g>
-        <g class="DISCONNECTOR ds1" id="ds1" transform="matrix(0.0,1.0,-1.0,0.0,99.0,306.0)">
+        <g class="DISCONNECTOR ds1" id="ds1" transform="translate(91.0,306.0)">
     <g class="closed" id="ds1_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
         <line y2="8" x1="8" x2="0" y1="0"/>
@@ -174,7 +210,7 @@
         <line y2="8" x1="8" x2="0" y1="0"/>
     </g>
 </g>
-        <g class="DISCONNECTOR ds2" id="ds2" transform="matrix(0.0,1.0,-1.0,0.0,99.0,331.0)">
+        <g class="DISCONNECTOR ds2" id="ds2" transform="translate(91.0,331.0)">
     <g class="closed" id="ds2_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
         <line y2="8" x1="8" x2="0" y1="0"/>
@@ -183,54 +219,18 @@
         <line y2="8" x1="8" x2="0" y1="0"/>
     </g>
 </g>
-        <g class="NODE FICT_vl_d1Fictif" id="FICT_vl_d1Fictif" transform="matrix(0.0,1.0,-1.0,0.0,49.0,266.0)">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g class="NODE FICT_vl_d2Fictif" id="FICT_vl_d2Fictif" transform="matrix(0.0,1.0,-1.0,0.0,149.0,266.0)">
-    <circle r="4" cx="4" cy="4"/>
-</g>
         <g class="NODE ds1fSwitch0" id="ds1fSwitch0" transform="translate(66.0,306.0)">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g class="NODE FICT_vl_ds1fNode0" id="FICT_vl_ds1fNode0" transform="matrix(0.0,1.0,-1.0,0.0,74.0,306.0)">
     <circle r="4" cx="4" cy="4"/>
 </g>
         <g class="NODE ds1fSwitch1" id="ds1fSwitch1" transform="translate(116.0,306.0)">
     <circle r="4" cx="4" cy="4"/>
 </g>
-        <g class="NODE FICT_vl_ds1fNode1" id="FICT_vl_ds1fNode1" transform="matrix(0.0,1.0,-1.0,0.0,124.0,306.0)">
-    <circle r="4" cx="4" cy="4"/>
-</g>
         <g class="NODE ds2fSwitch0" id="ds2fSwitch0" transform="translate(66.0,331.0)">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <g class="NODE FICT_vl_ds2fNode0" id="FICT_vl_ds2fNode0" transform="matrix(0.0,1.0,-1.0,0.0,74.0,331.0)">
     <circle r="4" cx="4" cy="4"/>
 </g>
         <g class="NODE ds2fSwitch1" id="ds2fSwitch1" transform="translate(116.0,331.0)">
     <circle r="4" cx="4" cy="4"/>
 </g>
-        <g class="NODE FICT_vl_ds2fNode1" id="FICT_vl_ds2fNode1" transform="matrix(0.0,1.0,-1.0,0.0,124.0,331.0)">
-    <circle r="4" cx="4" cy="4"/>
-</g>
-        <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="vl_Wire0"/>
-        <polyline class="wire wire_vl" points="145.0,335.0,145.0,335.0" id="vl_Wire1"/>
-        <polyline class="wire wire_vl" points="60.0,270.0,45.0,270.0" id="vl_Wire2"/>
-        <polyline class="wire wire_vl" points="45.0,310.0,45.0,270.0" id="vl_Wire3"/>
-        <polyline class="wire wire_vl" points="80.0,270.0,145.0,270.0" id="vl_Wire4"/>
-        <polyline class="wire wire_vl" points="145.0,335.0,145.0,270.0" id="vl_Wire5"/>
-        <polyline class="wire wire_vl" points="60.0,310.0,70.0,310.0" id="vl_Wire6"/>
-        <polyline class="wire wire_vl" points="70.0,310.0,70.0,310.0" id="vl_Wire7"/>
-        <polyline class="wire wire_vl" points="70.0,310.0,95.0,310.0" id="vl_Wire8"/>
-        <polyline class="wire wire_vl" points="130.0,310.0,120.0,310.0" id="vl_Wire9"/>
-        <polyline class="wire wire_vl" points="120.0,310.0,120.0,310.0" id="vl_Wire10"/>
-        <polyline class="wire wire_vl" points="120.0,310.0,95.0,310.0" id="vl_Wire11"/>
-        <polyline class="wire wire_vl" points="60.0,335.0,70.0,335.0" id="vl_Wire12"/>
-        <polyline class="wire wire_vl" points="70.0,335.0,70.0,335.0" id="vl_Wire13"/>
-        <polyline class="wire wire_vl" points="70.0,335.0,95.0,335.0" id="vl_Wire14"/>
-        <polyline class="wire wire_vl" points="130.0,335.0,120.0,335.0" id="vl_Wire15"/>
-        <polyline class="wire wire_vl" points="120.0,335.0,120.0,335.0" id="vl_Wire16"/>
-        <polyline class="wire wire_vl" points="120.0,335.0,95.0,335.0" id="vl_Wire17"/>
         <g id="LABEL_VL_vl">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestDefaultFeedersPosition.svg
+++ b/single-line-diagram-core/src/test/resources/TestDefaultFeedersPosition.svg
@@ -274,6 +274,114 @@
     <path d="M6,6 A 6 20 0 0 0 12,6"/>
 <text x="-5.0" font-size="8" y="25.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="gen2_S_LABEL">gen2</text>
         </g>
+        <g class="NODE FICT_vl1_dsect11Fictif" id="FICT_vl1_dsect11Fictif" transform="matrix(0.0,1.0,-1.0,0.0,174.0,356.0)"/>
+        <g class="NODE FICT_vl1_dload1Fictif" id="FICT_vl1_dload1Fictif" transform="translate(91.0,326.0)"/>
+        <g class="NODE FICT_vl1_dsect12Fictif" id="FICT_vl1_dsect12Fictif" transform="matrix(0.0,1.0,-1.0,0.0,224.0,356.0)"/>
+        <g class="NODE FICT_vl1_dload2Fictif" id="FICT_vl1_dload2Fictif" transform="translate(241.0,326.0)"/>
+        <g class="NODE FICT_vl1_dsect21Fictif" id="FICT_vl1_dsect21Fictif" transform="matrix(0.0,1.0,-1.0,0.0,174.0,381.0)"/>
+        <g class="NODE FICT_vl1_dgen1Fictif" id="FICT_vl1_dgen1Fictif" transform="translate(141.0,411.0)"/>
+        <g class="NODE FICT_vl1_dsect22Fictif" id="FICT_vl1_dsect22Fictif" transform="matrix(0.0,1.0,-1.0,0.0,224.0,381.0)"/>
+        <g class="NODE FICT_vl1_dgen2Fictif" id="FICT_vl1_dgen2Fictif" transform="translate(291.0,411.0)"/>
+        <polyline class="wire wire_vl1" points="160.0,360.0,170.0,360.0" id="vl1_Wire0"/>
+        <polyline class="wire wire_vl1" points="220.0,360.0,230.0,360.0" id="vl1_Wire1"/>
+        <polyline class="wire wire_vl1" points="160.0,385.0,170.0,385.0" id="vl1_Wire2"/>
+        <polyline class="wire wire_vl1" points="220.0,385.0,230.0,385.0" id="vl1_Wire3"/>
+        <polyline class="wire wire_vl1" points="95.0,360.0,95.0,360.0" id="vl1_Wire4"/>
+        <polyline class="wire wire_vl1" points="95.0,84.0,95.0,195.0" id="vl1_Wire5"/>
+        <g class="ARROW1_load1_UP" id="vl1_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
+     <g class="arrow-up" id="vl1_Wire5_ARROW1_ARROW-arrow-up">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire5_ARROW1_ARROW-arrow-down">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        </g>
+        <g class="ARROW2_load1_UP" id="vl1_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
+     <g class="arrow-up" id="vl1_Wire5_ARROW2_ARROW-arrow-up">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire5_ARROW2_ARROW-arrow-down">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        </g>
+        <polyline class="wire wire_vl1" points="145.0,385.0,145.0,385.0" id="vl1_Wire6"/>
+        <polyline class="wire wire_vl1" points="145.0,659.0,145.0,550.0" id="vl1_Wire7"/>
+        <g class="ARROW1_gen1_DOWN" id="vl1_Wire7_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,140.0,634.0)">
+     <g class="arrow-up" id="vl1_Wire7_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire7_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
+        </g>
+        <g class="ARROW2_gen1_DOWN" id="vl1_Wire7_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,140.0,614.0)">
+     <g class="arrow-up" id="vl1_Wire7_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire7_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
+        </g>
+        <polyline class="wire wire_vl1" points="245.0,360.0,245.0,360.0" id="vl1_Wire8"/>
+        <polyline class="wire wire_vl1" points="245.0,84.0,245.0,195.0" id="vl1_Wire9"/>
+        <g class="ARROW1_load2_UP" id="vl1_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,240.0,99.0)">
+     <g class="arrow-up" id="vl1_Wire9_ARROW1_ARROW-arrow-up">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire9_ARROW1_ARROW-arrow-down">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        </g>
+        <g class="ARROW2_load2_UP" id="vl1_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,240.0,119.0)">
+     <g class="arrow-up" id="vl1_Wire9_ARROW2_ARROW-arrow-up">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire9_ARROW2_ARROW-arrow-down">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        </g>
+        <polyline class="wire wire_vl1" points="295.0,385.0,295.0,385.0" id="vl1_Wire10"/>
+        <polyline class="wire wire_vl1" points="295.0,659.0,295.0,550.0" id="vl1_Wire11"/>
+        <g class="ARROW1_gen2_DOWN" id="vl1_Wire11_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,290.0,634.0)">
+     <g class="arrow-up" id="vl1_Wire11_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire11_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
+        </g>
+        <g class="ARROW2_gen2_DOWN" id="vl1_Wire11_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,290.0,614.0)">
+     <g class="arrow-up" id="vl1_Wire11_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire11_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
+        </g>
+        <polyline class="wire wire_vl1" points="185.0,360.0,170.0,360.0" id="vl1_Wire12"/>
+        <polyline class="wire wire_vl1" points="170.0,360.0,170.0,360.0" id="vl1_Wire13"/>
+        <polyline class="wire wire_vl1" points="95.0,215.0,95.0,330.0" id="vl1_Wire14"/>
+        <polyline class="wire wire_vl1" points="95.0,360.0,95.0,330.0" id="vl1_Wire15"/>
+        <polyline class="wire wire_vl1" points="205.0,360.0,220.0,360.0" id="vl1_Wire16"/>
+        <polyline class="wire wire_vl1" points="220.0,360.0,220.0,360.0" id="vl1_Wire17"/>
+        <polyline class="wire wire_vl1" points="245.0,215.0,245.0,330.0" id="vl1_Wire18"/>
+        <polyline class="wire wire_vl1" points="245.0,360.0,245.0,330.0" id="vl1_Wire19"/>
+        <polyline class="wire wire_vl1" points="185.0,385.0,170.0,385.0" id="vl1_Wire20"/>
+        <polyline class="wire wire_vl1" points="170.0,385.0,170.0,385.0" id="vl1_Wire21"/>
+        <polyline class="wire wire_vl1" points="145.0,530.0,145.0,415.0" id="vl1_Wire22"/>
+        <polyline class="wire wire_vl1" points="145.0,385.0,145.0,415.0" id="vl1_Wire23"/>
+        <polyline class="wire wire_vl1" points="205.0,385.0,220.0,385.0" id="vl1_Wire24"/>
+        <polyline class="wire wire_vl1" points="220.0,385.0,220.0,385.0" id="vl1_Wire25"/>
+        <polyline class="wire wire_vl1" points="295.0,530.0,295.0,415.0" id="vl1_Wire26"/>
+        <polyline class="wire wire_vl1" points="295.0,385.0,295.0,415.0" id="vl1_Wire27"/>
         <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(166.0,356.0)">
     <g class="closed" id="dsect11_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
@@ -406,114 +514,6 @@
         <line y2="10" x1="5" x2="15" y1="10"/>
     </g>
 </g>
-        <g class="NODE FICT_vl1_dsect11Fictif" id="FICT_vl1_dsect11Fictif" transform="matrix(0.0,1.0,-1.0,0.0,174.0,356.0)"/>
-        <g class="NODE FICT_vl1_dload1Fictif" id="FICT_vl1_dload1Fictif" transform="translate(91.0,326.0)"/>
-        <g class="NODE FICT_vl1_dsect12Fictif" id="FICT_vl1_dsect12Fictif" transform="matrix(0.0,1.0,-1.0,0.0,224.0,356.0)"/>
-        <g class="NODE FICT_vl1_dload2Fictif" id="FICT_vl1_dload2Fictif" transform="translate(241.0,326.0)"/>
-        <g class="NODE FICT_vl1_dsect21Fictif" id="FICT_vl1_dsect21Fictif" transform="matrix(0.0,1.0,-1.0,0.0,174.0,381.0)"/>
-        <g class="NODE FICT_vl1_dgen1Fictif" id="FICT_vl1_dgen1Fictif" transform="translate(141.0,411.0)"/>
-        <g class="NODE FICT_vl1_dsect22Fictif" id="FICT_vl1_dsect22Fictif" transform="matrix(0.0,1.0,-1.0,0.0,224.0,381.0)"/>
-        <g class="NODE FICT_vl1_dgen2Fictif" id="FICT_vl1_dgen2Fictif" transform="translate(291.0,411.0)"/>
-        <polyline class="wire wire_vl1" points="160.0,360.0,170.0,360.0" id="vl1_Wire0"/>
-        <polyline class="wire wire_vl1" points="220.0,360.0,230.0,360.0" id="vl1_Wire1"/>
-        <polyline class="wire wire_vl1" points="160.0,385.0,170.0,385.0" id="vl1_Wire2"/>
-        <polyline class="wire wire_vl1" points="220.0,385.0,230.0,385.0" id="vl1_Wire3"/>
-        <polyline class="wire wire_vl1" points="95.0,360.0,95.0,360.0" id="vl1_Wire4"/>
-        <polyline class="wire wire_vl1" points="95.0,84.0,95.0,195.0" id="vl1_Wire5"/>
-        <g class="ARROW1_load1_UP" id="vl1_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
-     <g class="arrow-up" id="vl1_Wire5_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire5_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
-        </g>
-        <g class="ARROW2_load1_UP" id="vl1_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
-     <g class="arrow-up" id="vl1_Wire5_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire5_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
-        </g>
-        <polyline class="wire wire_vl1" points="145.0,385.0,145.0,385.0" id="vl1_Wire6"/>
-        <polyline class="wire wire_vl1" points="145.0,659.0,145.0,550.0" id="vl1_Wire7"/>
-        <g class="ARROW1_gen1_DOWN" id="vl1_Wire7_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,140.0,634.0)">
-     <g class="arrow-up" id="vl1_Wire7_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire7_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
-        </g>
-        <g class="ARROW2_gen1_DOWN" id="vl1_Wire7_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,140.0,614.0)">
-     <g class="arrow-up" id="vl1_Wire7_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire7_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
-        </g>
-        <polyline class="wire wire_vl1" points="245.0,360.0,245.0,360.0" id="vl1_Wire8"/>
-        <polyline class="wire wire_vl1" points="245.0,84.0,245.0,195.0" id="vl1_Wire9"/>
-        <g class="ARROW1_load2_UP" id="vl1_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,240.0,99.0)">
-     <g class="arrow-up" id="vl1_Wire9_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire9_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
-        </g>
-        <g class="ARROW2_load2_UP" id="vl1_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,240.0,119.0)">
-     <g class="arrow-up" id="vl1_Wire9_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire9_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
-        </g>
-        <polyline class="wire wire_vl1" points="295.0,385.0,295.0,385.0" id="vl1_Wire10"/>
-        <polyline class="wire wire_vl1" points="295.0,659.0,295.0,550.0" id="vl1_Wire11"/>
-        <g class="ARROW1_gen2_DOWN" id="vl1_Wire11_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,290.0,634.0)">
-     <g class="arrow-up" id="vl1_Wire11_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire11_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
-        </g>
-        <g class="ARROW2_gen2_DOWN" id="vl1_Wire11_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,290.0,614.0)">
-     <g class="arrow-up" id="vl1_Wire11_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire11_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
-        </g>
-        <polyline class="wire wire_vl1" points="185.0,360.0,170.0,360.0" id="vl1_Wire12"/>
-        <polyline class="wire wire_vl1" points="170.0,360.0,170.0,360.0" id="vl1_Wire13"/>
-        <polyline class="wire wire_vl1" points="95.0,215.0,95.0,330.0" id="vl1_Wire14"/>
-        <polyline class="wire wire_vl1" points="95.0,360.0,95.0,330.0" id="vl1_Wire15"/>
-        <polyline class="wire wire_vl1" points="205.0,360.0,220.0,360.0" id="vl1_Wire16"/>
-        <polyline class="wire wire_vl1" points="220.0,360.0,220.0,360.0" id="vl1_Wire17"/>
-        <polyline class="wire wire_vl1" points="245.0,215.0,245.0,330.0" id="vl1_Wire18"/>
-        <polyline class="wire wire_vl1" points="245.0,360.0,245.0,330.0" id="vl1_Wire19"/>
-        <polyline class="wire wire_vl1" points="185.0,385.0,170.0,385.0" id="vl1_Wire20"/>
-        <polyline class="wire wire_vl1" points="170.0,385.0,170.0,385.0" id="vl1_Wire21"/>
-        <polyline class="wire wire_vl1" points="145.0,530.0,145.0,415.0" id="vl1_Wire22"/>
-        <polyline class="wire wire_vl1" points="145.0,385.0,145.0,415.0" id="vl1_Wire23"/>
-        <polyline class="wire wire_vl1" points="205.0,385.0,220.0,385.0" id="vl1_Wire24"/>
-        <polyline class="wire wire_vl1" points="220.0,385.0,220.0,385.0" id="vl1_Wire25"/>
-        <polyline class="wire wire_vl1" points="295.0,530.0,295.0,415.0" id="vl1_Wire26"/>
-        <polyline class="wire wire_vl1" points="295.0,385.0,295.0,415.0" id="vl1_Wire27"/>
         <g id="LABEL_VL_vl1">
             <text x="50.0" font-size="12" y="50.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestDefaultFeedersPosition2.svg
+++ b/single-line-diagram-core/src/test/resources/TestDefaultFeedersPosition2.svg
@@ -263,145 +263,13 @@
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="gen2__LABEL">gen2</text>
         </g>
         <g class="NODE FICT_vl1_14" id="FICT_vl1_14" transform="translate(15.0,45.0)"/>
-        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(15.0,45.0)">
-    <g class="closed" id="dsect11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
         <g class="NODE FICT_vl1_15" id="FICT_vl1_15" transform="translate(15.0,45.0)"/>
-        <g class="BREAKER dtrct11" id="dtrct11" transform="translate(9.0,39.0)">
-    <g class="closed" id="dtrct11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(15.0,45.0)">
-    <g class="closed" id="dsect12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
         <g class="NODE FICT_vl1_16" id="FICT_vl1_16" transform="translate(15.0,45.0)"/>
-        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(15.0,45.0)">
-    <g class="closed" id="dsect21_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect21_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
         <g class="NODE FICT_vl1_17" id="FICT_vl1_17" transform="translate(15.0,45.0)"/>
-        <g class="BREAKER dtrct21" id="dtrct21" transform="translate(9.0,39.0)">
-    <g class="closed" id="dtrct21_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct21_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(15.0,45.0)">
-    <g class="closed" id="dsect22_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect22_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
         <g class="NODE FICT_vl1_5" id="FICT_vl1_5" transform="translate(15.0,45.0)"/>
-        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(15.0,45.0)">
-    <g class="closed" id="dload1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload1" id="bload1" transform="translate(9.0,39.0)">
-    <g class="closed" id="bload1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="NODE FICT_vl1_7" id="FICT_vl1_7" transform="translate(15.0,45.0)"/>
-        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(15.0,45.0)">
-    <g class="closed" id="dgen1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen1" id="bgen1" transform="translate(9.0,39.0)">
-    <g class="closed" id="bgen1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="NODE FICT_vl1_9" id="FICT_vl1_9" transform="translate(15.0,45.0)"/>
-        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(15.0,45.0)">
-    <g class="closed" id="dload2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload2" id="bload2" transform="translate(9.0,39.0)">
-    <g class="closed" id="bload2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="NODE FICT_vl1_11" id="FICT_vl1_11" transform="translate(15.0,45.0)"/>
-        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(15.0,45.0)">
-    <g class="closed" id="dgen2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen2" id="bgen2" transform="translate(9.0,39.0)">
-    <g class="closed" id="bgen2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="vl1_Wire0"/>
         <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="vl1_Wire1"/>
         <polyline class="wire wire_vl1" points="19.0,49.0,19.0,39.0" id="vl1_Wire2"/>
@@ -502,6 +370,138 @@
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="19.0,39.0,19.0,49.0" id="vl1_Wire27"/>
+        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(15.0,45.0)">
+    <g class="closed" id="dsect11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct11" id="dtrct11" transform="translate(9.0,39.0)">
+    <g class="closed" id="dtrct11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(15.0,45.0)">
+    <g class="closed" id="dsect12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(15.0,45.0)">
+    <g class="closed" id="dsect21_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect21_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct21" id="dtrct21" transform="translate(9.0,39.0)">
+    <g class="closed" id="dtrct21_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct21_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(15.0,45.0)">
+    <g class="closed" id="dsect22_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect22_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(15.0,45.0)">
+    <g class="closed" id="dload1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload1" id="bload1" transform="translate(9.0,39.0)">
+    <g class="closed" id="bload1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(15.0,45.0)">
+    <g class="closed" id="dgen1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen1" id="bgen1" transform="translate(9.0,39.0)">
+    <g class="closed" id="bgen1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(15.0,45.0)">
+    <g class="closed" id="dload2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload2" id="bload2" transform="translate(9.0,39.0)">
+    <g class="closed" id="bload2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(15.0,45.0)">
+    <g class="closed" id="dgen2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen2" id="bgen2" transform="translate(9.0,39.0)">
+    <g class="closed" id="bgen2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl1">
             <text x="50.0" font-size="12" y="50.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestShiftFeedersPosition.svg
+++ b/single-line-diagram-core/src/test/resources/TestShiftFeedersPosition.svg
@@ -274,6 +274,114 @@
     <path d="M6,6 A 6 20 0 0 0 12,6"/>
 <text x="-5.0" font-size="8" y="25.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="gen2_S_LABEL">gen2</text>
         </g>
+        <g class="NODE FICT_vl1_dsect11Fictif" id="FICT_vl1_dsect11Fictif" transform="matrix(0.0,1.0,-1.0,0.0,174.0,356.0)"/>
+        <g class="NODE FICT_vl1_dload1Fictif" id="FICT_vl1_dload1Fictif" transform="translate(91.0,326.0)"/>
+        <g class="NODE FICT_vl1_dsect12Fictif" id="FICT_vl1_dsect12Fictif" transform="matrix(0.0,1.0,-1.0,0.0,224.0,356.0)"/>
+        <g class="NODE FICT_vl1_dload2Fictif" id="FICT_vl1_dload2Fictif" transform="translate(241.0,326.0)"/>
+        <g class="NODE FICT_vl1_dsect21Fictif" id="FICT_vl1_dsect21Fictif" transform="matrix(0.0,1.0,-1.0,0.0,174.0,381.0)"/>
+        <g class="NODE FICT_vl1_dgen1Fictif" id="FICT_vl1_dgen1Fictif" transform="translate(141.0,411.0)"/>
+        <g class="NODE FICT_vl1_dsect22Fictif" id="FICT_vl1_dsect22Fictif" transform="matrix(0.0,1.0,-1.0,0.0,224.0,381.0)"/>
+        <g class="NODE FICT_vl1_dgen2Fictif" id="FICT_vl1_dgen2Fictif" transform="translate(291.0,411.0)"/>
+        <polyline class="wire wire_vl1" points="160.0,360.0,170.0,360.0" id="vl1_Wire0"/>
+        <polyline class="wire wire_vl1" points="220.0,360.0,230.0,360.0" id="vl1_Wire1"/>
+        <polyline class="wire wire_vl1" points="160.0,385.0,170.0,385.0" id="vl1_Wire2"/>
+        <polyline class="wire wire_vl1" points="220.0,385.0,230.0,385.0" id="vl1_Wire3"/>
+        <polyline class="wire wire_vl1" points="95.0,360.0,95.0,360.0" id="vl1_Wire4"/>
+        <polyline class="wire wire_vl1" points="95.0,84.0,95.0,195.0" id="vl1_Wire5"/>
+        <g class="ARROW1_load1_UP" id="vl1_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
+     <g class="arrow-up" id="vl1_Wire5_ARROW1_ARROW-arrow-up">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire5_ARROW1_ARROW-arrow-down">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        </g>
+        <g class="ARROW2_load1_UP" id="vl1_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
+     <g class="arrow-up" id="vl1_Wire5_ARROW2_ARROW-arrow-up">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire5_ARROW2_ARROW-arrow-down">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        </g>
+        <polyline class="wire wire_vl1" points="145.0,385.0,145.0,385.0" id="vl1_Wire6"/>
+        <polyline class="wire wire_vl1" points="145.0,659.0,145.0,550.0" id="vl1_Wire7"/>
+        <g class="ARROW1_gen1_DOWN" id="vl1_Wire7_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,140.0,634.0)">
+     <g class="arrow-up" id="vl1_Wire7_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire7_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
+        </g>
+        <g class="ARROW2_gen1_DOWN" id="vl1_Wire7_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,140.0,614.0)">
+     <g class="arrow-up" id="vl1_Wire7_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire7_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
+        </g>
+        <polyline class="wire wire_vl1" points="245.0,360.0,245.0,360.0" id="vl1_Wire8"/>
+        <polyline class="wire wire_vl1" points="245.0,101.0,245.0,195.0" id="vl1_Wire9"/>
+        <g class="ARROW1_load2_UP" id="vl1_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,240.0,116.0)">
+     <g class="arrow-up" id="vl1_Wire9_ARROW1_ARROW-arrow-up">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire9_ARROW1_ARROW-arrow-down">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        </g>
+        <g class="ARROW2_load2_UP" id="vl1_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,240.0,136.0)">
+     <g class="arrow-up" id="vl1_Wire9_ARROW2_ARROW-arrow-up">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire9_ARROW2_ARROW-arrow-down">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        </g>
+        <polyline class="wire wire_vl1" points="295.0,385.0,295.0,385.0" id="vl1_Wire10"/>
+        <polyline class="wire wire_vl1" points="295.0,639.0,295.0,550.0" id="vl1_Wire11"/>
+        <g class="ARROW1_gen2_DOWN" id="vl1_Wire11_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,290.0,614.0)">
+     <g class="arrow-up" id="vl1_Wire11_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire11_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
+        </g>
+        <g class="ARROW2_gen2_DOWN" id="vl1_Wire11_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,290.0,594.0)">
+     <g class="arrow-up" id="vl1_Wire11_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="vl1_Wire11_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
+        </g>
+        <polyline class="wire wire_vl1" points="185.0,360.0,170.0,360.0" id="vl1_Wire12"/>
+        <polyline class="wire wire_vl1" points="170.0,360.0,170.0,360.0" id="vl1_Wire13"/>
+        <polyline class="wire wire_vl1" points="95.0,215.0,95.0,330.0" id="vl1_Wire14"/>
+        <polyline class="wire wire_vl1" points="95.0,360.0,95.0,330.0" id="vl1_Wire15"/>
+        <polyline class="wire wire_vl1" points="205.0,360.0,220.0,360.0" id="vl1_Wire16"/>
+        <polyline class="wire wire_vl1" points="220.0,360.0,220.0,360.0" id="vl1_Wire17"/>
+        <polyline class="wire wire_vl1" points="245.0,215.0,245.0,330.0" id="vl1_Wire18"/>
+        <polyline class="wire wire_vl1" points="245.0,360.0,245.0,330.0" id="vl1_Wire19"/>
+        <polyline class="wire wire_vl1" points="185.0,385.0,170.0,385.0" id="vl1_Wire20"/>
+        <polyline class="wire wire_vl1" points="170.0,385.0,170.0,385.0" id="vl1_Wire21"/>
+        <polyline class="wire wire_vl1" points="145.0,530.0,145.0,415.0" id="vl1_Wire22"/>
+        <polyline class="wire wire_vl1" points="145.0,385.0,145.0,415.0" id="vl1_Wire23"/>
+        <polyline class="wire wire_vl1" points="205.0,385.0,220.0,385.0" id="vl1_Wire24"/>
+        <polyline class="wire wire_vl1" points="220.0,385.0,220.0,385.0" id="vl1_Wire25"/>
+        <polyline class="wire wire_vl1" points="295.0,530.0,295.0,415.0" id="vl1_Wire26"/>
+        <polyline class="wire wire_vl1" points="295.0,385.0,295.0,415.0" id="vl1_Wire27"/>
         <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(166.0,356.0)">
     <g class="closed" id="dsect11_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
@@ -406,114 +514,6 @@
         <line y2="10" x1="5" x2="15" y1="10"/>
     </g>
 </g>
-        <g class="NODE FICT_vl1_dsect11Fictif" id="FICT_vl1_dsect11Fictif" transform="matrix(0.0,1.0,-1.0,0.0,174.0,356.0)"/>
-        <g class="NODE FICT_vl1_dload1Fictif" id="FICT_vl1_dload1Fictif" transform="translate(91.0,326.0)"/>
-        <g class="NODE FICT_vl1_dsect12Fictif" id="FICT_vl1_dsect12Fictif" transform="matrix(0.0,1.0,-1.0,0.0,224.0,356.0)"/>
-        <g class="NODE FICT_vl1_dload2Fictif" id="FICT_vl1_dload2Fictif" transform="translate(241.0,326.0)"/>
-        <g class="NODE FICT_vl1_dsect21Fictif" id="FICT_vl1_dsect21Fictif" transform="matrix(0.0,1.0,-1.0,0.0,174.0,381.0)"/>
-        <g class="NODE FICT_vl1_dgen1Fictif" id="FICT_vl1_dgen1Fictif" transform="translate(141.0,411.0)"/>
-        <g class="NODE FICT_vl1_dsect22Fictif" id="FICT_vl1_dsect22Fictif" transform="matrix(0.0,1.0,-1.0,0.0,224.0,381.0)"/>
-        <g class="NODE FICT_vl1_dgen2Fictif" id="FICT_vl1_dgen2Fictif" transform="translate(291.0,411.0)"/>
-        <polyline class="wire wire_vl1" points="160.0,360.0,170.0,360.0" id="vl1_Wire0"/>
-        <polyline class="wire wire_vl1" points="220.0,360.0,230.0,360.0" id="vl1_Wire1"/>
-        <polyline class="wire wire_vl1" points="160.0,385.0,170.0,385.0" id="vl1_Wire2"/>
-        <polyline class="wire wire_vl1" points="220.0,385.0,230.0,385.0" id="vl1_Wire3"/>
-        <polyline class="wire wire_vl1" points="95.0,360.0,95.0,360.0" id="vl1_Wire4"/>
-        <polyline class="wire wire_vl1" points="95.0,84.0,95.0,195.0" id="vl1_Wire5"/>
-        <g class="ARROW1_load1_UP" id="vl1_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
-     <g class="arrow-up" id="vl1_Wire5_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire5_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
-        </g>
-        <g class="ARROW2_load1_UP" id="vl1_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
-     <g class="arrow-up" id="vl1_Wire5_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire5_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
-        </g>
-        <polyline class="wire wire_vl1" points="145.0,385.0,145.0,385.0" id="vl1_Wire6"/>
-        <polyline class="wire wire_vl1" points="145.0,659.0,145.0,550.0" id="vl1_Wire7"/>
-        <g class="ARROW1_gen1_DOWN" id="vl1_Wire7_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,140.0,634.0)">
-     <g class="arrow-up" id="vl1_Wire7_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire7_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
-        </g>
-        <g class="ARROW2_gen1_DOWN" id="vl1_Wire7_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,140.0,614.0)">
-     <g class="arrow-up" id="vl1_Wire7_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire7_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
-        </g>
-        <polyline class="wire wire_vl1" points="245.0,360.0,245.0,360.0" id="vl1_Wire8"/>
-        <polyline class="wire wire_vl1" points="245.0,101.0,245.0,195.0" id="vl1_Wire9"/>
-        <g class="ARROW1_load2_UP" id="vl1_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,240.0,116.0)">
-     <g class="arrow-up" id="vl1_Wire9_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire9_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
-        </g>
-        <g class="ARROW2_load2_UP" id="vl1_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,240.0,136.0)">
-     <g class="arrow-up" id="vl1_Wire9_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire9_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
-        </g>
-        <polyline class="wire wire_vl1" points="295.0,385.0,295.0,385.0" id="vl1_Wire10"/>
-        <polyline class="wire wire_vl1" points="295.0,639.0,295.0,550.0" id="vl1_Wire11"/>
-        <g class="ARROW1_gen2_DOWN" id="vl1_Wire11_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,290.0,614.0)">
-     <g class="arrow-up" id="vl1_Wire11_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire11_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
-        </g>
-        <g class="ARROW2_gen2_DOWN" id="vl1_Wire11_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,290.0,594.0)">
-     <g class="arrow-up" id="vl1_Wire11_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="vl1_Wire11_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
-        </g>
-        <polyline class="wire wire_vl1" points="185.0,360.0,170.0,360.0" id="vl1_Wire12"/>
-        <polyline class="wire wire_vl1" points="170.0,360.0,170.0,360.0" id="vl1_Wire13"/>
-        <polyline class="wire wire_vl1" points="95.0,215.0,95.0,330.0" id="vl1_Wire14"/>
-        <polyline class="wire wire_vl1" points="95.0,360.0,95.0,330.0" id="vl1_Wire15"/>
-        <polyline class="wire wire_vl1" points="205.0,360.0,220.0,360.0" id="vl1_Wire16"/>
-        <polyline class="wire wire_vl1" points="220.0,360.0,220.0,360.0" id="vl1_Wire17"/>
-        <polyline class="wire wire_vl1" points="245.0,215.0,245.0,330.0" id="vl1_Wire18"/>
-        <polyline class="wire wire_vl1" points="245.0,360.0,245.0,330.0" id="vl1_Wire19"/>
-        <polyline class="wire wire_vl1" points="185.0,385.0,170.0,385.0" id="vl1_Wire20"/>
-        <polyline class="wire wire_vl1" points="170.0,385.0,170.0,385.0" id="vl1_Wire21"/>
-        <polyline class="wire wire_vl1" points="145.0,530.0,145.0,415.0" id="vl1_Wire22"/>
-        <polyline class="wire wire_vl1" points="145.0,385.0,145.0,415.0" id="vl1_Wire23"/>
-        <polyline class="wire wire_vl1" points="205.0,385.0,220.0,385.0" id="vl1_Wire24"/>
-        <polyline class="wire wire_vl1" points="220.0,385.0,220.0,385.0" id="vl1_Wire25"/>
-        <polyline class="wire wire_vl1" points="295.0,530.0,295.0,415.0" id="vl1_Wire26"/>
-        <polyline class="wire wire_vl1" points="295.0,385.0,295.0,415.0" id="vl1_Wire27"/>
         <g id="LABEL_VL_vl1">
             <text x="50.0" font-size="12" y="50.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestSubstation.svg
+++ b/single-line-diagram-core/src/test/resources/TestSubstation.svg
@@ -232,25 +232,6 @@
     <line y2="9" x1="16" x2="0" y1="0"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="l_N_LABEL">l</text>
         </g>
-        <g class="DISCONNECTOR d" id="d" transform="translate(91.0,356.0)">
-    <g class="closed" id="d_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="d_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER b" id="b" transform="translate(85.0,195.0)">
-    <g class="closed" id="b_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="b_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="NODE FICT_vl_dFictif" id="FICT_vl_dFictif" transform="translate(91.0,326.0)"/>
         <polyline class="wire wire_vl" points="95.0,360.0,95.0,360.0" id="vl_Wire0"/>
         <polyline class="wire wire_vl" points="95.0,195.0,95.0,84.0" id="vl_Wire1"/>
@@ -274,6 +255,25 @@
         </g>
         <polyline class="wire wire_vl" points="95.0,215.0,95.0,330.0" id="vl_Wire2"/>
         <polyline class="wire wire_vl" points="95.0,360.0,95.0,330.0" id="vl_Wire3"/>
+        <g class="DISCONNECTOR d" id="d" transform="translate(91.0,356.0)">
+    <g class="closed" id="d_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="d_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER b" id="b" transform="translate(85.0,195.0)">
+    <g class="closed" id="b_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="b_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl">
             <text x="50.0" font-size="12" y="50.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork1.svg
+++ b/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork1.svg
@@ -121,25 +121,6 @@
     <line y2="9" x1="16" x2="0" y1="0"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="network1_l_N_LABEL">l</text>
         </g>
-        <g class="DISCONNECTOR network1_d" id="network1_d" transform="translate(41.0,306.0)">
-    <g class="closed" id="network1_d_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="network1_d_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER network1_b" id="network1_b" transform="translate(35.0,145.0)">
-    <g class="closed" id="network1_b_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="network1_b_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="NODE network1_FICT_vl_dFictif" id="network1_FICT_vl_dFictif" transform="translate(41.0,276.0)"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="network1_vl_Wire0"/>
         <polyline class="wire wire_vl" points="45.0,145.0,45.0,34.0" id="network1_vl_Wire1"/>
@@ -163,6 +144,25 @@
         </g>
         <polyline class="wire wire_vl" points="45.0,165.0,45.0,280.0" id="network1_vl_Wire2"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="network1_vl_Wire3"/>
+        <g class="DISCONNECTOR network1_d" id="network1_d" transform="translate(41.0,306.0)">
+    <g class="closed" id="network1_d_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="network1_d_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER network1_b" id="network1_b" transform="translate(35.0,145.0)">
+    <g class="closed" id="network1_b_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="network1_b_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="network1_LABEL_VL_vl">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork2.svg
+++ b/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork2.svg
@@ -121,25 +121,6 @@
     <line y2="9" x1="16" x2="0" y1="0"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="network2_l_N_LABEL">l</text>
         </g>
-        <g class="DISCONNECTOR network2_d" id="network2_d" transform="translate(41.0,306.0)">
-    <g class="closed" id="network2_d_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="network2_d_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER network2_b" id="network2_b" transform="translate(35.0,145.0)">
-    <g class="closed" id="network2_b_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="network2_b_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="NODE network2_FICT_vl_dFictif" id="network2_FICT_vl_dFictif" transform="translate(41.0,276.0)"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="network2_vl_Wire0"/>
         <polyline class="wire wire_vl" points="45.0,145.0,45.0,34.0" id="network2_vl_Wire1"/>
@@ -163,6 +144,25 @@
         </g>
         <polyline class="wire wire_vl" points="45.0,165.0,45.0,280.0" id="network2_vl_Wire2"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="network2_vl_Wire3"/>
+        <g class="DISCONNECTOR network2_d" id="network2_d" transform="translate(41.0,306.0)">
+    <g class="closed" id="network2_d_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="network2_d_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER network2_b" id="network2_b" transform="translate(35.0,145.0)">
+    <g class="closed" id="network2_b_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="network2_b_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="network2_LABEL_VL_vl">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestVL.svg
+++ b/single-line-diagram-core/src/test/resources/TestVL.svg
@@ -121,25 +121,6 @@
     <line y2="9" x1="16" x2="0" y1="0"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="l_N_LABEL">l</text>
         </g>
-        <g class="DISCONNECTOR d" id="d" transform="translate(41.0,306.0)">
-    <g class="closed" id="d_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="d_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER b" id="b" transform="translate(35.0,145.0)">
-    <g class="closed" id="b_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="b_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="NODE FICT_vl_dFictif" id="FICT_vl_dFictif" transform="translate(41.0,276.0)"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="vl_Wire0"/>
         <polyline class="wire wire_vl" points="45.0,145.0,45.0,34.0" id="vl_Wire1"/>
@@ -163,6 +144,25 @@
         </g>
         <polyline class="wire wire_vl" points="45.0,165.0,45.0,280.0" id="vl_Wire2"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="vl_Wire3"/>
+        <g class="DISCONNECTOR d" id="d" transform="translate(41.0,306.0)">
+    <g class="closed" id="d_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="d_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER b" id="b" transform="translate(35.0,145.0)">
+    <g class="closed" id="b_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="b_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/nominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/nominalVoltage.svg
@@ -232,25 +232,6 @@
     <line y2="9" x1="16" x2="0" y1="0"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="l_N_LABEL">l</text>
         </g>
-        <g class="DISCONNECTOR d" id="d" transform="translate(91.0,356.0)">
-    <g class="closed" id="d_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="d_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER b" id="b" transform="translate(85.0,195.0)">
-    <g class="closed" id="b_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="b_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="NODE FICT_vl_dFictif" id="FICT_vl_dFictif" transform="translate(91.0,326.0)"/>
         <polyline class="wire wire_vl" points="95.0,360.0,95.0,360.0" id="vl_Wire0"/>
         <polyline class="wire wire_vl" points="95.0,195.0,95.0,84.0" id="vl_Wire1"/>
@@ -274,6 +255,25 @@
         </g>
         <polyline class="wire wire_vl" points="95.0,215.0,95.0,330.0" id="vl_Wire2"/>
         <polyline class="wire wire_vl" points="95.0,360.0,95.0,330.0" id="vl_Wire3"/>
+        <g class="DISCONNECTOR d" id="d" transform="translate(91.0,356.0)">
+    <g class="closed" id="d_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="d_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER b" id="b" transform="translate(85.0,195.0)">
+    <g class="closed" id="b_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="b_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl">
             <text x="50.0" font-size="12" y="50.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/substDiag.svg
+++ b/single-line-diagram-core/src/test/resources/substDiag.svg
@@ -350,309 +350,6 @@
         <g class="LINE line1_ONE" id="line1_ONE" transform="translate(545.0,80.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="line1_ONE_N_LABEL">line1</text>
         </g>
-        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(566.0,356.0)">
-    <g class="closed" id="dsect11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,605.0,350.0)">
-    <g class="closed" id="dtrct11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(616.0,356.0)">
-    <g class="closed" id="dsect12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(566.0,381.0)">
-    <g class="closed" id="dsect21_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect21_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,605.0,375.0)">
-    <g class="closed" id="dtrct21_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct21_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(616.0,381.0)">
-    <g class="closed" id="dsect22_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect22_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(91.0,356.0)">
-    <g class="closed" id="dload1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload1" id="bload1" transform="translate(85.0,195.0)">
-    <g class="closed" id="bload1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(191.0,381.0)">
-    <g class="closed" id="dgen1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen1" id="bgen1" transform="translate(185.0,530.0)">
-    <g class="closed" id="bgen1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(641.0,356.0)">
-    <g class="closed" id="dload2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload2" id="bload2" transform="translate(635.0,195.0)">
-    <g class="closed" id="bload2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(891.0,381.0)">
-    <g class="closed" id="dgen2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen2" id="bgen2" transform="translate(885.0,530.0)">
-    <g class="closed" id="bgen2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(141.0,356.0)">
-    <g class="closed" id="dtrf11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf11" id="btrf11" transform="translate(135.0,195.0)">
-    <g class="closed" id="btrf11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(841.0,356.0)">
-    <g class="closed" id="dtrf12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf12" id="btrf12" transform="translate(835.0,195.0)">
-    <g class="closed" id="btrf12_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf12_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(241.0,381.0)">
-    <g class="closed" id="dtrf13_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf13_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf13" id="btrf13" transform="translate(235.0,530.0)">
-    <g class="closed" id="btrf13_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf13_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(791.0,381.0)">
-    <g class="closed" id="dtrf14_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf14_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf14" id="btrf14" transform="translate(785.0,530.0)">
-    <g class="closed" id="btrf14_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf14_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(291.0,356.0)">
-    <g class="closed" id="dtrf15_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf15_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf15" id="btrf15" transform="translate(285.0,195.0)">
-    <g class="closed" id="btrf15_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf15_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(366.0,356.0)">
-    <g class="closed" id="dtrf16_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf16_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf16" id="btrf16" transform="translate(360.0,236.66666666666669)">
-    <g class="closed" id="btrf16_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf16_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(466.0,381.0)">
-    <g class="closed" id="dtrf17_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf17_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf17" id="btrf17" transform="translate(460.0,488.3333333333333)">
-    <g class="closed" id="btrf17_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf17_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(716.0,356.0)">
-    <g class="closed" id="dtrf18_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf18_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf18" id="btrf18" transform="translate(710.0,236.66666666666669)">
-    <g class="closed" id="btrf18_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf18_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dline11_2" id="dline11_2" transform="translate(541.0,356.0)">
-    <g class="closed" id="dline11_2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dline11_2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bline11_2" id="bline11_2" transform="translate(535.0,195.0)">
-    <g class="closed" id="bline11_2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bline11_2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl1_trf61_fictif" id="FICT_vl1_trf61_fictif" transform="translate(363.0,157.33333333333331)">
     <circle r="4" id="FICT_vl1_trf61_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="FICT_vl1_trf61_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
@@ -1061,6 +758,309 @@
         <polyline class="wire wire_vl1" points="895.0,385.0,895.0,415.0" id="vl1_Wire67"/>
         <polyline class="wire wire_vl1" points="795.0,530.0,795.0,415.0" id="vl1_Wire68"/>
         <polyline class="wire wire_vl1" points="795.0,385.0,795.0,415.0" id="vl1_Wire69"/>
+        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(566.0,356.0)">
+    <g class="closed" id="dsect11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,605.0,350.0)">
+    <g class="closed" id="dtrct11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(616.0,356.0)">
+    <g class="closed" id="dsect12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(566.0,381.0)">
+    <g class="closed" id="dsect21_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect21_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,605.0,375.0)">
+    <g class="closed" id="dtrct21_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct21_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(616.0,381.0)">
+    <g class="closed" id="dsect22_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect22_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(91.0,356.0)">
+    <g class="closed" id="dload1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload1" id="bload1" transform="translate(85.0,195.0)">
+    <g class="closed" id="bload1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(191.0,381.0)">
+    <g class="closed" id="dgen1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen1" id="bgen1" transform="translate(185.0,530.0)">
+    <g class="closed" id="bgen1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(641.0,356.0)">
+    <g class="closed" id="dload2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload2" id="bload2" transform="translate(635.0,195.0)">
+    <g class="closed" id="bload2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(891.0,381.0)">
+    <g class="closed" id="dgen2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen2" id="bgen2" transform="translate(885.0,530.0)">
+    <g class="closed" id="bgen2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(141.0,356.0)">
+    <g class="closed" id="dtrf11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf11" id="btrf11" transform="translate(135.0,195.0)">
+    <g class="closed" id="btrf11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(841.0,356.0)">
+    <g class="closed" id="dtrf12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf12" id="btrf12" transform="translate(835.0,195.0)">
+    <g class="closed" id="btrf12_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf12_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(241.0,381.0)">
+    <g class="closed" id="dtrf13_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf13_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf13" id="btrf13" transform="translate(235.0,530.0)">
+    <g class="closed" id="btrf13_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf13_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(791.0,381.0)">
+    <g class="closed" id="dtrf14_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf14_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf14" id="btrf14" transform="translate(785.0,530.0)">
+    <g class="closed" id="btrf14_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf14_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(291.0,356.0)">
+    <g class="closed" id="dtrf15_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf15_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf15" id="btrf15" transform="translate(285.0,195.0)">
+    <g class="closed" id="btrf15_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf15_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(366.0,356.0)">
+    <g class="closed" id="dtrf16_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf16_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf16" id="btrf16" transform="translate(360.0,236.66666666666669)">
+    <g class="closed" id="btrf16_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf16_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(466.0,381.0)">
+    <g class="closed" id="dtrf17_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf17_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf17" id="btrf17" transform="translate(460.0,488.3333333333333)">
+    <g class="closed" id="btrf17_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf17_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(716.0,356.0)">
+    <g class="closed" id="dtrf18_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf18_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf18" id="btrf18" transform="translate(710.0,236.66666666666669)">
+    <g class="closed" id="btrf18_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf18_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dline11_2" id="dline11_2" transform="translate(541.0,356.0)">
+    <g class="closed" id="dline11_2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dline11_2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bline11_2" id="bline11_2" transform="translate(535.0,195.0)">
+    <g class="closed" id="bline11_2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bline11_2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g class="BUSBAR_SECTION bbs5" id="bbs5" transform="translate(1080.0,360.0)">
             <line y2="0" x1="0" x2="680.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs5_NW_LABEL">bbs5</text>
@@ -1101,205 +1101,6 @@
     <circle r="4" id="trf4_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_TWO_N_LABEL">trf4</text>
         </g>
-        <g class="DISCONNECTOR dscpl1" id="dscpl1" transform="translate(1091.0,356.0)">
-    <g class="closed" id="dscpl1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dscpl1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER ddcpl1" id="ddcpl1" transform="matrix(0.0,1.0,-1.0,0.0,1130.0,310.0)">
-    <g class="closed" id="ddcpl1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="ddcpl1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dscpl2" id="dscpl2" transform="translate(1141.0,381.0)">
-    <g class="closed" id="dscpl2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dscpl2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload3" id="dload3" transform="translate(1191.0,356.0)">
-    <g class="closed" id="dload3_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload3_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload3" id="bload3" transform="translate(1185.0,195.0)">
-    <g class="closed" id="bload3_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload3_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen4" id="dgen4" transform="translate(1291.0,381.0)">
-    <g class="closed" id="dgen4_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen4_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen4" id="bgen4" transform="translate(1285.0,530.0)">
-    <g class="closed" id="bgen4_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen4_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf21" id="dtrf21" transform="translate(1241.0,356.0)">
-    <g class="closed" id="dtrf21_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf21_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf21" id="btrf21" transform="translate(1235.0,195.0)">
-    <g class="closed" id="btrf21_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf21_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf22" id="dtrf22" transform="translate(1691.0,381.0)">
-    <g class="closed" id="dtrf22_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf22_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf22" id="btrf22" transform="translate(1685.0,530.0)">
-    <g class="closed" id="btrf22_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf22_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf23" id="dtrf23" transform="translate(1741.0,381.0)">
-    <g class="closed" id="dtrf23_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf23_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf23" id="btrf23" transform="translate(1735.0,530.0)">
-    <g class="closed" id="btrf23_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf23_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf24" id="dtrf24" transform="translate(1341.0,356.0)">
-    <g class="closed" id="dtrf24_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf24_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf24" id="btrf24" transform="translate(1335.0,195.0)">
-    <g class="closed" id="btrf24_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf24_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf26" id="dtrf26" transform="translate(1516.0,381.0)">
-    <g class="closed" id="dtrf26_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf26_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf26" id="btrf26" transform="translate(1510.0,236.66666666666669)">
-    <g class="closed" id="btrf26_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf26_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf27" id="dtrf27" transform="translate(1416.0,356.0)">
-    <g class="closed" id="dtrf27_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf27_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf27" id="btrf27" transform="translate(1410.0,236.66666666666669)">
-    <g class="closed" id="btrf27_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf27_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf28" id="dtrf28" transform="translate(1616.0,381.0)">
-    <g class="closed" id="dtrf28_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf28_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf28" id="btrf28" transform="translate(1610.0,488.3333333333333)">
-    <g class="closed" id="btrf28_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf28_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl2_trf62_fictif" id="FICT_vl2_trf62_fictif" transform="translate(1513.0,157.33333333333331)">
     <circle r="4" id="FICT_vl2_trf62_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="FICT_vl2_trf62_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
@@ -1608,6 +1409,205 @@
         <polyline class="wire wire_vl2" points="1520.0,385.0,1520.0,330.0" id="vl2_Wire45"/>
         <polyline class="wire wire_vl2" points="1620.0,488.3333333333333,1620.0,415.0" id="vl2_Wire46"/>
         <polyline class="wire wire_vl2" points="1620.0,385.0,1620.0,415.0" id="vl2_Wire47"/>
+        <g class="DISCONNECTOR dscpl1" id="dscpl1" transform="translate(1091.0,356.0)">
+    <g class="closed" id="dscpl1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dscpl1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER ddcpl1" id="ddcpl1" transform="matrix(0.0,1.0,-1.0,0.0,1130.0,310.0)">
+    <g class="closed" id="ddcpl1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="ddcpl1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dscpl2" id="dscpl2" transform="translate(1141.0,381.0)">
+    <g class="closed" id="dscpl2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dscpl2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload3" id="dload3" transform="translate(1191.0,356.0)">
+    <g class="closed" id="dload3_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload3_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload3" id="bload3" transform="translate(1185.0,195.0)">
+    <g class="closed" id="bload3_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload3_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen4" id="dgen4" transform="translate(1291.0,381.0)">
+    <g class="closed" id="dgen4_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen4_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen4" id="bgen4" transform="translate(1285.0,530.0)">
+    <g class="closed" id="bgen4_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen4_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf21" id="dtrf21" transform="translate(1241.0,356.0)">
+    <g class="closed" id="dtrf21_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf21_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf21" id="btrf21" transform="translate(1235.0,195.0)">
+    <g class="closed" id="btrf21_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf21_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf22" id="dtrf22" transform="translate(1691.0,381.0)">
+    <g class="closed" id="dtrf22_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf22_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf22" id="btrf22" transform="translate(1685.0,530.0)">
+    <g class="closed" id="btrf22_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf22_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf23" id="dtrf23" transform="translate(1741.0,381.0)">
+    <g class="closed" id="dtrf23_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf23_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf23" id="btrf23" transform="translate(1735.0,530.0)">
+    <g class="closed" id="btrf23_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf23_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf24" id="dtrf24" transform="translate(1341.0,356.0)">
+    <g class="closed" id="dtrf24_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf24_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf24" id="btrf24" transform="translate(1335.0,195.0)">
+    <g class="closed" id="btrf24_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf24_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf26" id="dtrf26" transform="translate(1516.0,381.0)">
+    <g class="closed" id="dtrf26_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf26_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf26" id="btrf26" transform="translate(1510.0,236.66666666666669)">
+    <g class="closed" id="btrf26_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf26_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf27" id="dtrf27" transform="translate(1416.0,356.0)">
+    <g class="closed" id="dtrf27_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf27_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf27" id="btrf27" transform="translate(1410.0,236.66666666666669)">
+    <g class="closed" id="btrf27_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf27_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf28" id="dtrf28" transform="translate(1616.0,381.0)">
+    <g class="closed" id="dtrf28_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf28_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf28" id="btrf28" transform="translate(1610.0,488.3333333333333)">
+    <g class="closed" id="btrf28_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf28_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g class="BUSBAR_SECTION bbs7" id="bbs7" transform="translate(1930.0,360.0)">
             <line y2="0" x1="0" x2="380.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs7_NW_LABEL">bbs7</text>
@@ -1623,101 +1623,6 @@
     <circle r="4" id="trf5_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4"/>
 <text x="-5.0" font-size="8" y="21.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_TWO_S_LABEL">trf5</text>
         </g>
-        <g class="DISCONNECTOR dload4" id="dload4" transform="translate(1941.0,356.0)">
-    <g class="closed" id="dload4_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload4_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload4" id="bload4" transform="translate(1935.0,195.0)">
-    <g class="closed" id="bload4_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload4_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf25" id="dtrf25" transform="translate(1991.0,356.0)">
-    <g class="closed" id="dtrf25_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf25_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf25" id="btrf25" transform="translate(1985.0,505.0)">
-    <g class="closed" id="btrf25_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf25_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf36" id="dtrf36" transform="translate(2066.0,356.0)">
-    <g class="closed" id="dtrf36_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf36_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf36" id="btrf36" transform="translate(2060.0,236.66666666666669)">
-    <g class="closed" id="btrf36_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf36_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf37" id="dtrf37" transform="translate(2166.0,356.0)">
-    <g class="closed" id="dtrf37_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf37_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf37" id="btrf37" transform="translate(2160.0,463.3333333333333)">
-    <g class="closed" id="btrf37_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf37_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf38" id="dtrf38" transform="translate(2266.0,356.0)">
-    <g class="closed" id="dtrf38_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf38_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf38" id="btrf38" transform="translate(2260.0,236.66666666666669)">
-    <g class="closed" id="btrf38_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf38_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl3_trf63_fictif" id="FICT_vl3_trf63_fictif" transform="translate(2063.0,157.33333333333331)">
     <circle r="4" id="FICT_vl3_trf63_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4"/>
     <circle r="4" id="FICT_vl3_trf63_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4"/>
@@ -1926,6 +1831,101 @@
         <polyline class="wire wire_vl3" points="2170.0,360.0,2170.0,390.0" id="vl3_Wire23"/>
         <polyline class="wire wire_vl3" points="2270.0,256.6666666666667,2270.0,330.0" id="vl3_Wire24"/>
         <polyline class="wire wire_vl3" points="2270.0,360.0,2270.0,330.0" id="vl3_Wire25"/>
+        <g class="DISCONNECTOR dload4" id="dload4" transform="translate(1941.0,356.0)">
+    <g class="closed" id="dload4_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload4_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload4" id="bload4" transform="translate(1935.0,195.0)">
+    <g class="closed" id="bload4_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload4_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf25" id="dtrf25" transform="translate(1991.0,356.0)">
+    <g class="closed" id="dtrf25_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf25_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf25" id="btrf25" transform="translate(1985.0,505.0)">
+    <g class="closed" id="btrf25_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf25_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf36" id="dtrf36" transform="translate(2066.0,356.0)">
+    <g class="closed" id="dtrf36_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf36_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf36" id="btrf36" transform="translate(2060.0,236.66666666666669)">
+    <g class="closed" id="btrf36_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf36_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf37" id="dtrf37" transform="translate(2166.0,356.0)">
+    <g class="closed" id="dtrf37_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf37_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf37" id="btrf37" transform="translate(2160.0,463.3333333333333)">
+    <g class="closed" id="btrf37_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf37_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf38" id="dtrf38" transform="translate(2266.0,356.0)">
+    <g class="closed" id="dtrf38_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf38_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf38" id="btrf38" transform="translate(2260.0,236.66666666666669)">
+    <g class="closed" id="btrf38_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf38_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <polyline class="wire wire_vl1" points="145.0,80.0,145.0,50.0,1245.0,50.0,1245.0,80.0" id="vl1_vl2_Wire0"/>
         <polyline class="wire wire_vl1" points="845.0,80.0,845.0,20.0,1040.0,20.0,1040.0,695.0,1695.0,695.0,1695.0,665.0" id="vl1_vl2_Wire1"/>
         <polyline class="wire wire_vl1" points="245.0,665.0,245.0,725.0,1745.0,725.0,1745.0,665.0" id="vl1_vl2_Wire2"/>

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -74,7 +74,8 @@
     "size" : {
       "width" : 0.0,
       "height" : 0.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "GENERATOR",
     "id" : null,
@@ -98,7 +99,8 @@
     "size" : {
       "width" : 12.0,
       "height" : 12.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "ARROW",
     "id" : null,
@@ -110,7 +112,8 @@
     "size" : {
       "width" : 10.0,
       "height" : 10.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "LOAD",
     "id" : null,
@@ -126,7 +129,8 @@
     "size" : {
       "width" : 16.0,
       "height" : 9.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "NODE",
     "id" : null,
@@ -138,7 +142,8 @@
     "size" : {
       "width" : 8.0,
       "height" : 8.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "LINE",
     "id" : null,
@@ -150,7 +155,8 @@
     "size" : {
       "width" : 0.0,
       "height" : 0.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "DISCONNECTOR",
     "id" : null,
@@ -162,7 +168,8 @@
     "size" : {
       "width" : 8.0,
       "height" : 8.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "TWO_WINDINGS_TRANSFORMER",
     "id" : null,
@@ -186,7 +193,8 @@
     "size" : {
       "width" : 13.0,
       "height" : 8.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "THREE_WINDINGS_TRANSFORMER",
     "id" : null,
@@ -206,7 +214,8 @@
     "size" : {
       "width" : 14.0,
       "height" : 12.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "BREAKER",
     "id" : null,
@@ -222,7 +231,8 @@
     "size" : {
       "width" : 20.0,
       "height" : 20.0
-    }
+    },
+    "allowRotation" : true
   } ],
   "nodes" : [ {
     "id" : "dtrct21",
@@ -558,15 +568,6 @@
     "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
-    "id" : "dtrf23",
-    "vid" : "vl2",
-    "nextVId" : null,
-    "componentType" : "DISCONNECTOR",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false
-  }, {
     "id" : "trf6_TWO_THREE",
     "vid" : "vl2",
     "nextVId" : "vl3",
@@ -574,6 +575,15 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
+    "vlabel" : false
+  }, {
+    "id" : "dtrf23",
+    "vid" : "vl2",
+    "nextVId" : null,
+    "componentType" : "DISCONNECTOR",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
     "id" : "btrf38",
@@ -900,20 +910,20 @@
     "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
-    "id" : "btrf15",
-    "vid" : "vl1",
-    "nextVId" : null,
-    "componentType" : "BREAKER",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false
-  }, {
     "id" : "FICT_vl1_dsect12Fictif",
     "vid" : "vl1",
     "nextVId" : null,
     "componentType" : "NODE",
     "rotationAngle" : 90.0,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false
+  }, {
+    "id" : "btrf15",
+    "vid" : "vl1",
+    "nextVId" : null,
+    "componentType" : "BREAKER",
+    "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
     "vlabel" : false
@@ -945,19 +955,19 @@
     "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
-    "id" : "btrf14",
+    "id" : "FICT_vl1_dline11_2Fictif",
     "vid" : "vl1",
     "nextVId" : null,
-    "componentType" : "BREAKER",
+    "componentType" : "NODE",
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
-    "id" : "FICT_vl1_dline11_2Fictif",
+    "id" : "btrf14",
     "vid" : "vl1",
     "nextVId" : null,
-    "componentType" : "NODE",
+    "componentType" : "BREAKER",
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
@@ -1305,15 +1315,6 @@
     "direction" : "BOTTOM",
     "vlabel" : false
   }, {
-    "id" : "bline11_2",
-    "vid" : "vl1",
-    "nextVId" : null,
-    "componentType" : "BREAKER",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false
-  }, {
     "id" : "FICT_vl1_dgen1Fictif",
     "vid" : "vl1",
     "nextVId" : null,
@@ -1323,8 +1324,8 @@
     "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
-    "id" : "bgen4",
-    "vid" : "vl2",
+    "id" : "bline11_2",
+    "vid" : "vl1",
     "nextVId" : null,
     "componentType" : "BREAKER",
     "rotationAngle" : null,
@@ -1336,6 +1337,15 @@
     "vid" : "vl2",
     "nextVId" : null,
     "componentType" : "NODE",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false
+  }, {
+    "id" : "bgen4",
+    "vid" : "vl2",
+    "nextVId" : null,
+    "componentType" : "BREAKER",
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
@@ -1395,15 +1405,6 @@
     "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
-    "id" : "dtrf11",
-    "vid" : "vl1",
-    "nextVId" : null,
-    "componentType" : "DISCONNECTOR",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false
-  }, {
     "id" : "trf8_ONE_THREE",
     "vid" : "vl1",
     "nextVId" : "vl3",
@@ -1413,7 +1414,7 @@
     "direction" : "TOP",
     "vlabel" : false
   }, {
-    "id" : "dtrf12",
+    "id" : "dtrf11",
     "vid" : "vl1",
     "nextVId" : null,
     "componentType" : "DISCONNECTOR",
@@ -1422,7 +1423,7 @@
     "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
-    "id" : "dtrf13",
+    "id" : "dtrf12",
     "vid" : "vl1",
     "nextVId" : null,
     "componentType" : "DISCONNECTOR",
@@ -1435,6 +1436,15 @@
     "vid" : "vl1",
     "nextVId" : null,
     "componentType" : "NODE",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false
+  }, {
+    "id" : "dtrf13",
+    "vid" : "vl1",
+    "nextVId" : null,
+    "componentType" : "DISCONNECTOR",
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",

--- a/single-line-diagram-core/src/test/resources/topological.svg
+++ b/single-line-diagram-core/src/test/resources/topological.svg
@@ -232,25 +232,6 @@
     <line y2="9" x1="16" x2="0" y1="0"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="l_N_LABEL">l</text>
         </g>
-        <g class="DISCONNECTOR d" id="d" transform="translate(91.0,356.0)">
-    <g class="closed" id="d_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="d_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER b" id="b" transform="translate(85.0,195.0)">
-    <g class="closed" id="b_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="b_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="NODE FICT_vl_dFictif" id="FICT_vl_dFictif" transform="translate(91.0,326.0)"/>
         <polyline class="wire wire_vl" points="95.0,360.0,95.0,360.0" id="vl_Wire0"/>
         <polyline class="wire wire_vl" points="95.0,195.0,95.0,84.0" id="vl_Wire1"/>
@@ -274,6 +255,25 @@
         </g>
         <polyline class="wire wire_vl" points="95.0,215.0,95.0,330.0" id="vl_Wire2"/>
         <polyline class="wire wire_vl" points="95.0,360.0,95.0,330.0" id="vl_Wire3"/>
+        <g class="DISCONNECTOR d" id="d" transform="translate(91.0,356.0)">
+    <g class="closed" id="d_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="d_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER b" id="b" transform="translate(85.0,195.0)">
+    <g class="closed" id="b_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="b_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl">
             <text x="50.0" font-size="12" y="50.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/vlDiag.svg
+++ b/single-line-diagram-core/src/test/resources/vlDiag.svg
@@ -199,290 +199,6 @@
     <circle r="4" id="trf5_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" cy="4" stroke="rgb(160, 32, 240)"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_ONE_N_LABEL">trf5</text>
         </g>
-        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(736.0,306.0)">
-    <g class="closed" id="dsect11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,790.0,300.0)">
-    <g class="closed" id="dtrct11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(816.0,306.0)">
-    <g class="closed" id="dsect12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(736.0,331.0)">
-    <g class="closed" id="dsect21_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect21_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,790.0,325.0)">
-    <g class="closed" id="dtrct21_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="dtrct21_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(816.0,331.0)">
-    <g class="closed" id="dsect22_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dsect22_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(56.0,306.0)">
-    <g class="closed" id="dload1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload1" id="bload1" transform="translate(50.0,145.0)">
-    <g class="closed" id="bload1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(216.0,331.0)">
-    <g class="closed" id="dgen1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen1" id="bgen1" transform="translate(210.0,480.0)">
-    <g class="closed" id="bgen1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(856.0,306.0)">
-    <g class="closed" id="dload2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dload2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bload2" id="bload2" transform="translate(850.0,145.0)">
-    <g class="closed" id="bload2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bload2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(1256.0,331.0)">
-    <g class="closed" id="dgen2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dgen2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER bgen2" id="bgen2" transform="translate(1250.0,480.0)">
-    <g class="closed" id="bgen2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="bgen2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(136.0,306.0)">
-    <g class="closed" id="dtrf11_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf11_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf11" id="btrf11" transform="translate(130.0,145.0)">
-    <g class="closed" id="btrf11_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf11_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(1176.0,306.0)">
-    <g class="closed" id="dtrf12_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf12_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf12" id="btrf12" transform="translate(1170.0,145.0)">
-    <g class="closed" id="btrf12_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf12_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(296.0,331.0)">
-    <g class="closed" id="dtrf13_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf13_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf13" id="btrf13" transform="translate(290.0,480.0)">
-    <g class="closed" id="btrf13_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf13_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(1096.0,331.0)">
-    <g class="closed" id="dtrf14_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf14_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf14" id="btrf14" transform="translate(1090.0,480.0)">
-    <g class="closed" id="btrf14_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf14_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(376.0,306.0)">
-    <g class="closed" id="dtrf15_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf15_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf15" id="btrf15" transform="translate(370.0,145.0)">
-    <g class="closed" id="btrf15_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf15_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(496.0,306.0)">
-    <g class="closed" id="dtrf16_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf16_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf16" id="btrf16" transform="translate(490.0,186.66666666666669)">
-    <g class="closed" id="btrf16_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf16_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(656.0,331.0)">
-    <g class="closed" id="dtrf17_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf17_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf17" id="btrf17" transform="translate(650.0,438.3333333333333)">
-    <g class="closed" id="btrf17_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf17_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
-        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(976.0,306.0)">
-    <g class="closed" id="dtrf18_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="dtrf18_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
-        <g class="BREAKER btrf18" id="btrf18" transform="translate(970.0,186.66666666666669)">
-    <g class="closed" id="btrf18_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="btrf18_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
         <g class="THREE_WINDINGS_TRANSFORMER FICT_vl1_trf61_fictif" id="FICT_vl1_trf61_fictif" transform="translate(493.0,107.33333333333334)">
     <circle r="4" id="FICT_vl1_trf61_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="4" cy="4" stroke="rgb(34, 139, 34)"/>
     <circle r="4" id="FICT_vl1_trf61_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="10" cy="4" stroke="rgb(160, 32, 240)"/>
@@ -871,6 +587,290 @@
         <polyline class="wire wire_vl1" points="1260.0,335.0,1260.0,365.0" id="vl1_Wire63"/>
         <polyline class="wire wire_vl1" points="1100.0,480.0,1100.0,365.0" id="vl1_Wire64"/>
         <polyline class="wire wire_vl1" points="1100.0,335.0,1100.0,365.0" id="vl1_Wire65"/>
+        <g class="DISCONNECTOR dsect11" id="dsect11" transform="translate(736.0,306.0)">
+    <g class="closed" id="dsect11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct11" id="dtrct11" transform="matrix(0.0,1.0,-1.0,0.0,790.0,300.0)">
+    <g class="closed" id="dtrct11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect12" id="dsect12" transform="translate(816.0,306.0)">
+    <g class="closed" id="dsect12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect21" id="dsect21" transform="translate(736.0,331.0)">
+    <g class="closed" id="dsect21_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect21_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER dtrct21" id="dtrct21" transform="matrix(0.0,1.0,-1.0,0.0,790.0,325.0)">
+    <g class="closed" id="dtrct21_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="dtrct21_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dsect22" id="dsect22" transform="translate(816.0,331.0)">
+    <g class="closed" id="dsect22_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dsect22_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload1" id="dload1" transform="translate(56.0,306.0)">
+    <g class="closed" id="dload1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload1" id="bload1" transform="translate(50.0,145.0)">
+    <g class="closed" id="bload1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen1" id="dgen1" transform="translate(216.0,331.0)">
+    <g class="closed" id="dgen1_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen1_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen1" id="bgen1" transform="translate(210.0,480.0)">
+    <g class="closed" id="bgen1_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen1_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dload2" id="dload2" transform="translate(856.0,306.0)">
+    <g class="closed" id="dload2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dload2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bload2" id="bload2" transform="translate(850.0,145.0)">
+    <g class="closed" id="bload2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bload2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dgen2" id="dgen2" transform="translate(1256.0,331.0)">
+    <g class="closed" id="dgen2_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dgen2_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER bgen2" id="bgen2" transform="translate(1250.0,480.0)">
+    <g class="closed" id="bgen2_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="bgen2_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf11" id="dtrf11" transform="translate(136.0,306.0)">
+    <g class="closed" id="dtrf11_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf11_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf11" id="btrf11" transform="translate(130.0,145.0)">
+    <g class="closed" id="btrf11_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf11_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf12" id="dtrf12" transform="translate(1176.0,306.0)">
+    <g class="closed" id="dtrf12_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf12_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf12" id="btrf12" transform="translate(1170.0,145.0)">
+    <g class="closed" id="btrf12_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf12_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf13" id="dtrf13" transform="translate(296.0,331.0)">
+    <g class="closed" id="dtrf13_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf13_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf13" id="btrf13" transform="translate(290.0,480.0)">
+    <g class="closed" id="btrf13_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf13_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf14" id="dtrf14" transform="translate(1096.0,331.0)">
+    <g class="closed" id="dtrf14_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf14_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf14" id="btrf14" transform="translate(1090.0,480.0)">
+    <g class="closed" id="btrf14_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf14_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf15" id="dtrf15" transform="translate(376.0,306.0)">
+    <g class="closed" id="dtrf15_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf15_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf15" id="btrf15" transform="translate(370.0,145.0)">
+    <g class="closed" id="btrf15_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf15_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf16" id="dtrf16" transform="translate(496.0,306.0)">
+    <g class="closed" id="dtrf16_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf16_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf16" id="btrf16" transform="translate(490.0,186.66666666666669)">
+    <g class="closed" id="btrf16_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf16_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf17" id="dtrf17" transform="translate(656.0,331.0)">
+    <g class="closed" id="dtrf17_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf17_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf17" id="btrf17" transform="translate(650.0,438.3333333333333)">
+    <g class="closed" id="btrf17_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf17_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+        <g class="DISCONNECTOR dtrf18" id="dtrf18" transform="translate(976.0,306.0)">
+    <g class="closed" id="dtrf18_DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="dtrf18_DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g class="BREAKER btrf18" id="btrf18" transform="translate(970.0,186.66666666666669)">
+    <g class="closed" id="btrf18_BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="btrf18_BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
         <g id="LABEL_VL_vl1">
             <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -58,7 +58,8 @@
     "size" : {
       "width" : 0.0,
       "height" : 0.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "GENERATOR",
     "id" : null,
@@ -82,7 +83,8 @@
     "size" : {
       "width" : 12.0,
       "height" : 12.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "ARROW",
     "id" : null,
@@ -94,7 +96,8 @@
     "size" : {
       "width" : 10.0,
       "height" : 10.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "LOAD",
     "id" : null,
@@ -110,7 +113,8 @@
     "size" : {
       "width" : 16.0,
       "height" : 9.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "NODE",
     "id" : null,
@@ -122,19 +126,8 @@
     "size" : {
       "width" : 8.0,
       "height" : 8.0
-    }
-  }, {
-    "type" : "DISCONNECTOR",
-    "id" : null,
-    "anchorPoints" : [ {
-      "x" : 0.0,
-      "y" : 0.0,
-      "orientation" : "VERTICAL"
-    } ],
-    "size" : {
-      "width" : 8.0,
-      "height" : 8.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "LINE",
     "id" : null,
@@ -146,7 +139,21 @@
     "size" : {
       "width" : 0.0,
       "height" : 0.0
-    }
+    },
+    "allowRotation" : true
+  }, {
+    "type" : "DISCONNECTOR",
+    "id" : null,
+    "anchorPoints" : [ {
+      "x" : 0.0,
+      "y" : 0.0,
+      "orientation" : "VERTICAL"
+    } ],
+    "size" : {
+      "width" : 8.0,
+      "height" : 8.0
+    },
+    "allowRotation" : true
   }, {
     "type" : "INDUCTOR",
     "id" : null,
@@ -162,7 +169,8 @@
     "size" : {
       "width" : 15.0,
       "height" : 9.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "TWO_WINDINGS_TRANSFORMER",
     "id" : null,
@@ -186,7 +194,8 @@
     "size" : {
       "width" : 13.0,
       "height" : 8.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "THREE_WINDINGS_TRANSFORMER",
     "id" : null,
@@ -206,7 +215,8 @@
     "size" : {
       "width" : 14.0,
       "height" : 12.0
-    }
+    },
+    "allowRotation" : true
   }, {
     "type" : "BREAKER",
     "id" : null,
@@ -222,7 +232,8 @@
     "size" : {
       "width" : 20.0,
       "height" : 20.0
-    }
+    },
+    "allowRotation" : true
   } ],
   "nodes" : [ {
     "id" : "dtrct21",
@@ -558,15 +569,6 @@
     "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
-    "id" : "dtrf13",
-    "vid" : "vl1",
-    "nextVId" : null,
-    "componentType" : "DISCONNECTOR",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false
-  }, {
     "id" : "FICT_vl1_dtrf17Fictif",
     "vid" : "vl1",
     "nextVId" : null,
@@ -585,6 +587,15 @@
     "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
+    "id" : "dtrf13",
+    "vid" : "vl1",
+    "nextVId" : null,
+    "componentType" : "DISCONNECTOR",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false
+  }, {
     "id" : "dtrf14",
     "vid" : "vl1",
     "nextVId" : null,
@@ -595,6 +606,15 @@
     "vlabel" : false
   }, {
     "id" : "self4_trf6",
+    "vid" : "vl1",
+    "nextVId" : "vl3",
+    "componentType" : "INDUCTOR",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "TOP",
+    "vlabel" : false
+  }, {
+    "id" : "self4_trf8",
     "vid" : "vl1",
     "nextVId" : "vl3",
     "componentType" : "INDUCTOR",
@@ -619,15 +639,6 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
-  }, {
-    "id" : "self4_trf8",
-    "vid" : "vl1",
-    "nextVId" : "vl3",
-    "componentType" : "INDUCTOR",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "TOP",
     "vlabel" : false
   }, {
     "id" : "self4_trf7",
@@ -774,20 +785,20 @@
     "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
-    "id" : "btrf15",
-    "vid" : "vl1",
-    "nextVId" : null,
-    "componentType" : "BREAKER",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false
-  }, {
     "id" : "FICT_vl1_dsect12Fictif",
     "vid" : "vl1",
     "nextVId" : null,
     "componentType" : "NODE",
     "rotationAngle" : 90.0,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false
+  }, {
+    "id" : "btrf15",
+    "vid" : "vl1",
+    "nextVId" : null,
+    "componentType" : "BREAKER",
+    "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
     "vlabel" : false
@@ -837,15 +848,6 @@
     "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
-    "id" : "btrf18",
-    "vid" : "vl1",
-    "nextVId" : null,
-    "componentType" : "BREAKER",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false
-  }, {
     "id" : "trf7_ONE_TWO",
     "vid" : "vl1",
     "nextVId" : "vl2",
@@ -853,6 +855,15 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
+    "vlabel" : false
+  }, {
+    "id" : "btrf18",
+    "vid" : "vl1",
+    "nextVId" : null,
+    "componentType" : "BREAKER",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "UNDEFINED",
     "vlabel" : false
   } ],
   "wires" : [ {

--- a/single-line-diagram-view/src/main/java/com/powsybl/sld/view/NodeHandler.java
+++ b/single-line-diagram-view/src/main/java/com/powsybl/sld/view/NodeHandler.java
@@ -147,7 +147,8 @@ public class NodeHandler implements BaseNode {
         node.setOnMouseReleased(event -> {
             if (event.getScreenX() == screenX &&
                 event.getScreenY() == screenY &&
-                    componentType.equals(LINE) || componentType.equals(TWO_WINDINGS_TRANSFORMER)) {
+                    componentType != null &&
+                    (componentType.equals(LINE) || componentType.equals(TWO_WINDINGS_TRANSFORMER))) {
                 displayNextVoltageLevel();
             }
         });


### PR DESCRIPTION
Adding a boolean element allowRotation in the component library to indicate if a component SVG can be rotated or not
Changing the capacitor component svg
Small correction in navigation between voltage levels (for 2WT)

Order change in drawing the nodes and edges in the final SVG :
1. drawing all nodes except switch nodes
2. drawing the edges
3. drawing switch nodes

Modification of the handlers installation process to reflect this change
Regeneration of the svg and json test resource files

Signed-off-by: Franck LECUYER <franck.lecuyer@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#4 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
