### PR TITLE
Fix DL import of multiple diagrams

### DIFF
--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImporter.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImporter.java
@@ -68,7 +68,7 @@ public class CgmesDLImporter {
         LOG.info("Importing Terminals DL Data");
         profiling.start();
         cgmesDLModel.getTerminalsDiagramData().forEach(terminalDiagramData -> {
-            String terminalKey = terminalDiagramData.getId("terminalEquipment") + "_" + terminalDiagramData.get("terminalSide");
+            String terminalKey = terminalDiagramData.get("diagramName") + "_" + terminalDiagramData.getId("terminalEquipment") + "_" + terminalDiagramData.get("terminalSide");
             PropertyBags equipmentTerminalsDiagramData = new PropertyBags();
             if (terminalsDiagramData.containsKey(terminalKey)) {
                 equipmentTerminalsDiagramData = terminalsDiagramData.get(terminalKey);

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/AbstractCouplingDeviceDiagramDataImporter.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/AbstractCouplingDeviceDiagramDataImporter.java
@@ -34,8 +34,8 @@ public abstract class AbstractCouplingDeviceDiagramDataImporter {
         this.terminalsDiagramData = Objects.requireNonNull(terminalsDiagramData);
     }
 
-    protected void addTerminalPoints(String equipmentId, String equipmentName, DiagramTerminal terminal, String terminalSide, CouplingDeviceDiagramData.CouplingDeviceDiagramDetails diagramDetails) {
-        String terminalKey = equipmentId + "_" + terminalSide;
+    protected void addTerminalPoints(String equipmentId, String equipmentName, String diagram, DiagramTerminal terminal, String terminalSide, CouplingDeviceDiagramData.CouplingDeviceDiagramDetails diagramDetails) {
+        String terminalKey = diagram + "_" + equipmentId + "_" + terminalSide;
         if (terminalsDiagramData.containsKey(terminalKey)) {
             PropertyBags equipmentTerminalsDiagramData = terminalsDiagramData.get(terminalKey);
             equipmentTerminalsDiagramData.forEach(terminalDiagramData ->

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/AbstractInjectionDiagramDataImporter.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/AbstractInjectionDiagramDataImporter.java
@@ -33,8 +33,8 @@ public abstract class AbstractInjectionDiagramDataImporter {
         this.terminalsDiagramData = Objects.requireNonNull(terminalsDiagramData);
     }
 
-    protected void addTerminalPoints(String equipmentId, String equipmentName, InjectionDiagramData.InjectionDiagramDetails diagramDetails) {
-        String terminalKey = equipmentId + "_1";
+    protected void addTerminalPoints(String equipmentId, String equipmentName, String diagram, InjectionDiagramData.InjectionDiagramDetails diagramDetails) {
+        String terminalKey = diagram + "_" + equipmentId + "_1";
         if (terminalsDiagramData.containsKey(terminalKey)) {
             PropertyBags equipmentTerminalsDiagramData = terminalsDiagramData.get(terminalKey);
             equipmentTerminalsDiagramData.forEach(terminalDiagramData ->

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/LoadDiagramDataImporter.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/LoadDiagramDataImporter.java
@@ -9,14 +9,14 @@ package com.powsybl.sld.cgmes.dl.conversion.importers;
 import java.util.Map;
 import java.util.Objects;
 
-import com.powsybl.sld.cgmes.dl.iidm.extensions.NetworkDiagramData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.powsybl.sld.cgmes.dl.iidm.extensions.DiagramPoint;
-import com.powsybl.sld.cgmes.dl.iidm.extensions.InjectionDiagramData;
 import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.sld.cgmes.dl.iidm.extensions.DiagramPoint;
+import com.powsybl.sld.cgmes.dl.iidm.extensions.InjectionDiagramData;
+import com.powsybl.sld.cgmes.dl.iidm.extensions.NetworkDiagramData;
 import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
 
@@ -37,10 +37,13 @@ public class LoadDiagramDataImporter extends AbstractInjectionDiagramDataImporte
         String loadId = loadDiagramData.getId("identifiedObject");
         Load load = network.getLoad(loadId);
         if (load != null) {
-            InjectionDiagramData<Load> loadIidmDiagramData = new InjectionDiagramData<>(load);
+            InjectionDiagramData<Load> loadIidmDiagramData = load.getExtension(InjectionDiagramData.class);
+            if (loadIidmDiagramData == null) {
+                loadIidmDiagramData = new InjectionDiagramData<>(load);
+            }
             InjectionDiagramData.InjectionDiagramDetails diagramDetails = loadIidmDiagramData.new InjectionDiagramDetails(new DiagramPoint(loadDiagramData.asDouble("x"), loadDiagramData.asDouble("y"), loadDiagramData.asInt("seq")),
                     loadDiagramData.asDouble("rotation"));
-            addTerminalPoints(loadId, load.getName(), diagramDetails);
+            addTerminalPoints(loadId, load.getName(), loadDiagramData.get("diagramName"), diagramDetails);
             loadIidmDiagramData.addData(loadDiagramData.get("diagramName"), diagramDetails);
             load.addExtension(InjectionDiagramData.class, loadIidmDiagramData);
             NetworkDiagramData.addDiagramName(network, loadDiagramData.get("diagramName"));

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/ShuntDiagramDataImporter.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/ShuntDiagramDataImporter.java
@@ -9,14 +9,14 @@ package com.powsybl.sld.cgmes.dl.conversion.importers;
 import java.util.Map;
 import java.util.Objects;
 
-import com.powsybl.sld.cgmes.dl.iidm.extensions.NetworkDiagramData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.powsybl.sld.cgmes.dl.iidm.extensions.DiagramPoint;
-import com.powsybl.sld.cgmes.dl.iidm.extensions.InjectionDiagramData;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ShuntCompensator;
+import com.powsybl.sld.cgmes.dl.iidm.extensions.DiagramPoint;
+import com.powsybl.sld.cgmes.dl.iidm.extensions.InjectionDiagramData;
+import com.powsybl.sld.cgmes.dl.iidm.extensions.NetworkDiagramData;
 import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
 
@@ -37,10 +37,13 @@ public class ShuntDiagramDataImporter extends AbstractInjectionDiagramDataImport
         String shuntId = shuntDiagramData.getId("identifiedObject");
         ShuntCompensator shunt = network.getShuntCompensator(shuntId);
         if (shunt != null) {
-            InjectionDiagramData<ShuntCompensator> shuntIidmDiagramData = new InjectionDiagramData<>(shunt);
+            InjectionDiagramData<ShuntCompensator> shuntIidmDiagramData = shunt.getExtension(InjectionDiagramData.class);
+            if (shuntIidmDiagramData == null) {
+                shuntIidmDiagramData = new InjectionDiagramData<>(shunt);
+            }
             InjectionDiagramData.InjectionDiagramDetails diagramDetails = shuntIidmDiagramData.new InjectionDiagramDetails(new DiagramPoint(shuntDiagramData.asDouble("x"), shuntDiagramData.asDouble("y"), shuntDiagramData.asInt("seq")),
                     shuntDiagramData.asDouble("rotation"));
-            addTerminalPoints(shuntId, shunt.getName(), diagramDetails);
+            addTerminalPoints(shuntId, shunt.getName(), shuntDiagramData.get("diagramName"), diagramDetails);
             shuntIidmDiagramData.addData(shuntDiagramData.get("diagramName"), diagramDetails);
             shunt.addExtension(InjectionDiagramData.class, shuntIidmDiagramData);
             NetworkDiagramData.addDiagramName(network, shuntDiagramData.get("diagramName"));

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/SvcDiagramDataImporter.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/SvcDiagramDataImporter.java
@@ -9,14 +9,14 @@ package com.powsybl.sld.cgmes.dl.conversion.importers;
 import java.util.Map;
 import java.util.Objects;
 
-import com.powsybl.sld.cgmes.dl.iidm.extensions.NetworkDiagramData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.powsybl.sld.cgmes.dl.iidm.extensions.DiagramPoint;
-import com.powsybl.sld.cgmes.dl.iidm.extensions.InjectionDiagramData;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.StaticVarCompensator;
+import com.powsybl.sld.cgmes.dl.iidm.extensions.DiagramPoint;
+import com.powsybl.sld.cgmes.dl.iidm.extensions.InjectionDiagramData;
+import com.powsybl.sld.cgmes.dl.iidm.extensions.NetworkDiagramData;
 import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
 
@@ -37,10 +37,13 @@ public class SvcDiagramDataImporter extends AbstractInjectionDiagramDataImporter
         String svcId = svcDiagramData.getId("identifiedObject");
         StaticVarCompensator svc = network.getStaticVarCompensator(svcId);
         if (svc != null) {
-            InjectionDiagramData<StaticVarCompensator> svcIidmDiagramData = new InjectionDiagramData<>(svc);
+            InjectionDiagramData<StaticVarCompensator> svcIidmDiagramData = svc.getExtension(InjectionDiagramData.class);
+            if (svcIidmDiagramData == null) {
+                svcIidmDiagramData = new InjectionDiagramData<>(svc);
+            }
             InjectionDiagramData.InjectionDiagramDetails diagramDetails = svcIidmDiagramData.new InjectionDiagramDetails(new DiagramPoint(svcDiagramData.asDouble("x"), svcDiagramData.asDouble("y"), svcDiagramData.asInt("seq")),
                     svcDiagramData.asDouble("rotation"));
-            addTerminalPoints(svcId, svc.getName(), diagramDetails);
+            addTerminalPoints(svcId, svc.getName(), svcDiagramData.get("diagramName"), diagramDetails);
             svcIidmDiagramData.addData(svcDiagramData.get("diagramName"), diagramDetails);
             svc.addExtension(InjectionDiagramData.class, svcIidmDiagramData);
             NetworkDiagramData.addDiagramName(network, svcDiagramData.get("diagramName"));

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/SwitchDiagramDataImporter.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/java/com/powsybl/sld/cgmes/dl/conversion/importers/SwitchDiagramDataImporter.java
@@ -9,15 +9,15 @@ package com.powsybl.sld.cgmes.dl.conversion.importers;
 import java.util.Map;
 import java.util.Objects;
 
-import com.powsybl.sld.cgmes.dl.iidm.extensions.NetworkDiagramData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Switch;
 import com.powsybl.sld.cgmes.dl.iidm.extensions.CouplingDeviceDiagramData;
 import com.powsybl.sld.cgmes.dl.iidm.extensions.DiagramPoint;
 import com.powsybl.sld.cgmes.dl.iidm.extensions.DiagramTerminal;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.Switch;
+import com.powsybl.sld.cgmes.dl.iidm.extensions.NetworkDiagramData;
 import com.powsybl.triplestore.api.PropertyBag;
 import com.powsybl.triplestore.api.PropertyBags;
 
@@ -37,11 +37,14 @@ public class SwitchDiagramDataImporter extends AbstractCouplingDeviceDiagramData
         String switchId = switchesDiagramData.getId("identifiedObject");
         Switch sw = network.getSwitch(switchId);
         if (sw != null) {
-            CouplingDeviceDiagramData<Switch> switchIidmDiagramData = new CouplingDeviceDiagramData<>(sw);
+            CouplingDeviceDiagramData<Switch> switchIidmDiagramData = sw.getExtension(CouplingDeviceDiagramData.class);
+            if (switchIidmDiagramData == null) {
+                switchIidmDiagramData = new CouplingDeviceDiagramData<>(sw);
+            }
             CouplingDeviceDiagramData.CouplingDeviceDiagramDetails diagramDetails = switchIidmDiagramData.new CouplingDeviceDiagramDetails(new DiagramPoint(switchesDiagramData.asDouble("x"), switchesDiagramData.asDouble("y"), 0),
                     switchesDiagramData.asDouble("rotation"));
-            addTerminalPoints(switchId, sw.getName(), DiagramTerminal.TERMINAL1, "1", diagramDetails);
-            addTerminalPoints(switchId, sw.getName(), DiagramTerminal.TERMINAL2, "2", diagramDetails);
+            addTerminalPoints(switchId, sw.getName(), switchesDiagramData.get("diagramName"), DiagramTerminal.TERMINAL1, "1", diagramDetails);
+            addTerminalPoints(switchId, sw.getName(), switchesDiagramData.get("diagramName"), DiagramTerminal.TERMINAL2, "2", diagramDetails);
             switchIidmDiagramData.addData(switchesDiagramData.get("diagramName"), diagramDetails);
             sw.addExtension(CouplingDeviceDiagramData.class, switchIidmDiagramData);
             NetworkDiagramData.addDiagramName(network, switchesDiagramData.get("diagramName"));

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/AbstractCgmesDLTest.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/AbstractCgmesDLTest.java
@@ -196,7 +196,7 @@ public abstract class AbstractCgmesDLTest {
         return createSwitchPropertyBag(identifiedObject, name, x, y, rotation, DEFAULT_DIAGRAM_NAME);
     }
 
-    private PropertyBag createTerminal(String terminal, int terminalSide, String equipment) {
+    protected PropertyBag createTerminal(String terminal, int terminalSide, String equipment) {
         PropertyBag propertyBag = new PropertyBag(Arrays.asList("terminal", "terminalSide", "equipment"));
         propertyBag.put("terminal", terminal);
         propertyBag.put("terminalSide", Integer.toString(terminalSide));
@@ -204,7 +204,7 @@ public abstract class AbstractCgmesDLTest {
         return propertyBag;
     }
 
-    private PropertyBag createBusbarNode(String busbar, String busbarNode) {
+    protected PropertyBag createBusbarNode(String busbar, String busbarNode) {
         PropertyBag propertyBag = new PropertyBag(Arrays.asList("busbarNode", "busbarSection"));
         propertyBag.put("busbarNode", busbarNode);
         propertyBag.put("busbarSection", busbar);

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImporterTest.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/test/java/com/powsybl/sld/cgmes/dl/conversion/CgmesDLImporterTest.java
@@ -24,11 +24,14 @@ import static org.junit.Assert.*;
  */
 public class CgmesDLImporterTest extends AbstractCgmesDLTest {
 
+    protected static String OTHER_DIAGRAM_NAME = "diagram-1";
+
     private CgmesDLModel cgmesDLModel;
 
     @Before
     public void setUp() {
         super.setUp();
+        addOtherDiagram();
         cgmesDLModel = Mockito.mock(CgmesDLModel.class);
         Mockito.when(cgmesDLModel.getTerminalsDiagramData()).thenReturn(terminalsPropertyBags);
         Mockito.when(cgmesDLModel.getBusesDiagramData()).thenReturn(busesPropertyBags);
@@ -44,14 +47,57 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         Mockito.when(cgmesDLModel.getVoltageLevelDiagramData()).thenReturn(voltageLevels);
     }
 
-    private <T> void checkDiagramData(NodeDiagramData.NodeDiagramDataDetails diagramDetails) {
+    private void addOtherDiagram() {
+        terminalsPropertyBags.addAll(Arrays.asList(createTerminalPropertyBag(NAMESPACE + "Generator", "1", 4, 20, 1, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Generator", "1", 12, 20, 2, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Load", "1", 4, 20, 1, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Load", "1", 12, 20, 2, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Shunt", "1", 4, 20, 1, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Shunt", "1", 12, 20, 2, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Switch", "1", 4, 20, 1, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Switch", "1", 12, 20, 2, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Switch", "2", 28, 20, 1, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Switch", "2", 36, 20, 2, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Transformer", "1", 4, 20, 1, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Transformer", "1", 12, 20, 2, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Transformer", "2", 28, 20, 1, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Transformer", "2", 36, 20, 2, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Transformer3w", "1", 4, 20, 1, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Transformer3w", "1", 12, 20, 2, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Transformer3w", "2", 28, 20, 1, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Transformer3w", "2", 36, 20, 2, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Transformer3w", "3", 20, 32, 1, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Transformer3w", "3", 20, 40, 2, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Svc", "1", 4, 20, 1, OTHER_DIAGRAM_NAME),
+                                                   createTerminalPropertyBag(NAMESPACE + "Svc", "1", 12, 20, 2, OTHER_DIAGRAM_NAME)));
+        busesPropertyBags.addAll(Arrays.asList(createBusPropertyBag(NAMESPACE + "Bus", "Bus", NAMESPACE + "VoltageLevel", "VoltageLevel", 40, 10, 1, OTHER_DIAGRAM_NAME),
+                                               createBusPropertyBag(NAMESPACE + "Bus", "Bus", NAMESPACE + "VoltageLevel", "VoltageLevel", 40, 80, 2, OTHER_DIAGRAM_NAME)));
+        busbarsPropertyBags.addAll(Arrays.asList(createBusbarPropertyBag(NAMESPACE + "Busbar", "Busbar", 40, 10, 1, OTHER_DIAGRAM_NAME),
+                                                 createBusbarPropertyBag(NAMESPACE + "Busbar", "Busbar", 40, 80, 2, OTHER_DIAGRAM_NAME)));
+        linesPropertyBags.addAll(Arrays.asList(createPropertyBag(NAMESPACE + "Line", "Line", 40, 10, 1, OTHER_DIAGRAM_NAME),
+                                               createPropertyBag(NAMESPACE + "Line", "Line", 40, 80, 2, OTHER_DIAGRAM_NAME)));
+        danglingLinesPropertyBags.addAll(Arrays.asList(createPropertyBag(NAMESPACE + "DanglingLine", "DanglingLine", 40, 10, 1, OTHER_DIAGRAM_NAME),
+                                                       createPropertyBag(NAMESPACE + "DanglingLine", "DanglingLine", 40, 80, 2, OTHER_DIAGRAM_NAME)));
+        generatorsPropertyBags.addAll(Arrays.asList(createPropertyBag(NAMESPACE + "Generator", "Generator", 20, 20, 0, 90, OTHER_DIAGRAM_NAME)));
+        loadsPropertyBags.addAll(Arrays.asList(createPropertyBag(NAMESPACE + "Load", "Load", 20, 20, 0, 90, OTHER_DIAGRAM_NAME)));
+        shuntsPropertyBags.addAll(Arrays.asList(createPropertyBag(NAMESPACE + "Shunt", "Shunt", 20, 20, 0, 90, OTHER_DIAGRAM_NAME)));
+        switchesPropertyBags.addAll(Arrays.asList(createSwitchPropertyBag(NAMESPACE + "Switch", "Switch", 20, 20, 90, OTHER_DIAGRAM_NAME)));
+        tranformersPropertyBags.addAll(Arrays.asList(createPropertyBag(NAMESPACE + "Transformer", "Transformer", 20, 20, 0, 90, OTHER_DIAGRAM_NAME)));
+        tranformers3wPropertyBags.addAll(Arrays.asList(createPropertyBag(NAMESPACE + "Transformer3w", "Transformer3w", 20, 26, 0, 90, OTHER_DIAGRAM_NAME)));
+        hvdcLinesPropertyBags.addAll(Arrays.asList(createPropertyBag(NAMESPACE + "HvdcLine", "HvdcLine", 40, 10, 1, OTHER_DIAGRAM_NAME),
+                                                   createPropertyBag(NAMESPACE + "HvdcLine", "HvdcLine", 40, 80, 2, OTHER_DIAGRAM_NAME)));
+        svcsPropertyBags.addAll(Arrays.asList(createPropertyBag(NAMESPACE + "Svc", "Svc", 20, 20, 0, 90, OTHER_DIAGRAM_NAME)));
+    }
+
+    private <T> void checkDiagramData(NodeDiagramData.NodeDiagramDataDetails diagramDetails, double x1, double y1,
+                                      double x2, double y2) {
         assertNotNull(diagramDetails);
         assertEquals(1, diagramDetails.getPoint1().getSeq(), 0);
-        assertEquals(20, diagramDetails.getPoint1().getX(), 0);
-        assertEquals(5, diagramDetails.getPoint1().getY(), 0);
+        assertEquals(x1, diagramDetails.getPoint1().getX(), 0);
+        assertEquals(y1, diagramDetails.getPoint1().getY(), 0);
         assertEquals(2, diagramDetails.getPoint2().getSeq(), 0);
-        assertEquals(20, diagramDetails.getPoint2().getX(), 0);
-        assertEquals(40, diagramDetails.getPoint2().getY(), 0);
+        assertEquals(x2, diagramDetails.getPoint2().getX(), 0);
+        assertEquals(y2, diagramDetails.getPoint2().getY(), 0);
     }
 
     @Test
@@ -62,7 +108,8 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         Bus bus = network.getVoltageLevel("VoltageLevel").getBusBreakerView().getBus("Bus");
         NodeDiagramData<Bus> busDiagramData = bus.getExtension(NodeDiagramData.class);
 
-        checkDiagramData(busDiagramData.getData(DEFAULT_DIAGRAM_NAME));
+        checkDiagramData(busDiagramData.getData(DEFAULT_DIAGRAM_NAME), 20, 5, 20, 40);
+        checkDiagramData(busDiagramData.getData(OTHER_DIAGRAM_NAME), 40, 10, 40, 80);
     }
 
     @Test
@@ -73,23 +120,24 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         BusbarSection busbar = network.getBusbarSection("Busbar");
         NodeDiagramData<BusbarSection> busbarDiagramData = busbar.getExtension(NodeDiagramData.class);
 
-        checkDiagramData(busbarDiagramData.getData(DEFAULT_DIAGRAM_NAME));
+        checkDiagramData(busbarDiagramData.getData(DEFAULT_DIAGRAM_NAME), 20, 5, 20, 40);
+        checkDiagramData(busbarDiagramData.getData(OTHER_DIAGRAM_NAME), 40, 10, 40, 80);
     }
 
-    private <T> void checkDiagramData(LineDiagramData<?> diagramData) {
+    private <T> void checkDiagramData(LineDiagramData<?> diagramData, String diagram, double x1, double y1, double x2, double y2) {
         assertNotNull(diagramData);
-        assertEquals(1, diagramData.getPoints(DEFAULT_DIAGRAM_NAME).get(0).getSeq(), 0);
-        assertEquals(20, diagramData.getPoints(DEFAULT_DIAGRAM_NAME).get(0).getX(), 0);
-        assertEquals(5, diagramData.getPoints(DEFAULT_DIAGRAM_NAME).get(0).getY(), 0);
-        assertEquals(2, diagramData.getPoints(DEFAULT_DIAGRAM_NAME).get(1).getSeq(), 0);
-        assertEquals(20, diagramData.getPoints(DEFAULT_DIAGRAM_NAME).get(1).getX(), 0);
-        assertEquals(40, diagramData.getPoints(DEFAULT_DIAGRAM_NAME).get(1).getY(), 0);
-        assertEquals(1, diagramData.getFirstPoint(DEFAULT_DIAGRAM_NAME).getSeq(), 0);
-        assertEquals(20, diagramData.getFirstPoint(DEFAULT_DIAGRAM_NAME).getX(), 0);
-        assertEquals(5, diagramData.getFirstPoint(DEFAULT_DIAGRAM_NAME).getY(), 0);
-        assertEquals(2, diagramData.getLastPoint(DEFAULT_DIAGRAM_NAME).getSeq(), 0);
-        assertEquals(20, diagramData.getLastPoint(DEFAULT_DIAGRAM_NAME).getX(), 0);
-        assertEquals(40, diagramData.getLastPoint(DEFAULT_DIAGRAM_NAME).getY(), 0);
+        assertEquals(1, diagramData.getPoints(diagram).get(0).getSeq(), 0);
+        assertEquals(x1, diagramData.getPoints(diagram).get(0).getX(), 0);
+        assertEquals(y1, diagramData.getPoints(diagram).get(0).getY(), 0);
+        assertEquals(2, diagramData.getPoints(diagram).get(1).getSeq(), 0);
+        assertEquals(x2, diagramData.getPoints(diagram).get(1).getX(), 0);
+        assertEquals(y2, diagramData.getPoints(diagram).get(1).getY(), 0);
+        assertEquals(1, diagramData.getFirstPoint(diagram).getSeq(), 0);
+        assertEquals(x1, diagramData.getFirstPoint(diagram).getX(), 0);
+        assertEquals(y1, diagramData.getFirstPoint(diagram).getY(), 0);
+        assertEquals(2, diagramData.getLastPoint(diagram).getSeq(), 0);
+        assertEquals(x2, diagramData.getLastPoint(diagram).getX(), 0);
+        assertEquals(y2, diagramData.getLastPoint(diagram).getY(), 0);
     }
 
     @Test
@@ -100,7 +148,8 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         Line line = network.getLine("Line");
         LineDiagramData<Line> lineDiagramData = line.getExtension(LineDiagramData.class);
 
-        checkDiagramData(lineDiagramData);
+        checkDiagramData(lineDiagramData, DEFAULT_DIAGRAM_NAME, 20, 5, 20, 40);
+        checkDiagramData(lineDiagramData, OTHER_DIAGRAM_NAME, 40, 10, 40, 80);
     }
 
     @Test
@@ -112,7 +161,8 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         DanglingLine danglingLine = network.getDanglingLine("DanglingLine");
         LineDiagramData<DanglingLine> danglingLineDiagramData = danglingLine.getExtension(LineDiagramData.class);
 
-        checkDiagramData(danglingLineDiagramData);
+        checkDiagramData(danglingLineDiagramData, DEFAULT_DIAGRAM_NAME, 20, 5, 20, 40);
+        checkDiagramData(danglingLineDiagramData, OTHER_DIAGRAM_NAME, 40, 10, 40, 80);
     }
 
     @Test
@@ -123,23 +173,25 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         HvdcLine hdcvLine = network.getHvdcLine("HvdcLine");
         LineDiagramData<HvdcLine> hvdcLineDiagramData = hdcvLine.getExtension(LineDiagramData.class);
 
-        checkDiagramData(hvdcLineDiagramData);
+        checkDiagramData(hvdcLineDiagramData, DEFAULT_DIAGRAM_NAME, 20, 5, 20, 40);
+        checkDiagramData(hvdcLineDiagramData, OTHER_DIAGRAM_NAME, 40, 10, 40, 80);
     }
 
-    private <T> void checkDiagramData(InjectionDiagramData.InjectionDiagramDetails diagramDetails) {
+    private <T> void checkDiagramData(InjectionDiagramData.InjectionDiagramDetails diagramDetails, double x, double y,
+                                      double tx1, double ty1, double tx2, double ty2) {
         assertNotNull(diagramDetails);
         assertEquals(0, diagramDetails.getPoint().getSeq(), 0);
-        assertEquals(10, diagramDetails.getPoint().getX(), 0);
-        assertEquals(10, diagramDetails.getPoint().getY(), 0);
+        assertEquals(x, diagramDetails.getPoint().getX(), 0);
+        assertEquals(y, diagramDetails.getPoint().getY(), 0);
         assertEquals(90, diagramDetails.getRotation(), 0);
 
         List<DiagramPoint> points = diagramDetails.getTerminalPoints();
         assertEquals(1, points.get(0).getSeq(), 0);
-        assertEquals(2, points.get(0).getX(), 0);
-        assertEquals(10, points.get(0).getY(), 0);
+        assertEquals(tx1, points.get(0).getX(), 0);
+        assertEquals(ty1, points.get(0).getY(), 0);
         assertEquals(2, points.get(1).getSeq(), 0);
-        assertEquals(6, points.get(1).getX(), 0);
-        assertEquals(10, points.get(1).getY(), 0);
+        assertEquals(tx2, points.get(1).getX(), 0);
+        assertEquals(ty2, points.get(1).getY(), 0);
     }
 
     @Test
@@ -150,7 +202,8 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         Generator generator = network.getGenerator("Generator");
         InjectionDiagramData<Generator> generatorDiagramData = generator.getExtension(InjectionDiagramData.class);
 
-        checkDiagramData(generatorDiagramData.getData(DEFAULT_DIAGRAM_NAME));
+        checkDiagramData(generatorDiagramData.getData(DEFAULT_DIAGRAM_NAME), 10, 10, 2, 10, 6, 10);
+        checkDiagramData(generatorDiagramData.getData(OTHER_DIAGRAM_NAME), 20, 20, 4, 20, 12, 20);
     }
 
     @Test
@@ -161,7 +214,8 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         Load load = network.getLoad("Load");
         InjectionDiagramData<Load> loadDiagramData = load.getExtension(InjectionDiagramData.class);
 
-        checkDiagramData(loadDiagramData.getData(DEFAULT_DIAGRAM_NAME));
+        checkDiagramData(loadDiagramData.getData(DEFAULT_DIAGRAM_NAME), 10, 10, 2, 10, 6, 10);
+        checkDiagramData(loadDiagramData.getData(OTHER_DIAGRAM_NAME), 20, 20, 4, 20, 12, 20);
     }
 
     @Test
@@ -172,7 +226,8 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         ShuntCompensator shunt = network.getShuntCompensator("Shunt");
         InjectionDiagramData<ShuntCompensator> shuntDiagramData = shunt.getExtension(InjectionDiagramData.class);
 
-        checkDiagramData(shuntDiagramData.getData(DEFAULT_DIAGRAM_NAME));
+        checkDiagramData(shuntDiagramData.getData(DEFAULT_DIAGRAM_NAME), 10, 10, 2, 10, 6, 10);
+        checkDiagramData(shuntDiagramData.getData(OTHER_DIAGRAM_NAME), 20, 20, 4, 20, 12, 20);
     }
 
     @Test
@@ -183,30 +238,32 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         StaticVarCompensator svc = network.getStaticVarCompensator("Svc");
         InjectionDiagramData<StaticVarCompensator> svcDiagramData = svc.getExtension(InjectionDiagramData.class);
 
-        checkDiagramData(svcDiagramData.getData(DEFAULT_DIAGRAM_NAME));
+        checkDiagramData(svcDiagramData.getData(DEFAULT_DIAGRAM_NAME), 10, 10, 2, 10, 6, 10);
+        checkDiagramData(svcDiagramData.getData(OTHER_DIAGRAM_NAME), 20, 20, 4, 20, 12, 20);
     }
 
-    private <T> void checkDiagramData(CouplingDeviceDiagramData.CouplingDeviceDiagramDetails diagramDataDetails) {
+    private <T> void checkDiagramData(CouplingDeviceDiagramData.CouplingDeviceDiagramDetails diagramDataDetails, double x, double y,
+                                      double tx1, double ty1, double tx2, double ty2, double tx3, double ty3, double tx4, double ty4) {
         assertNotNull(diagramDataDetails);
         assertEquals(0, diagramDataDetails.getPoint().getSeq(), 0);
-        assertEquals(10, diagramDataDetails.getPoint().getX(), 0);
-        assertEquals(10, diagramDataDetails.getPoint().getY(), 0);
+        assertEquals(x, diagramDataDetails.getPoint().getX(), 0);
+        assertEquals(y, diagramDataDetails.getPoint().getY(), 0);
         assertEquals(90, diagramDataDetails.getRotation(), 0);
 
         List<DiagramPoint> pointsT1 = diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL1);
         List<DiagramPoint> pointsT2 = diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL2);
         assertEquals(1, pointsT1.get(0).getSeq(), 0);
-        assertEquals(2, pointsT1.get(0).getX(), 0);
-        assertEquals(10, pointsT1.get(0).getY(), 0);
+        assertEquals(tx1, pointsT1.get(0).getX(), 0);
+        assertEquals(ty1, pointsT1.get(0).getY(), 0);
         assertEquals(2, pointsT1.get(1).getSeq(), 0);
-        assertEquals(6, pointsT1.get(1).getX(), 0);
-        assertEquals(10, pointsT1.get(1).getY(), 0);
+        assertEquals(tx2, pointsT1.get(1).getX(), 0);
+        assertEquals(ty2, pointsT1.get(1).getY(), 0);
         assertEquals(1, pointsT2.get(0).getSeq(), 0);
-        assertEquals(14, pointsT2.get(0).getX(), 0);
-        assertEquals(10, pointsT2.get(0).getY(), 0);
+        assertEquals(tx3, pointsT2.get(0).getX(), 0);
+        assertEquals(ty3, pointsT2.get(0).getY(), 0);
         assertEquals(2, pointsT2.get(1).getSeq(), 0);
-        assertEquals(18, pointsT2.get(1).getX(), 0);
-        assertEquals(10, pointsT2.get(1).getY(), 0);
+        assertEquals(tx4, pointsT2.get(1).getX(), 0);
+        assertEquals(ty4, pointsT2.get(1).getY(), 0);
     }
 
     @Test
@@ -217,7 +274,8 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         Switch sw = network.getSwitch("Switch");
         CouplingDeviceDiagramData<Switch> shuntDiagramData = sw.getExtension(CouplingDeviceDiagramData.class);
 
-        checkDiagramData(shuntDiagramData.getData(DEFAULT_DIAGRAM_NAME));
+        checkDiagramData(shuntDiagramData.getData(DEFAULT_DIAGRAM_NAME), 10, 10, 2, 10, 6, 10, 14, 10, 18, 10);
+        checkDiagramData(shuntDiagramData.getData(OTHER_DIAGRAM_NAME), 20, 20, 4, 20, 12, 20, 28, 20, 36, 20);
     }
 
     @Test
@@ -228,33 +286,36 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         TwoWindingsTransformer transformer = network.getTwoWindingsTransformer("Transformer");
         CouplingDeviceDiagramData<TwoWindingsTransformer> transformerDiagramData = transformer.getExtension(CouplingDeviceDiagramData.class);
 
-        checkDiagramData(transformerDiagramData.getData(DEFAULT_DIAGRAM_NAME));
+        checkDiagramData(transformerDiagramData.getData(DEFAULT_DIAGRAM_NAME), 10, 10, 2, 10, 6, 10, 14, 10, 18, 10);
+        checkDiagramData(transformerDiagramData.getData(OTHER_DIAGRAM_NAME), 20, 20, 4, 20, 12, 20, 28, 20, 36, 20);
     }
 
-    private <T> void checkDiagramData(ThreeWindingsTransformerDiagramData.ThreeWindingsTransformerDiagramDataDetails diagramDataDetails) {
+    private <T> void checkDiagramData(ThreeWindingsTransformerDiagramData.ThreeWindingsTransformerDiagramDataDetails diagramDataDetails, double x, double y,
+                                      double tx1, double ty1, double tx2, double ty2, double tx3, double ty3, double tx4, double ty4, double tx5,
+                                      double ty5, double tx6, double ty6) {
         assertNotNull(diagramDataDetails);
         assertEquals(0, diagramDataDetails.getPoint().getSeq(), 0);
-        assertEquals(10, diagramDataDetails.getPoint().getX(), 0);
-        assertEquals(13, diagramDataDetails.getPoint().getY(), 0);
+        assertEquals(x, diagramDataDetails.getPoint().getX(), 0);
+        assertEquals(y, diagramDataDetails.getPoint().getY(), 0);
         assertEquals(90, diagramDataDetails.getRotation(), 0);
         assertEquals(1, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL1).get(0).getSeq(), 0);
-        assertEquals(2, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL1).get(0).getX(), 0);
-        assertEquals(10, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL1).get(0).getY(), 0);
+        assertEquals(tx1, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL1).get(0).getX(), 0);
+        assertEquals(ty1, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL1).get(0).getY(), 0);
         assertEquals(2, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL1).get(1).getSeq(), 0);
-        assertEquals(6, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL1).get(1).getX(), 0);
-        assertEquals(10, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL1).get(1).getY(), 0);
+        assertEquals(tx2, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL1).get(1).getX(), 0);
+        assertEquals(ty2, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL1).get(1).getY(), 0);
         assertEquals(1, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL2).get(0).getSeq(), 0);
-        assertEquals(14, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL2).get(0).getX(), 0);
-        assertEquals(10, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL2).get(0).getY(), 0);
+        assertEquals(tx3, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL2).get(0).getX(), 0);
+        assertEquals(ty3, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL2).get(0).getY(), 0);
         assertEquals(2, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL2).get(1).getSeq(), 0);
