### PR TITLE
removing_iidm_network_references_in_default_diagram_style_provider

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/NetworkGraphBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/NetworkGraphBuilder.java
@@ -23,6 +23,7 @@ import static com.powsybl.sld.library.ComponentTypeName.VSC_CONVERTER_STATION;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -513,7 +514,18 @@ public class NetworkGraphBuilder implements GraphBuilder {
                     ThreeWindingsTransformer transformer = network.getThreeWindingsTransformer(n3WT.getTransformerId());
 
                     // Create a new fictitious node
-                    Fictitious3WTNode nf = new Fictitious3WTNode(graph, n3WT.getLabel() + "_fictif", n3WT.getTransformerId());
+                    Map<Feeder3WTNode.Side, String> idsLegs = new EnumMap<>(Feeder3WTNode.Side.class);
+                    Map<Feeder3WTNode.Side, Double> vNomsLegs = new EnumMap<>(Feeder3WTNode.Side.class);
+
+                    idsLegs.put(Feeder3WTNode.Side.ONE, transformer.getLeg1().getTerminal().getVoltageLevel().getId());
+                    idsLegs.put(Feeder3WTNode.Side.TWO, transformer.getLeg2().getTerminal().getVoltageLevel().getId());
+                    idsLegs.put(Feeder3WTNode.Side.THREE, transformer.getLeg3().getTerminal().getVoltageLevel().getId());
+
+                    vNomsLegs.put(Feeder3WTNode.Side.ONE, transformer.getLeg1().getTerminal().getVoltageLevel().getNominalV());
+                    vNomsLegs.put(Feeder3WTNode.Side.TWO, transformer.getLeg2().getTerminal().getVoltageLevel().getNominalV());
+                    vNomsLegs.put(Feeder3WTNode.Side.THREE, transformer.getLeg3().getTerminal().getVoltageLevel().getNominalV());
+
+                    Fictitious3WTNode nf = new Fictitious3WTNode(graph, n3WT.getLabel() + "_fictif", idsLegs, vNomsLegs);
                     graph.addNode(nf);
 
                     FeederNode nfeeder1 = null;

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagramTool.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagramTool.java
@@ -118,7 +118,7 @@ public class SingleLineDiagramTool implements Tool {
             VoltageLevelDiagram.build(graphBuilder, vl.getId(), generationConfig.voltageLevelLayoutFactory, true, generationConfig.parameters.isShowInductorFor3WT())
                     .writeSvg("", generationConfig.componentLibrary, generationConfig.parameters,
                             new DefaultDiagramInitialValueProvider(network),
-                            new DefaultDiagramStyleProvider(network),
+                            new DefaultDiagramStyleProvider(),
                             svgFile);
         } catch (Exception e) {
             e.printStackTrace(context.getErrorStream());
@@ -133,7 +133,7 @@ public class SingleLineDiagramTool implements Tool {
             SubstationDiagram.build(graphBuilder, s.getId(), generationConfig.substationLayoutFactory, generationConfig.voltageLevelLayoutFactory, true)
                     .writeSvg("", generationConfig.componentLibrary, generationConfig.parameters,
                             new DefaultDiagramInitialValueProvider(network),
-                            new DefaultDiagramStyleProvider(network),
+                            new DefaultDiagramStyleProvider(),
                             svgFile);
         } catch (Exception e) {
             e.printStackTrace(context.getErrorStream());

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Fictitious3WTNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Fictitious3WTNode.java
@@ -9,6 +9,7 @@ package com.powsybl.sld.model;
 import com.fasterxml.jackson.core.JsonGenerator;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static com.powsybl.sld.library.ComponentTypeName.THREE_WINDINGS_TRANSFORMER;
 
@@ -17,20 +18,43 @@ import static com.powsybl.sld.library.ComponentTypeName.THREE_WINDINGS_TRANSFORM
  */
 public class Fictitious3WTNode extends FictitiousNode {
 
-    private final String transformerId;
+    private final Map<Feeder3WTNode.Side, String> idsLegs;
+    private final Map<Feeder3WTNode.Side, Double> vNomsLegs;
 
-    public Fictitious3WTNode(Graph graph, String id, String transformerId) {
+    public Fictitious3WTNode(Graph graph, String id,
+                             Map<Feeder3WTNode.Side, String> idsLegs,
+                             Map<Feeder3WTNode.Side, Double> vNomsLegs) {
         super(graph, id, THREE_WINDINGS_TRANSFORMER);
-        this.transformerId = transformerId;
+        this.idsLegs = idsLegs;
+        this.vNomsLegs = vNomsLegs;
     }
 
-    public String getTransformerId() {
-        return transformerId;
+    public Map<Feeder3WTNode.Side, String> getIdsLegs() {
+        return idsLegs;
+    }
+
+    public Map<Feeder3WTNode.Side, Double> getvNomsLegs() {
+        return vNomsLegs;
     }
 
     @Override
     protected void writeJsonContent(JsonGenerator generator) throws IOException {
         super.writeJsonContent(generator);
-        generator.writeStringField("transformerId", transformerId);
+
+        generator.writeArrayFieldStart("idsLegs");
+        for (Map.Entry<Feeder3WTNode.Side, String> idL : idsLegs.entrySet()) {
+            generator.writeStartObject();
+            generator.writeObjectField(idL.getKey().name(), idL.getValue());
+            generator.writeEndObject();
+        }
+        generator.writeEndArray();
+
+        generator.writeArrayFieldStart("vNomsLegs");
+        for (Map.Entry<Feeder3WTNode.Side, Double> vNomL : vNomsLegs.entrySet()) {
+            generator.writeStartObject();
+            generator.writeObjectField(vNomL.getKey().name(), vNomL.getValue());
+            generator.writeEndObject();
+        }
+        generator.writeEndArray();
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramStyleProvider.java
@@ -19,14 +19,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.ThreeWindingsTransformer;
-import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.sld.library.ComponentSize;
 import com.powsybl.sld.model.BusCell;
 import com.powsybl.sld.model.Edge;
 import com.powsybl.sld.model.ExternCell;
 import com.powsybl.sld.model.Feeder2WTNode;
+import com.powsybl.sld.model.Feeder3WTNode;
 import com.powsybl.sld.model.FeederNode;
 import com.powsybl.sld.model.Fictitious3WTNode;
 import com.powsybl.sld.model.Graph;
@@ -45,12 +43,6 @@ public class DefaultDiagramStyleProvider implements DiagramStyleProvider {
     protected static final String WINDING1 = "WINDING1";
     protected static final String WINDING2 = "WINDING2";
     protected static final String WINDING3 = "WINDING3";
-
-    protected final Network network;
-
-    public DefaultDiagramStyleProvider(Network network) {
-        this.network = network;
-    }
 
     @Override
     public Optional<String> getNodeStyle(Node node, boolean avoidSVGComponentsDuplication, boolean isShowInternalNodes) {
@@ -130,7 +122,7 @@ public class DefaultDiagramStyleProvider implements DiagramStyleProvider {
                         && ((ExternCell) node.getCell()).getDirection() == BusCell.Direction.BOTTOM;
 
                 if (node instanceof Fictitious3WTNode) {
-                    color = network != null ? getColor3WT(((Fictitious3WTNode) node).getTransformerId(), nameSubComponent, rotateSVG, vlId) : Optional.empty();
+                    color = getColor3WT((Fictitious3WTNode) node, nameSubComponent, rotateSVG, vlId);
                 } else {
                     color = getColor(nameSubComponent.equals(WINDING1) ? node.getGraph().getVoltageLevelNominalV() : ((Feeder2WTNode) node).getNominalVOtherSide(), null);
                 }
@@ -221,49 +213,39 @@ public class DefaultDiagramStyleProvider implements DiagramStyleProvider {
         return attributes;
     }
 
-    private Optional<String> getColor3WT(String transformerId, String nameSubComponent, boolean rotateSVG, String vlId) {
-        Optional<String> color = Optional.empty();
+    private Optional<String> getColor3WT(Fictitious3WTNode node, String nameSubComponent, boolean rotateSVG, String vlId) {
+        Map<Feeder3WTNode.Side, String> idsLegs = node.getIdsLegs();
+        Map<Feeder3WTNode.Side, Double> vNomsLegs = node.getvNomsLegs();
 
-        ThreeWindingsTransformer transformer = network.getThreeWindingsTransformer(transformerId);
-        ThreeWindingsTransformer.Side otherSide = ThreeWindingsTransformer.Side.ONE;
-
-        VoltageLevel leg1Vl = transformer.getLeg1().getTerminal().getVoltageLevel();
-        VoltageLevel leg2Vl = transformer.getLeg2().getTerminal().getVoltageLevel();
-        VoltageLevel leg3Vl = transformer.getLeg3().getTerminal().getVoltageLevel();
-
-        ThreeWindingsTransformer.Side side1 = ThreeWindingsTransformer.Side.ONE;
-        ThreeWindingsTransformer.Side side2 = ThreeWindingsTransformer.Side.TWO;
-        ThreeWindingsTransformer.Side side3 = ThreeWindingsTransformer.Side.THREE;
+        Feeder3WTNode.Side otherSide = Feeder3WTNode.Side.ONE;
 
         if (nameSubComponent.equals(WINDING1)) {
-            if (leg1Vl.getId().equals(vlId)) {
-                otherSide = !rotateSVG ? side3 : side2;
-            } else if (leg2Vl.getId().equals(vlId)) {
-                otherSide = !rotateSVG ? side3 : side1;
-            } else if (leg3Vl.getId().equals(vlId)) {
-                otherSide = !rotateSVG ? side2 : side1;
+            if (idsLegs.get(Feeder3WTNode.Side.ONE).equals(vlId)) {
+                otherSide = !rotateSVG ? Feeder3WTNode.Side.THREE : Feeder3WTNode.Side.TWO;
+            } else if (idsLegs.get(Feeder3WTNode.Side.TWO).equals(vlId)) {
+                otherSide = !rotateSVG ? Feeder3WTNode.Side.THREE : Feeder3WTNode.Side.ONE;
+            } else if (idsLegs.get(Feeder3WTNode.Side.THREE).equals(vlId)) {
+                otherSide = !rotateSVG ? Feeder3WTNode.Side.TWO : Feeder3WTNode.Side.ONE;
             }
-            color = getColor(transformer.getTerminal(otherSide).getVoltageLevel().getNominalV(), null);
         } else if (nameSubComponent.equals(WINDING2)) {
-            if (leg1Vl.getId().equals(vlId)) {
-                otherSide = !rotateSVG ? side2 : side3;
-            } else if (leg2Vl.getId().equals(vlId)) {
-                otherSide = !rotateSVG ? side1 : side3;
-            } else if (leg3Vl.getId().equals(vlId)) {
-                otherSide = !rotateSVG ? side1 : side2;
+            if (idsLegs.get(Feeder3WTNode.Side.ONE).equals(vlId)) {
+                otherSide = !rotateSVG ? Feeder3WTNode.Side.TWO : Feeder3WTNode.Side.THREE;
+            } else if (idsLegs.get(Feeder3WTNode.Side.TWO).equals(vlId)) {
+                otherSide = !rotateSVG ? Feeder3WTNode.Side.ONE : Feeder3WTNode.Side.THREE;
+            } else if (idsLegs.get(Feeder3WTNode.Side.THREE).equals(vlId)) {
+                otherSide = !rotateSVG ? Feeder3WTNode.Side.ONE : Feeder3WTNode.Side.TWO;
             }
-            color = getColor(transformer.getTerminal(otherSide).getVoltageLevel().getNominalV(), null);
         } else {
-            if (leg1Vl.getId().equals(vlId)) {
-                color = getColor(leg1Vl.getNominalV(), null);
-            } else if (leg2Vl.getId().equals(vlId)) {
-                color = getColor(leg2Vl.getNominalV(), null);
-            } else if (leg3Vl.getId().equals(vlId)) {
-                color = getColor(leg3Vl.getNominalV(), null);
+            if (idsLegs.get(Feeder3WTNode.Side.ONE).equals(vlId)) {
+                otherSide = Feeder3WTNode.Side.ONE;
+            } else if (idsLegs.get(Feeder3WTNode.Side.TWO).equals(vlId)) {
+                otherSide = Feeder3WTNode.Side.TWO;
+            } else if (idsLegs.get(Feeder3WTNode.Side.THREE).equals(vlId)) {
+                otherSide = Feeder3WTNode.Side.THREE;
             }
         }
 
-        return color;
+        return getColor(vNomsLegs.get(otherSide), null);
     }
 
     @Override

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/NominalVoltageDiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/NominalVoltageDiagramStyleProvider.java
@@ -12,7 +12,6 @@ import static com.powsybl.sld.svg.DiagramStyles.escapeId;
 
 import java.util.Optional;
 
-import com.powsybl.iidm.network.Network;
 import com.powsybl.sld.model.Edge;
 import com.powsybl.sld.model.Feeder2WTNode;
 import com.powsybl.sld.model.Fictitious3WTNode;
@@ -25,10 +24,6 @@ import com.powsybl.sld.svg.DefaultDiagramStyleProvider;
  */
 public class NominalVoltageDiagramStyleProvider extends DefaultDiagramStyleProvider {
     private static final String DEFAULT_COLOR = "rgb(171, 175, 40)";
-
-    public NominalVoltageDiagramStyleProvider(Network network) {
-        super(network);
-    }
 
     @Override
     public Optional<String> getColor(double nominalV, Node node) {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologicalStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologicalStyleProvider.java
@@ -41,8 +41,10 @@ public class TopologicalStyleProvider extends DefaultDiagramStyleProvider {
     private static final String DISCONNECTED_COLOR = "#808080";
     private String disconnectedColor;
 
+    private Network network;
+
     public TopologicalStyleProvider(Path config, Network network) {
-        super(network);
+        this.network = network;
         try {
             baseVoltageColor = config != null ? new BaseVoltageColor(config) : new BaseVoltageColor();
         } catch (IOException e) {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/NominalVoltageStyleTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/NominalVoltageStyleTest.java
@@ -87,7 +87,7 @@ public class NominalVoltageStyleTest extends AbstractTestCase {
         Graph graph2 = graphBuilder.buildVoltageLevelGraph(vl2.getId(), false, true, false);
         Graph graph3 = graphBuilder.buildVoltageLevelGraph(vl3.getId(), false, true, false);
 
-        DiagramStyleProvider styleProvider = new NominalVoltageDiagramStyleProvider(network);
+        DiagramStyleProvider styleProvider = new NominalVoltageDiagramStyleProvider();
 
         Node node1 = graph1.getNode("bbs1");
         Optional<String> nodeStyle1 = styleProvider.getNodeStyle(node1, false, false);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase11SubstationGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase11SubstationGraph.java
@@ -247,6 +247,6 @@ public class TestCase11SubstationGraph extends AbstractTestCase {
 
         compareMetadata(diagram, layoutParameters, "/substDiag_metadata.json",
                 new DefaultDiagramInitialValueProvider(network),
-                new DefaultDiagramStyleProvider(network));
+                new DefaultDiagramStyleProvider());
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase12GraphWith3WT.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase12GraphWith3WT.java
@@ -255,6 +255,6 @@ public class TestCase12GraphWith3WT extends AbstractTestCase {
                 new PositionVoltageLevelLayoutFactory(), false, true);
         compareMetadata(diagram, layoutParameters, "/vlDiag_metadata.json",
                 new DefaultDiagramInitialValueProvider(network),
-                new NominalVoltageDiagramStyleProvider(network));
+                new NominalVoltageDiagramStyleProvider());
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestSVGWriter.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestSVGWriter.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +80,17 @@ public class TestSVGWriter extends AbstractTestCase {
         g1 = Graph.create("vl1", "vl1", 400, false, true, false);
         g1.setX(0);
         g1.setY(20);
+
+        Map<Feeder3WTNode.Side, String> idsLegs = new EnumMap<>(Feeder3WTNode.Side.class);
+        Map<Feeder3WTNode.Side, Double> vNomsLegs = new EnumMap<>(Feeder3WTNode.Side.class);
+
+        idsLegs.put(Feeder3WTNode.Side.ONE, "vl1");
+        idsLegs.put(Feeder3WTNode.Side.TWO, "vl2");
+        idsLegs.put(Feeder3WTNode.Side.THREE, "vl3");
+
+        vNomsLegs.put(Feeder3WTNode.Side.ONE, 400.);
+        vNomsLegs.put(Feeder3WTNode.Side.TWO, 225.);
+        vNomsLegs.put(Feeder3WTNode.Side.THREE, 63.);
 
         BusNode vl1Bbs1 = BusNode.create(g1, "vl1_bbs1", "vl1_bbs1");
         vl1Bbs1.setX(0);
@@ -158,7 +170,7 @@ public class TestSVGWriter extends AbstractTestCase {
         vl1Trf2Two.setX(440);
         vl1Trf2Two.setY(80);
         g1.addNode(vl1Trf2Two);
-        Fictitious3WTNode vl1Trf2Fict = new Fictitious3WTNode(g1, "vl1_trf2", "vl1_trf2");
+        Fictitious3WTNode vl1Trf2Fict = new Fictitious3WTNode(g1, "vl1_trf2", idsLegs, vNomsLegs);
         vl1Trf2Fict.setX(400);
         vl1Trf2Fict.setY(140);
         g1.addNode(vl1Trf2Fict);
@@ -237,7 +249,7 @@ public class TestSVGWriter extends AbstractTestCase {
         vl2Trf2Two.setX(190);
         vl2Trf2Two.setY(80);
         g2.addNode(vl2Trf2Two);
-        Fictitious3WTNode vl2Trf2Fict = new Fictitious3WTNode(g2, "vl2_trf2", "vl2_trf2");
+        Fictitious3WTNode vl2Trf2Fict = new Fictitious3WTNode(g2, "vl2_trf2", idsLegs, vNomsLegs);
         vl2Trf2Fict.setX(160);
         vl2Trf2Fict.setY(140);
         g2.addNode(vl2Trf2Fict);
@@ -297,7 +309,7 @@ public class TestSVGWriter extends AbstractTestCase {
         vl3Trf2Two.setX(190);
         vl3Trf2Two.setY(80);
         g3.addNode(vl3Trf2Two);
-        Fictitious3WTNode vl3Trf2Fict = new Fictitious3WTNode(g3, "vl3_trf2", "vl3_trf2");
+        Fictitious3WTNode vl3Trf2Fict = new Fictitious3WTNode(g3, "vl3_trf2", idsLegs, vNomsLegs);
         vl3Trf2Fict.setX(150);
         vl3Trf2Fict.setY(140);
         g3.addNode(vl3Trf2Fict);
@@ -700,7 +712,7 @@ public class TestSVGWriter extends AbstractTestCase {
     @Test
     public void test() {
 
-        DiagramStyleProvider styleProvider = new DefaultDiagramStyleProvider(null);
+        DiagramStyleProvider styleProvider = new DefaultDiagramStyleProvider();
 
         // Layout parameters :
         //
@@ -762,7 +774,7 @@ public class TestSVGWriter extends AbstractTestCase {
 
     @Test
     public void testWriteZone() {
-        DiagramStyleProvider styleProvider = new DefaultDiagramStyleProvider(null);
+        DiagramStyleProvider styleProvider = new DefaultDiagramStyleProvider();
 
         LayoutParameters layoutParameters = new LayoutParameters()
                 .setTranslateX(20)

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.json
@@ -976,7 +976,20 @@
           "x" : 480.0,
           "y" : 63.33333333333335,
           "open" : false,
-          "transformerId" : "trf6"
+          "idsLegs" : [ {
+            "ONE" : "vl1"
+          }, {
+            "TWO" : "vl2"
+          }, {
+            "THREE" : "vl3"
+          } ],
+          "vNomsLegs" : [ {
+            "ONE" : 400.0
+          }, {
+            "TWO" : 225.0
+          }, {
+            "THREE" : 63.0
+          } ]
         } ]
       }, {
         "type" : "PARALLEL",
@@ -1027,7 +1040,20 @@
             "x" : 480.0,
             "y" : 63.33333333333335,
             "open" : false,
-            "transformerId" : "trf6"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "self4",
@@ -1070,7 +1096,20 @@
             "x" : 480.0,
             "y" : 63.33333333333335,
             "open" : false,
-            "transformerId" : "trf6"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "trf6_ONE_TWO",
@@ -1508,7 +1547,20 @@
           "x" : 960.0,
           "y" : 63.33333333333335,
           "open" : false,
-          "transformerId" : "trf8"
+          "idsLegs" : [ {
+            "ONE" : "vl1"
+          }, {
+            "TWO" : "vl2"
+          }, {
+            "THREE" : "vl3"
+          } ],
+          "vNomsLegs" : [ {
+            "ONE" : 400.0
+          }, {
+            "TWO" : 225.0
+          }, {
+            "THREE" : 63.0
+          } ]
         } ]
       }, {
         "type" : "PARALLEL",
@@ -1559,7 +1611,20 @@
             "x" : 960.0,
             "y" : 63.33333333333335,
             "open" : false,
-            "transformerId" : "trf8"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "self4",
@@ -1602,7 +1667,20 @@
             "x" : 960.0,
             "y" : 63.33333333333335,
             "open" : false,
-            "transformerId" : "trf8"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "trf8_ONE_TWO",
@@ -2040,7 +2118,20 @@
           "x" : 640.0,
           "y" : 481.6666666666666,
           "open" : false,
-          "transformerId" : "trf7"
+          "idsLegs" : [ {
+            "ONE" : "vl1"
+          }, {
+            "TWO" : "vl2"
+          }, {
+            "THREE" : "vl3"
+          } ],
+          "vNomsLegs" : [ {
+            "ONE" : 400.0
+          }, {
+            "TWO" : 225.0
+          }, {
+            "THREE" : 63.0
+          } ]
         } ]
       }, {
         "type" : "PARALLEL",
@@ -2091,7 +2182,20 @@
             "x" : 640.0,
             "y" : 481.6666666666666,
             "open" : false,
-            "transformerId" : "trf7"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "self4",
@@ -2134,7 +2238,20 @@
             "x" : 640.0,
             "y" : 481.6666666666666,
             "open" : false,
-            "transformerId" : "trf7"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "trf7_ONE_TWO",

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.json
@@ -771,7 +771,20 @@
           "x" : 560.0,
           "y" : 63.33333333333335,
           "open" : false,
-          "transformerId" : "trf7"
+          "idsLegs" : [ {
+            "ONE" : "vl1"
+          }, {
+            "TWO" : "vl2"
+          }, {
+            "THREE" : "vl3"
+          } ],
+          "vNomsLegs" : [ {
+            "ONE" : 400.0
+          }, {
+            "TWO" : 225.0
+          }, {
+            "THREE" : 63.0
+          } ]
         } ]
       }, {
         "type" : "PARALLEL",
@@ -822,7 +835,20 @@
             "x" : 560.0,
             "y" : 63.33333333333335,
             "open" : false,
-            "transformerId" : "trf7"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "self4",
@@ -865,7 +891,20 @@
             "x" : 560.0,
             "y" : 63.33333333333335,
             "open" : false,
-            "transformerId" : "trf7"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "trf7_TWO_ONE",
@@ -1446,7 +1485,20 @@
           "x" : 720.0,
           "y" : 63.33333333333335,
           "open" : false,
-          "transformerId" : "trf6"
+          "idsLegs" : [ {
+            "ONE" : "vl1"
+          }, {
+            "TWO" : "vl2"
+          }, {
+            "THREE" : "vl3"
+          } ],
+          "vNomsLegs" : [ {
+            "ONE" : 400.0
+          }, {
+            "TWO" : 225.0
+          }, {
+            "THREE" : 63.0
+          } ]
         } ]
       }, {
         "type" : "PARALLEL",
@@ -1497,7 +1549,20 @@
             "x" : 720.0,
             "y" : 63.33333333333335,
             "open" : false,
-            "transformerId" : "trf6"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "self4",
@@ -1540,7 +1605,20 @@
             "x" : 720.0,
             "y" : 63.33333333333335,
             "open" : false,
-            "transformerId" : "trf6"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "trf6_TWO_ONE",
@@ -1693,7 +1771,20 @@
           "x" : 880.0,
           "y" : 481.6666666666666,
           "open" : false,
-          "transformerId" : "trf8"
+          "idsLegs" : [ {
+            "ONE" : "vl1"
+          }, {
+            "TWO" : "vl2"
+          }, {
+            "THREE" : "vl3"
+          } ],
+          "vNomsLegs" : [ {
+            "ONE" : 400.0
+          }, {
+            "TWO" : 225.0
+          }, {
+            "THREE" : 63.0
+          } ]
         } ]
       }, {
         "type" : "PARALLEL",
@@ -1744,7 +1835,20 @@
             "x" : 880.0,
             "y" : 481.6666666666666,
             "open" : false,
-            "transformerId" : "trf8"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "self4",
@@ -1787,7 +1891,20 @@
             "x" : 880.0,
             "y" : 481.6666666666666,
             "open" : false,
-            "transformerId" : "trf8"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "trf8_TWO_ONE",

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL3.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL3.json
@@ -565,7 +565,20 @@
           "x" : 320.0,
           "y" : 63.33333333333335,
           "open" : false,
-          "transformerId" : "trf6"
+          "idsLegs" : [ {
+            "ONE" : "vl1"
+          }, {
+            "TWO" : "vl2"
+          }, {
+            "THREE" : "vl3"
+          } ],
+          "vNomsLegs" : [ {
+            "ONE" : 400.0
+          }, {
+            "TWO" : 225.0
+          }, {
+            "THREE" : 63.0
+          } ]
         } ]
       }, {
         "type" : "PARALLEL",
@@ -616,7 +629,20 @@
             "x" : 320.0,
             "y" : 63.33333333333335,
             "open" : false,
-            "transformerId" : "trf6"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "trf6_THREE_TWO",
@@ -659,7 +685,20 @@
             "x" : 320.0,
             "y" : 63.33333333333335,
             "open" : false,
-            "transformerId" : "trf6"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "trf6_THREE_ONE",
@@ -812,7 +851,20 @@
           "x" : 480.0,
           "y" : 456.6666666666667,
           "open" : false,
-          "transformerId" : "trf7"
+          "idsLegs" : [ {
+            "ONE" : "vl1"
+          }, {
+            "TWO" : "vl2"
+          }, {
+            "THREE" : "vl3"
+          } ],
+          "vNomsLegs" : [ {
+            "ONE" : 400.0
+          }, {
+            "TWO" : 225.0
+          }, {
+            "THREE" : 63.0
+          } ]
         } ]
       }, {
         "type" : "PARALLEL",
@@ -863,7 +915,20 @@
             "x" : 480.0,
             "y" : 456.6666666666667,
             "open" : false,
-            "transformerId" : "trf7"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "trf7_THREE_TWO",
@@ -906,7 +971,20 @@
             "x" : 480.0,
             "y" : 456.6666666666667,
             "open" : false,
-            "transformerId" : "trf7"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "trf7_THREE_ONE",
@@ -1059,7 +1137,20 @@
           "x" : 640.0,
           "y" : 63.33333333333335,
           "open" : false,
-          "transformerId" : "trf8"
+          "idsLegs" : [ {
+            "ONE" : "vl1"
+          }, {
+            "TWO" : "vl2"
+          }, {
+            "THREE" : "vl3"
+          } ],
+          "vNomsLegs" : [ {
+            "ONE" : 400.0
+          }, {
+            "TWO" : 225.0
+          }, {
+            "THREE" : 63.0
+          } ]
         } ]
       }, {
         "type" : "PARALLEL",
@@ -1110,7 +1201,20 @@
             "x" : 640.0,
             "y" : 63.33333333333335,
             "open" : false,
-            "transformerId" : "trf8"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "trf8_THREE_TWO",
@@ -1153,7 +1257,20 @@
             "x" : 640.0,
             "y" : 63.33333333333335,
             "open" : false,
-            "transformerId" : "trf8"
+            "idsLegs" : [ {
+              "ONE" : "vl1"
+            }, {
+              "TWO" : "vl2"
+            }, {
+              "THREE" : "vl3"
+            } ],
+            "vNomsLegs" : [ {
+              "ONE" : 400.0
+            }, {
+              "TWO" : 225.0
+            }, {
+              "THREE" : 63.0
+            } ]
           }, {
             "type" : "FEEDER",
             "id" : "trf8_THREE_ONE",

--- a/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
+++ b/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
@@ -1066,14 +1066,12 @@ public abstract class AbstractSingleLineDiagramViewer extends Application implem
     }
 
     private void initStylesProvider() {
-        styles.put("Default", new DefaultDiagramStyleProvider(null));
-        styles.put("Nominal voltage", new NominalVoltageDiagramStyleProvider(null));
+        styles.put("Default", new DefaultDiagramStyleProvider());
+        styles.put("Nominal voltage", new NominalVoltageDiagramStyleProvider());
         styles.put("Topology", new TopologicalStyleProvider(null, null));
     }
 
     private void updateStylesProvider(Network network) {
-        styles.put("Default", new DefaultDiagramStyleProvider(network));
-        styles.put("Nominal voltage", new NominalVoltageDiagramStyleProvider(network));
         styles.put("Topology", new TopologicalStyleProvider(null, network));
     }
 }


### PR DESCRIPTION
Removing all iidm class references in DefaultDiagramStyleProvider class (network, three windings transformer, voltage level), by adding the necessary informations in the fictitious 3WT node class, during the graph building phase.

Modification of some of the test cases subsequently.

Signed-off-by: Franck LECUYER <franck.lecuyer@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
