### PR TITLE
missing_initial_values_for_dangling_lines

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramInitialValueProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramInitialValueProvider.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Branch.Side;
 import com.powsybl.iidm.network.Injection;
-import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.sld.model.BusNode;
@@ -25,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import static com.powsybl.sld.library.ComponentTypeName.BREAKER;
 import static com.powsybl.sld.library.ComponentTypeName.BUSBAR_SECTION;
 import static com.powsybl.sld.library.ComponentTypeName.CAPACITOR;
+import static com.powsybl.sld.library.ComponentTypeName.DANGLING_LINE;
 import static com.powsybl.sld.library.ComponentTypeName.DISCONNECTOR;
 import static com.powsybl.sld.library.ComponentTypeName.GENERATOR;
 import static com.powsybl.sld.library.ComponentTypeName.INDUCTOR;
@@ -63,7 +63,7 @@ public class DefaultDiagramInitialValueProvider implements DiagramInitialValuePr
                     break;
 
                 case LOAD:
-                    initialValue = getLoadInitialValue(network.getLoad(nodeId));
+                    initialValue = getInjectionInitialValue(network.getLoad(nodeId));
                     break;
 
                 case INDUCTOR:
@@ -83,6 +83,10 @@ public class DefaultDiagramInitialValueProvider implements DiagramInitialValuePr
                     initialValue = getInjectionInitialValue(network.getVscConverterStation(nodeId));
                     break;
 
+                case DANGLING_LINE:
+                    initialValue = getInjectionInitialValue(network.getDanglingLine(nodeId));
+                    break;
+
                 case BUSBAR_SECTION:
                 case BREAKER:
                 case LOAD_BREAK_SWITCH:
@@ -97,14 +101,6 @@ public class DefaultDiagramInitialValueProvider implements DiagramInitialValuePr
     private InitialValue getInjectionInitialValue(Injection<?> injection) {
         if (injection != null) {
             return new InitialValue(injection);
-        } else {
-            return new InitialValue(null, null, null, null, null, null);
-        }
-    }
-
-    private InitialValue getLoadInitialValue(Load load) {
-        if (load != null) {
-            return new InitialValue(load);
         } else {
             return new InitialValue(null, null, null, null, null, null);
         }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/InitialValue.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/InitialValue.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Branch.Side;
 import com.powsybl.iidm.network.Injection;
-import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.sld.svg.DiagramInitialValueProvider.Direction;
 
@@ -42,18 +41,6 @@ public class InitialValue {
         Objects.requireNonNull(side);
         double p = side.equals(Side.ONE) ? ln.getTerminal1().getP() : ln.getTerminal2().getP();
         double q = side.equals(Side.ONE) ? ln.getTerminal1().getQ() : ln.getTerminal2().getQ();
-        label1 = String.valueOf(Math.round(p));
-        label2 = String.valueOf(Math.round(q));
-        label3 = null;
-        label4 = null;
-        direction1 = p > 0 ? Direction.UP : Direction.DOWN;
-        direction2 = q > 0 ? Direction.UP : Direction.DOWN;
-    }
-
-    public InitialValue(Load load) {
-        Objects.requireNonNull(load);
-        double p = load.getP0();
-        double q = load.getQ0();
         label1 = String.valueOf(Math.round(p));
         label2 = String.valueOf(Math.round(q));
         label3 = null;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/InitialValueProviderTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/InitialValueProviderTest.java
@@ -60,9 +60,21 @@ public class InitialValueProviderTest {
             .setCurrentSectionCount(1)
             .setMaximumSectionCount(1)
             .add();
+        vl.newDanglingLine()
+                .setId("dl1")
+                .setName("Dangling line 1")
+                .setNode(5)
+                .setP0(1)
+                .setQ0(1)
+                .setR(0)
+                .setX(0)
+                .setB(0)
+                .setG(0)
+                .add();
         view.newDisconnector().setId("d").setNode1(0).setNode2(1).add();
         view.newBreaker().setId("b").setNode1(1).setNode2(2).add();
         view.newBreaker().setId("b2").setNode1(3).setNode2(4).add();
+        view.newBreaker().setId("b3").setNode1(3).setNode2(5).add();
     }
 
     @Test
@@ -106,5 +118,12 @@ public class InitialValueProviderTest {
         assertFalse(init4.getLabel4().isPresent());
         assertFalse(init4.getArrowDirection1().isPresent());
         assertFalse(init4.getArrowDirection2().isPresent());
+        InitialValue init5 = initProvider1.getInitialValue(g.getNode("dl1"));
+        assertTrue(init5.getLabel1().isPresent());
+        assertTrue(init5.getLabel2().isPresent());
+        assertFalse(init5.getLabel3().isPresent());
+        assertFalse(init5.getLabel4().isPresent());
+        assertTrue(init5.getArrowDirection1().isPresent());
+        assertTrue(init5.getArrowDirection2().isPresent());
     }
 }

--- a/single-line-diagram-core/src/test/resources/TestCase1.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase1.svg
@@ -134,23 +134,23 @@
 </g>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="idvl_95_Wire0"/>
         <polyline class="wire wire_vl" points="45.0,145.0,45.0,34.0" id="idvl_95_Wire1"/>
-        <g class="ARROW1__95_l_UP" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
+        <g class="ARROW1__95_l_DOWN" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2__95_l_UP" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
+        <g class="ARROW2__95_l_DOWN" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="45.0,165.0,45.0,280.0" id="idvl_95_Wire2"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="idvl_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHorizontal.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHorizontal.svg
@@ -406,23 +406,23 @@
         <polyline class="wire wire_vl1" points="620.0,385.0,630.0,385.0" id="idvl1_95_Wire3"/>
         <polyline class="wire wire_vl1" points="95.0,360.0,95.0,360.0" id="idvl1_95_Wire4"/>
         <polyline class="wire wire_vl1" points="95.0,84.0,95.0,195.0" id="idvl1_95_Wire5"/>
-        <g class="ARROW1_load1_UP" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
+        <g class="ARROW1_load1_DOWN" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load1_UP" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
+        <g class="ARROW2_load1_DOWN" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="195.0,385.0,195.0,385.0" id="idvl1_95_Wire6"/>
         <polyline class="wire wire_vl1" points="195.0,659.0,195.0,550.0" id="idvl1_95_Wire7"/>
@@ -446,23 +446,23 @@
         </g>
         <polyline class="wire wire_vl1" points="645.0,360.0,645.0,360.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="645.0,84.0,645.0,195.0" id="idvl1_95_Wire9"/>
-        <g class="ARROW1_load2_UP" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,99.0)">
+        <g class="ARROW1_load2_DOWN" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,99.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load2_UP" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,119.0)">
+        <g class="ARROW2_load2_DOWN" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,119.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="895.0,385.0,895.0,385.0" id="idvl1_95_Wire10"/>
         <polyline class="wire wire_vl1" points="895.0,659.0,895.0,550.0" id="idvl1_95_Wire11"/>