-        assertEquals(18, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL2).get(1).getX(), 0);
-        assertEquals(10, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL2).get(1).getY(), 0);
+        assertEquals(tx4, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL2).get(1).getX(), 0);
+        assertEquals(ty4, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL2).get(1).getY(), 0);
         assertEquals(1, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL3).get(0).getSeq(), 0);
-        assertEquals(10, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL3).get(0).getX(), 0);
-        assertEquals(16, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL3).get(0).getY(), 0);
+        assertEquals(tx5, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL3).get(0).getX(), 0);
+        assertEquals(ty5, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL3).get(0).getY(), 0);
         assertEquals(2, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL3).get(1).getSeq(), 0);
-        assertEquals(10, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL3).get(1).getX(), 0);
-        assertEquals(20, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL3).get(1).getY(), 0);
+        assertEquals(tx6, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL3).get(1).getX(), 0);
+        assertEquals(ty6, diagramDataDetails.getTerminalPoints(DiagramTerminal.TERMINAL3).get(1).getY(), 0);
     }
 
     @Test
@@ -266,7 +327,8 @@ public class CgmesDLImporterTest extends AbstractCgmesDLTest {
         ThreeWindingsTransformer transformer = network.getThreeWindingsTransformer("Transformer3w");
         ThreeWindingsTransformerDiagramData transformerDiagramData = transformer.getExtension(ThreeWindingsTransformerDiagramData.class);
 
-        checkDiagramData(transformerDiagramData.getData(DEFAULT_DIAGRAM_NAME));
+        checkDiagramData(transformerDiagramData.getData(DEFAULT_DIAGRAM_NAME), 10, 13, 2, 10, 6, 10, 14, 10, 18, 10, 10, 16, 10, 20);
+        checkDiagramData(transformerDiagramData.getData(OTHER_DIAGRAM_NAME), 20, 26, 4, 20, 12, 20, 28, 20, 36, 20, 20, 32, 20, 40);
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: massimo.ferraro <massimo.ferraro@techrain.eu>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Part of the DL data is not correctly imported in the IIDM extensions when there are multiple diagrams 


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
