### PR TITLE
don't query the tstore for DL data,  when the DL profile is missing

### DIFF
--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImportPostProcessorTest.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImportPostProcessorTest.java
@@ -6,9 +6,6 @@
  */
 package com.powsybl.sld.cgmes.dl.conversion;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import org.junit.Test;
 
 import com.powsybl.cgmes.conversion.Profiling;
@@ -16,6 +13,12 @@ import com.powsybl.sld.cgmes.dl.iidm.extensions.Networks;
 import com.powsybl.sld.cgmes.dl.iidm.extensions.NodeDiagramData;
 import com.powsybl.iidm.network.BusbarSection;
 import com.powsybl.iidm.network.Network;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.junit.Assert.*;
 
 /**
  *
@@ -39,5 +42,13 @@ public class CgmesDLImportPostProcessorTest extends CgmesDLModelTest  {
         assertEquals(2, nodeDiagramDataDetails.getPoint2().getSeq(), 0);
         assertEquals(20, nodeDiagramDataDetails.getPoint2().getX(), 0);
         assertEquals(40, nodeDiagramDataDetails.getPoint2().getY(), 0);
+    }
+
+    @Test
+    public void processNoDlContext() {
+        Network network = Networks.createNetworkWithBusbar();
+        Mockito.when(tripleStore.contextNames()).thenReturn(new HashSet<>(Arrays.asList("Network_EQ.xml", "Network_SV.xml", "Network_TP.xml")));
+        new CgmesDLImportPostProcessor(queryCatalog).process(network, tripleStore, new Profiling());
+        assertNull(network.getBusbarSection("Busbar").getExtension(NodeDiagramData.class));
     }
 }

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLModelTest.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLModelTest.java
@@ -16,6 +16,9 @@ import com.powsybl.triplestore.api.PropertyBags;
 import com.powsybl.triplestore.api.QueryCatalog;
 import com.powsybl.triplestore.api.TripleStore;
 
+import java.util.Arrays;
+import java.util.HashSet;
+
 /**
  *
  * @author Massimo Ferraro <massimo.ferraro@techrain.eu>
@@ -44,6 +47,7 @@ public class CgmesDLModelTest extends AbstractCgmesDLTest {
         setQuery(CgmesDLModel.SVC_DIAGRAM_DATA_QUERY_KEY, "SvcLineQuery", svcsPropertyBags);
         setQuery(CgmesDLModel.TERMINALS_QUERY_KEY, "TerminalsQuery", terminals);
         setQuery(CgmesDLModel.BUSBAR_NODES_QUERY_KEY, "BusbarNodesQuery", busbarNodes);
+        Mockito.when(tripleStore.contextNames()).thenReturn(new HashSet<>(Arrays.asList("Network_EQ.xml", "Network_SV.xml", "Network_TP.xml", "Network_DL.xml")));
         cgmesDLModel = new CgmesDLModel(tripleStore, queryCatalog);
     }
 


### PR DESCRIPTION
Signed-off-by: Christian Biasuzzi <christian.biasuzzi@techrain.eu>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#79 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
bug fix


**What is the current behavior?** *(You can also link to an open issue here)*

#79 

**What is the new behavior (if this is a feature change)?**


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