@@ -1149,23 +1149,23 @@
         <polyline class="wire wire_vl2" points="1145.0,385.0,1145.0,385.0" id="idvl2_95_Wire1"/>
         <polyline class="wire wire_vl2" points="1195.0,360.0,1195.0,360.0" id="idvl2_95_Wire2"/>
         <polyline class="wire wire_vl2" points="1195.0,84.0,1195.0,195.0" id="idvl2_95_Wire3"/>
-        <g class="ARROW1_load3_UP" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1190.0,99.0)">
+        <g class="ARROW1_load3_DOWN" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1190.0,99.0)">
      <g class="arrow-up" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load3_UP" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1190.0,119.0)">
+        <g class="ARROW2_load3_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1190.0,119.0)">
      <g class="arrow-up" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl2" points="1295.0,385.0,1295.0,385.0" id="idvl2_95_Wire4"/>
         <polyline class="wire wire_vl2" points="1295.0,659.0,1295.0,550.0" id="idvl2_95_Wire5"/>
@@ -1663,23 +1663,23 @@
         <g class="NODE idFICT_95_vl3_95_dtrf38Fictif" id="idFICT_95_vl3_95_dtrf38Fictif" transform="translate(2266.0,326.0)"/>
         <polyline class="wire wire_vl3" points="1945.0,360.0,1945.0,360.0" id="idvl3_95_Wire0"/>
         <polyline class="wire wire_vl3" points="1945.0,195.0,1945.0,84.0" id="idvl3_95_Wire1"/>
-        <g class="ARROW1_load4_UP" id="idvl3_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,1940.0,170.0)">
+        <g class="ARROW1_load4_DOWN" id="idvl3_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,1940.0,170.0)">
      <g class="arrow-up" id="idvl3_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl3_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load4_UP" id="idvl3_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,1940.0,150.0)">
+        <g class="ARROW2_load4_DOWN" id="idvl3_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,1940.0,150.0)">
      <g class="arrow-up" id="idvl3_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl3_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl3" points="1995.0,360.0,1995.0,360.0" id="idvl3_95_Wire2"/>
         <polyline class="wire wire_vl3" points="1995.0,525.0,1995.0,636.0" id="idvl3_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHorizontalNominalVoltageLevel.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHorizontalNominalVoltageLevel.svg
@@ -406,23 +406,23 @@
         <polyline class="wire wire_vl1" points="620.0,385.0,630.0,385.0" id="idvl1_95_Wire3"/>
         <polyline class="wire wire_vl1" points="95.0,360.0,95.0,360.0" id="idvl1_95_Wire4"/>
         <polyline class="wire wire_vl1" points="95.0,84.0,95.0,195.0" id="idvl1_95_Wire5"/>
-        <g class="ARROW1_load1_UP" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
+        <g class="ARROW1_load1_DOWN" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load1_UP" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
+        <g class="ARROW2_load1_DOWN" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="195.0,385.0,195.0,385.0" id="idvl1_95_Wire6"/>
         <polyline class="wire wire_vl1" points="195.0,659.0,195.0,550.0" id="idvl1_95_Wire7"/>
@@ -446,23 +446,23 @@
         </g>
         <polyline class="wire wire_vl1" points="645.0,360.0,645.0,360.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="645.0,84.0,645.0,195.0" id="idvl1_95_Wire9"/>
-        <g class="ARROW1_load2_UP" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,99.0)">
+        <g class="ARROW1_load2_DOWN" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,99.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load2_UP" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,119.0)">
+        <g class="ARROW2_load2_DOWN" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,119.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="895.0,385.0,895.0,385.0" id="idvl1_95_Wire10"/>
         <polyline class="wire wire_vl1" points="895.0,659.0,895.0,550.0" id="idvl1_95_Wire11"/>
@@ -1149,23 +1149,23 @@
         <polyline class="wire wire_vl2" points="1145.0,385.0,1145.0,385.0" id="idvl2_95_Wire1"/>
         <polyline class="wire wire_vl2" points="1195.0,360.0,1195.0,360.0" id="idvl2_95_Wire2"/>
         <polyline class="wire wire_vl2" points="1195.0,84.0,1195.0,195.0" id="idvl2_95_Wire3"/>
-        <g class="ARROW1_load3_UP" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1190.0,99.0)">
+        <g class="ARROW1_load3_DOWN" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1190.0,99.0)">
      <g class="arrow-up" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load3_UP" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1190.0,119.0)">
+        <g class="ARROW2_load3_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1190.0,119.0)">
      <g class="arrow-up" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl2" points="1295.0,385.0,1295.0,385.0" id="idvl2_95_Wire4"/>
         <polyline class="wire wire_vl2" points="1295.0,659.0,1295.0,550.0" id="idvl2_95_Wire5"/>
@@ -1663,23 +1663,23 @@
         <g class="NODE idFICT_95_vl3_95_dtrf38Fictif" id="idFICT_95_vl3_95_dtrf38Fictif" transform="translate(2266.0,326.0)"/>
         <polyline class="wire wire_vl3" points="1945.0,360.0,1945.0,360.0" id="idvl3_95_Wire0"/>
         <polyline class="wire wire_vl3" points="1945.0,195.0,1945.0,84.0" id="idvl3_95_Wire1"/>
-        <g class="ARROW1_load4_UP" id="idvl3_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,1940.0,170.0)">
+        <g class="ARROW1_load4_DOWN" id="idvl3_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,1940.0,170.0)">
      <g class="arrow-up" id="idvl3_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl3_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load4_UP" id="idvl3_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,1940.0,150.0)">
