### PR TITLE
correction_shift_feeders

### DIFF
--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesVoltageLevelLayout.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesVoltageLevelLayout.java
@@ -46,5 +46,8 @@ public class CgmesVoltageLevelLayout extends AbstractCgmesLayout implements Volt
         if (layoutParam.getScaleFactor() != 1) {
             graph.getNodes().forEach(node -> scaleNodeCoordinates(node, layoutParam.getScaleFactor()));
         }
+        if (layoutParam.isShiftFeedersPosition()) {
+            graph.shiftFeedersPosition(layoutParam.getScaleShiftFeedersPosition());
+        }
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalSubstationLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/HorizontalSubstationLayout.java
@@ -58,8 +58,10 @@ public class HorizontalSubstationLayout extends AbstractSubstationLayout {
 
         double x1 = node1.getX();
         double y1 = node1.getY();
+        double initY1 = node1.getInitY() != -1 ? node1.getInitY() : y1;
         double x2 = node2.getX();
         double y2 = node2.getY();
+        double initY2 = node2.getInitY() != -1 ? node2.getInitY() : y2;
 
         InfoCalcPoints info = new InfoCalcPoints();
         info.setLayoutParam(layoutParam);
@@ -70,7 +72,9 @@ public class HorizontalSubstationLayout extends AbstractSubstationLayout {
         info.setX1(x1);
         info.setX2(x2);
         info.setY1(y1);
+        info.setInitY1(initY1);
         info.setY2(y2);
+        info.setInitY2(initY2);
         info.setxMaxGraph(xMaxGraph);
         info.setIdMaxGraph(idMaxGraph);
         info.setIncrement(increment);
@@ -89,7 +93,9 @@ public class HorizontalSubstationLayout extends AbstractSubstationLayout {
         double x1 = info.getX1();
         double x2 = info.getX2();
         double y1 = info.getY1();
+        double initY1 = info.getInitY1();
         double y2 = info.getY2();
+        double initY2 = info.getInitY2();
         double xMaxGraph = info.getxMaxGraph();
         String idMaxGraph = info.getIdMaxGraph();
 
@@ -100,7 +106,7 @@ public class HorizontalSubstationLayout extends AbstractSubstationLayout {
                         nbSnakeLinesTopBottom.compute(dNode1, (k, v) -> v + 1);
                     }
                     double decalV = nbSnakeLinesTopBottom.get(dNode1) * layoutParam.getVerticalSnakeLinePadding();
-                    double yDecal = Math.max(y1 + decalV, y2 + decalV);
+                    double yDecal = Math.max(initY1 + decalV, initY2 + decalV);
 
                     pol.addAll(Arrays.asList(x1, y1,
                             x1, yDecal,
@@ -119,10 +125,10 @@ public class HorizontalSubstationLayout extends AbstractSubstationLayout {
                     double xBetweenGraph = xMaxGraph - (nbSnakeLinesBetween.get(idMaxGraph) * layoutParam.getHorizontalSnakeLinePadding());
 
                     pol.addAll(Arrays.asList(x1, y1,
-                            x1, y1 + decal1V,
-                            xBetweenGraph, y1 + decal1V,
-                            xBetweenGraph, y2 - decal2V,
-                            x2, y2 - decal2V,
+                            x1, initY1 + decal1V,
+                            xBetweenGraph, initY1 + decal1V,
+                            xBetweenGraph, initY2 - decal2V,
+                            x2, initY2 - decal2V,
                             x2, y2));
                 }
                 break;
@@ -133,7 +139,7 @@ public class HorizontalSubstationLayout extends AbstractSubstationLayout {
                         nbSnakeLinesTopBottom.compute(dNode1, (k, v) -> v + 1);
                     }
                     double decalV = nbSnakeLinesTopBottom.get(dNode1) * layoutParam.getVerticalSnakeLinePadding();
-                    double yDecal = Math.min(y1 - decalV, y2 - decalV);
+                    double yDecal = Math.min(initY1 - decalV, initY2 - decalV);
 
                     pol.addAll(Arrays.asList(x1, y1,
                             x1, yDecal,
@@ -151,10 +157,10 @@ public class HorizontalSubstationLayout extends AbstractSubstationLayout {
                     double xBetweenGraph = xMaxGraph - (nbSnakeLinesBetween.get(idMaxGraph) * layoutParam.getHorizontalSnakeLinePadding());
 
                     pol.addAll(Arrays.asList(x1, y1,
-                            x1, y1 - decal1V,
-                            xBetweenGraph, y1 - decal1V,
-                            xBetweenGraph, y2 + decal2V,
-                            x2, y2 + decal2V,
+                            x1, initY1 - decal1V,
+                            xBetweenGraph, initY1 - decal1V,
+                            xBetweenGraph, initY2 + decal2V,
+                            x2, initY2 + decal2V,
                             x2, y2));
                 }
                 break;

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/InfoCalcPoints.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/InfoCalcPoints.java
@@ -22,7 +22,9 @@ public class InfoCalcPoints {
     private double x1;
     private double x2;
     private double y1;
+    private double initY1;
     private double y2;
+    private double initY2;
     private double xMaxGraph;
     private String idMaxGraph;
     private boolean increment;
@@ -97,6 +99,22 @@ public class InfoCalcPoints {
 
     public void setY2(double y2) {
         this.y2 = y2;
+    }
+
+    public double getInitY1() {
+        return initY1;
+    }
+
+    public void setInitY1(double initY1) {
+        this.initY1 = initY1;
+    }
+
+    public double getInitY2() {
+        return initY2;
+    }
+
+    public void setInitY2(double initY2) {
+        this.initY2 = initY2;
     }
 
     public double getxMaxGraph() {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
@@ -40,6 +40,9 @@ public class PositionVoltageLevelLayout implements VoltageLevelLayout {
         graph.getNodes().stream()
                 .filter(node -> node.getType() != Node.NodeType.BUS)
                 .forEach(Node::finalizeCoord);
+        if (layoutParam.isShiftFeedersPosition()) {
+            graph.shiftFeedersPosition(layoutParam.getScaleShiftFeedersPosition());
+        }
     }
 
     private void calculateBusNodeCoord(Graph graph, LayoutParameters layoutParam) {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalSubstationLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalSubstationLayout.java
@@ -49,8 +49,10 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
 
         double x1 = node1.getX();
         double y1 = node1.getY();
+        double initY1 = node1.getInitY() != -1 ? node1.getInitY() : y1;
         double x2 = node2.getX();
         double y2 = node2.getY();
+        double initY2 = node2.getInitY() != -1 ? node2.getInitY() : y2;
 
         int maxH1 = node1.getGraph().getNodeBuses().stream()
                 .mapToInt(nodeBus -> nodeBus.getPosition().getH() + nodeBus.getPosition().getHSpan())
@@ -77,10 +79,10 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
                     double xSnakeLine = maxH + infosNbSnakeLines.getNbSnakeLinesLeftRight().get(Side.RIGHT) * layoutParam.getHorizontalSnakeLinePadding();
 
                     pol.addAll(Arrays.asList(x1, y1,
-                            x1, y1 + decal1V,
-                            xSnakeLine, y1 + decal1V,
-                            xSnakeLine, y2 + decal2V,
-                            x2, y2 + decal2V,
+                            x1, initY1 + decal1V,
+                            xSnakeLine, initY1 + decal1V,
+                            xSnakeLine, initY2 + decal2V,
+                            x2, initY2 + decal2V,
                             x2, y2));
                 } else {  // BOTTOM to TOP
                     if (!graph.graphAdjacents(node1.getGraph(), node2.getGraph())) {
@@ -94,10 +96,10 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
                         double xSnakeLine = maxH + infosNbSnakeLines.getNbSnakeLinesLeftRight().get(Side.RIGHT) * layoutParam.getHorizontalSnakeLinePadding();
 
                         pol.addAll(Arrays.asList(x1, y1,
-                                x1, y1 + decal1V,
-                                xSnakeLine, y1 + decal1V,
-                                xSnakeLine, y2 - decal2V,
-                                x2, y2 - decal2V,
+                                x1, initY1 + decal1V,
+                                xSnakeLine, initY1 + decal1V,
+                                xSnakeLine, initY2 - decal2V,
+                                x2, initY2 - decal2V,
                                 x2, y2));
                     } else {  // node1 and node2 adjacent and node1 before node2
                         if (increment) {
@@ -106,7 +108,7 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
                         }
                         double decal1V = infosNbSnakeLines.getNbSnakeLinesBottomVL().get(node1.getGraph().getVoltageLevelId()) * layoutParam.getVerticalSnakeLinePadding();
                         double decal2V = infosNbSnakeLines.getNbSnakeLinesTopVL().get(node2.getGraph().getVoltageLevelId()) * layoutParam.getVerticalSnakeLinePadding();
-                        double ySnakeLine = Math.max(y1 + decal1V, y2 - decal2V);
+                        double ySnakeLine = Math.max(initY1 + decal1V, initY2 - decal2V);
 
                         pol.addAll(Arrays.asList(x1, y1,
                                 x1, ySnakeLine,
@@ -128,10 +130,10 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
                     double xSnakeLine = xMinGraph - infosNbSnakeLines.getNbSnakeLinesLeftRight().get(Side.LEFT) * layoutParam.getHorizontalSnakeLinePadding();
 
                     pol.addAll(Arrays.asList(x1, y1,
-                            x1, y1 - decal1V,
-                            xSnakeLine, y1 - decal1V,
-                            xSnakeLine, y2 - decal2V,
-                            x2, y2 - decal2V,
+                            x1, initY1 - decal1V,
+                            xSnakeLine, initY1 - decal1V,
+                            xSnakeLine, initY2 - decal2V,
+                            x2, initY2 - decal2V,
                             x2, y2));
                 } else {  // TOP to BOTTOM
                     if (!graph.graphAdjacents(node2.getGraph(), node1.getGraph())) {
@@ -145,10 +147,10 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
                         double xSnakeLine = xMinGraph - infosNbSnakeLines.getNbSnakeLinesLeftRight().get(Side.LEFT) * layoutParam.getHorizontalSnakeLinePadding();
 
                         pol.addAll(Arrays.asList(x1, y1,
-                                x1, y1 - decal1V,
-                                xSnakeLine, y1 - decal1V,
-                                xSnakeLine, y2 + decal2V,
-                                x2, y2 + decal2V,
+                                x1, initY1 - decal1V,
+                                xSnakeLine, initY1 - decal1V,
+                                xSnakeLine, initY2 + decal2V,
+                                x2, initY2 + decal2V,
                                 x2, y2));
                     } else {  // node1 and node2 adjacent and node2 before node1
                         if (increment) {
@@ -157,7 +159,7 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
                         }
                         double decal1V = infosNbSnakeLines.getNbSnakeLinesTopVL().get(node1.getGraph().getVoltageLevelId()) * layoutParam.getVerticalSnakeLinePadding();
                         double decal2V = infosNbSnakeLines.getNbSnakeLinesBottomVL().get(node2.getGraph().getVoltageLevelId()) * layoutParam.getVerticalSnakeLinePadding();
-                        double ySnakeLine = Math.max(y1 - decal1V, y2 + decal2V);
+                        double ySnakeLine = Math.max(initY1 - decal1V, initY2 + decal2V);
 
                         pol.addAll(Arrays.asList(x1, y1,
                                 x1, ySnakeLine,

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Node.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Node.java
@@ -53,6 +53,8 @@ public class Node implements BaseNode {
     private boolean xPriority = false;
     private boolean yPriority = false;
 
+    private double initY = -1;
+
     private Cell cell;
 
     private Double rotationAngle;
@@ -218,6 +220,14 @@ public class Node implements BaseNode {
             this.y = yNode;
             ys.add(yNode);
         }
+    }
+
+    public double getInitY() {
+        return initY;
+    }
+
+    public void setInitY(double initY) {
+        this.initY = initY;
     }
 
     public NodeType getType() {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestShiftFeedersPosition.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestShiftFeedersPosition.java
@@ -87,9 +87,15 @@ public class TestShiftFeedersPosition extends AbstractTestCase {
         // build substation graph
         SubstationGraph g = graphBuilder.buildSubstationGraph(substation.getId(), false);
 
-        // write Json and compare to reference (with horizontal substation layout)
+        // write Json and compare to reference (with no shift feeder height and horizontal substation layout)
         new HorizontalSubstationLayoutFactory().create(g, new PositionVoltageLevelLayoutFactory()).run(layoutParameters);
         assertEquals(toJson(g, "/TestDefaultFeedersPosition.json"), toString("/TestDefaultFeedersPosition.json"));
+
+        // write Json and compare to reference (with shift feeder height and horizontal substation layout)
+        LayoutParameters layoutParameters2 = new LayoutParameters(layoutParameters);
+        layoutParameters2.setShiftFeedersPosition(true);
+        new HorizontalSubstationLayoutFactory().create(g, new PositionVoltageLevelLayoutFactory()).run(layoutParameters2);
+        assertEquals(toJson(g, "/TestShiftFeedersPosition.json"), toString("/TestShiftFeedersPosition.json"));
     }
 
     @Test

--- a/single-line-diagram-core/src/test/resources/TestShiftFeedersPosition.json
+++ b/single-line-diagram-core/src/test/resources/TestShiftFeedersPosition.json
@@ -1,0 +1,2047 @@
+[ {
+  "id" : "vl1",
+  "x" : 50.0,
+  "y" : 50.0,
+  "cells" : [ {
+    "type" : "INTERN",
+    "number" : 0,
+    "direction" : "FLAT",
+    "direction" : "FLAT",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0,
+        "orientation" : "HORIZONTAL"
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 4,
+          "v" : 0,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "HORIZONTAL"
+        },
+        "coord" : {
+          "x" : 200.0,
+          "y" : 235.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs1",
+          "name" : "bbs1",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 60.0,
+          "y" : 310.0,
+          "open" : false,
+          "pxWidth" : 180.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 1,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 1,
+            "hSpan" : 4,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dsect11",
+          "name" : "dsect11",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 216.66666666666666,
+          "y" : 310.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect11Fictif",
+          "name" : "dsect11Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 250.0,
+          "y" : 310.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "HORIZONTAL"
+        },
+        "coord" : {
+          "x" : -1.0,
+          "y" : -1.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect11Fictif",
+          "name" : "dsect11Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 250.0,
+          "y" : 310.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "dtrct11",
+          "name" : "dtrct11",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 241.66666666666666,
+          "y" : 310.0,
+          "rotationAngle" : 90.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect12Fictif",
+          "name" : "dsect12Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 300.0,
+          "y" : 310.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 5,
+          "v" : 2,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "HORIZONTAL"
+        },
+        "coord" : {
+          "x" : 250.0,
+          "y" : 285.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs2",
+          "name" : "bbs2",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 210.0,
+          "y" : 310.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 2,
+            "v" : 1,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 3,
+            "v" : 1,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dsect12",
+          "name" : "dsect12",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 266.6666666666667,
+          "y" : 310.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect12Fictif",
+          "name" : "dsect12Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 300.0,
+          "y" : 310.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "INTERN",
+    "number" : 1,
+    "direction" : "FLAT",
+    "direction" : "FLAT",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0,
+        "orientation" : "HORIZONTAL"
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 4,
+          "v" : 0,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "HORIZONTAL"
+        },
+        "coord" : {
+          "x" : 200.0,
+          "y" : 235.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs3",
+          "name" : "bbs3",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 60.0,
+          "y" : 335.0,
+          "open" : false,
+          "pxWidth" : 180.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 2,
+            "hSpan" : 4,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dsect21",
+          "name" : "dsect21",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 216.66666666666666,
+          "y" : 335.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect21Fictif",
+          "name" : "dsect21Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 250.0,
+          "y" : 335.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "HORIZONTAL"
+        },
+        "coord" : {
+          "x" : -1.0,
+          "y" : -1.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect21Fictif",
+          "name" : "dsect21Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 250.0,
+          "y" : 335.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "dtrct21",
+          "name" : "dtrct21",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 241.66666666666666,
+          "y" : 335.0,
+          "rotationAngle" : 90.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect22Fictif",
+          "name" : "dsect22Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 300.0,
+          "y" : 335.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 5,
+          "v" : 2,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "HORIZONTAL"
+        },
+        "coord" : {
+          "x" : 250.0,
+          "y" : 285.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs4",
+          "name" : "bbs4",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 210.0,
+          "y" : 335.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 2,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 3,
+            "v" : 2,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dsect22",
+          "name" : "dsect22",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 266.6666666666667,
+          "y" : 335.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect22Fictif",
+          "name" : "dsect22Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 300.0,
+          "y" : 335.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 2,
+    "direction" : "TOP",
+    "direction" : "TOP",
+    "order" : 0,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 0,
+        "v" : 0,
+        "hSpan" : 1,
+        "vSpan" : 2,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 25.0,
+        "y" : 105.0,
+        "xSpan" : 50.0,
+        "ySpan" : 250.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 230.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs1",
+          "name" : "bbs1",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 60.0,
+          "y" : 310.0,
+          "open" : false,
+          "pxWidth" : 180.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 1,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 1,
+            "hSpan" : 4,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dload1",
+          "name" : "dload1",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 91.66666666666667,
+          "y" : 310.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dload1Fictif",
+          "name" : "dload1Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 100.0,
+          "y" : 280.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 105.0,
+          "xSpan" : 50.0,
+          "ySpan" : 250.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dload1Fictif",
+          "name" : "dload1Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 100.0,
+          "y" : 280.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "bload1",
+          "name" : "bload1",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 91.66666666666667,
+          "y" : 155.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "load1",
+          "name" : "load1",
+          "componentType" : "LOAD",
+          "fictitious" : false,
+          "x" : 91.66666666666667,
+          "y" : 30.0,
+          "open" : false,
+          "label" : "load1",
+          "order" : 0,
+          "direction" : "TOP"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 3,
+    "direction" : "TOP",
+    "direction" : "TOP",
+    "order" : 2,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 5,
+        "v" : 0,
+        "hSpan" : 1,
+        "vSpan" : 2,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 275.0,
+        "y" : 105.0,
+        "xSpan" : 50.0,
+        "ySpan" : 250.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 275.0,
+          "y" : 230.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs2",
+          "name" : "bbs2",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 210.0,
+          "y" : 310.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 2,
+            "v" : 1,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 3,
+            "v" : 1,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dload2",
+          "name" : "dload2",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 308.3333333333333,
+          "y" : 310.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dload2Fictif",
+          "name" : "dload2Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 350.0,
+          "y" : 280.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 275.0,
+          "y" : 105.0,
+          "xSpan" : 50.0,
+          "ySpan" : 250.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dload2Fictif",
+          "name" : "dload2Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 350.0,
+          "y" : 280.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "bload2",
+          "name" : "bload2",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 308.3333333333333,
+          "y" : 155.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "load2",
+          "name" : "load2",
+          "componentType" : "LOAD",
+          "fictitious" : false,
+          "x" : 308.3333333333333,
+          "y" : 38.0,
+          "open" : false,
+          "label" : "load2",
+          "order" : 2,
+          "direction" : "TOP"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 4,
+    "direction" : "BOTTOM",
+    "direction" : "BOTTOM",
+    "order" : 1,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 2,
+        "v" : 0,
+        "hSpan" : 1,
+        "vSpan" : 2,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 125.0,
+        "y" : 440.0,
+        "xSpan" : 50.0,
+        "ySpan" : 250.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 315.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs3",
+          "name" : "bbs3",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 60.0,
+          "y" : 335.0,
+          "open" : false,
+          "pxWidth" : 180.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 2,
+            "hSpan" : 4,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dgen1",
+          "name" : "dgen1",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 175.0,
+          "y" : 335.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dgen1Fictif",
+          "name" : "dgen1Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 200.0,
+          "y" : 365.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 440.0,
+          "xSpan" : 50.0,
+          "ySpan" : 250.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dgen1Fictif",
+          "name" : "dgen1Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 200.0,
+          "y" : 365.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "bgen1",
+          "name" : "bgen1",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 175.0,
+          "y" : 490.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "gen1",
+          "name" : "gen1",
+          "componentType" : "GENERATOR",
+          "fictitious" : false,
+          "x" : 175.0,
+          "y" : 615.0,
+          "open" : false,
+          "label" : "gen1",
+          "order" : 1,
+          "direction" : "BOTTOM"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 5,
+    "direction" : "BOTTOM",
+    "direction" : "BOTTOM",
+    "order" : 3,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 7,
+        "v" : 0,
+        "hSpan" : 1,
+        "vSpan" : 2,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 375.0,
+        "y" : 440.0,
+        "xSpan" : 50.0,
+        "ySpan" : 250.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 375.0,
+          "y" : 315.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs4",
+          "name" : "bbs4",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 210.0,
+          "y" : 335.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 2,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 3,
+            "v" : 2,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dgen2",
+          "name" : "dgen2",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 391.6666666666667,
+          "y" : 335.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dgen2Fictif",
+          "name" : "dgen2Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 450.0,
+          "y" : 365.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 375.0,
+          "y" : 440.0,
+          "xSpan" : 50.0,
+          "ySpan" : 250.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dgen2Fictif",
+          "name" : "dgen2Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 450.0,
+          "y" : 365.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "bgen2",
+          "name" : "bgen2",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 391.6666666666667,
+          "y" : 490.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "gen2",
+          "name" : "gen2",
+          "componentType" : "GENERATOR",
+          "fictitious" : false,
+          "x" : 391.6666666666667,
+          "y" : 607.0,
+          "open" : false,
+          "label" : "gen2",
+          "order" : 3,
+          "direction" : "BOTTOM"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "INTERN",
+    "number" : 6,
+    "direction" : "FLAT",
+    "direction" : "FLAT",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0,
+        "orientation" : "HORIZONTAL"
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 4,
+          "v" : 0,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "HORIZONTAL"
+        },
+        "coord" : {
+          "x" : 200.0,
+          "y" : 235.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs1",
+          "name" : "bbs1",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 60.0,
+          "y" : 310.0,
+          "open" : false,
+          "pxWidth" : 180.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 1,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 1,
+            "hSpan" : 4,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dsect11",
+          "name" : "dsect11",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 216.66666666666666,
+          "y" : 310.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect11Fictif",
+          "name" : "dsect11Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 250.0,
+          "y" : 310.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "HORIZONTAL"
+        },
+        "coord" : {
+          "x" : -1.0,
+          "y" : -1.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect11Fictif",
+          "name" : "dsect11Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 250.0,
+          "y" : 310.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "dtrct11",
+          "name" : "dtrct11",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 241.66666666666666,
+          "y" : 310.0,
+          "rotationAngle" : 90.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect12Fictif",
+          "name" : "dsect12Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 300.0,
+          "y" : 310.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 5,
+          "v" : 2,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "HORIZONTAL"
+        },
+        "coord" : {
+          "x" : 250.0,
+          "y" : 285.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs2",
+          "name" : "bbs2",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 210.0,
+          "y" : 310.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 2,
+            "v" : 1,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 3,
+            "v" : 1,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dsect12",
+          "name" : "dsect12",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 266.6666666666667,
+          "y" : 310.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect12Fictif",
+          "name" : "dsect12Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 300.0,
+          "y" : 310.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "INTERN",
+    "number" : 7,
+    "direction" : "FLAT",
+    "direction" : "FLAT",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0,
+        "orientation" : "HORIZONTAL"
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 4,
+          "v" : 0,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "HORIZONTAL"
+        },
+        "coord" : {
+          "x" : 200.0,
+          "y" : 235.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs3",
+          "name" : "bbs3",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 60.0,
+          "y" : 335.0,
+          "open" : false,
+          "pxWidth" : 180.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 2,
+            "hSpan" : 4,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dsect21",
+          "name" : "dsect21",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 216.66666666666666,
+          "y" : 335.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect21Fictif",
+          "name" : "dsect21Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 250.0,
+          "y" : 335.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "HORIZONTAL"
+        },
+        "coord" : {
+          "x" : -1.0,
+          "y" : -1.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect21Fictif",
+          "name" : "dsect21Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 250.0,
+          "y" : 335.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "dtrct21",
+          "name" : "dtrct21",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 241.66666666666666,
+          "y" : 335.0,
+          "rotationAngle" : 90.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect22Fictif",
+          "name" : "dsect22Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 300.0,
+          "y" : 335.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 5,
+          "v" : 2,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "HORIZONTAL"
+        },
+        "coord" : {
+          "x" : 250.0,
+          "y" : 285.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs4",
+          "name" : "bbs4",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 210.0,
+          "y" : 335.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 2,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 3,
+            "v" : 2,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dsect22",
+          "name" : "dsect22",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 266.6666666666667,
+          "y" : 335.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dsect22Fictif",
+          "name" : "dsect22Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 300.0,
+          "y" : 335.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 8,
+    "direction" : "TOP",
+    "direction" : "TOP",
+    "order" : 0,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 1,
+        "v" : 0,
+        "hSpan" : 1,
+        "vSpan" : 2,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 75.0,
+        "y" : 105.0,
+        "xSpan" : 50.0,
+        "ySpan" : 250.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 230.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs1",
+          "name" : "bbs1",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 60.0,
+          "y" : 310.0,
+          "open" : false,
+          "pxWidth" : 180.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 1,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 1,
+            "hSpan" : 4,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dload1",
+          "name" : "dload1",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 91.66666666666667,
+          "y" : 310.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dload1Fictif",
+          "name" : "dload1Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 100.0,
+          "y" : 280.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 105.0,
+          "xSpan" : 50.0,
+          "ySpan" : 250.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dload1Fictif",
+          "name" : "dload1Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 100.0,
+          "y" : 280.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "bload1",
+          "name" : "bload1",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 91.66666666666667,
+          "y" : 155.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "load1",
+          "name" : "load1",
+          "componentType" : "LOAD",
+          "fictitious" : false,
+          "x" : 91.66666666666667,
+          "y" : 30.0,
+          "open" : false,
+          "label" : "load1",
+          "order" : 0,
+          "direction" : "TOP"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 9,
+    "direction" : "TOP",
+    "direction" : "TOP",
+    "order" : 2,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 6,
+        "v" : 0,
+        "hSpan" : 1,
+        "vSpan" : 2,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 325.0,
+        "y" : 105.0,
+        "xSpan" : 50.0,
+        "ySpan" : 250.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 325.0,
+          "y" : 230.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs2",
+          "name" : "bbs2",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 210.0,
+          "y" : 310.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 2,
+            "v" : 1,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 3,
+            "v" : 1,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dload2",
+          "name" : "dload2",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 308.3333333333333,
+          "y" : 310.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dload2Fictif",
+          "name" : "dload2Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 350.0,
+          "y" : 280.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 325.0,
+          "y" : 105.0,
+          "xSpan" : 50.0,
+          "ySpan" : 250.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dload2Fictif",
+          "name" : "dload2Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 350.0,
+          "y" : 280.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "bload2",
+          "name" : "bload2",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 308.3333333333333,
+          "y" : 155.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "load2",
+          "name" : "load2",
+          "componentType" : "LOAD",
+          "fictitious" : false,
+          "x" : 308.3333333333333,
+          "y" : 38.0,
+          "open" : false,
+          "label" : "load2",
+          "order" : 2,
+          "direction" : "TOP"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 10,
+    "direction" : "BOTTOM",
+    "direction" : "BOTTOM",
+    "order" : 1,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 3,
+        "v" : 0,
+        "hSpan" : 1,
+        "vSpan" : 2,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 175.0,
+        "y" : 440.0,
+        "xSpan" : 50.0,
+        "ySpan" : 250.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 175.0,
+          "y" : 315.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs3",
+          "name" : "bbs3",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 60.0,
+          "y" : 335.0,
+          "open" : false,
+          "pxWidth" : 180.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 2,
+            "hSpan" : 4,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dgen1",
+          "name" : "dgen1",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 175.0,
+          "y" : 335.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dgen1Fictif",
+          "name" : "dgen1Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 200.0,
+          "y" : 365.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 175.0,
+          "y" : 440.0,
+          "xSpan" : 50.0,
+          "ySpan" : 250.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dgen1Fictif",
+          "name" : "dgen1Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 200.0,
+          "y" : 365.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "bgen1",
+          "name" : "bgen1",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 175.0,
+          "y" : 490.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "gen1",
+          "name" : "gen1",
+          "componentType" : "GENERATOR",
+          "fictitious" : false,
+          "x" : 175.0,
+          "y" : 615.0,
+          "open" : false,
+          "label" : "gen1",
+          "order" : 1,
+          "direction" : "BOTTOM"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 11,
+    "direction" : "BOTTOM",
+    "direction" : "BOTTOM",
+    "order" : 3,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 8,
+        "v" : 0,
+        "hSpan" : 1,
+        "vSpan" : 2,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 425.0,
+        "y" : 440.0,
+        "xSpan" : 50.0,
+        "ySpan" : 250.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 425.0,
+          "y" : 315.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs4",
+          "name" : "bbs4",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 210.0,
+          "y" : 335.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 2,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 3,
+            "v" : 2,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "dgen2",
+          "name" : "dgen2",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 391.6666666666667,
+          "y" : 335.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dgen2Fictif",
+          "name" : "dgen2Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 450.0,
+          "y" : 365.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 425.0,
+          "y" : 440.0,
+          "xSpan" : 50.0,
+          "ySpan" : 250.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl1_dgen2Fictif",
+          "name" : "dgen2Fictif",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 450.0,
+          "y" : 365.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "bgen2",
+          "name" : "bgen2",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 391.6666666666667,
+          "y" : 490.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "gen2",
+          "name" : "gen2",
+          "componentType" : "GENERATOR",
+          "fictitious" : false,
+          "x" : 391.6666666666667,
+          "y" : 607.0,
+          "open" : false,
+          "label" : "gen2",
+          "order" : 3,
+          "direction" : "BOTTOM"
+        } ]
+      } ]
+    }
+  } ],
+  "edges" : [ {
+    "node1" : "bbs1",
+    "node2" : "dsect11"
+  }, {
+    "node1" : "dsect12",
+    "node2" : "bbs2"
+  }, {
+    "node1" : "bbs3",
+    "node2" : "dsect21"
+  }, {
+    "node1" : "dsect22",
+    "node2" : "bbs4"
+  }, {
+    "node1" : "bbs1",
+    "node2" : "dload1"
+  }, {
+    "node1" : "load1",
+    "node2" : "bload1"
+  }, {
+    "node1" : "bbs3",
+    "node2" : "dgen1"
+  }, {
+    "node1" : "gen1",
+    "node2" : "bgen1"
+  }, {
+    "node1" : "bbs2",
+    "node2" : "dload2"
+  }, {
+    "node1" : "load2",
+    "node2" : "bload2"
+  }, {
+    "node1" : "bbs4",
+    "node2" : "dgen2"
+  }, {
+    "node1" : "gen2",
+    "node2" : "bgen2"
+  }, {
+    "node1" : "dtrct11",
+    "node2" : "FICT_vl1_dsect11Fictif"
+  }, {
+    "node1" : "dsect11",
+    "node2" : "FICT_vl1_dsect11Fictif"
+  }, {
+    "node1" : "bload1",
+    "node2" : "FICT_vl1_dload1Fictif"
+  }, {
+    "node1" : "dload1",
+    "node2" : "FICT_vl1_dload1Fictif"
+  }, {
+    "node1" : "dtrct11",
+    "node2" : "FICT_vl1_dsect12Fictif"
+  }, {
+    "node1" : "dsect12",
+    "node2" : "FICT_vl1_dsect12Fictif"
+  }, {
+    "node1" : "bload2",
+    "node2" : "FICT_vl1_dload2Fictif"
+  }, {
+    "node1" : "dload2",
+    "node2" : "FICT_vl1_dload2Fictif"
+  }, {
+    "node1" : "dtrct21",
+    "node2" : "FICT_vl1_dsect21Fictif"
+  }, {
+    "node1" : "dsect21",
+    "node2" : "FICT_vl1_dsect21Fictif"
+  }, {
+    "node1" : "bgen1",
+    "node2" : "FICT_vl1_dgen1Fictif"
+  }, {
+    "node1" : "dgen1",
+    "node2" : "FICT_vl1_dgen1Fictif"
+  }, {
+    "node1" : "dtrct21",
+    "node2" : "FICT_vl1_dsect22Fictif"
+  }, {
+    "node1" : "dsect22",
+    "node2" : "FICT_vl1_dsect22Fictif"
+  }, {
+    "node1" : "bgen2",
+    "node2" : "FICT_vl1_dgen2Fictif"
+  }, {
+    "node1" : "dgen2",
+    "node2" : "FICT_vl1_dgen2Fictif"
+  } ]
+} ]


### PR DESCRIPTION
Moving the shift feeders height functionality from SVGWriter processing to the layout application processing
Saving the initial feeder node height during the height shifting process
Changing the computation of the snake lines coordinates (we need to use both old and new height feeder node position)

Signed-off-by: Franck LECUYER <franck.lecuyer@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
