### PR TITLE
Access to network model from graph post processor

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/NetworkGraphBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/NetworkGraphBuilder.java
@@ -651,7 +651,7 @@ public class NetworkGraphBuilder implements GraphBuilder {
         for (GraphBuildPostProcessor gbp : listPostProcessors) {
             LOGGER.info("Graph post-processor id '{}' : Adding custom node in graph '{}'",
                     gbp.getId(), graph.getVoltageLevelId());
-            gbp.addNode(graph);
+            gbp.addNode(graph, network);
         }
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/postprocessor/GraphBuildPostProcessor.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/postprocessor/GraphBuildPostProcessor.java
@@ -15,5 +15,5 @@ import com.powsybl.sld.model.Graph;
 public interface GraphBuildPostProcessor {
     String getId();
 
-    void addNode(Graph graph);
+    void addNode(Graph graph, Object network);
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/postprocessor/GraphBuildPostProcessorMock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/postprocessor/GraphBuildPostProcessorMock.java
@@ -23,8 +23,9 @@ public class GraphBuildPostProcessorMock implements GraphBuildPostProcessor {
         return ID;
     }
 
-    public void addNode(Graph graph) {
+    public void addNode(Graph graph, Object network) {
         Objects.requireNonNull(graph);
+        Objects.requireNonNull(network);
 
         // this mock does nothing
     }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
There is no way to access network model from graph post processor.


**What is the new behavior (if this is a feature change)?**
An additional parameter as been added to GraphBuildPostProcessor.addNode to get access to original network model.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