+        <g class="ARROW2_load4_DOWN" id="idvl3_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,1940.0,150.0)">
      <g class="arrow-up" id="idvl3_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl3_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl3" points="1995.0,360.0,1995.0,360.0" id="idvl3_95_Wire2"/>
         <polyline class="wire wire_vl3" points="1995.0,525.0,1995.0,636.0" id="idvl3_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphVertical.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphVertical.svg
@@ -406,23 +406,23 @@
         <polyline class="wire wire_vl1" points="620.0,385.0,630.0,385.0" id="idvl1_95_Wire3"/>
         <polyline class="wire wire_vl1" points="95.0,360.0,95.0,360.0" id="idvl1_95_Wire4"/>
         <polyline class="wire wire_vl1" points="95.0,84.0,95.0,195.0" id="idvl1_95_Wire5"/>
-        <g class="ARROW1_load1_UP" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
+        <g class="ARROW1_load1_DOWN" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load1_UP" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
+        <g class="ARROW2_load1_DOWN" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="195.0,385.0,195.0,385.0" id="idvl1_95_Wire6"/>
         <polyline class="wire wire_vl1" points="195.0,659.0,195.0,550.0" id="idvl1_95_Wire7"/>
@@ -446,23 +446,23 @@
         </g>
         <polyline class="wire wire_vl1" points="645.0,360.0,645.0,360.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="645.0,84.0,645.0,195.0" id="idvl1_95_Wire9"/>
-        <g class="ARROW1_load2_UP" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,99.0)">
+        <g class="ARROW1_load2_DOWN" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,99.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load2_UP" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,119.0)">
+        <g class="ARROW2_load2_DOWN" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,119.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="895.0,385.0,895.0,385.0" id="idvl1_95_Wire10"/>
         <polyline class="wire wire_vl1" points="895.0,659.0,895.0,550.0" id="idvl1_95_Wire11"/>
@@ -1149,23 +1149,23 @@
         <polyline class="wire wire_vl2" points="145.0,1075.0,145.0,1075.0" id="idvl2_95_Wire1"/>
         <polyline class="wire wire_vl2" points="195.0,1050.0,195.0,1050.0" id="idvl2_95_Wire2"/>
         <polyline class="wire wire_vl2" points="195.0,774.0,195.0,885.0" id="idvl2_95_Wire3"/>
-        <g class="ARROW1_load3_UP" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,190.0,789.0)">
+        <g class="ARROW1_load3_DOWN" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,190.0,789.0)">
      <g class="arrow-up" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load3_UP" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,190.0,809.0)">
+        <g class="ARROW2_load3_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,190.0,809.0)">
      <g class="arrow-up" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl2" points="295.0,1075.0,295.0,1075.0" id="idvl2_95_Wire4"/>
         <polyline class="wire wire_vl2" points="295.0,1349.0,295.0,1240.0" id="idvl2_95_Wire5"/>
@@ -1663,23 +1663,23 @@
         <g class="NODE idFICT_95_vl3_95_dtrf38Fictif" id="idFICT_95_vl3_95_dtrf38Fictif" transform="translate(416.0,1706.0)"/>
         <polyline class="wire wire_vl3" points="95.0,1740.0,95.0,1740.0" id="idvl3_95_Wire0"/>
         <polyline class="wire wire_vl3" points="95.0,1575.0,95.0,1464.0" id="idvl3_95_Wire1"/>
-        <g class="ARROW1_load4_UP" id="idvl3_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,90.0,1550.0)">
+        <g class="ARROW1_load4_DOWN" id="idvl3_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,90.0,1550.0)">
      <g class="arrow-up" id="idvl3_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl3_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load4_UP" id="idvl3_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,90.0,1530.0)">
+        <g class="ARROW2_load4_DOWN" id="idvl3_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,90.0,1530.0)">
      <g class="arrow-up" id="idvl3_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl3_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl3" points="145.0,1740.0,145.0,1740.0" id="idvl3_95_Wire2"/>
         <polyline class="wire wire_vl3" points="145.0,1905.0,145.0,2016.0" id="idvl3_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.svg
@@ -263,23 +263,23 @@
         <polyline class="wire wire_vl1" points="820.0,335.0,830.0,335.0" id="idvl1_95_Wire3"/>
         <polyline class="wire wire_vl1" points="60.0,310.0,60.0,310.0" id="idvl1_95_Wire4"/>
         <polyline class="wire wire_vl1" points="60.0,34.0,60.0,145.0" id="idvl1_95_Wire5"/>
-        <g class="ARROW1_load1_UP" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,49.0)">
+        <g class="ARROW1_load1_DOWN" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,49.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load1_UP" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,69.0)">
+        <g class="ARROW2_load1_DOWN" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,69.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="220.0,335.0,220.0,335.0" id="idvl1_95_Wire6"/>
         <polyline class="wire wire_vl1" points="220.0,609.0,220.0,500.0" id="idvl1_95_Wire7"/>
@@ -303,23 +303,23 @@
         </g>
         <polyline class="wire wire_vl1" points="860.0,310.0,860.0,310.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="860.0,34.0,860.0,145.0" id="idvl1_95_Wire9"/>
-        <g class="ARROW1_load2_UP" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,49.0)">
+        <g class="ARROW1_load2_DOWN" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,49.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load2_UP" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,69.0)">
+        <g class="ARROW2_load2_DOWN" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,69.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="1260.0,335.0,1260.0,335.0" id="idvl1_95_Wire10"/>
         <polyline class="wire wire_vl1" points="1260.0,609.0,1260.0,500.0" id="idvl1_95_Wire11"/>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL1_optimized.svg
@@ -305,13 +305,13 @@
         <polyline class="wire wire_vl1" points="820.0,335.0,830.0,335.0" id="idvl1_95_Wire3"/>
         <polyline class="wire wire_vl1" points="60.0,310.0,60.0,310.0" id="idvl1_95_Wire4"/>
         <polyline class="wire wire_vl1" points="60.0,34.0,60.0,145.0" id="idvl1_95_Wire5"/>
-        <g class="ARROW1_load1_UP" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,49.0)">
-            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        <g class="ARROW1_load1_DOWN" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,49.0)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-down" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load1_UP" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,69.0)">
-            <use fill="blue" fill-opacity="1" href="#ARROW-arrow-up" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        <g class="ARROW2_load1_DOWN" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,69.0)">
+            <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
+            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="220.0,335.0,220.0,335.0" id="idvl1_95_Wire6"/>
         <polyline class="wire wire_vl1" points="220.0,609.0,220.0,500.0" id="idvl1_95_Wire7"/>
