### PR TITLE
adapt_cell_height_to_content

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/SubstationDiagram.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/SubstationDiagram.java
@@ -54,6 +54,10 @@ public final class SubstationDiagram {
                      new PositionVoltageLevelLayoutFactory(), false);
     }
 
+    public SubstationGraph getSubGraph() {
+        return subGraph;
+    }
+
     public static SubstationDiagram build(GraphBuilder graphBuilder, String substationId,
                                           SubstationLayoutFactory sLayoutFactory,
                                           VoltageLevelLayoutFactory vLayoutFactory,

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/VoltageLevelDiagram.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/VoltageLevelDiagram.java
@@ -62,6 +62,10 @@ public final class VoltageLevelDiagram {
         return new VoltageLevelDiagram(graph, layout);
     }
 
+    public Graph getGraph() {
+        return graph;
+    }
+
     public void writeSvg(String prefixId,
                          ComponentLibrary componentLibrary,
                          LayoutParameters layoutParameters,

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -7,8 +7,11 @@
 package com.powsybl.sld.layout;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.powsybl.sld.library.ComponentSize;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -61,6 +64,9 @@ public class LayoutParameters {
     private double maxComponentHeight = 12;
     private double minSpaceBetweenComponents = 15;
     private double minExternCellHeight = 80;
+
+    @JsonIgnore
+    private Map<String, ComponentSize> componentsSize;
 
     @JsonCreator
     public LayoutParameters() {
@@ -155,6 +161,7 @@ public class LayoutParameters {
         maxComponentHeight = other.maxComponentHeight;
         minSpaceBetweenComponents = other.minSpaceBetweenComponents;
         minExternCellHeight = other.minExternCellHeight;
+        componentsSize = other.componentsSize;
     }
 
     public double getTranslateX() {
@@ -407,5 +414,13 @@ public class LayoutParameters {
     public LayoutParameters setMinExternCellHeight(double minExternCellHeight) {
         this.minExternCellHeight = minExternCellHeight;
         return this;
+    }
+
+    public void setComponentsSize(Map<String, ComponentSize> componentsSize) {
+        this.componentsSize = componentsSize;
+    }
+
+    public Map<String, ComponentSize> getComponentsSize() {
+        return componentsSize;
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -57,6 +57,11 @@ public class LayoutParameters {
     private double scaleShiftFeedersPosition = 1;
     private boolean avoidSVGComponentsDuplication = false;
 
+    private boolean adaptCellHeightToContent = false;
+    private double maxComponentHeight = 12;
+    private double minSpaceBetweenComponents = 15;
+    private double minExternCellHeight = 80;
+
     @JsonCreator
     public LayoutParameters() {
     }
@@ -85,7 +90,11 @@ public class LayoutParameters {
                             @JsonProperty("diagramName") String diagramName,
                             @JsonProperty("shiftFeedersPosition") boolean shiftFeedersPosition,
                             @JsonProperty("scaleShiftFeedersPosition") double scaleShiftFeedersPosition,
-                            @JsonProperty("avoidSVGComponentsDuplication") boolean avoidSVGComponentsDuplication) {
+                            @JsonProperty("avoidSVGComponentsDuplication") boolean avoidSVGComponentsDuplication,
+                            @JsonProperty("adaptCellHeightToContent") boolean adaptCellHeightToContent,
+                            @JsonProperty("maxComponentHeight") double maxComponentHeight,
+                            @JsonProperty("minSpaceBetweenComponents") double minSpaceBetweenComponents,
+                            @JsonProperty("minExternCellHeight") double minExternCellHeight) {
         this.translateX = translateX;
         this.translateY = translateY;
         this.initialXBus = initialXBus;
@@ -110,6 +119,10 @@ public class LayoutParameters {
         this.shiftFeedersPosition = shiftFeedersPosition;
         this.scaleShiftFeedersPosition = scaleShiftFeedersPosition;
         this.avoidSVGComponentsDuplication = avoidSVGComponentsDuplication;
+        this.adaptCellHeightToContent = adaptCellHeightToContent;
+        this.maxComponentHeight = maxComponentHeight;
+        this.minSpaceBetweenComponents = minSpaceBetweenComponents;
+        this.minExternCellHeight = minExternCellHeight;
     }
 
     public LayoutParameters(LayoutParameters other) {
@@ -138,6 +151,10 @@ public class LayoutParameters {
         shiftFeedersPosition = other.shiftFeedersPosition;
         scaleShiftFeedersPosition = other.scaleShiftFeedersPosition;
         avoidSVGComponentsDuplication = other.avoidSVGComponentsDuplication;
+        adaptCellHeightToContent = other.adaptCellHeightToContent;
+        maxComponentHeight = other.maxComponentHeight;
+        minSpaceBetweenComponents = other.minSpaceBetweenComponents;
+        minExternCellHeight = other.minExternCellHeight;
     }
 
     public double getTranslateX() {
@@ -353,6 +370,42 @@ public class LayoutParameters {
 
     public LayoutParameters setAvoidSVGComponentsDuplication(boolean avoidSVGComponentsDuplication) {
         this.avoidSVGComponentsDuplication = avoidSVGComponentsDuplication;
+        return this;
+    }
+
+    public boolean isAdaptCellHeightToContent() {
+        return adaptCellHeightToContent;
+    }
+
+    public LayoutParameters setAdaptCellHeightToContent(boolean adaptCellHeightToContent) {
+        this.adaptCellHeightToContent = adaptCellHeightToContent;
+        return this;
+    }
+
+    public double getMaxComponentHeight() {
+        return maxComponentHeight;
+    }
+
+    public LayoutParameters setMaxComponentHeight(double maxComponentHeight) {
+        this.maxComponentHeight = maxComponentHeight;
+        return this;
+    }
+
+    public double getMinSpaceBetweenComponents() {
+        return minSpaceBetweenComponents;
+    }
+
+    public LayoutParameters setMinSpaceBetweenComponents(double minSpaceBetweenComponents) {
+        this.minSpaceBetweenComponents = minSpaceBetweenComponents;
+        return this;
+    }
+
+    public double getMinExternCellHeight() {
+        return minExternCellHeight;
+    }
+
+    public LayoutParameters setMinExternCellHeight(double minExternCellHeight) {
+        this.minExternCellHeight = minExternCellHeight;
         return this;
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
@@ -6,18 +6,25 @@
  */
 package com.powsybl.sld.layout;
 
+import com.powsybl.sld.model.BusCell;
 import com.powsybl.sld.model.Cell;
+import com.powsybl.sld.model.ExternCell;
 import com.powsybl.sld.model.Graph;
 import com.powsybl.sld.model.Node;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.EnumSet;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public class PositionVoltageLevelLayout implements VoltageLevelLayout {
 
@@ -40,6 +47,17 @@ public class PositionVoltageLevelLayout implements VoltageLevelLayout {
         graph.getNodes().stream()
                 .filter(node -> node.getType() != Node.NodeType.BUS)
                 .forEach(Node::finalizeCoord);
+
+        // when adapting cell height to content, we need to leave enough space around feeder nodes for the arrow nodes
+        graph.getNodes().stream()
+                .forEach(n -> {
+                    double shiftY = 0.;
+                    if (n.getType() == Node.NodeType.FEEDER && layoutParam.isAdaptCellHeightToContent()) {
+                        shiftY += (((ExternCell) n.getCell()).getDirection() == BusCell.Direction.TOP ? -1 : 1) * 20;
+                    }
+                    n.shiftY(shiftY);
+                });
+
         if (layoutParam.isShiftFeedersPosition()) {
             graph.shiftFeedersPosition(layoutParam.getScaleShiftFeedersPosition());
         }
@@ -50,6 +68,11 @@ public class PositionVoltageLevelLayout implements VoltageLevelLayout {
     }
 
     private void calculateCellCoord(Graph graph, LayoutParameters layoutParam) {
+        if (layoutParam.isAdaptCellHeightToContent()) {
+            // when using the adapt cell height to content option, we have to calculate the
+            // maximum height of all the extern cells in each direction (top and bottom)
+            calculateMaxCellHeight(layoutParam);
+        }
         graph.getCells().stream()
                 .filter(cell -> cell.getType() == Cell.CellType.EXTERN
                         || cell.getType() == Cell.CellType.INTERN)
@@ -57,5 +80,22 @@ public class PositionVoltageLevelLayout implements VoltageLevelLayout {
         graph.getCells().stream()
                 .filter(cell -> cell.getType() == Cell.CellType.SHUNT)
                 .forEach(cell -> cell.calculateCoord(layoutParam));
+    }
+
+    /*
+     * Calculating the maximum height of all the extern cells in each direction (top and bottom)
+     */
+    private void calculateMaxCellHeight(LayoutParameters layoutParam) {
+        Map<BusCell.Direction, Double> maxCalculatedCellHeight = EnumSet.allOf(BusCell.Direction.class).stream().collect(Collectors.toMap(Function.identity(), v -> 0.));
+
+        graph.getCells().stream()
+                .filter(cell -> cell.getType() == Cell.CellType.EXTERN)
+                .forEach(cell -> maxCalculatedCellHeight.compute(((BusCell) cell).getDirection(), (k, v) -> Math.max(v, cell.calculateHeight(layoutParam))));
+
+        // if needed, adjusting the maximum calculated cell height to the minimum extern cell height parameter
+        maxCalculatedCellHeight.compute(BusCell.Direction.TOP, (k, v) -> Math.max(v, layoutParam.getMinExternCellHeight()));
+        maxCalculatedCellHeight.compute(BusCell.Direction.BOTTOM, (k, v) -> Math.max(v, layoutParam.getMinExternCellHeight()));
+
+        graph.setMaxCalculatedCellHeight(maxCalculatedCellHeight);
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentLibrary.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentLibrary.java
@@ -28,4 +28,6 @@ public interface ComponentLibrary {
     boolean isAllowRotation(String type);
 
     String getStyleSheet();
+
+    Map<String, ComponentSize> getComponentsSize();
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ResourcesComponentLibrary.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ResourcesComponentLibrary.java
@@ -88,6 +88,13 @@ public class ResourcesComponentLibrary implements ComponentLibrary {
     }
 
     @Override
+    public Map<String, ComponentSize> getComponentsSize() {
+        Map<String, ComponentSize> res = new HashMap<>();
+        components.entrySet().forEach(e -> res.put(e.getKey(), e.getValue().getMetadata().getSize()));
+        return res;
+    }
+
+    @Override
     public boolean isAllowRotation(String type) {
         Objects.requireNonNull(type);
         Component component = components.get(type);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBlock.java
@@ -11,13 +11,16 @@ import com.powsybl.sld.layout.LayoutParameters;
 
 import java.io.IOException;
 import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public abstract class AbstractBlock implements Block {
 
@@ -163,8 +166,13 @@ public abstract class AbstractBlock implements Block {
                 dyToBus = layoutParam.getInternCellHeight() * position.getV();
             }
         } else {
-            coord.setYSpan(layoutParam.getExternCellHeight());
-            dyToBus = layoutParam.getExternCellHeight() / 2 + layoutParam.getStackHeight();
+            // when using the adapt cell height to content option, the extern cell height, here,
+            // is the previously calculated maximum height of all the extern cells having the same direction
+            double externCellHeight = !layoutParam.isAdaptCellHeightToContent()
+                    ? layoutParam.getExternCellHeight()
+                    : getGraph().getMaxCalculatedCellHeight(((BusCell) cell).getDirection());
+            coord.setYSpan(externCellHeight);
+            dyToBus = externCellHeight / 2 + layoutParam.getStackHeight();
         }
 
         coord.setX(layoutParam.getInitialXBus()
@@ -188,6 +196,12 @@ public abstract class AbstractBlock implements Block {
             default:
         }
         calculateCoord(layoutParam);
+    }
+
+    @Override
+    public double calculateRootHeight(LayoutParameters layoutParam) {
+        Set<Node> encounteredNodes = new HashSet<>();
+        return calculateHeight(encounteredNodes, layoutParam);
     }
 
     @Override

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBusCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBusCell.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public abstract class AbstractBusCell extends AbstractCell implements BusCell {
 
@@ -65,6 +66,11 @@ public abstract class AbstractBusCell extends AbstractCell implements BusCell {
     @Override
     public void calculateCoord(LayoutParameters layoutParam) {
         getRootBlock().calculateRootCoord(layoutParam);
+    }
+
+    @Override
+    public double calculateHeight(LayoutParameters layoutParam) {
+        return getRootBlock().calculateRootHeight(layoutParam);
     }
 
     @Override

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractCell.java
@@ -7,6 +7,7 @@
 package com.powsybl.sld.model;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.powsybl.sld.layout.LayoutParameters;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 
 public abstract class AbstractCell implements Cell {
@@ -105,5 +107,10 @@ public abstract class AbstractCell implements Cell {
 
     public Graph getGraph() {
         return graph;
+    }
+
+    @Override
+    public double calculateHeight(LayoutParameters layoutParam) {
+        return 0.;
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractComposedBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractComposedBlock.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public abstract class AbstractComposedBlock extends AbstractBlock implements ComposedBlock {
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractParallelBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractParallelBlock.java
@@ -10,11 +10,13 @@ import com.powsybl.sld.layout.LayoutParameters;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 abstract class AbstractParallelBlock extends AbstractComposedBlock implements ParallelBlock {
 
@@ -56,4 +58,14 @@ abstract class AbstractParallelBlock extends AbstractComposedBlock implements Pa
         });
     }
 
+    @Override
+    public double calculateHeight(Set<Node> encounteredNodes, LayoutParameters layoutParameters) {
+        double blockHeight = 0.;
+        for (int i = 0; i < subBlocks.size(); i++) {
+            Block sub = subBlocks.get(i);
+            // Here, the subBlocks are positioned in parallel, so we calculate the max height of all these subBlocks
+            blockHeight = Math.max(blockHeight, sub.calculateHeight(encounteredNodes, layoutParameters));
+        }
+        return blockHeight;
+    }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractPrimaryBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractPrimaryBlock.java
@@ -9,11 +9,13 @@ package com.powsybl.sld.model;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.sld.layout.LayoutParameters;
+import com.powsybl.sld.library.ComponentSize;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -110,12 +112,20 @@ public abstract class AbstractPrimaryBlock extends AbstractBlock implements Prim
     public double calculateHeight(Set<Node> encounteredNodes, LayoutParameters layoutParameters) {
         double blockHeight = 0.;
         int nbNodes = nodes.size();
+        Map<String, ComponentSize> componentsSize = layoutParameters.getComponentsSize();
+
         for (int i = 0; i < nbNodes; i++) {
             Node node = nodes.get(i);
             if (!encounteredNodes.contains(node) && node.getType() != Node.NodeType.BUS) {
                 // the node is not a bus node and has not been already encountered
                 encounteredNodes.add(node);
-                blockHeight += layoutParameters.getMaxComponentHeight();
+                double nodeHeight = layoutParameters.getMaxComponentHeight();
+                if (componentsSize != null) {
+                    nodeHeight = componentsSize.containsKey(node.getComponentType())
+                            ? componentsSize.get(node.getComponentType()).getHeight()
+                            : 0;
+                }
+                blockHeight += nodeHeight;
                 if (i < nbNodes - 1 || node.getType() != Node.NodeType.FEEDER) {
                     // not the last node or last node is not a feeder node
                     blockHeight += layoutParameters.getMinSpaceBetweenComponents();

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractPrimaryBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractPrimaryBlock.java
@@ -8,16 +8,19 @@ package com.powsybl.sld.model;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.powsybl.commons.PowsyblException;
+import com.powsybl.sld.layout.LayoutParameters;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public abstract class AbstractPrimaryBlock extends AbstractBlock implements PrimaryBlock {
 
@@ -101,6 +104,25 @@ public abstract class AbstractPrimaryBlock extends AbstractBlock implements Prim
             node.writeJson(generator);
         }
         generator.writeEndArray();
+    }
+
+    @Override
+    public double calculateHeight(Set<Node> encounteredNodes, LayoutParameters layoutParameters) {
+        double blockHeight = 0.;
+        int nbNodes = nodes.size();
+        for (int i = 0; i < nbNodes; i++) {
+            Node node = nodes.get(i);
+            if (!encounteredNodes.contains(node) && node.getType() != Node.NodeType.BUS) {
+                // the node is not a bus node and has not been already encountered
+                encounteredNodes.add(node);
+                blockHeight += layoutParameters.getMaxComponentHeight();
+                if (i < nbNodes - 1 || node.getType() != Node.NodeType.FEEDER) {
+                    // not the last node or last node is not a feeder node
+                    blockHeight += layoutParameters.getMinSpaceBetweenComponents();
+                }
+            }
+        }
+        return blockHeight;
     }
 
     @Override

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Block.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Block.java
@@ -10,11 +10,13 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.powsybl.sld.layout.LayoutParameters;
 
 import java.io.IOException;
+import java.util.Set;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public interface Block {
     enum Type {
@@ -77,6 +79,10 @@ public interface Block {
     void calculateCoord(LayoutParameters layoutParam);
 
     void calculateRootCoord(LayoutParameters layoutParam);
+
+    double calculateHeight(Set<Node> encounteredNodes, LayoutParameters layoutParam);
+
+    double calculateRootHeight(LayoutParameters layoutParam);
 
     int getOrder();
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/BusNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/BusNode.java
@@ -19,6 +19,7 @@ import static com.powsybl.sld.library.ComponentTypeName.BUSBAR_SECTION;
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public class BusNode extends Node {
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Cell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Cell.java
@@ -16,6 +16,7 @@ import java.util.*;
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public interface Cell {
     enum CellType {
@@ -41,6 +42,8 @@ public interface Cell {
     int getNumber();
 
     void calculateCoord(LayoutParameters layoutParam);
+
+    double calculateHeight(LayoutParameters layoutParam);
 
     void writeJson(JsonGenerator generator) throws IOException;
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Graph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Graph.java
@@ -78,6 +78,10 @@ public final class Graph {
 
     protected static final int VALUE_SHIFT_FEEDER = 8;
 
+    // by direction, max calculated height of the extern cells
+    // (filled and used only when using the adapt cell height to content option)
+    private Map<BusCell.Direction, Double> maxCalculatedCellHeight = new EnumMap<>(BusCell.Direction.class);
+
     private Graph(String id, String name, double nominalV,
                   boolean useName, boolean forVoltageLevelDiagram, boolean showInductorFor3WT) {
         this.voltageLevelId = Objects.requireNonNull(id);
@@ -557,6 +561,14 @@ public final class Graph {
         return getNodeBuses().stream()
                 .mapToInt(nodeBus -> nodeBus.getPosition().getV() + nodeBus.getPosition().getVSpan())
                 .max().orElse(0);
+    }
+
+    public Double getMaxCalculatedCellHeight(BusCell.Direction direction) {
+        return maxCalculatedCellHeight.get(direction);
+    }
+
+    public void setMaxCalculatedCellHeight(Map<BusCell.Direction, Double> maxCalculatedCellHeight) {
+        this.maxCalculatedCellHeight = maxCalculatedCellHeight;
     }
 
     public void setGenerateCoordsInJson(boolean generateCoordsInJson) {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/InternCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/InternCell.java
@@ -15,6 +15,7 @@ import java.util.*;
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public class InternCell extends AbstractBusCell {
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Node.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Node.java
@@ -315,4 +315,8 @@ public class Node implements BaseNode {
         xs.clear();
         ys.clear();
     }
+
+    public void shiftY(double yShift) {
+        y += yShift;
+    }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Position.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Position.java
@@ -15,6 +15,7 @@ import java.util.Objects;
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public class Position {
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/SerialBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/SerialBlock.java
@@ -14,6 +14,7 @@ import java.util.*;
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public class SerialBlock extends AbstractComposedBlock {
 
@@ -199,6 +200,17 @@ public class SerialBlock extends AbstractComposedBlock {
             sub.setYSpan(getCoord().getYSpan());
             sub.calculateCoord(layoutParam);
         }
+    }
+
+    @Override
+    public double calculateHeight(Set<Node> encounteredNodes, LayoutParameters layoutParameters) {
+        double blockHeight = 0.;
+        for (int i = 0; i < subBlocks.size(); i++) {
+            Block sub = subBlocks.get(i);
+            // Here, the subBlocks are positioned serially, so we add the height of all these subBlocks
+            blockHeight += sub.calculateHeight(encounteredNodes, layoutParameters);
+        }
+        return blockHeight;
     }
 
     @Override

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/UndefinedBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/UndefinedBlock.java
@@ -11,12 +11,14 @@ import com.powsybl.sld.layout.LayoutParameters;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * A block group that cannot be correctly decomposed anymore.
  * All subBlocks are superposed.
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public class UndefinedBlock extends AbstractComposedBlock {
 
@@ -56,6 +58,17 @@ public class UndefinedBlock extends AbstractComposedBlock {
     @Override
     public void coordHorizontalCase(LayoutParameters layoutParam) {
         throw new UnsupportedOperationException("Horizontal layout of undefined  block not supported");
+    }
+
+    @Override
+    public double calculateHeight(Set<Node> encounteredNodes, LayoutParameters layoutParameters) {
+        double blockHeight = 0.;
+        for (int i = 0; i < subBlocks.size(); i++) {
+            Block sub = subBlocks.get(i);
+            // Here, the subBlocks are superposed, so we calculate the max height of all these subBlocks
+            blockHeight = Math.max(blockHeight, sub.calculateHeight(encounteredNodes, layoutParameters));
+        }
+        return blockHeight;
     }
 
     @Override

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -562,10 +562,15 @@ public class DefaultSVGWriter implements SVGWriter {
         Element gLabel = root.getOwnerDocument().createElement("g");
         gLabel.setAttribute("id", idLabelVoltageLevel);
 
+        double yPos = graph.getY() + layoutParameters.getInitialYBus()
+                - (!layoutParameters.isAdaptCellHeightToContent()
+                ? layoutParameters.getExternCellHeight()
+                : graph.getMaxCalculatedCellHeight(BusCell.Direction.TOP))
+                - 20.;
         drawLabel(null, graph.isUseName()
                      ? graph.getVoltageLevelName()
                      : graph.getVoltageLevelId(),
-                  false, graph.getX(), graph.getY(), gLabel, FONT_VOLTAGE_LEVEL_LABEL_SIZE);
+                  false, graph.getX(), yPos, gLabel, FONT_VOLTAGE_LEVEL_LABEL_SIZE);
         root.appendChild(gLabel);
 
         metadata.addNodeMetadata(new GraphMetadata.NodeMetadata(idLabelVoltageLevel,

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCaseGraphAdaptCellHeightToContent.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCaseGraphAdaptCellHeightToContent.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld;
+
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.SwitchKind;
+import com.powsybl.iidm.network.TopologyKind;
+import com.powsybl.sld.iidm.extensions.ConnectablePosition;
+import com.powsybl.sld.layout.BlockOrganizer;
+import com.powsybl.sld.layout.ImplicitCellDetector;
+import com.powsybl.sld.layout.LayoutParameters;
+import com.powsybl.sld.layout.PositionFromExtension;
+import com.powsybl.sld.layout.PositionVoltageLevelLayout;
+import com.powsybl.sld.model.Graph;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ */
+public class TestCaseGraphAdaptCellHeightToContent extends AbstractTestCase {
+
+    @Before
+    public void setUp() {
+        network = Network.create("testCaseGraphAdaptCellHeightToContent", "test");
+        graphBuilder = new NetworkGraphBuilder(network);
+
+        substation = createSubstation(network, "subst", "subst", Country.FR);
+
+        vl = createVoltageLevel(substation, "vl", "vl", TopologyKind.NODE_BREAKER, 400, 50);
+
+        createBusBarSection(vl, "bbs1", "bbs1", 0, 1, 1);
+        createBusBarSection(vl, "bbs2", "bbs2", 1, 2, 1);
+
+        // coupling (intern cell)
+        createSwitch(vl, "d1", "d1", SwitchKind.DISCONNECTOR, false, false, false, 0, 2);
+        createSwitch(vl, "b1", "b1", SwitchKind.BREAKER, false, false, false, 2, 3);
+        createSwitch(vl, "d2", "d2", SwitchKind.DISCONNECTOR, false, false, false, 3, 1);
+
+        // load (huge feeder cell with serial blocks)
+        createSwitch(vl, "d3", "d3", SwitchKind.DISCONNECTOR, false, false, false, 0, 4);
+        createSwitch(vl, "b2", "b2", SwitchKind.BREAKER, false, true, false, 4, 5);
+        createSwitch(vl, "b3", "b3", SwitchKind.BREAKER, false, false, false, 5, 6);
+        createSwitch(vl, "b4", "b4", SwitchKind.BREAKER, false, true, false, 6, 7);
+        createSwitch(vl, "b5", "b5", SwitchKind.BREAKER, false, false, false, 7, 8);
+        createSwitch(vl, "b6", "b6", SwitchKind.BREAKER, false, false, false, 8, 9);
+        createSwitch(vl, "b7", "b7", SwitchKind.BREAKER, false, true, false, 9, 10);
+        createSwitch(vl, "b8", "b8", SwitchKind.BREAKER, false, true, false, 10, 11);
+        createSwitch(vl, "b9", "b9", SwitchKind.BREAKER, false, false, false, 11, 12);
+        createSwitch(vl, "b10", "b10", SwitchKind.BREAKER, false, false, false, 12, 13);
+        createSwitch(vl, "b11", "b11", SwitchKind.BREAKER, false, false, false, 13, 14);
+        createSwitch(vl, "b12", "b12", SwitchKind.BREAKER, false, false, false, 14, 15);
+        createLoad(vl, "load1", "load1", "load1", 1, ConnectablePosition.Direction.TOP, 15, 10, 10);
+
+        // generator (small feeder cell with serial blocks)
+        createSwitch(vl, "d4", "d4", SwitchKind.DISCONNECTOR, false, true, false, 1, 16);
+        createSwitch(vl, "b13", "b13", SwitchKind.BREAKER, true, false, false, 16, 17);
+        createGenerator(vl, "gen1", "gen1", "gen1", 2, ConnectablePosition.Direction.BOTTOM, 17, 0, 20, false, 10, 10);
+
+        // load (small feeder cell with parallel blocks)
+        createSwitch(vl, "d5", "d5", SwitchKind.DISCONNECTOR, false, true, false, 0, 18);
+        createSwitch(vl, "d6", "d6", SwitchKind.DISCONNECTOR, false, true, false, 1, 19);
+        createSwitch(vl, "b14", "b14", SwitchKind.BREAKER, true, false, false, 18, 20);
+        createSwitch(vl, "b15", "b15", SwitchKind.BREAKER, true, false, false, 19, 20);
+        createSwitch(vl, "b16", "b16", SwitchKind.BREAKER, true, false, false, 20, 21);
+        createLoad(vl, "load2", "load2", "load2", 1, ConnectablePosition.Direction.TOP, 21, 10, 10);
+
+        // undefined block
+        createSwitch(vl, "d7", "d7", SwitchKind.DISCONNECTOR, false, true, false, 0, 22);
+        createSwitch(vl, "b17", "b17", SwitchKind.BREAKER, true, false, false, 22, 23);
+        createSwitch(vl, "b18", "b18", SwitchKind.BREAKER, true, false, false, 23, 24);
+        createSwitch(vl, "b19", "b19", SwitchKind.BREAKER, true, false, false, 23, 24);
+        createSwitch(vl, "b20", "b20", SwitchKind.BREAKER, true, false, false, 24, 25);
+        createGenerator(vl, "gen2", "gen2", "gen2", 2, ConnectablePosition.Direction.BOTTOM, 25, 0, 20, false, 10, 10);
+    }
+
+    @Test
+    public void test() {
+        // layout parameters with extern cell height fixed
+        LayoutParameters layoutParameters = new LayoutParameters()
+                .setExternCellHeight(200)
+                .setShowInternalNodes(true)
+                .setAdaptCellHeightToContent(false);
+
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, true);
+        new ImplicitCellDetector(false, true, false).detectCells(g);
+        new BlockOrganizer(new PositionFromExtension(), false).organize(g);
+        new PositionVoltageLevelLayout(g).run(layoutParameters);
+
+        assertEquals(toJson(g, "/TestCaseGraphExternCellHeightFixed.json"), toString("/TestCaseGraphExternCellHeightFixed.json"));
+
+        // layout parameters with adapt cell height to content
+        LayoutParameters layoutParametersAdaptCellHeightToContent = new LayoutParameters(layoutParameters);
+        layoutParametersAdaptCellHeightToContent.setAdaptCellHeightToContent(true);
+
+        g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, true);
+        new ImplicitCellDetector(false, true, false).detectCells(g);
+        new BlockOrganizer(new PositionFromExtension(), true).organize(g);
+        new PositionVoltageLevelLayout(g).run(layoutParametersAdaptCellHeightToContent);
+
+        assertEquals(toJson(g, "/TestCaseGraphAdaptCellHeightToContent.json"), toString("/TestCaseGraphAdaptCellHeightToContent.json"));
+    }
+}

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 /**
  * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public class LayoutParametersTest {
 
@@ -41,7 +42,11 @@ public class LayoutParametersTest {
                 .setDiagramName("diag")
                 .setShiftFeedersPosition(false)
                 .setScaleShiftFeedersPosition(2)
-                .setAvoidSVGComponentsDuplication(true);
+                .setAvoidSVGComponentsDuplication(true)
+                .setAdaptCellHeightToContent(true)
+                .setMaxComponentHeight(10)
+                .setMinSpaceBetweenComponents(30)
+                .setMinExternCellHeight(150);
         LayoutParameters layoutParameters2 = new LayoutParameters(layoutParameters);
 
         assertEquals(layoutParameters.getTranslateX(), layoutParameters2.getTranslateX(), 0);
@@ -68,5 +73,9 @@ public class LayoutParametersTest {
         assertEquals(layoutParameters.isShowInductorFor3WT(), layoutParameters2.isShowInductorFor3WT());
         assertEquals(layoutParameters.getDiagramName(), layoutParameters2.getDiagramName());
         assertEquals(layoutParameters.isAvoidSVGComponentsDuplication(), layoutParameters2.isAvoidSVGComponentsDuplication());
+        assertEquals(layoutParameters.isAdaptCellHeightToContent(), layoutParameters2.isAdaptCellHeightToContent());
+        assertEquals(layoutParameters.getMaxComponentHeight(), layoutParameters2.getMaxComponentHeight(), 0);
+        assertEquals(layoutParameters.getMinSpaceBetweenComponents(), layoutParameters2.getMinSpaceBetweenComponents(), 0);
+        assertEquals(layoutParameters.getMinExternCellHeight(), layoutParameters2.getMinExternCellHeight(), 0);
     }
 }

--- a/single-line-diagram-core/src/test/resources/TestCaseGraphAdaptCellHeightToContent.json
+++ b/single-line-diagram-core/src/test/resources/TestCaseGraphAdaptCellHeightToContent.json
@@ -1,0 +1,1839 @@
+{
+  "id" : "vl",
+  "x" : 0.0,
+  "y" : 0.0,
+  "cells" : [ {
+    "type" : "INTERN",
+    "number" : 0,
+    "direction" : "TOP",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 260.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs2",
+          "name" : "bbs2",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 10.0,
+          "y" : 285.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 2,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "d2",
+          "name" : "d2",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 25.0,
+          "y" : 285.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_3",
+          "name" : "3",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 25.0,
+          "y" : 220.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : -1.0,
+          "y" : -1.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_3",
+          "name" : "3",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 25.0,
+          "y" : 220.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b1",
+          "name" : "b1",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 50.0,
+          "y" : 220.0,
+          "rotationAngle" : 90.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_2",
+          "name" : "2",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 75.0,
+          "y" : 220.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 1,
+          "v" : 2,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 180.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs1",
+          "name" : "bbs1",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 10.0,
+          "y" : 260.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 1,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 1,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "d1",
+          "name" : "d1",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 75.0,
+          "y" : 260.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_2",
+          "name" : "2",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 75.0,
+          "y" : 220.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 1,
+    "direction" : "TOP",
+    "order" : 1,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 2,
+        "v" : 0,
+        "hSpan" : 1,
+        "vSpan" : 22,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 125.0,
+        "y" : -86.5,
+        "xSpan" : 50.0,
+        "ySpan" : 633.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 230.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs1",
+          "name" : "bbs1",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 10.0,
+          "y" : 260.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 1,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 1,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "d3",
+          "name" : "d3",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 260.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_4",
+          "name" : "4",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 230.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 201.22727272727272,
+          "xSpan" : 50.0,
+          "ySpan" : 57.54545454545455
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_4",
+          "name" : "4",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 230.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b2",
+          "name" : "b2",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 201.22727272727272,
+          "open" : true,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_5",
+          "name" : "5",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 172.45454545454544,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 2,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 143.6818181818182,
+          "xSpan" : 50.0,
+          "ySpan" : 57.54545454545455
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_5",
+          "name" : "5",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 172.45454545454544,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b3",
+          "name" : "b3",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 143.6818181818182,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_6",
+          "name" : "6",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 114.9090909090909,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 4,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 86.13636363636363,
+          "xSpan" : 50.0,
+          "ySpan" : 57.54545454545455
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_6",
+          "name" : "6",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 114.9090909090909,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b4",
+          "name" : "b4",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 86.13636363636363,
+          "open" : true,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_7",
+          "name" : "7",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 57.36363636363636,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 6,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 28.590909090909093,
+          "xSpan" : 50.0,
+          "ySpan" : 57.54545454545455
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_7",
+          "name" : "7",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 57.36363636363636,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b5",
+          "name" : "b5",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 28.590909090909093,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_8",
+          "name" : "8",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -0.18181818181817277,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 8,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : -28.95454545454544,
+          "xSpan" : 50.0,
+          "ySpan" : 57.54545454545455
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_8",
+          "name" : "8",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -0.18181818181817277,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b6",
+          "name" : "b6",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : -28.95454545454544,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_9",
+          "name" : "9",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -57.72727272727272,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 10,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : -86.5,
+          "xSpan" : 50.0,
+          "ySpan" : 57.54545454545455
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_9",
+          "name" : "9",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -57.72727272727272,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b7",
+          "name" : "b7",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : -86.5,
+          "open" : true,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_10",
+          "name" : "10",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -115.27272727272728,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 12,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : -144.04545454545456,
+          "xSpan" : 50.0,
+          "ySpan" : 57.54545454545455
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_10",
+          "name" : "10",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -115.27272727272728,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b8",
+          "name" : "b8",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : -144.04545454545456,
+          "open" : true,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_11",
+          "name" : "11",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -172.8181818181818,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 14,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : -201.59090909090912,
+          "xSpan" : 50.0,
+          "ySpan" : 57.54545454545455
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_11",
+          "name" : "11",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -172.8181818181818,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b9",
+          "name" : "b9",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : -201.59090909090912,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_12",
+          "name" : "12",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -230.36363636363637,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 16,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : -259.1363636363636,
+          "xSpan" : 50.0,
+          "ySpan" : 57.54545454545455
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_12",
+          "name" : "12",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -230.36363636363637,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b10",
+          "name" : "b10",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : -259.1363636363636,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_13",
+          "name" : "13",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -287.90909090909093,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 18,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : -316.68181818181824,
+          "xSpan" : 50.0,
+          "ySpan" : 57.54545454545455
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_13",
+          "name" : "13",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -287.90909090909093,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b11",
+          "name" : "b11",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : -316.68181818181824,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_14",
+          "name" : "14",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -345.4545454545455,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 20,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : -374.22727272727275,
+          "xSpan" : 50.0,
+          "ySpan" : 57.54545454545455
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_14",
+          "name" : "14",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : -345.4545454545455,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b12",
+          "name" : "b12",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : -374.22727272727275,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "load1",
+          "name" : "load1",
+          "componentType" : "LOAD",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : -423.00000000000006,
+          "open" : false,
+          "label" : "load1",
+          "order" : 1,
+          "direction" : "TOP"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 2,
+    "direction" : "TOP",
+    "order" : 1,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 2
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 3,
+        "v" : 0,
+        "hSpan" : 2,
+        "vSpan" : 4,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 200.0,
+        "y" : -86.5,
+        "xSpan" : 100.0,
+        "ySpan" : 633.0
+      },
+      "subBlocks" : [ {
+        "type" : "PARALLEL",
+        "cardinalities" : [ {
+          "START" : 2
+        }, {
+          "END" : 2
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 200.0,
+          "y" : 71.75,
+          "xSpan" : 100.0,
+          "ySpan" : 316.5
+        },
+        "subBlocks" : [ {
+          "type" : "SERIAL",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 0,
+            "hSpan" : 1,
+            "vSpan" : 2,
+            "orientation" : "VERTICAL"
+          },
+          "coord" : {
+            "x" : 175.0,
+            "y" : 71.75,
+            "xSpan" : 50.0,
+            "ySpan" : 316.5
+          },
+          "subBlocks" : [ {
+            "type" : "PRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 1,
+              "vSpan" : 0,
+              "orientation" : "VERTICAL"
+            },
+            "coord" : {
+              "x" : 175.0,
+              "y" : 230.0,
+              "xSpan" : 50.0,
+              "ySpan" : 0.0
+            },
+            "nodes" : [ {
+              "type" : "BUS",
+              "id" : "bbs2",
+              "name" : "bbs2",
+              "componentType" : "BUSBAR_SECTION",
+              "fictitious" : false,
+              "x" : 10.0,
+              "y" : 285.0,
+              "open" : false,
+              "pxWidth" : 280.0,
+              "structuralPosition" : {
+                "h" : 1,
+                "v" : 2,
+                "hSpan" : 1,
+                "vSpan" : 0
+              },
+              "position" : {
+                "h" : 0,
+                "v" : 2,
+                "hSpan" : 6,
+                "vSpan" : 0
+              }
+            }, {
+              "type" : "SWITCH",
+              "id" : "d6",
+              "name" : "d6",
+              "componentType" : "DISCONNECTOR",
+              "fictitious" : false,
+              "x" : 175.0,
+              "y" : 285.0,
+              "open" : true,
+              "kind" : "DISCONNECTOR"
+            }, {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_19",
+              "name" : "19",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 175.0,
+              "y" : 230.0,
+              "open" : false
+            } ]
+          }, {
+            "type" : "PRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 1,
+              "vSpan" : 2,
+              "orientation" : "VERTICAL"
+            },
+            "coord" : {
+              "x" : 175.0,
+              "y" : 71.75,
+              "xSpan" : 50.0,
+              "ySpan" : 316.5
+            },
+            "nodes" : [ {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_19",
+              "name" : "19",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 175.0,
+              "y" : 230.0,
+              "open" : false
+            }, {
+              "type" : "SWITCH",
+              "id" : "b15",
+              "name" : "b15",
+              "componentType" : "BREAKER",
+              "fictitious" : false,
+              "x" : 175.0,
+              "y" : 71.75,
+              "open" : false,
+              "kind" : "BREAKER"
+            }, {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_20",
+              "name" : "20",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 200.0,
+              "y" : -86.5,
+              "open" : false
+            } ]
+          } ]
+        }, {
+          "type" : "SERIAL",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 1,
+            "v" : 0,
+            "hSpan" : 1,
+            "vSpan" : 2,
+            "orientation" : "VERTICAL"
+          },
+          "coord" : {
+            "x" : 225.0,
+            "y" : 71.75,
+            "xSpan" : 50.0,
+            "ySpan" : 316.5
+          },
+          "subBlocks" : [ {
+            "type" : "PRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 1,
+              "vSpan" : 0,
+              "orientation" : "VERTICAL"
+            },
+            "coord" : {
+              "x" : 225.0,
+              "y" : 230.0,
+              "xSpan" : 50.0,
+              "ySpan" : 0.0
+            },
+            "nodes" : [ {
+              "type" : "BUS",
+              "id" : "bbs1",
+              "name" : "bbs1",
+              "componentType" : "BUSBAR_SECTION",
+              "fictitious" : false,
+              "x" : 10.0,
+              "y" : 260.0,
+              "open" : false,
+              "pxWidth" : 280.0,
+              "structuralPosition" : {
+                "h" : 1,
+                "v" : 1,
+                "hSpan" : 1,
+                "vSpan" : 0
+              },
+              "position" : {
+                "h" : 0,
+                "v" : 1,
+                "hSpan" : 6,
+                "vSpan" : 0
+              }
+            }, {
+              "type" : "SWITCH",
+              "id" : "d5",
+              "name" : "d5",
+              "componentType" : "DISCONNECTOR",
+              "fictitious" : false,
+              "x" : 225.0,
+              "y" : 260.0,
+              "open" : true,
+              "kind" : "DISCONNECTOR"
+            }, {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_18",
+              "name" : "18",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 225.0,
+              "y" : 230.0,
+              "open" : false
+            } ]
+          }, {
+            "type" : "PRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 1,
+              "vSpan" : 2,
+              "orientation" : "VERTICAL"
+            },
+            "coord" : {
+              "x" : 225.0,
+              "y" : 71.75,
+              "xSpan" : 50.0,
+              "ySpan" : 316.5
+            },
+            "nodes" : [ {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_18",
+              "name" : "18",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 225.0,
+              "y" : 230.0,
+              "open" : false
+            }, {
+              "type" : "SWITCH",
+              "id" : "b14",
+              "name" : "b14",
+              "componentType" : "BREAKER",
+              "fictitious" : false,
+              "x" : 225.0,
+              "y" : 71.75,
+              "open" : false,
+              "kind" : "BREAKER"
+            }, {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_20",
+              "name" : "20",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 200.0,
+              "y" : -86.5,
+              "open" : false
+            } ]
+          } ]
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 2,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 200.0,
+          "y" : -244.75,
+          "xSpan" : 100.0,
+          "ySpan" : 316.5
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_20",
+          "name" : "20",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 200.0,
+          "y" : -86.5,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b16",
+          "name" : "b16",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 200.0,
+          "y" : -244.75,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "load2",
+          "name" : "load2",
+          "componentType" : "LOAD",
+          "fictitious" : false,
+          "x" : 200.0,
+          "y" : -423.0,
+          "open" : false,
+          "label" : "load2",
+          "order" : 1,
+          "direction" : "TOP"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 3,
+    "direction" : "BOTTOM",
+    "order" : 2,
+    "rootBlock" : {
+      "type" : "UNDEFINED",
+      "cardinalities" : [ {
+        "START" : 0
+      }, {
+        "END" : 0
+      } ],
+      "position" : {
+        "h" : 5,
+        "v" : 0,
+        "hSpan" : 0,
+        "vSpan" : 0,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 250.0,
+        "y" : 396.0,
+        "xSpan" : 0.0,
+        "ySpan" : 162.0
+      },
+      "subBlocks" : [ {
+        "type" : "SERIAL",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 2
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 4,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 250.0,
+          "y" : 396.0,
+          "xSpan" : 0.0,
+          "ySpan" : 162.0
+        },
+        "subBlocks" : [ {
+          "type" : "PARALLEL",
+          "cardinalities" : [ {
+            "START" : 2
+          }, {
+            "END" : 2
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 0,
+            "hSpan" : 2,
+            "vSpan" : 2,
+            "orientation" : "VERTICAL"
+          },
+          "coord" : {
+            "x" : 250.0,
+            "y" : 355.5,
+            "xSpan" : 0.0,
+            "ySpan" : 81.0
+          },
+          "subBlocks" : [ {
+            "type" : "PRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 1,
+              "vSpan" : 2,
+              "orientation" : "VERTICAL"
+            },
+            "coord" : {
+              "x" : 250.0,
+              "y" : 355.5,
+              "xSpan" : 0.0,
+              "ySpan" : 81.0
+            },
+            "nodes" : [ {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_24",
+              "name" : "24",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 250.0,
+              "y" : 315.0,
+              "open" : false
+            }, {
+              "type" : "SWITCH",
+              "id" : "b19",
+              "name" : "b19",
+              "componentType" : "BREAKER",
+              "fictitious" : false,
+              "x" : 250.0,
+              "y" : 355.5,
+              "open" : false,
+              "kind" : "BREAKER"
+            }, {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_23",
+              "name" : "23",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 250.0,
+              "y" : 396.0,
+              "open" : false
+            } ]
+          }, {
+            "type" : "PRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 1,
+              "v" : 0,
+              "hSpan" : 1,
+              "vSpan" : 2,
+              "orientation" : "VERTICAL"
+            },
+            "coord" : {
+              "x" : 250.0,
+              "y" : 355.5,
+              "xSpan" : 0.0,
+              "ySpan" : 81.0
+            },
+            "nodes" : [ {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_24",
+              "name" : "24",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 250.0,
+              "y" : 315.0,
+              "open" : false
+            }, {
+              "type" : "SWITCH",
+              "id" : "b18",
+              "name" : "b18",
+              "componentType" : "BREAKER",
+              "fictitious" : false,
+              "x" : 250.0,
+              "y" : 355.5,
+              "open" : false,
+              "kind" : "BREAKER"
+            }, {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_23",
+              "name" : "23",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 250.0,
+              "y" : 396.0,
+              "open" : false
+            } ]
+          } ]
+        }, {
+          "type" : "PRIMARY",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 2,
+            "orientation" : "VERTICAL"
+          },
+          "coord" : {
+            "x" : 250.0,
+            "y" : 436.5,
+            "xSpan" : 0.0,
+            "ySpan" : 81.0
+          },
+          "nodes" : [ {
+            "type" : "FICTITIOUS",
+            "id" : "FICT_vl_23",
+            "name" : "23",
+            "componentType" : "NODE",
+            "fictitious" : true,
+            "x" : 250.0,
+            "y" : 396.0,
+            "open" : false
+          }, {
+            "type" : "SWITCH",
+            "id" : "b17",
+            "name" : "b17",
+            "componentType" : "BREAKER",
+            "fictitious" : false,
+            "x" : 250.0,
+            "y" : 436.5,
+            "open" : false,
+            "kind" : "BREAKER"
+          }, {
+            "type" : "FICTITIOUS",
+            "id" : "FICT_vl_22",
+            "name" : "22",
+            "componentType" : "NODE",
+            "fictitious" : true,
+            "x" : 250.0,
+            "y" : 477.0,
+            "open" : false
+          } ]
+        }, {
+          "type" : "PRIMARY",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 4,
+            "hSpan" : 1,
+            "vSpan" : 0,
+            "orientation" : "VERTICAL"
+          },
+          "coord" : {
+            "x" : 250.0,
+            "y" : 477.0,
+            "xSpan" : 0.0,
+            "ySpan" : 0.0
+          },
+          "nodes" : [ {
+            "type" : "BUS",
+            "id" : "bbs1",
+            "name" : "bbs1",
+            "componentType" : "BUSBAR_SECTION",
+            "fictitious" : false,
+            "x" : 10.0,
+            "y" : 260.0,
+            "open" : false,
+            "pxWidth" : 280.0,
+            "structuralPosition" : {
+              "h" : 1,
+              "v" : 1,
+              "hSpan" : 1,
+              "vSpan" : 0
+            },
+            "position" : {
+              "h" : 0,
+              "v" : 1,
+              "hSpan" : 6,
+              "vSpan" : 0
+            }
+          }, {
+            "type" : "SWITCH",
+            "id" : "d7",
+            "name" : "d7",
+            "componentType" : "DISCONNECTOR",
+            "fictitious" : false,
+            "x" : 250.0,
+            "y" : 260.0,
+            "open" : true,
+            "kind" : "DISCONNECTOR"
+          }, {
+            "type" : "FICTITIOUS",
+            "id" : "FICT_vl_22",
+            "name" : "22",
+            "componentType" : "NODE",
+            "fictitious" : true,
+            "x" : 250.0,
+            "y" : 477.0,
+            "open" : false
+          } ]
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 250.0,
+          "y" : 396.0,
+          "xSpan" : 0.0,
+          "ySpan" : 162.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_24",
+          "name" : "24",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 250.0,
+          "y" : 315.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b20",
+          "name" : "b20",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 250.0,
+          "y" : 396.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "gen2",
+          "name" : "gen2",
+          "componentType" : "GENERATOR",
+          "fictitious" : false,
+          "x" : 250.0,
+          "y" : 497.0,
+          "open" : false,
+          "label" : "gen2",
+          "order" : 2,
+          "direction" : "BOTTOM"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 4,
+    "direction" : "BOTTOM",
+    "order" : 2,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 5,
+        "v" : 0,
+        "hSpan" : 1,
+        "vSpan" : 2,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 275.0,
+        "y" : 396.0,
+        "xSpan" : 50.0,
+        "ySpan" : 162.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 275.0,
+          "y" : 315.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs2",
+          "name" : "bbs2",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 10.0,
+          "y" : 285.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 2,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "d4",
+          "name" : "d4",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 275.0,
+          "y" : 285.0,
+          "open" : true,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_16",
+          "name" : "16",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 275.0,
+          "y" : 315.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 275.0,
+          "y" : 396.0,
+          "xSpan" : 50.0,
+          "ySpan" : 162.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_16",
+          "name" : "16",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 275.0,
+          "y" : 315.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b13",
+          "name" : "b13",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 275.0,
+          "y" : 396.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "gen1",
+          "name" : "gen1",
+          "componentType" : "GENERATOR",
+          "fictitious" : false,
+          "x" : 275.0,
+          "y" : 497.0,
+          "open" : false,
+          "label" : "gen1",
+          "order" : 2,
+          "direction" : "BOTTOM"
+        } ]
+      } ]
+    }
+  } ],
+  "edges" : [ {
+    "node1" : "bbs1",
+    "node2" : "d1"
+  }, {
+    "node1" : "d1",
+    "node2" : "FICT_vl_2"
+  }, {
+    "node1" : "FICT_vl_2",
+    "node2" : "b1"
+  }, {
+    "node1" : "b1",
+    "node2" : "FICT_vl_3"
+  }, {
+    "node1" : "FICT_vl_3",
+    "node2" : "d2"
+  }, {
+    "node1" : "d2",
+    "node2" : "bbs2"
+  }, {
+    "node1" : "bbs1",
+    "node2" : "d3"
+  }, {
+    "node1" : "d3",
+    "node2" : "FICT_vl_4"
+  }, {
+    "node1" : "FICT_vl_4",
+    "node2" : "b2"
+  }, {
+    "node1" : "b2",
+    "node2" : "FICT_vl_5"
+  }, {
+    "node1" : "FICT_vl_5",
+    "node2" : "b3"
+  }, {
+    "node1" : "b3",
+    "node2" : "FICT_vl_6"
+  }, {
+    "node1" : "FICT_vl_6",
+    "node2" : "b4"
+  }, {
+    "node1" : "b4",
+    "node2" : "FICT_vl_7"
+  }, {
+    "node1" : "FICT_vl_7",
+    "node2" : "b5"
+  }, {
+    "node1" : "b5",
+    "node2" : "FICT_vl_8"
+  }, {
+    "node1" : "FICT_vl_8",
+    "node2" : "b6"
+  }, {
+    "node1" : "b6",
+    "node2" : "FICT_vl_9"
+  }, {
+    "node1" : "FICT_vl_9",
+    "node2" : "b7"
+  }, {
+    "node1" : "b7",
+    "node2" : "FICT_vl_10"
+  }, {
+    "node1" : "FICT_vl_10",
+    "node2" : "b8"
+  }, {
+    "node1" : "b8",
+    "node2" : "FICT_vl_11"
+  }, {
+    "node1" : "FICT_vl_11",
+    "node2" : "b9"
+  }, {
+    "node1" : "b9",
+    "node2" : "FICT_vl_12"
+  }, {
+    "node1" : "FICT_vl_12",
+    "node2" : "b10"
+  }, {
+    "node1" : "b10",
+    "node2" : "FICT_vl_13"
+  }, {
+    "node1" : "FICT_vl_13",
+    "node2" : "b11"
+  }, {
+    "node1" : "b11",
+    "node2" : "FICT_vl_14"
+  }, {
+    "node1" : "FICT_vl_14",
+    "node2" : "b12"
+  }, {
+    "node1" : "b12",
+    "node2" : "load1"
+  }, {
+    "node1" : "bbs2",
+    "node2" : "d4"
+  }, {
+    "node1" : "d4",
+    "node2" : "FICT_vl_16"
+  }, {
+    "node1" : "FICT_vl_16",
+    "node2" : "b13"
+  }, {
+    "node1" : "b13",
+    "node2" : "gen1"
+  }, {
+    "node1" : "bbs1",
+    "node2" : "d5"
+  }, {
+    "node1" : "d5",
+    "node2" : "FICT_vl_18"
+  }, {
+    "node1" : "bbs2",
+    "node2" : "d6"
+  }, {
+    "node1" : "d6",
+    "node2" : "FICT_vl_19"
+  }, {
+    "node1" : "FICT_vl_18",
+    "node2" : "b14"
+  }, {
+    "node1" : "b14",
+    "node2" : "FICT_vl_20"
+  }, {
+    "node1" : "FICT_vl_19",
+    "node2" : "b15"
+  }, {
+    "node1" : "b15",
+    "node2" : "FICT_vl_20"
+  }, {
+    "node1" : "FICT_vl_20",
+    "node2" : "b16"
+  }, {
+    "node1" : "b16",
+    "node2" : "load2"
+  }, {
+    "node1" : "bbs1",
+    "node2" : "d7"
+  }, {
+    "node1" : "d7",
+    "node2" : "FICT_vl_22"
+  }, {
+    "node1" : "FICT_vl_22",
+    "node2" : "b17"
+  }, {
+    "node1" : "b17",
+    "node2" : "FICT_vl_23"
+  }, {
+    "node1" : "FICT_vl_23",
+    "node2" : "b18"
+  }, {
+    "node1" : "b18",
+    "node2" : "FICT_vl_24"
+  }, {
+    "node1" : "FICT_vl_23",
+    "node2" : "b19"
+  }, {
+    "node1" : "b19",
+    "node2" : "FICT_vl_24"
+  }, {
+    "node1" : "FICT_vl_24",
+    "node2" : "b20"
+  }, {
+    "node1" : "b20",
+    "node2" : "gen2"
+  } ]
+}

--- a/single-line-diagram-core/src/test/resources/TestCaseGraphExternCellHeightFixed.json
+++ b/single-line-diagram-core/src/test/resources/TestCaseGraphExternCellHeightFixed.json
@@ -1,0 +1,1839 @@
+{
+  "id" : "vl",
+  "x" : 0.0,
+  "y" : 0.0,
+  "cells" : [ {
+    "type" : "INTERN",
+    "number" : 0,
+    "direction" : "TOP",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 260.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs2",
+          "name" : "bbs2",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 10.0,
+          "y" : 285.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 2,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "d2",
+          "name" : "d2",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 25.0,
+          "y" : 285.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_3",
+          "name" : "3",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 25.0,
+          "y" : 220.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : -1.0,
+          "y" : -1.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_3",
+          "name" : "3",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 25.0,
+          "y" : 220.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b1",
+          "name" : "b1",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 50.0,
+          "y" : 220.0,
+          "rotationAngle" : 90.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_2",
+          "name" : "2",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 75.0,
+          "y" : 220.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 1,
+          "v" : 2,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 180.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs1",
+          "name" : "bbs1",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 10.0,
+          "y" : 260.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 1,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 1,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "d1",
+          "name" : "d1",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 75.0,
+          "y" : 260.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_2",
+          "name" : "2",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 75.0,
+          "y" : 220.0,
+          "rotationAngle" : 90.0,
+          "open" : false
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 1,
+    "direction" : "TOP",
+    "order" : 1,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 2,
+        "v" : 0,
+        "hSpan" : 1,
+        "vSpan" : 22,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 125.0,
+        "y" : 130.0,
+        "xSpan" : 50.0,
+        "ySpan" : 200.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 230.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs1",
+          "name" : "bbs1",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 10.0,
+          "y" : 260.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 1,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 1,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "d3",
+          "name" : "d3",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 260.0,
+          "open" : false,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_4",
+          "name" : "4",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 230.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 220.9090909090909,
+          "xSpan" : 50.0,
+          "ySpan" : 18.181818181818183
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_4",
+          "name" : "4",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 230.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b2",
+          "name" : "b2",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 220.9090909090909,
+          "open" : true,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_5",
+          "name" : "5",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 211.8181818181818,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 2,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 202.72727272727272,
+          "xSpan" : 50.0,
+          "ySpan" : 18.181818181818183
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_5",
+          "name" : "5",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 211.8181818181818,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b3",
+          "name" : "b3",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 202.72727272727272,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_6",
+          "name" : "6",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 193.63636363636363,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 4,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 184.54545454545453,
+          "xSpan" : 50.0,
+          "ySpan" : 18.181818181818183
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_6",
+          "name" : "6",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 193.63636363636363,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b4",
+          "name" : "b4",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 184.54545454545453,
+          "open" : true,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_7",
+          "name" : "7",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 175.45454545454544,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 6,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 166.36363636363637,
+          "xSpan" : 50.0,
+          "ySpan" : 18.181818181818183
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_7",
+          "name" : "7",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 175.45454545454544,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b5",
+          "name" : "b5",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 166.36363636363637,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_8",
+          "name" : "8",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 157.27272727272728,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 8,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 148.1818181818182,
+          "xSpan" : 50.0,
+          "ySpan" : 18.181818181818183
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_8",
+          "name" : "8",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 157.27272727272728,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b6",
+          "name" : "b6",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 148.1818181818182,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_9",
+          "name" : "9",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 139.0909090909091,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 10,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 130.0,
+          "xSpan" : 50.0,
+          "ySpan" : 18.181818181818183
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_9",
+          "name" : "9",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 139.0909090909091,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b7",
+          "name" : "b7",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 130.0,
+          "open" : true,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_10",
+          "name" : "10",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 120.9090909090909,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 12,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 111.81818181818181,
+          "xSpan" : 50.0,
+          "ySpan" : 18.181818181818183
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_10",
+          "name" : "10",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 120.9090909090909,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b8",
+          "name" : "b8",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 111.81818181818181,
+          "open" : true,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_11",
+          "name" : "11",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 102.72727272727272,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 14,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 93.63636363636363,
+          "xSpan" : 50.0,
+          "ySpan" : 18.181818181818183
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_11",
+          "name" : "11",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 102.72727272727272,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b9",
+          "name" : "b9",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 93.63636363636363,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_12",
+          "name" : "12",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 84.54545454545453,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 16,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 75.45454545454544,
+          "xSpan" : 50.0,
+          "ySpan" : 18.181818181818183
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_12",
+          "name" : "12",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 84.54545454545453,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b10",
+          "name" : "b10",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 75.45454545454544,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_13",
+          "name" : "13",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 66.36363636363635,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 18,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 57.27272727272725,
+          "xSpan" : 50.0,
+          "ySpan" : 18.181818181818183
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_13",
+          "name" : "13",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 66.36363636363635,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b11",
+          "name" : "b11",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 57.27272727272725,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_14",
+          "name" : "14",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 48.18181818181816,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 20,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 39.090909090909065,
+          "xSpan" : 50.0,
+          "ySpan" : 18.181818181818183
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_14",
+          "name" : "14",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 125.0,
+          "y" : 48.18181818181816,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b12",
+          "name" : "b12",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 39.090909090909065,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "load1",
+          "name" : "load1",
+          "componentType" : "LOAD",
+          "fictitious" : false,
+          "x" : 125.0,
+          "y" : 29.999999999999975,
+          "open" : false,
+          "label" : "load1",
+          "order" : 1,
+          "direction" : "TOP"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 2,
+    "direction" : "TOP",
+    "order" : 1,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 2
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 3,
+        "v" : 0,
+        "hSpan" : 2,
+        "vSpan" : 4,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 200.0,
+        "y" : 130.0,
+        "xSpan" : 100.0,
+        "ySpan" : 200.0
+      },
+      "subBlocks" : [ {
+        "type" : "PARALLEL",
+        "cardinalities" : [ {
+          "START" : 2
+        }, {
+          "END" : 2
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 200.0,
+          "y" : 180.0,
+          "xSpan" : 100.0,
+          "ySpan" : 100.0
+        },
+        "subBlocks" : [ {
+          "type" : "SERIAL",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 0,
+            "hSpan" : 1,
+            "vSpan" : 2,
+            "orientation" : "VERTICAL"
+          },
+          "coord" : {
+            "x" : 175.0,
+            "y" : 180.0,
+            "xSpan" : 50.0,
+            "ySpan" : 100.0
+          },
+          "subBlocks" : [ {
+            "type" : "PRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 1,
+              "vSpan" : 0,
+              "orientation" : "VERTICAL"
+            },
+            "coord" : {
+              "x" : 175.0,
+              "y" : 230.0,
+              "xSpan" : 50.0,
+              "ySpan" : 0.0
+            },
+            "nodes" : [ {
+              "type" : "BUS",
+              "id" : "bbs2",
+              "name" : "bbs2",
+              "componentType" : "BUSBAR_SECTION",
+              "fictitious" : false,
+              "x" : 10.0,
+              "y" : 285.0,
+              "open" : false,
+              "pxWidth" : 280.0,
+              "structuralPosition" : {
+                "h" : 1,
+                "v" : 2,
+                "hSpan" : 1,
+                "vSpan" : 0
+              },
+              "position" : {
+                "h" : 0,
+                "v" : 2,
+                "hSpan" : 6,
+                "vSpan" : 0
+              }
+            }, {
+              "type" : "SWITCH",
+              "id" : "d6",
+              "name" : "d6",
+              "componentType" : "DISCONNECTOR",
+              "fictitious" : false,
+              "x" : 175.0,
+              "y" : 285.0,
+              "open" : true,
+              "kind" : "DISCONNECTOR"
+            }, {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_19",
+              "name" : "19",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 175.0,
+              "y" : 230.0,
+              "open" : false
+            } ]
+          }, {
+            "type" : "PRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 1,
+              "vSpan" : 2,
+              "orientation" : "VERTICAL"
+            },
+            "coord" : {
+              "x" : 175.0,
+              "y" : 180.0,
+              "xSpan" : 50.0,
+              "ySpan" : 100.0
+            },
+            "nodes" : [ {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_19",
+              "name" : "19",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 175.0,
+              "y" : 230.0,
+              "open" : false
+            }, {
+              "type" : "SWITCH",
+              "id" : "b15",
+              "name" : "b15",
+              "componentType" : "BREAKER",
+              "fictitious" : false,
+              "x" : 175.0,
+              "y" : 180.0,
+              "open" : false,
+              "kind" : "BREAKER"
+            }, {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_20",
+              "name" : "20",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 200.0,
+              "y" : 130.0,
+              "open" : false
+            } ]
+          } ]
+        }, {
+          "type" : "SERIAL",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 1,
+            "v" : 0,
+            "hSpan" : 1,
+            "vSpan" : 2,
+            "orientation" : "VERTICAL"
+          },
+          "coord" : {
+            "x" : 225.0,
+            "y" : 180.0,
+            "xSpan" : 50.0,
+            "ySpan" : 100.0
+          },
+          "subBlocks" : [ {
+            "type" : "PRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 1,
+              "vSpan" : 0,
+              "orientation" : "VERTICAL"
+            },
+            "coord" : {
+              "x" : 225.0,
+              "y" : 230.0,
+              "xSpan" : 50.0,
+              "ySpan" : 0.0
+            },
+            "nodes" : [ {
+              "type" : "BUS",
+              "id" : "bbs1",
+              "name" : "bbs1",
+              "componentType" : "BUSBAR_SECTION",
+              "fictitious" : false,
+              "x" : 10.0,
+              "y" : 260.0,
+              "open" : false,
+              "pxWidth" : 280.0,
+              "structuralPosition" : {
+                "h" : 1,
+                "v" : 1,
+                "hSpan" : 1,
+                "vSpan" : 0
+              },
+              "position" : {
+                "h" : 0,
+                "v" : 1,
+                "hSpan" : 6,
+                "vSpan" : 0
+              }
+            }, {
+              "type" : "SWITCH",
+              "id" : "d5",
+              "name" : "d5",
+              "componentType" : "DISCONNECTOR",
+              "fictitious" : false,
+              "x" : 225.0,
+              "y" : 260.0,
+              "open" : true,
+              "kind" : "DISCONNECTOR"
+            }, {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_18",
+              "name" : "18",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 225.0,
+              "y" : 230.0,
+              "open" : false
+            } ]
+          }, {
+            "type" : "PRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 1,
+              "vSpan" : 2,
+              "orientation" : "VERTICAL"
+            },
+            "coord" : {
+              "x" : 225.0,
+              "y" : 180.0,
+              "xSpan" : 50.0,
+              "ySpan" : 100.0
+            },
+            "nodes" : [ {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_18",
+              "name" : "18",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 225.0,
+              "y" : 230.0,
+              "open" : false
+            }, {
+              "type" : "SWITCH",
+              "id" : "b14",
+              "name" : "b14",
+              "componentType" : "BREAKER",
+              "fictitious" : false,
+              "x" : 225.0,
+              "y" : 180.0,
+              "open" : false,
+              "kind" : "BREAKER"
+            }, {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_20",
+              "name" : "20",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 200.0,
+              "y" : 130.0,
+              "open" : false
+            } ]
+          } ]
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 2,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 200.0,
+          "y" : 80.0,
+          "xSpan" : 100.0,
+          "ySpan" : 100.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_20",
+          "name" : "20",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 200.0,
+          "y" : 130.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b16",
+          "name" : "b16",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 200.0,
+          "y" : 80.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "load2",
+          "name" : "load2",
+          "componentType" : "LOAD",
+          "fictitious" : false,
+          "x" : 200.0,
+          "y" : 30.0,
+          "open" : false,
+          "label" : "load2",
+          "order" : 1,
+          "direction" : "TOP"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 3,
+    "direction" : "BOTTOM",
+    "order" : 2,
+    "rootBlock" : {
+      "type" : "UNDEFINED",
+      "cardinalities" : [ {
+        "START" : 0
+      }, {
+        "END" : 0
+      } ],
+      "position" : {
+        "h" : 5,
+        "v" : 0,
+        "hSpan" : 0,
+        "vSpan" : 0,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 250.0,
+        "y" : 415.0,
+        "xSpan" : 0.0,
+        "ySpan" : 200.0
+      },
+      "subBlocks" : [ {
+        "type" : "SERIAL",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 2
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 4,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 250.0,
+          "y" : 415.0,
+          "xSpan" : 0.0,
+          "ySpan" : 200.0
+        },
+        "subBlocks" : [ {
+          "type" : "PARALLEL",
+          "cardinalities" : [ {
+            "START" : 2
+          }, {
+            "END" : 2
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 0,
+            "hSpan" : 2,
+            "vSpan" : 2,
+            "orientation" : "VERTICAL"
+          },
+          "coord" : {
+            "x" : 250.0,
+            "y" : 365.0,
+            "xSpan" : 0.0,
+            "ySpan" : 100.0
+          },
+          "subBlocks" : [ {
+            "type" : "PRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 1,
+              "vSpan" : 2,
+              "orientation" : "VERTICAL"
+            },
+            "coord" : {
+              "x" : 250.0,
+              "y" : 365.0,
+              "xSpan" : 0.0,
+              "ySpan" : 100.0
+            },
+            "nodes" : [ {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_24",
+              "name" : "24",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 250.0,
+              "y" : 315.0,
+              "open" : false
+            }, {
+              "type" : "SWITCH",
+              "id" : "b19",
+              "name" : "b19",
+              "componentType" : "BREAKER",
+              "fictitious" : false,
+              "x" : 250.0,
+              "y" : 365.0,
+              "open" : false,
+              "kind" : "BREAKER"
+            }, {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_23",
+              "name" : "23",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 250.0,
+              "y" : 415.0,
+              "open" : false
+            } ]
+          }, {
+            "type" : "PRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 1,
+              "v" : 0,
+              "hSpan" : 1,
+              "vSpan" : 2,
+              "orientation" : "VERTICAL"
+            },
+            "coord" : {
+              "x" : 250.0,
+              "y" : 365.0,
+              "xSpan" : 0.0,
+              "ySpan" : 100.0
+            },
+            "nodes" : [ {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_24",
+              "name" : "24",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 250.0,
+              "y" : 315.0,
+              "open" : false
+            }, {
+              "type" : "SWITCH",
+              "id" : "b18",
+              "name" : "b18",
+              "componentType" : "BREAKER",
+              "fictitious" : false,
+              "x" : 250.0,
+              "y" : 365.0,
+              "open" : false,
+              "kind" : "BREAKER"
+            }, {
+              "type" : "FICTITIOUS",
+              "id" : "FICT_vl_23",
+              "name" : "23",
+              "componentType" : "NODE",
+              "fictitious" : true,
+              "x" : 250.0,
+              "y" : 415.0,
+              "open" : false
+            } ]
+          } ]
+        }, {
+          "type" : "PRIMARY",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 2,
+            "orientation" : "VERTICAL"
+          },
+          "coord" : {
+            "x" : 250.0,
+            "y" : 465.0,
+            "xSpan" : 0.0,
+            "ySpan" : 100.0
+          },
+          "nodes" : [ {
+            "type" : "FICTITIOUS",
+            "id" : "FICT_vl_23",
+            "name" : "23",
+            "componentType" : "NODE",
+            "fictitious" : true,
+            "x" : 250.0,
+            "y" : 415.0,
+            "open" : false
+          }, {
+            "type" : "SWITCH",
+            "id" : "b17",
+            "name" : "b17",
+            "componentType" : "BREAKER",
+            "fictitious" : false,
+            "x" : 250.0,
+            "y" : 465.0,
+            "open" : false,
+            "kind" : "BREAKER"
+          }, {
+            "type" : "FICTITIOUS",
+            "id" : "FICT_vl_22",
+            "name" : "22",
+            "componentType" : "NODE",
+            "fictitious" : true,
+            "x" : 250.0,
+            "y" : 515.0,
+            "open" : false
+          } ]
+        }, {
+          "type" : "PRIMARY",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 4,
+            "hSpan" : 1,
+            "vSpan" : 0,
+            "orientation" : "VERTICAL"
+          },
+          "coord" : {
+            "x" : 250.0,
+            "y" : 515.0,
+            "xSpan" : 0.0,
+            "ySpan" : 0.0
+          },
+          "nodes" : [ {
+            "type" : "BUS",
+            "id" : "bbs1",
+            "name" : "bbs1",
+            "componentType" : "BUSBAR_SECTION",
+            "fictitious" : false,
+            "x" : 10.0,
+            "y" : 260.0,
+            "open" : false,
+            "pxWidth" : 280.0,
+            "structuralPosition" : {
+              "h" : 1,
+              "v" : 1,
+              "hSpan" : 1,
+              "vSpan" : 0
+            },
+            "position" : {
+              "h" : 0,
+              "v" : 1,
+              "hSpan" : 6,
+              "vSpan" : 0
+            }
+          }, {
+            "type" : "SWITCH",
+            "id" : "d7",
+            "name" : "d7",
+            "componentType" : "DISCONNECTOR",
+            "fictitious" : false,
+            "x" : 250.0,
+            "y" : 260.0,
+            "open" : true,
+            "kind" : "DISCONNECTOR"
+          }, {
+            "type" : "FICTITIOUS",
+            "id" : "FICT_vl_22",
+            "name" : "22",
+            "componentType" : "NODE",
+            "fictitious" : true,
+            "x" : 250.0,
+            "y" : 515.0,
+            "open" : false
+          } ]
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 250.0,
+          "y" : 415.0,
+          "xSpan" : 0.0,
+          "ySpan" : 200.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_24",
+          "name" : "24",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 250.0,
+          "y" : 315.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b20",
+          "name" : "b20",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 250.0,
+          "y" : 415.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "gen2",
+          "name" : "gen2",
+          "componentType" : "GENERATOR",
+          "fictitious" : false,
+          "x" : 250.0,
+          "y" : 515.0,
+          "open" : false,
+          "label" : "gen2",
+          "order" : 2,
+          "direction" : "BOTTOM"
+        } ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 4,
+    "direction" : "BOTTOM",
+    "order" : 2,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 5,
+        "v" : 0,
+        "hSpan" : 1,
+        "vSpan" : 2,
+        "orientation" : "VERTICAL"
+      },
+      "coord" : {
+        "x" : 275.0,
+        "y" : 415.0,
+        "xSpan" : 50.0,
+        "ySpan" : 200.0
+      },
+      "subBlocks" : [ {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 0,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 275.0,
+          "y" : 315.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ {
+          "type" : "BUS",
+          "id" : "bbs2",
+          "name" : "bbs2",
+          "componentType" : "BUSBAR_SECTION",
+          "fictitious" : false,
+          "x" : 10.0,
+          "y" : 285.0,
+          "open" : false,
+          "pxWidth" : 280.0,
+          "structuralPosition" : {
+            "h" : 1,
+            "v" : 2,
+            "hSpan" : 1,
+            "vSpan" : 0
+          },
+          "position" : {
+            "h" : 0,
+            "v" : 2,
+            "hSpan" : 6,
+            "vSpan" : 0
+          }
+        }, {
+          "type" : "SWITCH",
+          "id" : "d4",
+          "name" : "d4",
+          "componentType" : "DISCONNECTOR",
+          "fictitious" : false,
+          "x" : 275.0,
+          "y" : 285.0,
+          "open" : true,
+          "kind" : "DISCONNECTOR"
+        }, {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_16",
+          "name" : "16",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 275.0,
+          "y" : 315.0,
+          "open" : false
+        } ]
+      }, {
+        "type" : "PRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 1,
+          "vSpan" : 2,
+          "orientation" : "VERTICAL"
+        },
+        "coord" : {
+          "x" : 275.0,
+          "y" : 415.0,
+          "xSpan" : 50.0,
+          "ySpan" : 200.0
+        },
+        "nodes" : [ {
+          "type" : "FICTITIOUS",
+          "id" : "FICT_vl_16",
+          "name" : "16",
+          "componentType" : "NODE",
+          "fictitious" : true,
+          "x" : 275.0,
+          "y" : 315.0,
+          "open" : false
+        }, {
+          "type" : "SWITCH",
+          "id" : "b13",
+          "name" : "b13",
+          "componentType" : "BREAKER",
+          "fictitious" : false,
+          "x" : 275.0,
+          "y" : 415.0,
+          "open" : false,
+          "kind" : "BREAKER"
+        }, {
+          "type" : "FEEDER",
+          "id" : "gen1",
+          "name" : "gen1",
+          "componentType" : "GENERATOR",
+          "fictitious" : false,
+          "x" : 275.0,
+          "y" : 515.0,
+          "open" : false,
+          "label" : "gen1",
+          "order" : 2,
+          "direction" : "BOTTOM"
+        } ]
+      } ]
+    }
+  } ],
+  "edges" : [ {
+    "node1" : "bbs1",
+    "node2" : "d1"
+  }, {
+    "node1" : "d1",
+    "node2" : "FICT_vl_2"
+  }, {
+    "node1" : "FICT_vl_2",
+    "node2" : "b1"
+  }, {
+    "node1" : "b1",
+    "node2" : "FICT_vl_3"
+  }, {
+    "node1" : "FICT_vl_3",
+    "node2" : "d2"
+  }, {
+    "node1" : "d2",
+    "node2" : "bbs2"
+  }, {
+    "node1" : "bbs1",
+    "node2" : "d3"
+  }, {
+    "node1" : "d3",
+    "node2" : "FICT_vl_4"
+  }, {
+    "node1" : "FICT_vl_4",
+    "node2" : "b2"
+  }, {
+    "node1" : "b2",
+    "node2" : "FICT_vl_5"
+  }, {
+    "node1" : "FICT_vl_5",
+    "node2" : "b3"
+  }, {
+    "node1" : "b3",
+    "node2" : "FICT_vl_6"
+  }, {
+    "node1" : "FICT_vl_6",
+    "node2" : "b4"
+  }, {
+    "node1" : "b4",
+    "node2" : "FICT_vl_7"
+  }, {
+    "node1" : "FICT_vl_7",
+    "node2" : "b5"
+  }, {
+    "node1" : "b5",
+    "node2" : "FICT_vl_8"
+  }, {
+    "node1" : "FICT_vl_8",
+    "node2" : "b6"
+  }, {
+    "node1" : "b6",
+    "node2" : "FICT_vl_9"
+  }, {
+    "node1" : "FICT_vl_9",
+    "node2" : "b7"
+  }, {
+    "node1" : "b7",
+    "node2" : "FICT_vl_10"
+  }, {
+    "node1" : "FICT_vl_10",
+    "node2" : "b8"
+  }, {
+    "node1" : "b8",
+    "node2" : "FICT_vl_11"
+  }, {
+    "node1" : "FICT_vl_11",
+    "node2" : "b9"
+  }, {
+    "node1" : "b9",
+    "node2" : "FICT_vl_12"
+  }, {
+    "node1" : "FICT_vl_12",
+    "node2" : "b10"
+  }, {
+    "node1" : "b10",
+    "node2" : "FICT_vl_13"
+  }, {
+    "node1" : "FICT_vl_13",
+    "node2" : "b11"
+  }, {
+    "node1" : "b11",
+    "node2" : "FICT_vl_14"
+  }, {
+    "node1" : "FICT_vl_14",
+    "node2" : "b12"
+  }, {
+    "node1" : "b12",
+    "node2" : "load1"
+  }, {
+    "node1" : "bbs2",
+    "node2" : "d4"
+  }, {
+    "node1" : "d4",
+    "node2" : "FICT_vl_16"
+  }, {
+    "node1" : "FICT_vl_16",
+    "node2" : "b13"
+  }, {
+    "node1" : "b13",
+    "node2" : "gen1"
+  }, {
+    "node1" : "bbs1",
+    "node2" : "d5"
+  }, {
+    "node1" : "d5",
+    "node2" : "FICT_vl_18"
+  }, {
+    "node1" : "bbs2",
+    "node2" : "d6"
+  }, {
+    "node1" : "d6",
+    "node2" : "FICT_vl_19"
+  }, {
+    "node1" : "FICT_vl_18",
+    "node2" : "b14"
+  }, {
+    "node1" : "b14",
+    "node2" : "FICT_vl_20"
+  }, {
+    "node1" : "FICT_vl_19",
+    "node2" : "b15"
+  }, {
+    "node1" : "b15",
+    "node2" : "FICT_vl_20"
+  }, {
+    "node1" : "FICT_vl_20",
+    "node2" : "b16"
+  }, {
+    "node1" : "b16",
+    "node2" : "load2"
+  }, {
+    "node1" : "bbs1",
+    "node2" : "d7"
+  }, {
+    "node1" : "d7",
+    "node2" : "FICT_vl_22"
+  }, {
+    "node1" : "FICT_vl_22",
+    "node2" : "b17"
+  }, {
+    "node1" : "b17",
+    "node2" : "FICT_vl_23"
+  }, {
+    "node1" : "FICT_vl_23",
+    "node2" : "b18"
+  }, {
+    "node1" : "b18",
+    "node2" : "FICT_vl_24"
+  }, {
+    "node1" : "FICT_vl_23",
+    "node2" : "b19"
+  }, {
+    "node1" : "b19",
+    "node2" : "FICT_vl_24"
+  }, {
+    "node1" : "FICT_vl_24",
+    "node2" : "b20"
+  }, {
+    "node1" : "b20",
+    "node2" : "gen2"
+  } ]
+}

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -2630,6 +2630,10 @@
     "diagramName" : null,
     "shiftFeedersPosition" : false,
     "scaleShiftFeedersPosition" : 1.0,
-    "avoidSVGComponentsDuplication" : false
+    "avoidSVGComponentsDuplication" : false,
+    "adaptCellHeightToContent" : false,
+    "maxComponentHeight" : 12.0,
+    "minSpaceBetweenComponents" : 15.0,
+    "minExternCellHeight" : 80.0
   }
 }

--- a/single-line-diagram-core/src/test/resources/substation.svg
+++ b/single-line-diagram-core/src/test/resources/substation.svg
@@ -597,13 +597,13 @@
         <polyline class="wire wire_vl2" points="730.0,106.0,730.0,130.0" id="id_95_vl2_95_Wire3"/>
         <polyline class="wire wire_vl3" points="737.0,96.0,1020.0,96.0,1020.0,130.0" id="id_95_vl3_95_Wire4"/>
         <g id="LABEL_VL_vl1">
-            <text x="0.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
+            <text x="0.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>
         <g id="LABEL_VL_vl2">
-            <text x="550.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
+            <text x="550.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
         </g>
         <g id="LABEL_VL_vl3">
-            <text x="850.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
+            <text x="850.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
+++ b/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
@@ -453,13 +453,13 @@
         <polyline class="wire wire_vl2" points="730.0,112.0,730.0,130.0" id="id_95_vl2_95_Wire3"/>
         <polyline class="wire wire_vl3" points="744.0,92.0,1020.0,92.0,1020.0,130.0" id="id_95_vl3_95_Wire4"/>
         <g id="LABEL_VL_vl1">
-            <text x="0.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
+            <text x="0.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>
         <g id="LABEL_VL_vl2">
-            <text x="550.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
+            <text x="550.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
         </g>
         <g id="LABEL_VL_vl3">
-            <text x="850.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
+            <text x="850.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/substation_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/substation_optimized.svg
@@ -414,13 +414,13 @@
         <polyline class="wire wire_vl2" points="730.0,118.0,730.0,130.0" id="id_95_vl2_95_Wire3"/>
         <polyline class="wire wire_vl3" points="751.0,88.0,1020.0,88.0,1020.0,130.0" id="id_95_vl3_95_Wire4"/>
         <g id="LABEL_VL_vl1">
-            <text x="0.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
+            <text x="0.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>
         <g id="LABEL_VL_vl2">
-            <text x="550.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
+            <text x="550.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
         </g>
         <g id="LABEL_VL_vl3">
-            <text x="850.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
+            <text x="850.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl1.svg
+++ b/single-line-diagram-core/src/test/resources/vl1.svg
@@ -349,7 +349,7 @@
     </g>
 </g>
         <g id="LABEL_VL_vl1">
-            <text x="0.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
+            <text x="0.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -279,7 +279,7 @@
             <use href="#DISCONNECTOR-closed"/>
         </g>
         <g id="LABEL_VL_vl1">
-            <text x="0.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
+            <text x="0.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl2.svg
+++ b/single-line-diagram-core/src/test/resources/vl2.svg
@@ -307,7 +307,7 @@
     </g>
 </g>
         <g id="LABEL_VL_vl2">
-            <text x="550.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
+            <text x="550.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -259,7 +259,7 @@
             <use href="#DISCONNECTOR-closed"/>
         </g>
         <g id="LABEL_VL_vl2">
-            <text x="550.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
+            <text x="550.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl3.svg
+++ b/single-line-diagram-core/src/test/resources/vl3.svg
@@ -259,7 +259,7 @@
     </g>
 </g>
         <g id="LABEL_VL_vl3">
-            <text x="850.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
+            <text x="850.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl3_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_optimized.svg
@@ -233,7 +233,7 @@
             <use href="#DISCONNECTOR-closed"/>
         </g>
         <g id="LABEL_VL_vl3">
-            <text x="850.0" font-size="12" y="20.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
+            <text x="850.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -1402,6 +1402,10 @@
     "diagramName" : null,
     "shiftFeedersPosition" : false,
     "scaleShiftFeedersPosition" : 1.0,
-    "avoidSVGComponentsDuplication" : false
+    "avoidSVGComponentsDuplication" : false,
+    "adaptCellHeightToContent" : false,
+    "maxComponentHeight" : 12.0,
+    "minSpaceBetweenComponents" : 15.0,
+    "minExternCellHeight" : 80.0
   }
 }

--- a/single-line-diagram-core/src/test/resources/zone.svg
+++ b/single-line-diagram-core/src/test/resources/zone.svg
@@ -282,13 +282,13 @@
         </g>
         <polyline class="LINE Line" points="70.0,700.0,70.0,850.0,170.0,850.0,170.0,1000.0" id="idLine"/>
         <g id="LABEL_VL_VoltageLevel11">
-            <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">VoltageLevel11</text>
+            <text x="0.0" font-size="12" y="-10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">VoltageLevel11</text>
         </g>
         <g id="LABEL_VL_VoltageLevel12">
-            <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">VoltageLevel12</text>
+            <text x="0.0" font-size="12" y="-10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">VoltageLevel12</text>
         </g>
         <g id="LABEL_VL_VoltageLevel21">
-            <text x="0.0" font-size="12" y="0.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">VoltageLevel21</text>
+            <text x="0.0" font-size="12" y="-10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">VoltageLevel21</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
+++ b/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
@@ -251,9 +251,10 @@ public abstract class AbstractSingleLineDiagramViewer extends Application implem
 
                 String dName = getSelectedDiagramName();
                 LayoutParameters diagramLayoutParameters = new LayoutParameters(layoutParameters.get()).setDiagramName(dName);
+                diagramLayoutParameters.setComponentsSize(getComponentLibrary().getComponentsSize());
                 if (c.getContainerType() == ContainerType.VOLTAGE_LEVEL) {
                     VoltageLevelDiagram diagram = VoltageLevelDiagram.build(graphBuilder, c.getId(), getVoltageLevelLayoutFactory(), showNames.isSelected(),
-                            layoutParameters.get().isShowInductorFor3WT());
+                            diagramLayoutParameters.isShowInductorFor3WT());
                     diagram.writeSvg("",
                             new DefaultSVGWriter(getComponentLibrary(), diagramLayoutParameters),
                             initProvider,
@@ -726,8 +727,6 @@ public abstract class AbstractSingleLineDiagramViewer extends Application implem
 
         rowIndex += 1;
         addCheckBox("Adapt cell height to content", rowIndex, LayoutParameters::isAdaptCellHeightToContent, LayoutParameters::setAdaptCellHeightToContent);
-        rowIndex += 2;
-        addSpinner("Max component height:", 6, 30, 1, rowIndex, LayoutParameters::getMaxComponentHeight, LayoutParameters::setMaxComponentHeight);
         rowIndex += 2;
         addSpinner("Min space between components:", 8, 60, 1, rowIndex, LayoutParameters::getMinSpaceBetweenComponents, LayoutParameters::setMinSpaceBetweenComponents);
         rowIndex += 2;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#61 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Compaction for simple extern cells and no more overlapping components for compex extern cells,
by dynamically calculating the extern cells height.


**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
