### PR TITLE
Improve position layout by clustering stability

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/HorizontalLane.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/HorizontalLane.java
@@ -25,15 +25,12 @@ import java.util.stream.Collectors;
  */
 class HorizontalLane {
 
-    private List<BusNode> busNodes;
-    private int index;
-    private int length;
+    private final List<BusNode> busNodes = new ArrayList<>();
+    private int index = 0;
+    private int length = 1;
 
     HorizontalLane(BusNode busNode) {
-        this.busNodes = new ArrayList<>();
-        this.busNodes.add(busNode);
-        index = 0;
-        length = 1;
+        busNodes.add(busNode);
     }
 
     void reverse(int parentSize) {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/LBSCluster.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/LBSCluster.java
@@ -23,27 +23,27 @@ import java.util.stream.Collectors;
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  */
 class LBSCluster {
-    private static final Logger LOGGER = LoggerFactory.getLogger(LBSCluster.class);
-    private List<LegBusSet> lbsList;
-    private Map<Side, LegBusSet> sideToLbs;
-    private List<HorizontalLane> horizontalLanes;
-    private List<LBSCluster> lbsClusters;
 
-    private int nb = 0;
+    private static final Logger LOGGER = LoggerFactory.getLogger(LBSCluster.class);
+
+    private final List<LegBusSet> lbsList = new ArrayList<>();
+    private final Map<Side, LegBusSet> sideToLbs = new EnumMap<>(Side.class);
+    private final List<HorizontalLane> horizontalLanes = new ArrayList<>();
+    private final List<LBSCluster> lbsClusters;
+    private final int nb;
 
     LBSCluster(List<LBSCluster> lbsClusters, LegBusSet lbs, int nb) {
-        lbsList = new ArrayList<>();
+        this.lbsClusters = Objects.requireNonNull(lbsClusters);
+        this.lbsClusters.add(this);
+
+        Objects.requireNonNull(lbs);
         lbsList.add(lbs);
-        horizontalLanes = new ArrayList<>();
         lbs.getBusNodeSet().forEach(nodeBus -> horizontalLanes.add(new HorizontalLane(nodeBus)));
         lbs.setLbsCluster(this);
 
-        sideToLbs = new EnumMap<>(Side.class);
         sideToLbs.put(Side.LEFT, lbs);
         sideToLbs.put(Side.RIGHT, lbs);
 
-        this.lbsClusters = lbsClusters;
-        this.lbsClusters.add(this);
         this.nb = nb;
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/LBSClusterSide.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/LBSClusterSide.java
@@ -10,10 +10,7 @@ import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.InternCell;
 import com.powsybl.sld.model.Side;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * LBSClusterSide is a ClusterConnector defined by one Side (LEFT/RIGHT) of a LBSCluster.
@@ -22,18 +19,17 @@ import java.util.Set;
  */
 class LBSClusterSide implements ClusterConnector<LBSClusterSide> {
 
-    private LBSCluster lbsCluster;
-    private Side side;
-    private List<Link<LBSClusterSide>> myLinks;
+    private final LBSCluster lbsCluster;
+    private final Side side;
+    private final List<Link<LBSClusterSide>> myLinks = new ArrayList<>();
 
     LBSClusterSide(LBSCluster lbsCluster, Side side) {
-        this.lbsCluster = lbsCluster;
-        this.side = side;
-        myLinks = new ArrayList<>();
+        this.lbsCluster = Objects.requireNonNull(lbsCluster);
+        this.side = Objects.requireNonNull(side);
     }
 
     public Set<BusNode> getBusNodeSet() {
-        return new HashSet<>(lbsCluster.laneSideBuses(side));
+        return new LinkedHashSet<>(lbsCluster.laneSideBuses(side));
     }
 
     public List<InternCell> getCandidateFlatCellList() {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/LegBusSet.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/LegBusSet.java
@@ -24,21 +24,21 @@ import java.util.*;
  */
 class LegBusSet implements ClusterConnector<LegBusSet> {
 
-    private Set<BusNode> busNodeSet;
-    private Set<BusCell> embeddedCells;
-    private Map<InternCell, Side> candidateFlatCells;
-    private Map<InternCell, Side> crossoverInternCells;
+    private final Set<BusNode> busNodeSet;
+    private final Set<BusCell> embeddedCells;
+    private final Map<InternCell, Side> candidateFlatCells;
+    private final Map<InternCell, Side> crossoverInternCells;
     private LBSCluster lbsCluster;
-    private List<Link<LegBusSet>> myLinks;
-    private Map<BusNode, Integer> nodeToNb;
+    private final List<Link<LegBusSet>> myLinks;
+    private final Map<BusNode, Integer> nodeToNb;
 
     LegBusSet(Map<BusNode, Integer> nodeToNb, List<BusNode> busNodes) {
         this.nodeToNb = nodeToNb;
         busNodeSet = new TreeSet<>(Comparator.comparingInt(nodeToNb::get));
         busNodeSet.addAll(busNodes);
-        embeddedCells = new HashSet<>();
-        candidateFlatCells = new HashMap<>();
-        crossoverInternCells = new HashMap<>();
+        embeddedCells = new LinkedHashSet<>();
+        candidateFlatCells = new LinkedHashMap<>();
+        crossoverInternCells = new LinkedHashMap<>();
         myLinks = new ArrayList<>();
     }
 
@@ -82,7 +82,7 @@ class LegBusSet implements ClusterConnector<LegBusSet> {
     }
 
     private void absorbMap(Map<InternCell, Side> myMap, Map<InternCell, Side> map) {
-        Set<InternCell> commonCells = new HashSet<>(myMap.keySet());
+        Set<InternCell> commonCells = new LinkedHashSet<>(myMap.keySet());
         Set<InternCell> cellToAbsorb = map.keySet();
         commonCells.retainAll(cellToAbsorb);
         for (InternCell commonCell : commonCells) {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/Link.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/Link.java
@@ -12,10 +12,10 @@ import com.powsybl.sld.model.Side;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.EnumMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A link is define between two clusterConnectors (having the same implementation).
@@ -46,11 +46,12 @@ import java.util.Map;
  */
 
 // TODO implement SHUNT in the link assessment
-class Link<T extends ClusterConnector> implements Comparable {
+class Link<T extends ClusterConnector> implements Comparable<Link<T>> {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(Link.class);
 
     enum LinkCategory {
-        COMMONBUSES, FLATCELLS, CROSSOVER//, SHUNT
+        COMMONBUSES, FLATCELLS, CROSSOVER //, SHUNT
     }
 
     private final T clusterConnector1;
@@ -66,11 +67,11 @@ class Link<T extends ClusterConnector> implements Comparable {
     }
 
     private void assessLink() {
-        HashSet<BusNode> nodeBusesIntersect = new HashSet<>(clusterConnector1.getBusNodeSet());
+        Set<BusNode> nodeBusesIntersect = new LinkedHashSet<>(clusterConnector1.getBusNodeSet());
         nodeBusesIntersect.retainAll(clusterConnector2.getBusNodeSet());
         categoryToWeight.put(LinkCategory.COMMONBUSES, nodeBusesIntersect.size());
 
-        HashSet<InternCell> flatCellIntersect = new HashSet<>(clusterConnector1.getCandidateFlatCellList());
+        Set<InternCell> flatCellIntersect = new LinkedHashSet<>(clusterConnector1.getCandidateFlatCellList());
         flatCellIntersect.retainAll(clusterConnector2.getCandidateFlatCellList());
         if (flatCellIntersect.isEmpty()) {
             categoryToWeight.put(LinkCategory.FLATCELLS, 0);
@@ -82,7 +83,7 @@ class Link<T extends ClusterConnector> implements Comparable {
                                     + clusterConnector2.getDistanceToEdge(internCell)).sum());
         }
 
-        HashSet<InternCell> commonInternCells = new HashSet<>(clusterConnector1.getCrossOverCellList());
+        Set<InternCell> commonInternCells = new LinkedHashSet<>(clusterConnector1.getCrossOverCellList());
         commonInternCells.retainAll(clusterConnector2.getCrossOverCellList());
         categoryToWeight.put(LinkCategory.CROSSOVER, (int) (commonInternCells
                 .stream()
@@ -154,16 +155,12 @@ class Link<T extends ClusterConnector> implements Comparable {
     }
 
     @Override
-    public int compareTo(@Nonnull Object o) {
-        if (!(o instanceof Link)) {
-            return 0;
-        }
-        Link link = (Link) o;
+    public int compareTo(Link<T> o) {
         for (LinkCategory category : LinkCategory.values()) {
-            if (link.getLinkCategoryWeight(category) > getLinkCategoryWeight(category)) {
+            if (o.getLinkCategoryWeight(category) > getLinkCategoryWeight(category)) {
                 return -1;
             }
-            if (link.getLinkCategoryWeight(category) < getLinkCategoryWeight(category)) {
+            if (o.getLinkCategoryWeight(category) < getLinkCategoryWeight(category)) {
                 return 1;
             }
         }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/Links.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/Links.java
@@ -6,10 +6,7 @@
  */
 package com.powsybl.sld.layout.positionbyclustering;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 /**
  * Manages the links between a list of clusterConnectors.
@@ -18,11 +15,11 @@ import java.util.TreeSet;
  */
 class Links<T extends ClusterConnector> {
 
-    private List<T> clusterConnectors;
-    private TreeSet<Link<T>> linkSet = new TreeSet<>();
+    private final List<T> clusterConnectors;
+    private final TreeSet<Link<T>> linkSet = new TreeSet<>();
 
     Links(List<T> clusterConnectors) {
-        this.clusterConnectors = clusterConnectors;
+        this.clusterConnectors = Objects.requireNonNull(clusterConnectors);
         for (int i = 0; i < clusterConnectors.size(); i++) {
             for (int j = i + 1; j < clusterConnectors.size(); j++) {
                 buildNewLink(clusterConnectors.get(i), clusterConnectors.get(j));

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/PositionByClustering.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/PositionByClustering.java
@@ -52,7 +52,7 @@ public class PositionByClustering implements PositionFinder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PositionByClustering.class);
 
-    private boolean useLBSLinkOnly;
+    private final boolean useLBSLinkOnly;
 
     public PositionByClustering(boolean useLBSLinkOnly) {
         this.useLBSLinkOnly = useLBSLinkOnly;
@@ -82,7 +82,7 @@ public class PositionByClustering implements PositionFinder {
     }
 
     private Map<BusNode, Integer> indexBusPosition(List<BusNode> busNodes) {
-        Map<BusNode, Integer> busToNb = new HashMap<>();
+        Map<BusNode, Integer> busToNb = new LinkedHashMap<>();
         int i = 1;
         for (BusNode n : busNodes.stream()
                 .sorted(Comparator.comparing(BusNode::getId))
@@ -203,7 +203,7 @@ public class PositionByClustering implements PositionFinder {
     private void establishBusPositions(Graph graph, LBSCluster lbsCluster) {
         graph.getNodeBuses().forEach(busNode -> busNode.setStructuralPosition(null));
         int v = 1;
-        Set<BusNode> remainingBuses = new HashSet<>(graph.getNodeBuses());
+        Set<BusNode> remainingBuses = new LinkedHashSet<>(graph.getNodeBuses());
         while (!remainingBuses.isEmpty()) {
             buildLane(lbsCluster, remainingBuses, v);
             v++;
@@ -228,7 +228,7 @@ public class PositionByClustering implements PositionFinder {
     }
 
     private void buildLane(LBSCluster lbsCluster, Set<BusNode> remainingBuses, int v) {
-        Set<BusNode> busOnLeftSide = new HashSet<>();
+        Set<BusNode> busOnLeftSide = new LinkedHashSet<>();
         int h = 1;
         List<LegBusSet> lbsList = new ArrayList<>(lbsCluster.getLbsList());
         BusNodeAndLbsIndex busIndex = new BusNodeAndLbsIndex();


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Voltage level layout "position by clustering" is not stable, so different call to layout could end up to different positions and so on a different SVG.


**What is the new behavior (if this is a feature change)?**
All HashSet and HashMap have been replaced by LinkedHashSet and LinkedHashMap to try to improve stability.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