@@ -325,13 +325,13 @@
         </g>
         <polyline class="wire wire_vl1" points="860.0,310.0,860.0,310.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="860.0,34.0,860.0,145.0" id="idvl1_95_Wire9"/>
-        <g class="ARROW1_load2_UP" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,49.0)">
-            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        <g class="ARROW1_load2_DOWN" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,49.0)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-down" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load2_UP" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,69.0)">
-            <use fill="blue" fill-opacity="1" href="#ARROW-arrow-up" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        <g class="ARROW2_load2_DOWN" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,69.0)">
+            <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
+            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="1260.0,335.0,1260.0,335.0" id="idvl1_95_Wire10"/>
         <polyline class="wire wire_vl1" points="1260.0,609.0,1260.0,500.0" id="idvl1_95_Wire11"/>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.svg
@@ -229,23 +229,23 @@
         <polyline class="wire wire_vl2" points="140.0,335.0,140.0,335.0" id="idvl2_95_Wire1"/>
         <polyline class="wire wire_vl2" points="220.0,310.0,220.0,310.0" id="idvl2_95_Wire2"/>
         <polyline class="wire wire_vl2" points="220.0,34.0,220.0,145.0" id="idvl2_95_Wire3"/>
-        <g class="ARROW1_load3_UP" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,49.0)">
+        <g class="ARROW1_load3_DOWN" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,49.0)">
      <g class="arrow-up" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load3_UP" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,69.0)">
+        <g class="ARROW2_load3_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,69.0)">
      <g class="arrow-up" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl2" points="380.0,335.0,380.0,335.0" id="idvl2_95_Wire4"/>
         <polyline class="wire wire_vl2" points="380.0,609.0,380.0,500.0" id="idvl2_95_Wire5"/>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL2_optimized.svg
@@ -275,13 +275,13 @@
         <polyline class="wire wire_vl2" points="140.0,335.0,140.0,335.0" id="idvl2_95_Wire1"/>
         <polyline class="wire wire_vl2" points="220.0,310.0,220.0,310.0" id="idvl2_95_Wire2"/>
         <polyline class="wire wire_vl2" points="220.0,34.0,220.0,145.0" id="idvl2_95_Wire3"/>
-        <g class="ARROW1_load3_UP" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,49.0)">
-            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        <g class="ARROW1_load3_DOWN" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,49.0)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-down" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load3_UP" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,69.0)">
-            <use fill="blue" fill-opacity="1" href="#ARROW-arrow-up" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        <g class="ARROW2_load3_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,69.0)">
+            <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
+            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl2" points="380.0,335.0,380.0,335.0" id="idvl2_95_Wire4"/>
         <polyline class="wire wire_vl2" points="380.0,609.0,380.0,500.0" id="idvl2_95_Wire5"/>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL3.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL3.svg
@@ -210,23 +210,23 @@
         <g class="NODE idFICT_95_vl3_95_dself6Fictif" id="idFICT_95_vl3_95_dself6Fictif" transform="translate(856.0,336.0)"/>
         <polyline class="wire wire_vl3" points="60.0,310.0,60.0,310.0" id="idvl3_95_Wire0"/>
         <polyline class="wire wire_vl3" points="60.0,145.0,60.0,34.0" id="idvl3_95_Wire1"/>
-        <g class="ARROW1_load4_UP" id="idvl3_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,55.0,120.0)">
+        <g class="ARROW1_load4_DOWN" id="idvl3_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,55.0,120.0)">
      <g class="arrow-up" id="idvl3_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl3_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load4_UP" id="idvl3_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,55.0,100.0)">
+        <g class="ARROW2_load4_DOWN" id="idvl3_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,55.0,100.0)">
      <g class="arrow-up" id="idvl3_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl3_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl3" points="140.0,310.0,140.0,310.0" id="idvl3_95_Wire2"/>
         <polyline class="wire wire_vl3" points="140.0,475.0,140.0,586.0" id="idvl3_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL3_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL3_optimized.svg
@@ -258,13 +258,13 @@
         <g class="NODE idFICT_95_vl3_95_dself6Fictif" id="idFICT_95_vl3_95_dself6Fictif" transform="translate(856.0,336.0)"/>
         <polyline class="wire wire_vl3" points="60.0,310.0,60.0,310.0" id="idvl3_95_Wire0"/>
         <polyline class="wire wire_vl3" points="60.0,145.0,60.0,34.0" id="idvl3_95_Wire1"/>
-        <g class="ARROW1_load4_UP" id="idvl3_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,55.0,120.0)">
-            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        <g class="ARROW1_load4_DOWN" id="idvl3_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,55.0,120.0)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load4_UP" id="idvl3_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,55.0,100.0)">
-            <use fill="blue" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+        <g class="ARROW2_load4_DOWN" id="idvl3_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,55.0,100.0)">
+            <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
+            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl3" points="140.0,310.0,140.0,310.0" id="idvl3_95_Wire2"/>
         <polyline class="wire wire_vl3" points="140.0,475.0,140.0,586.0" id="idvl3_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/TestCase1BusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase1BusBreaker.svg
@@ -138,23 +138,23 @@
 </g>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="idvl_95_Wire0"/>
         <polyline class="wire wire_vl" points="45.0,34.0,45.0,280.0" id="idvl_95_Wire1"/>
-        <g class="ARROW1__95_l_UP" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,40.0,49.0)">
+        <g class="ARROW1__95_l_DOWN" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,40.0,49.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2__95_l_UP" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,40.0,69.0)">
+        <g class="ARROW2__95_l_DOWN" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,40.0,69.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="idvl_95_Wire2"/>
         <g class="DISCONNECTOR idb1_95_l" id="idb1_95_l" transform="translate(41.0,306.0)">

--- a/single-line-diagram-core/src/test/resources/TestCase1inverted.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase1inverted.svg
@@ -134,23 +134,23 @@
 </g>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="idvl_95_Wire0"/>
         <polyline class="wire wire_vl" points="45.0,145.0,45.0,34.0" id="idvl_95_Wire1"/>
