### PR TITLE
svg_transformers_rotation_in_svg_writer

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import com.powsybl.sld.model.Fictitious3WTNode;
 import org.apache.batik.anim.dom.SVGOMDocument;
 import org.apache.batik.dom.GenericDOMImplementation;
 import org.apache.commons.lang3.StringUtils;
@@ -638,6 +640,32 @@ public class DefaultSVGWriter implements SVGWriter {
         }
     }
 
+    private void handleNodeRotation(Node node) {
+        if (node.getGraph() != null) { // node in voltage level graph
+            if (node instanceof Fictitious3WTNode && node.getCell() != null && ((ExternCell) node.getCell()).getDirection() == BusCell.Direction.BOTTOM) {
+                node.setRotationAngle(180.);  // rotation if 3WT cell direction is BOTTOM
+            }
+        } else {  // node outside any graph
+            List<Node> adjacentNodes = node.getAdjacentNodes();
+            adjacentNodes.sort(Comparator.comparingDouble(Node::getX));
+            if (adjacentNodes.size() == 2) {  // 2 windings transformer
+                List<Edge> edges = node.getAdjacentEdges();
+                List<Double> pol1 = ((TwtEdge) edges.get(0)).getSnakeLine();
+                List<Double> pol2 = ((TwtEdge) edges.get(1)).getSnakeLine();
+                double x1 = pol1.get(pol1.size() - 4); // absciss of the first polyline second last point
+                double x2 = pol2.get(2);  // absciss of the second polyline third point
+                if (x1 == x2) {
+                    node.setRotationAngle(90.);  // rotation if points abscisses are the same
+                }
+            } else {  // 3 windings transformer
+                Node n2 = adjacentNodes.get(1);
+                if (n2.getCell() != null && ((ExternCell) n2.getCell()).getDirection() == BusCell.Direction.BOTTOM) {
+                    node.setRotationAngle(180.);  // rotation if middle node cell orientation is BOTTOM
+                }
+            }
+        }
+    }
+
     protected void insertComponentSVGIntoDocumentSVG(String prefixId,
                                                      Map<String, SVGOMDocument> subComponents,
                                                      Element g, Node node,
@@ -645,6 +673,8 @@ public class DefaultSVGWriter implements SVGWriter {
                                                      String componentDefsId,
                                                      boolean forArrow) {
         ComponentSize size = componentLibrary.getSize(node.getComponentType());
+
+        handleNodeRotation(node);
 
         if (!layoutParameters.isAvoidSVGComponentsDuplication()) {
             // The following code work correctly considering SVG part describing the component is the first child of the SVGDocument.
@@ -657,6 +687,10 @@ public class DefaultSVGWriter implements SVGWriter {
                     org.w3c.dom.Node n = svgSubComponent.getChildNodes().item(0).getChildNodes().item(i).cloneNode(true);
 
                     if (n instanceof SVGElement) {
+                        if (!(node instanceof SwitchNode) && node.isRotated()) {
+                            ((Element) n).setAttribute(TRANSFORM, ROTATE + "(" + node.getRotationAngle() + "," + size.getWidth() / 2 + "," + size.getHeight() / 2 + ")");
+                        }
+
                         Map<String, String> svgStyle = styleProvider.getNodeSVGStyle(node, size, nameSubComponent, layoutParameters.isShowInternalNodes());
                         svgStyle.forEach(((Element) n)::setAttribute);
                     }
@@ -686,6 +720,10 @@ public class DefaultSVGWriter implements SVGWriter {
                 subCmpsName.forEach(s -> {
                     Element eltUse = g.getOwnerDocument().createElement("use");
                     eltUse.setAttribute("href", subCmpsName.size() > 1 ? prefixHref + "-" + s : prefixHref);
+
+                    if (!(node instanceof SwitchNode) && node.isRotated()) {
+                        eltUse.setAttribute(TRANSFORM, ROTATE + "(" + node.getRotationAngle() + "," + size.getWidth() / 2 + "," + size.getHeight() / 2 + ")");
+                    }
 
                     Map<String, String> svgStyle = styleProvider.getNodeSVGStyle(node, size, s, layoutParameters.isShowInternalNodes());
                     svgStyle.forEach(eltUse::setAttribute);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestSVGWriter.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestSVGWriter.java
@@ -633,9 +633,9 @@ public class TestSVGWriter extends AbstractTestCase {
         nMulti1.setX(50, false, false);
         nMulti1.setY(350, false, false);
         TwtEdge edge1 = s1Graph.addEdge(ComponentTypeName.TWO_WINDINGS_TRANSFORMER, twtSide1Node, nMulti1);
-        edge1.setSnakeLine(Arrays.asList(50., 300., 50., 350.));
+        edge1.setSnakeLine(Arrays.asList(50., 300., 50., 320., 50., 350.));
         TwtEdge edge2 = s1Graph.addEdge(ComponentTypeName.TWO_WINDINGS_TRANSFORMER, nMulti1, twtSide2Node);
-        edge2.setSnakeLine(Arrays.asList(50., 350., 50., 400.));
+        edge2.setSnakeLine(Arrays.asList(50., 350., 50., 380., 50., 400.));
         nMulti1.addAdjacentEdge(edge1);
         nMulti1.addAdjacentEdge(edge2);
         s1Graph.addMultiTermNode(nMulti1);

--- a/single-line-diagram-core/src/test/resources/zone.svg
+++ b/single-line-diagram-core/src/test/resources/zone.svg
@@ -227,8 +227,8 @@
 
     <circle r="4" id="idTransformer_95_ONE_95_Transformer_95_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="9" transform="rotate(90.0,6.5,4.0)" cy="4"/>
 </g>
-        <polyline class="wire wire_VoltageLevel11" points="70.0,350.0,70.0,393.5" id="idVoltageLevel11_95__95_Wire0"/>
-        <polyline class="wire wire_VoltageLevel12" points="70.0,406.5,70.0,450.0" id="id_95_VoltageLevel12_95_Wire1"/>
+        <polyline class="wire wire_VoltageLevel11" points="70.0,350.0,70.0,370.0,70.0,393.5" id="idVoltageLevel11_95__95_Wire0"/>
+        <polyline class="wire wire_VoltageLevel12" points="70.0,406.5,70.0,430.0,70.0,450.0" id="id_95_VoltageLevel12_95_Wire1"/>
         <g class="BUSBAR_SECTION idBus21" id="idBus21" transform="translate(150.0,1150.0)">
             <line y2="0" x1="0" x2="40.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Bus21_NW_LABEL">Bus21</text>


### PR DESCRIPTION
Moving the svg transformers components rotation from default style provider methods to the default svg writer class
Correction in the zone test case (the 2 windings transformer svg in the first substation was not rotated)

Signed-off-by: Franck LECUYER <franck.lecuyer@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
