### PR TITLE
fixes cgmes-dl sparql queries, to include ProtectedSwitches

### DIFF
--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/resources/CGMES-DL.sparql
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-dl-conversion/src/main/resources/CGMES-DL.sparql
@@ -234,7 +234,7 @@ SELECT ?identifiedObject ?name ?x ?y ?rotation ?diagramName
     ?identifiedObject
         a ?type ;
         cim:IdentifiedObject.name ?name .
-    VALUES ?type { cim:Breaker cim:Disconnector cim:LoadBreakSwitch } .
+    VALUES ?type { cim:Breaker cim:Disconnector cim:LoadBreakSwitch cim:ProtectedSwitch } .
     ?diagramObjectPoint
         a cim:DiagramObjectPoint ;
         cim:DiagramObjectPoint.DiagramObject ?diagramObject ;
@@ -321,7 +321,7 @@ SELECT ?forkNode ?switch ?type
         cim:Terminal.ConductingEquipment ?switch .
     ?switch
         a ?type .
-	VALUES ?type { cim:Breaker cim:Disconnector cim:LoadBreakSwitch } .
+	VALUES ?type { cim:Breaker cim:Disconnector cim:LoadBreakSwitch cim:ProtectedSwitch } .
 }
 
 # query: voltageLevelDiagramData
@@ -340,7 +340,7 @@ SELECT ?connectivityNode ?switch ?name ?type ?diagramName ?x ?y ?seq
     ?switch
         a ?type ;
         cim:IdentifiedObject.name ?name .
-        VALUES ?type { cim:Breaker cim:Disconnector cim:LoadBreakSwitch } .
+        VALUES ?type { cim:Breaker cim:Disconnector cim:LoadBreakSwitch cim:ProtectedSwitch } .
     ?diagramObjectPoint
         a cim:DiagramObjectPoint ;
         cim:DiagramObjectPoint.DiagramObject ?diagramObject ;
@@ -368,7 +368,7 @@ SELECT DISTINCT ?connectivityNode
     ?switch
         a ?type ;
         cim:IdentifiedObject.name ?name .
-        FILTER ( ?type not in ( cim:Breaker, cim:Disconnector, cim:LoadBreakSwitch ) ) .
+        FILTER ( ?type not in ( cim:Breaker, cim:Disconnector, cim:LoadBreakSwitch, cim:ProtectedSwitch ) ) .
     ?diagram
         a cim:Diagram ;
         cim:IdentifiedObject.name ?diagramName .


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
without this fix, CGMES' ProtectedSwitch is not included in DL import queries as a kind of switch

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