-        <g class="ARROW1__95_l_UP" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
+        <g class="ARROW1__95_l_DOWN" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2__95_l_UP" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
+        <g class="ARROW2__95_l_DOWN" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="45.0,165.0,45.0,280.0" id="idvl_95_Wire2"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="idvl_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/TestCase2StackedCell.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase2StackedCell.svg
@@ -142,23 +142,23 @@
         <polyline class="wire wire_vl" points="45.0,335.0,45.0,280.0" id="idvl_95_Wire3"/>
         <polyline class="wire wire_vl" points="45.0,280.0,45.0,165.0" id="idvl_95_Wire4"/>
         <polyline class="wire wire_vl" points="45.0,145.0,45.0,34.0" id="idvl_95_Wire5"/>
-        <g class="ARROW1__95_l_UP" id="idvl_95_Wire5_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
+        <g class="ARROW1__95_l_DOWN" id="idvl_95_Wire5_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
      <g class="arrow-up" id="idvl_95_Wire5_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire5_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2__95_l_UP" id="idvl_95_Wire5_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
+        <g class="ARROW2__95_l_DOWN" id="idvl_95_Wire5_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
      <g class="arrow-up" id="idvl_95_Wire5_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire5_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <g class="DISCONNECTOR idd1" id="idd1" transform="translate(41.0,306.0)">
     <g class="closed" id="idd1_DISCONNECTOR-closed">

--- a/single-line-diagram-core/src/test/resources/TestCase4NotParallelel.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase4NotParallelel.svg
@@ -168,23 +168,23 @@
     <circle r="4" cx="4" cy="4"/>
 </g>
         <polyline class="wire wire_vl" points="45.0,34.0,45.0,145.0" id="idvl_95_Wire0"/>
-        <g class="ARROW1_la_UP" id="idvl_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,40.0,49.0)">
+        <g class="ARROW1_la_DOWN" id="idvl_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,40.0,49.0)">
      <g class="arrow-up" id="idvl_95_Wire0_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire0_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_la_UP" id="idvl_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,40.0,69.0)">
+        <g class="ARROW2_la_DOWN" id="idvl_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,40.0,69.0)">
      <g class="arrow-up" id="idvl_95_Wire0_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire0_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="45.0,165.0,45.0,280.0" id="idvl_95_Wire1"/>
         <polyline class="wire wire_vl" points="45.0,280.0,45.0,310.0" id="idvl_95_Wire2"/>
@@ -192,23 +192,23 @@
         <polyline class="wire wire_vl" points="45.0,280.0,45.0,335.0" id="idvl_95_Wire4"/>
         <polyline class="wire wire_vl" points="45.0,335.0,45.0,335.0" id="idvl_95_Wire5"/>
         <polyline class="wire wire_vl" points="145.0,611.0,145.0,500.0" id="idvl_95_Wire6"/>
-        <g class="ARROW1_lb_UP" id="idvl_95_Wire6_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,140.0,586.0)">
+        <g class="ARROW1_lb_DOWN" id="idvl_95_Wire6_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,140.0,586.0)">
      <g class="arrow-up" id="idvl_95_Wire6_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire6_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_lb_UP" id="idvl_95_Wire6_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,140.0,566.0)">
+        <g class="ARROW2_lb_DOWN" id="idvl_95_Wire6_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,140.0,566.0)">
      <g class="arrow-up" id="idvl_95_Wire6_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire6_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="145.0,480.0,145.0,365.0" id="idvl_95_Wire7"/>
         <polyline class="wire wire_vl" points="145.0,365.0,145.0,310.0" id="idvl_95_Wire8"/>

--- a/single-line-diagram-core/src/test/resources/TestCase5ShuntHorizontal.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase5ShuntHorizontal.svg
@@ -153,44 +153,44 @@
         <polyline class="wire wire_vl" points="45.0,113.33333333333334,45.0,186.66666666666669" id="idvl_95_Wire2"/>
         <polyline class="wire wire_vl" points="45.0,113.33333333333334,45.0,113.33333333333334,60.0,113.33333333333334" id="idvl_95_Wire3"/>
         <polyline class="wire wire_vl" points="45.0,34.00000000000002,45.0,113.33333333333334" id="idvl_95_Wire4"/>
-        <g class="ARROW1_la_UP" id="idvl_95_Wire4_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,40.0,49.0)">
+        <g class="ARROW1_la_DOWN" id="idvl_95_Wire4_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,40.0,49.0)">
      <g class="arrow-up" id="idvl_95_Wire4_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire4_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_la_UP" id="idvl_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,40.0,69.0)">
+        <g class="ARROW2_la_DOWN" id="idvl_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,40.0,69.0)">
      <g class="arrow-up" id="idvl_95_Wire4_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire4_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="95.0,113.33333333333334,95.0,186.66666666666669" id="idvl_95_Wire5"/>
         <polyline class="wire wire_vl" points="95.0,113.33333333333334,95.0,113.33333333333334,80.0,113.33333333333334" id="idvl_95_Wire6"/>
         <polyline class="wire wire_vl" points="95.0,34.00000000000002,95.0,113.33333333333334" id="idvl_95_Wire7"/>
-        <g class="ARROW1_lb_UP" id="idvl_95_Wire7_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,49.0)">
+        <g class="ARROW1_lb_DOWN" id="idvl_95_Wire7_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,49.0)">
      <g class="arrow-up" id="idvl_95_Wire7_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire7_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_lb_UP" id="idvl_95_Wire7_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,69.0)">
+        <g class="ARROW2_lb_DOWN" id="idvl_95_Wire7_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,69.0)">
      <g class="arrow-up" id="idvl_95_Wire7_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire7_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="45.0,206.66666666666669,45.0,280.0" id="idvl_95_Wire8"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="idvl_95_Wire9"/>

--- a/single-line-diagram-core/src/test/resources/TestCase5ShuntVertical.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase5ShuntVertical.svg
@@ -147,23 +147,23 @@
 </g>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="idvl_95_Wire0"/>
         <polyline class="wire wire_vl" points="95.0,34.0,95.0,145.0" id="idvl_95_Wire1"/>
-        <g class="ARROW1_lb_UP" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,49.0)">
+        <g class="ARROW1_lb_DOWN" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,49.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_lb_UP" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,69.0)">
+        <g class="ARROW2_lb_DOWN" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,69.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="95.0,165.0,95.0,280.0" id="idvl_95_Wire2"/>
         <polyline class="wire wire_vl" points="95.0,280.0,95.0,310.0" id="idvl_95_Wire3"/>
@@ -172,23 +172,23 @@
         <polyline class="wire wire_vl" points="45.0,113.33333333333334,45.0,186.66666666666669" id="idvl_95_Wire6"/>
         <polyline class="wire wire_vl" points="45.0,113.33333333333334,70.0,113.33333333333334,70.0,186.66666666666669" id="idvl_95_Wire7"/>
         <polyline class="wire wire_vl" points="45.0,34.00000000000002,45.0,113.33333333333334" id="idvl_95_Wire8"/>
-        <g class="ARROW1_la_UP" id="idvl_95_Wire8_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,40.0,49.0)">
+        <g class="ARROW1_la_DOWN" id="idvl_95_Wire8_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,40.0,49.0)">
      <g class="arrow-up" id="idvl_95_Wire8_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire8_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_la_UP" id="idvl_95_Wire8_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,40.0,69.0)">
+        <g class="ARROW2_la_DOWN" id="idvl_95_Wire8_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,40.0,69.0)">
      <g class="arrow-up" id="idvl_95_Wire8_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire8_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="45.0,206.66666666666669,45.0,280.0" id="idvl_95_Wire9"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="idvl_95_Wire10"/>

--- a/single-line-diagram-core/src/test/resources/TestDefaultFeedersPosition.svg
+++ b/single-line-diagram-core/src/test/resources/TestDefaultFeedersPosition.svg
@@ -288,23 +288,23 @@
         <polyline class="wire wire_vl1" points="220.0,385.0,230.0,385.0" id="idvl1_95_Wire3"/>
         <polyline class="wire wire_vl1" points="95.0,360.0,95.0,360.0" id="idvl1_95_Wire4"/>
         <polyline class="wire wire_vl1" points="95.0,84.0,95.0,195.0" id="idvl1_95_Wire5"/>
-        <g class="ARROW1_load1_UP" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
+        <g class="ARROW1_load1_DOWN" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load1_UP" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
+        <g class="ARROW2_load1_DOWN" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="145.0,385.0,145.0,385.0" id="idvl1_95_Wire6"/>
         <polyline class="wire wire_vl1" points="145.0,659.0,145.0,550.0" id="idvl1_95_Wire7"/>
@@ -328,23 +328,23 @@
         </g>
         <polyline class="wire wire_vl1" points="245.0,360.0,245.0,360.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="245.0,84.0,245.0,195.0" id="idvl1_95_Wire9"/>
-        <g class="ARROW1_load2_UP" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,240.0,99.0)">
+        <g class="ARROW1_load2_DOWN" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,240.0,99.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load2_UP" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,240.0,119.0)">
+        <g class="ARROW2_load2_DOWN" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,240.0,119.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="295.0,385.0,295.0,385.0" id="idvl1_95_Wire10"/>
         <polyline class="wire wire_vl1" points="295.0,659.0,295.0,550.0" id="idvl1_95_Wire11"/>

--- a/single-line-diagram-core/src/test/resources/TestDefaultFeedersPosition2.svg
+++ b/single-line-diagram-core/src/test/resources/TestDefaultFeedersPosition2.svg
@@ -285,23 +285,23 @@
         <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="idvl1_95_Wire12"/>
         <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="idvl1_95_Wire13"/>
         <polyline class="wire wire_vl1" points="19.0,45.0,19.0,39.0" id="idvl1_95_Wire14"/>
-        <g class="ARROW1_load1_UP" id="idvl1_95_Wire14_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,14.0,20.0)">
+        <g class="ARROW1_load1_DOWN" id="idvl1_95_Wire14_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,14.0,20.0)">
      <g class="arrow-up" id="idvl1_95_Wire14_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire14_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load1_UP" id="idvl1_95_Wire14_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,14.0,0.0)">
+        <g class="ARROW2_load1_DOWN" id="idvl1_95_Wire14_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,14.0,0.0)">
      <g class="arrow-up" id="idvl1_95_Wire14_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire14_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="19.0,39.0,19.0,49.0" id="idvl1_95_Wire15"/>
         <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="idvl1_95_Wire16"/>
@@ -329,23 +329,23 @@
         <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="idvl1_95_Wire20"/>
         <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="idvl1_95_Wire21"/>
         <polyline class="wire wire_vl1" points="19.0,45.0,19.0,39.0" id="idvl1_95_Wire22"/>
-        <g class="ARROW1_load2_UP" id="idvl1_95_Wire22_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,14.0,20.0)">
+        <g class="ARROW1_load2_DOWN" id="idvl1_95_Wire22_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,14.0,20.0)">
      <g class="arrow-up" id="idvl1_95_Wire22_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire22_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load2_UP" id="idvl1_95_Wire22_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,14.0,0.0)">
+        <g class="ARROW2_load2_DOWN" id="idvl1_95_Wire22_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,14.0,0.0)">
      <g class="arrow-up" id="idvl1_95_Wire22_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire22_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="19.0,39.0,19.0,49.0" id="idvl1_95_Wire23"/>
         <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="idvl1_95_Wire24"/>

--- a/single-line-diagram-core/src/test/resources/TestShiftFeedersPosition.svg
+++ b/single-line-diagram-core/src/test/resources/TestShiftFeedersPosition.svg
@@ -288,23 +288,23 @@
         <polyline class="wire wire_vl1" points="220.0,385.0,230.0,385.0" id="idvl1_95_Wire3"/>
         <polyline class="wire wire_vl1" points="95.0,360.0,95.0,360.0" id="idvl1_95_Wire4"/>
         <polyline class="wire wire_vl1" points="95.0,84.0,95.0,195.0" id="idvl1_95_Wire5"/>
-        <g class="ARROW1_load1_UP" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
+        <g class="ARROW1_load1_DOWN" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load1_UP" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
+        <g class="ARROW2_load1_DOWN" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="145.0,385.0,145.0,385.0" id="idvl1_95_Wire6"/>
         <polyline class="wire wire_vl1" points="145.0,659.0,145.0,550.0" id="idvl1_95_Wire7"/>
@@ -328,23 +328,23 @@
         </g>
         <polyline class="wire wire_vl1" points="245.0,360.0,245.0,360.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="245.0,101.0,245.0,195.0" id="idvl1_95_Wire9"/>
-        <g class="ARROW1_load2_UP" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,240.0,116.0)">
+        <g class="ARROW1_load2_DOWN" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,240.0,116.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load2_UP" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,240.0,136.0)">
+        <g class="ARROW2_load2_DOWN" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,240.0,136.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="295.0,385.0,295.0,385.0" id="idvl1_95_Wire10"/>
         <polyline class="wire wire_vl1" points="295.0,639.0,295.0,550.0" id="idvl1_95_Wire11"/>

--- a/single-line-diagram-core/src/test/resources/TestSubstation.svg
+++ b/single-line-diagram-core/src/test/resources/TestSubstation.svg
@@ -235,23 +235,23 @@
         <g class="NODE idFICT_95_vl_95_dFictif" id="idFICT_95_vl_95_dFictif" transform="translate(91.0,326.0)"/>
         <polyline class="wire wire_vl" points="95.0,360.0,95.0,360.0" id="idvl_95_Wire0"/>
         <polyline class="wire wire_vl" points="95.0,195.0,95.0,84.0" id="idvl_95_Wire1"/>
-        <g class="ARROW1__95_l_UP" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,90.0,170.0)">
+        <g class="ARROW1__95_l_DOWN" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,90.0,170.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2__95_l_UP" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,90.0,150.0)">
+        <g class="ARROW2__95_l_DOWN" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,90.0,150.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="95.0,215.0,95.0,330.0" id="idvl_95_Wire2"/>
         <polyline class="wire wire_vl" points="95.0,360.0,95.0,330.0" id="idvl_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork1.svg
+++ b/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork1.svg
@@ -124,23 +124,23 @@
         <g class="NODE idnetwork1_95_FICT_95_vl_95_dFictif" id="idnetwork1_95_FICT_95_vl_95_dFictif" transform="translate(41.0,276.0)"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="idnetwork1_95_vl_95_Wire0"/>
         <polyline class="wire wire_vl" points="45.0,145.0,45.0,34.0" id="idnetwork1_95_vl_95_Wire1"/>
-        <g class="ARROW1__95_l_UP" id="idnetwork1_95_vl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
+        <g class="ARROW1__95_l_DOWN" id="idnetwork1_95_vl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
      <g class="arrow-up" id="network1_idnetwork1_95_vl_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="network1_idnetwork1_95_vl_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2__95_l_UP" id="idnetwork1_95_vl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
+        <g class="ARROW2__95_l_DOWN" id="idnetwork1_95_vl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
      <g class="arrow-up" id="network1_idnetwork1_95_vl_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="network1_idnetwork1_95_vl_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="45.0,165.0,45.0,280.0" id="idnetwork1_95_vl_95_Wire2"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="idnetwork1_95_vl_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork2.svg
+++ b/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork2.svg
@@ -124,23 +124,23 @@
         <g class="NODE idnetwork2_95_FICT_95_vl_95_dFictif" id="idnetwork2_95_FICT_95_vl_95_dFictif" transform="translate(41.0,276.0)"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="idnetwork2_95_vl_95_Wire0"/>
         <polyline class="wire wire_vl" points="45.0,145.0,45.0,34.0" id="idnetwork2_95_vl_95_Wire1"/>
-        <g class="ARROW1__95_l_UP" id="idnetwork2_95_vl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
+        <g class="ARROW1__95_l_DOWN" id="idnetwork2_95_vl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
      <g class="arrow-up" id="network2_idnetwork2_95_vl_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="network2_idnetwork2_95_vl_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2__95_l_UP" id="idnetwork2_95_vl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
+        <g class="ARROW2__95_l_DOWN" id="idnetwork2_95_vl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
      <g class="arrow-up" id="network2_idnetwork2_95_vl_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="network2_idnetwork2_95_vl_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="45.0,165.0,45.0,280.0" id="idnetwork2_95_vl_95_Wire2"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="idnetwork2_95_vl_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/TestVL.svg
+++ b/single-line-diagram-core/src/test/resources/TestVL.svg
@@ -124,23 +124,23 @@
         <g class="NODE idFICT_95_vl_95_dFictif" id="idFICT_95_vl_95_dFictif" transform="translate(41.0,276.0)"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,310.0" id="idvl_95_Wire0"/>
         <polyline class="wire wire_vl" points="45.0,145.0,45.0,34.0" id="idvl_95_Wire1"/>
-        <g class="ARROW1__95_l_UP" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
+        <g class="ARROW1__95_l_DOWN" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,40.0,120.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2__95_l_UP" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
+        <g class="ARROW2__95_l_DOWN" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,40.0,100.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="45.0,165.0,45.0,280.0" id="idvl_95_Wire2"/>
         <polyline class="wire wire_vl" points="45.0,310.0,45.0,280.0" id="idvl_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/nominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/nominalVoltage.svg
@@ -235,23 +235,23 @@
         <g class="NODE idFICT_95_vl_95_dFictif" id="idFICT_95_vl_95_dFictif" transform="translate(91.0,326.0)"/>
         <polyline class="wire wire_vl" points="95.0,360.0,95.0,360.0" id="idvl_95_Wire0"/>
         <polyline class="wire wire_vl" points="95.0,195.0,95.0,84.0" id="idvl_95_Wire1"/>
-        <g class="ARROW1__95_l_UP" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,90.0,170.0)">
+        <g class="ARROW1__95_l_DOWN" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,90.0,170.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2__95_l_UP" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,90.0,150.0)">
+        <g class="ARROW2__95_l_DOWN" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,90.0,150.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="95.0,215.0,95.0,330.0" id="idvl_95_Wire2"/>
         <polyline class="wire wire_vl" points="95.0,360.0,95.0,330.0" id="idvl_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/substDiag.svg
+++ b/single-line-diagram-core/src/test/resources/substDiag.svg
@@ -406,23 +406,23 @@
         <polyline class="wire wire_vl1" points="620.0,385.0,630.0,385.0" id="idvl1_95_Wire3"/>
         <polyline class="wire wire_vl1" points="95.0,360.0,95.0,360.0" id="idvl1_95_Wire4"/>
         <polyline class="wire wire_vl1" points="95.0,84.0,95.0,195.0" id="idvl1_95_Wire5"/>
-        <g class="ARROW1_load1_UP" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
+        <g class="ARROW1_load1_DOWN" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,90.0,99.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load1_UP" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
+        <g class="ARROW2_load1_DOWN" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,90.0,119.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="195.0,385.0,195.0,385.0" id="idvl1_95_Wire6"/>
         <polyline class="wire wire_vl1" points="195.0,659.0,195.0,550.0" id="idvl1_95_Wire7"/>
@@ -446,23 +446,23 @@
         </g>
         <polyline class="wire wire_vl1" points="645.0,360.0,645.0,360.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="645.0,84.0,645.0,195.0" id="idvl1_95_Wire9"/>
-        <g class="ARROW1_load2_UP" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,99.0)">
+        <g class="ARROW1_load2_DOWN" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,99.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load2_UP" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,119.0)">
+        <g class="ARROW2_load2_DOWN" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,119.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="895.0,385.0,895.0,385.0" id="idvl1_95_Wire10"/>
         <polyline class="wire wire_vl1" points="895.0,659.0,895.0,550.0" id="idvl1_95_Wire11"/>
@@ -1149,23 +1149,23 @@
         <polyline class="wire wire_vl2" points="1145.0,385.0,1145.0,385.0" id="idvl2_95_Wire1"/>
         <polyline class="wire wire_vl2" points="1195.0,360.0,1195.0,360.0" id="idvl2_95_Wire2"/>
         <polyline class="wire wire_vl2" points="1195.0,84.0,1195.0,195.0" id="idvl2_95_Wire3"/>
-        <g class="ARROW1_load3_UP" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1190.0,99.0)">
+        <g class="ARROW1_load3_DOWN" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1190.0,99.0)">
      <g class="arrow-up" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load3_UP" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1190.0,119.0)">
+        <g class="ARROW2_load3_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1190.0,119.0)">
      <g class="arrow-up" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl2" points="1295.0,385.0,1295.0,385.0" id="idvl2_95_Wire4"/>
         <polyline class="wire wire_vl2" points="1295.0,659.0,1295.0,550.0" id="idvl2_95_Wire5"/>
@@ -1663,23 +1663,23 @@
         <g class="NODE idFICT_95_vl3_95_dtrf38Fictif" id="idFICT_95_vl3_95_dtrf38Fictif" transform="translate(2266.0,326.0)"/>
         <polyline class="wire wire_vl3" points="1945.0,360.0,1945.0,360.0" id="idvl3_95_Wire0"/>
         <polyline class="wire wire_vl3" points="1945.0,195.0,1945.0,84.0" id="idvl3_95_Wire1"/>
-        <g class="ARROW1_load4_UP" id="idvl3_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,1940.0,170.0)">
+        <g class="ARROW1_load4_DOWN" id="idvl3_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,1940.0,170.0)">
      <g class="arrow-up" id="idvl3_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl3_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load4_UP" id="idvl3_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,1940.0,150.0)">
+        <g class="ARROW2_load4_DOWN" id="idvl3_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,1940.0,150.0)">
      <g class="arrow-up" id="idvl3_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl3_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl3" points="1995.0,360.0,1995.0,360.0" id="idvl3_95_Wire2"/>
         <polyline class="wire wire_vl3" points="1995.0,525.0,1995.0,636.0" id="idvl3_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/topological.svg
+++ b/single-line-diagram-core/src/test/resources/topological.svg
@@ -235,23 +235,23 @@
         <g class="NODE idFICT_95_vl_95_dFictif" id="idFICT_95_vl_95_dFictif" transform="translate(91.0,326.0)"/>
         <polyline class="wire wire_vl" points="95.0,360.0,95.0,360.0" id="idvl_95_Wire0"/>
         <polyline class="wire wire_vl" points="95.0,195.0,95.0,84.0" id="idvl_95_Wire1"/>
-        <g class="ARROW1__95_l_UP" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,90.0,170.0)">
+        <g class="ARROW1__95_l_DOWN" id="idvl_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,90.0,170.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2__95_l_UP" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,90.0,150.0)">
+        <g class="ARROW2__95_l_DOWN" id="idvl_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,90.0,150.0)">
      <g class="arrow-up" id="idvl_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl" points="95.0,215.0,95.0,330.0" id="idvl_95_Wire2"/>
         <polyline class="wire wire_vl" points="95.0,360.0,95.0,330.0" id="idvl_95_Wire3"/>

--- a/single-line-diagram-core/src/test/resources/vlDiag.svg
+++ b/single-line-diagram-core/src/test/resources/vlDiag.svg
@@ -263,23 +263,23 @@
         <polyline class="wire wire_vl1" points="820.0,335.0,830.0,335.0" id="idvl1_95_Wire3"/>
         <polyline class="wire wire_vl1" points="60.0,310.0,60.0,310.0" id="idvl1_95_Wire4"/>
         <polyline class="wire wire_vl1" points="60.0,34.0,60.0,145.0" id="idvl1_95_Wire5"/>
-        <g class="ARROW1_load1_UP" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,49.0)">
+        <g class="ARROW1_load1_DOWN" id="idvl1_95_Wire5_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,49.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load1_UP" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,69.0)">
+        <g class="ARROW2_load1_DOWN" id="idvl1_95_Wire5_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,69.0)">
      <g class="arrow-up" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire5_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="220.0,335.0,220.0,335.0" id="idvl1_95_Wire6"/>
         <polyline class="wire wire_vl1" points="220.0,609.0,220.0,500.0" id="idvl1_95_Wire7"/>
@@ -303,23 +303,23 @@
         </g>
         <polyline class="wire wire_vl1" points="860.0,310.0,860.0,310.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="860.0,34.0,860.0,145.0" id="idvl1_95_Wire9"/>
-        <g class="ARROW1_load2_UP" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,49.0)">
+        <g class="ARROW1_load2_DOWN" id="idvl1_95_Wire9_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,49.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
-        <g class="ARROW2_load2_UP" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,69.0)">
+        <g class="ARROW2_load2_DOWN" id="idvl1_95_Wire9_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,69.0)">
      <g class="arrow-up" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
      <g class="arrow-down" id="idvl1_95_Wire9_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">0</text>
         </g>
         <polyline class="wire wire_vl1" points="1260.0,335.0,1260.0,335.0" id="idvl1_95_Wire10"/>
         <polyline class="wire wire_vl1" points="1260.0,609.0,1260.0,500.0" id="idvl1_95_Wire11"/>


### PR DESCRIPTION
Providing an initial value for a dangling line, which was missing
Correction in providing an initial value for a load : we now get the calculated P and Q values from the terminal
Regenerating the svg test cases files

Signed-off-by: Franck LECUYER <franck.lecuyer@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
