### PR TITLE
Drop show inductor support for 3 windings transformer

### DIFF
--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/AbstractCgmesVoltageLevelLayoutTest.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/AbstractCgmesVoltageLevelLayoutTest.java
@@ -24,10 +24,8 @@ public abstract class AbstractCgmesVoltageLevelLayoutTest {
 
     protected static final String DIAGRAM_NAME = "default";
 
-    protected NetworkGraphBuilder graphBuilder;
-
     protected void test(VoltageLevel vl) {
-        Graph graph = new NetworkGraphBuilder(vl.getNetwork()).buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph graph = new NetworkGraphBuilder(vl.getNetwork()).buildVoltageLevelGraph(vl.getId(), false, true);
         LayoutParameters layoutParameters = new LayoutParameters();
         layoutParameters.setScaleFactor(2);
         layoutParameters.setDiagramName(DIAGRAM_NAME);

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/DoubleBusbarSectionTest.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/DoubleBusbarSectionTest.java
@@ -130,7 +130,7 @@ public class DoubleBusbarSectionTest {
 
     private Graph processCgmesLayout() {
         NetworkGraphBuilder graphBuilder = new NetworkGraphBuilder(voltageLevel.getNetwork());
-        Graph graph = graphBuilder.buildVoltageLevelGraph(voltageLevel.getId(), false, true, false);
+        Graph graph = graphBuilder.buildVoltageLevelGraph(voltageLevel.getId(), false, true);
         LayoutParameters layoutParameters = new LayoutParameters();
         layoutParameters.setScaleFactor(1);
         layoutParameters.setDiagramName(DIAGRAM_NAME);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/GraphBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/GraphBuilder.java
@@ -19,8 +19,7 @@ public interface GraphBuilder {
 
     Graph buildVoltageLevelGraph(String id,
                                  boolean useName,
-                                 boolean forVoltageLevelDiagram,
-                                 boolean showInductorFor3WT);
+                                 boolean forVoltageLevelDiagram);
 
     SubstationGraph buildSubstationGraph(String id,
                                          boolean useName);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagramTool.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagramTool.java
@@ -115,7 +115,7 @@ public class SingleLineDiagramTool implements Tool {
         Path svgFile = getSvgFile(outputDir, vl);
         context.getOutputStream().println("Generating '" + svgFile + "' (" + vl.getNominalV() + ")");
         try {
-            VoltageLevelDiagram.build(graphBuilder, vl.getId(), generationConfig.voltageLevelLayoutFactory, true, generationConfig.parameters.isShowInductorFor3WT())
+            VoltageLevelDiagram.build(graphBuilder, vl.getId(), generationConfig.voltageLevelLayoutFactory, true)
                     .writeSvg("", generationConfig.componentLibrary, generationConfig.parameters,
                             new DefaultDiagramInitialValueProvider(network),
                             new DefaultDiagramStyleProvider(),

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/VoltageLevelDiagram.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/VoltageLevelDiagram.java
@@ -50,12 +50,12 @@ public final class VoltageLevelDiagram {
 
     public static VoltageLevelDiagram build(GraphBuilder graphBuilder, String voltageLevelId,
                                             VoltageLevelLayoutFactory layoutFactory,
-                                            boolean useName, boolean showInductorFor3WT) {
+                                            boolean useName) {
         Objects.requireNonNull(graphBuilder);
         Objects.requireNonNull(voltageLevelId);
         Objects.requireNonNull(layoutFactory);
 
-        Graph graph = graphBuilder.buildVoltageLevelGraph(voltageLevelId, useName, true, showInductorFor3WT);
+        Graph graph = graphBuilder.buildVoltageLevelGraph(voltageLevelId, useName, true);
 
         VoltageLevelLayout layout = layoutFactory.create(graph);
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -53,8 +53,6 @@ public class LayoutParameters {
     private double verticalSnakeLinePadding = 25;
     private double arrowDistance = 20;
 
-    private boolean showInductorFor3WT = false;
-
     private boolean shiftFeedersPosition = false;
 
     private double scaleShiftFeedersPosition = 1;
@@ -92,7 +90,6 @@ public class LayoutParameters {
                             @JsonProperty("horizontalSnakeLinePadding") double horizontalSnakeLinePadding,
                             @JsonProperty("verticalSnakeLinePadding") double verticalSnakeLinePadding,
                             @JsonProperty("arrowDistance") double arrowDistance,
-                            @JsonProperty("showInductorFor3WT") boolean showInductorFor3WT,
                             @JsonProperty("diagramName") String diagramName,
                             @JsonProperty("shiftFeedersPosition") boolean shiftFeedersPosition,
                             @JsonProperty("scaleShiftFeedersPosition") double scaleShiftFeedersPosition,
@@ -120,7 +117,6 @@ public class LayoutParameters {
         this.horizontalSnakeLinePadding = horizontalSnakeLinePadding;
         this.verticalSnakeLinePadding = verticalSnakeLinePadding;
         this.arrowDistance = arrowDistance;
-        this.showInductorFor3WT = showInductorFor3WT;
         this.diagramName = diagramName;
         this.shiftFeedersPosition = shiftFeedersPosition;
         this.scaleShiftFeedersPosition = scaleShiftFeedersPosition;
@@ -152,7 +148,6 @@ public class LayoutParameters {
         horizontalSnakeLinePadding = other.horizontalSnakeLinePadding;
         verticalSnakeLinePadding = other.verticalSnakeLinePadding;
         arrowDistance = other.arrowDistance;
-        showInductorFor3WT = other.showInductorFor3WT;
         diagramName = other.diagramName;
         shiftFeedersPosition = other.shiftFeedersPosition;
         scaleShiftFeedersPosition = other.scaleShiftFeedersPosition;
@@ -341,15 +336,6 @@ public class LayoutParameters {
 
     public LayoutParameters setArrowDistance(double arrowDistance) {
         this.arrowDistance = arrowDistance;
-        return this;
-    }
-
-    public boolean isShowInductorFor3WT() {
-        return showInductorFor3WT;
-    }
-
-    public LayoutParameters setShowInductorFor3WT(boolean showInductorFor3WT) {
-        this.showInductorFor3WT = showInductorFor3WT;
         return this;
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Graph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Graph.java
@@ -65,8 +65,6 @@ public final class Graph {
     private final boolean forVoltageLevelDiagram;  // true if voltageLevel diagram
                                                    // false if substation diagram
 
-    private final boolean showInductorFor3WT;
-
     private boolean generateCoordsInJson = true;
 
     Function<Node, BusCell.Direction> nodeDirection = node ->
@@ -78,25 +76,19 @@ public final class Graph {
     // (filled and used only when using the adapt cell height to content option)
     private Map<BusCell.Direction, Double> maxCalculatedCellHeight = new EnumMap<>(BusCell.Direction.class);
 
-    private Graph(VoltageLevelInfos voltageLevelInfos, boolean useName, boolean forVoltageLevelDiagram, boolean showInductorFor3WT) {
+    private Graph(VoltageLevelInfos voltageLevelInfos, boolean useName, boolean forVoltageLevelDiagram) {
         this.voltageLevelInfos = Objects.requireNonNull(voltageLevelInfos);
         this.useName = useName;
         this.forVoltageLevelDiagram = forVoltageLevelDiagram;
-        this.showInductorFor3WT = showInductorFor3WT;
     }
 
     public static Graph create(VoltageLevelInfos voltageLevelInfos,
-                               boolean useName, boolean forVoltageLevelDiagram,
-                               boolean showInductorFor3WT) {
-        return new Graph(voltageLevelInfos, useName, forVoltageLevelDiagram, showInductorFor3WT);
+                               boolean useName, boolean forVoltageLevelDiagram) {
+        return new Graph(voltageLevelInfos, useName, forVoltageLevelDiagram);
     }
 
     public boolean isUseName() {
         return useName;
-    }
-
-    public boolean isShowInductorFor3WT() {
-        return showInductorFor3WT;
     }
 
     public boolean isForVoltageLevelDiagram() {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramStyleProvider.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.sld.svg;
 
-import static com.powsybl.sld.library.ComponentTypeName.INDUCTOR;
 import static com.powsybl.sld.library.ComponentTypeName.NODE;
 import static com.powsybl.sld.library.ComponentTypeName.TWO_WINDINGS_TRANSFORMER;
 import static com.powsybl.sld.svg.DiagramStyles.WIRE_STYLE_CLASS;
@@ -115,9 +114,6 @@ public class DefaultDiagramStyleProvider implements DiagramStyleProvider {
                     color = getColor(nameSubComponent.equals(WINDING1) ? node.getGraph().getVoltageLevelInfos().getNominalVoltage() : ((Feeder2WTNode) node).getOtherSideVoltageLevelInfos().getNominalVoltage(), null);
                 }
 
-                color.ifPresent(s -> attributes.put(STROKE, s));
-            } else if (node instanceof Feeder2WTNode && node.getComponentType().equals(INDUCTOR)) {
-                color = getColor(((Feeder2WTNode) node).getOtherSideVoltageLevelInfos().getNominalVoltage(), null);
                 color.ifPresent(s -> attributes.put(STROKE, s));
             } else if (!isShowInternalNodes && node.getComponentType().equals(NODE)) {
                 attributes.put("stroke-opacity", "0");

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/NominalVoltageStyleTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/NominalVoltageStyleTest.java
@@ -83,9 +83,9 @@ public class NominalVoltageStyleTest extends AbstractTestCase {
     @Test
     public void test() {
         // construction des graphes
-        Graph graph1 = graphBuilder.buildVoltageLevelGraph(vl1.getId(), false, true, false);
-        Graph graph2 = graphBuilder.buildVoltageLevelGraph(vl2.getId(), false, true, false);
-        Graph graph3 = graphBuilder.buildVoltageLevelGraph(vl3.getId(), false, true, false);
+        Graph graph1 = graphBuilder.buildVoltageLevelGraph(vl1.getId(), false, true);
+        Graph graph2 = graphBuilder.buildVoltageLevelGraph(vl2.getId(), false, true);
+        Graph graph3 = graphBuilder.buildVoltageLevelGraph(vl3.getId(), false, true);
 
         DiagramStyleProvider styleProvider = new NominalVoltageDiagramStyleProvider();
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase1.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase1.java
@@ -51,7 +51,7 @@ public class TestCase1 extends AbstractTestCase {
     @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
 
         // detect cells
         new ImplicitCellDetector().detectCells(g);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase11SubstationGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase11SubstationGraph.java
@@ -225,8 +225,7 @@ public class TestCase11SubstationGraph extends AbstractTestCase {
                 .setVerticalSubstationPadding(50)
                 .setDrawStraightWires(false)
                 .setHorizontalSnakeLinePadding(30)
-                .setVerticalSnakeLinePadding(30)
-                .setShowInductorFor3WT(false);
+                .setVerticalSnakeLinePadding(30);
 
         // build substation graph
         SubstationGraph g = graphBuilder.buildSubstationGraph(substation.getId(), false);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase12GraphWith3WT.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase12GraphWith3WT.java
@@ -223,36 +223,35 @@ public class TestCase12GraphWith3WT extends AbstractTestCase {
                 .setVerticalSubstationPadding(50)
                 .setDrawStraightWires(false)
                 .setHorizontalSnakeLinePadding(30)
-                .setVerticalSnakeLinePadding(30)
-                .setShowInductorFor3WT(true);
+                .setVerticalSnakeLinePadding(30);
 
         // build voltage level 1 graph
-        Graph g1 = graphBuilder.buildVoltageLevelGraph(vl1.getId(), false, true, true);
+        Graph g1 = graphBuilder.buildVoltageLevelGraph(vl1.getId(), false, true);
         new ImplicitCellDetector().detectCells(g1);
         new BlockOrganizer().organize(g1);
         new PositionVoltageLevelLayout(g1).run(layoutParameters);
 
-        Graph g2 = graphBuilder.buildVoltageLevelGraph(vl2.getId(), false, true, true);
+        Graph g2 = graphBuilder.buildVoltageLevelGraph(vl2.getId(), false, true);
         new ImplicitCellDetector().detectCells(g2);
         new BlockOrganizer().organize(g2);
         new PositionVoltageLevelLayout(g2).run(layoutParameters);
 
-        Graph g3 = graphBuilder.buildVoltageLevelGraph(vl3.getId(), false, true, false);
+        Graph g3 = graphBuilder.buildVoltageLevelGraph(vl3.getId(), false, true);
         new ImplicitCellDetector().detectCells(g3);
         new BlockOrganizer().organize(g3);
         new PositionVoltageLevelLayout(g3).run(layoutParameters);
 
         // write JSON and compare to reference (horizontal layout)
-        assertEquals(toJson(g1, "/TestCase12GraphVL1.json"), toString("/TestCase12GraphVL1.json"));
-        assertEquals(toJson(g2, "/TestCase12GraphVL2.json"), toString("/TestCase12GraphVL2.json"));
-        assertEquals(toJson(g3, "/TestCase12GraphVL3.json"), toString("/TestCase12GraphVL3.json"));
+        assertEquals(toString("/TestCase12GraphVL1.json"), toJson(g1, "/TestCase12GraphVL1.json"));
+        assertEquals(toString("/TestCase12GraphVL2.json"), toJson(g2, "/TestCase12GraphVL2.json"));
+        assertEquals(toString("/TestCase12GraphVL3.json"), toJson(g3, "/TestCase12GraphVL3.json"));
 
         LayoutParameters layoutParametersOptimized = new LayoutParameters(layoutParameters);
         layoutParametersOptimized.setAvoidSVGComponentsDuplication(true);
 
         // compare metadata of voltage level diagram with reference
         VoltageLevelDiagram diagram = VoltageLevelDiagram.build(graphBuilder, vl1.getId(),
-                new PositionVoltageLevelLayoutFactory(), false, true);
+                new PositionVoltageLevelLayoutFactory(), false);
         compareMetadata(diagram, layoutParameters, "/vlDiag_metadata.json",
                 new DefaultDiagramInitialValueProvider(network),
                 new NominalVoltageDiagramStyleProvider());

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase1BusBreaker.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase1BusBreaker.java
@@ -49,7 +49,7 @@ public class TestCase1BusBreaker extends AbstractTestCase {
     @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
 
         // detect cells
         new ImplicitCellDetector().detectCells(g);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase1inverted.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase1inverted.java
@@ -51,7 +51,7 @@ public class TestCase1inverted extends AbstractTestCase {
     @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
 
         // detect cells
         new ImplicitCellDetector().detectCells(g);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase2StackedCell.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase2StackedCell.java
@@ -54,7 +54,7 @@ public class TestCase2StackedCell extends AbstractTestCase {
     @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
 
         // detect cells
         new ImplicitCellDetector().detectCells(g);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase3Coupling.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase3Coupling.java
@@ -50,7 +50,7 @@ public class TestCase3Coupling extends AbstractTestCase {
     @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
 
         // detect cells
         new ImplicitCellDetector().detectCells(g);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase4NotParallelel.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase4NotParallelel.java
@@ -70,7 +70,7 @@ public class TestCase4NotParallelel extends AbstractTestCase {
     @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
 
         // detect cells
         new ImplicitCellDetector().detectCells(g);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase5ShuntHorizontal.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase5ShuntHorizontal.java
@@ -57,7 +57,7 @@ public class TestCase5ShuntHorizontal extends AbstractTestCase {
     @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
 
         // detect cells
         new ImplicitCellDetector().detectCells(g);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase5ShuntVertical.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase5ShuntVertical.java
@@ -57,7 +57,7 @@ public class TestCase5ShuntVertical extends AbstractTestCase {
     @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
 
         // detect cells
         new ImplicitCellDetector().detectCells(g);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase6CouplingNonFlatHorizontal.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase6CouplingNonFlatHorizontal.java
@@ -54,7 +54,7 @@ public class TestCase6CouplingNonFlatHorizontal extends AbstractTestCase {
     @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
 
         // detect cells
         new ImplicitCellDetector().detectCells(g);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCase7CellDetectionIssue.java
@@ -49,7 +49,7 @@ public class TestCase7CellDetectionIssue extends AbstractTestCase {
 //    @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
 
         // detect cells
         new ImplicitCellDetector().detectCells(g);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCaseGraphAdaptCellHeightToContent.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestCaseGraphAdaptCellHeightToContent.java
@@ -89,7 +89,7 @@ public class TestCaseGraphAdaptCellHeightToContent extends AbstractTestCase {
                 .setShowInternalNodes(true)
                 .setAdaptCellHeightToContent(false);
 
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, true);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
         new ImplicitCellDetector(false, true, false).detectCells(g);
         new BlockOrganizer(new PositionFromExtension(), false).organize(g);
         new PositionVoltageLevelLayout(g).run(layoutParameters);
@@ -100,7 +100,7 @@ public class TestCaseGraphAdaptCellHeightToContent extends AbstractTestCase {
         LayoutParameters layoutParametersAdaptCellHeightToContent = new LayoutParameters(layoutParameters);
         layoutParametersAdaptCellHeightToContent.setAdaptCellHeightToContent(true);
 
-        g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, true);
+        g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
         new ImplicitCellDetector(false, true, false).detectCells(g);
         new BlockOrganizer(new PositionFromExtension(), true).organize(g);
         new PositionVoltageLevelLayout(g).run(layoutParametersAdaptCellHeightToContent);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestSVGWriter.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestSVGWriter.java
@@ -62,7 +62,7 @@ public class TestSVGWriter extends AbstractTestCase {
 
         // First voltage level graph :
         //
-        g1 = Graph.create(new VoltageLevelInfos("vl1", "vl1", 400), false, true, false);
+        g1 = Graph.create(new VoltageLevelInfos("vl1", "vl1", 400), false, true);
         g1.setX(0);
         g1.setY(20);
 
@@ -168,7 +168,7 @@ public class TestSVGWriter extends AbstractTestCase {
 
         // Second voltage level graph :
         //
-        g2 = Graph.create(new VoltageLevelInfos("vl2", "vl2", 225), false, true, false);
+        g2 = Graph.create(new VoltageLevelInfos("vl2", "vl2", 225), false, true);
         g2.setX(550);
         g2.setY(20);
 
@@ -247,7 +247,7 @@ public class TestSVGWriter extends AbstractTestCase {
 
         // Third voltage level graph :
         //
-        g3 = Graph.create(new VoltageLevelInfos("vl3", "vl3", 63), false, true, false);
+        g3 = Graph.create(new VoltageLevelInfos("vl3", "vl3", 63), false, true);
         g3.setX(850);
         g3.setY(20);
 
@@ -313,7 +313,7 @@ public class TestSVGWriter extends AbstractTestCase {
 
         // First voltage level graph :
         //
-        Graph g1Graph = Graph.create(new VoltageLevelInfos("vl1", "vl1", 400), false, true, false);
+        Graph g1Graph = Graph.create(new VoltageLevelInfos("vl1", "vl1", 400), false, true);
         g1Graph.setX(0);
         g1Graph.setY(20);
 
@@ -403,7 +403,7 @@ public class TestSVGWriter extends AbstractTestCase {
 
         // Second voltage level graph :
         //
-        Graph g2Graph = Graph.create(new VoltageLevelInfos("vl2", "vl2", 225), false, true, false);
+        Graph g2Graph = Graph.create(new VoltageLevelInfos("vl2", "vl2", 225), false, true);
         g2Graph.setX(550);
         g2Graph.setY(20);
 
@@ -470,7 +470,7 @@ public class TestSVGWriter extends AbstractTestCase {
 
         // Third voltage level graph :
         //
-        Graph g3Graph = Graph.create(new VoltageLevelInfos("vl3", "vl3", 63), false, true, false);
+        Graph g3Graph = Graph.create(new VoltageLevelInfos("vl3", "vl3", 63), false, true);
         g3Graph.setX(850);
         g3Graph.setY(20);
 
@@ -551,7 +551,7 @@ public class TestSVGWriter extends AbstractTestCase {
 
     private void createZoneGraph() {
       //create first voltage level graph
-        Graph vl11Graph = Graph.create(new VoltageLevelInfos(VOLTAGE_LEVEL_11_ID, VOLTAGE_LEVEL_11_ID, VOLTAGE_LEVEL_11_V), false, false, false);
+        Graph vl11Graph = Graph.create(new VoltageLevelInfos(VOLTAGE_LEVEL_11_ID, VOLTAGE_LEVEL_11_ID, VOLTAGE_LEVEL_11_V), false, false);
         BusNode bus11Node = BusNode.create(vl11Graph, BUS_11_ID, BUS_11_ID);
         bus11Node.setX(30);
         bus11Node.setY(200);
@@ -568,7 +568,7 @@ public class TestSVGWriter extends AbstractTestCase {
         vl11Graph.addEdge(bus11Node, loadNode);
         vl11Graph.addEdge(bus11Node, twtSide1Node);
         // create second voltage level graph
-        Graph vl12Graph = Graph.create(new VoltageLevelInfos(VOLTAGE_LEVEL_12_ID, VOLTAGE_LEVEL_12_ID, VOLTAGE_LEVEL_12_V), false, false, false);
+        Graph vl12Graph = Graph.create(new VoltageLevelInfos(VOLTAGE_LEVEL_12_ID, VOLTAGE_LEVEL_12_ID, VOLTAGE_LEVEL_12_V), false, false);
         BusNode bus12Node = BusNode.create(vl12Graph, BUS_12_ID, BUS_12_ID);
         bus12Node.setX(30);
         bus12Node.setY(500);
@@ -585,7 +585,7 @@ public class TestSVGWriter extends AbstractTestCase {
         vl12Graph.addEdge(bus12Node, twtSide2Node);
         vl12Graph.addEdge(bus12Node, lineSide1Node);
         // create third voltage level graph
-        Graph vl21Graph = Graph.create(new VoltageLevelInfos(VOLTAGE_LEVEL_21_ID, VOLTAGE_LEVEL_21_ID, VOLTAGE_LEVEL_21_V), false, false, false);
+        Graph vl21Graph = Graph.create(new VoltageLevelInfos(VOLTAGE_LEVEL_21_ID, VOLTAGE_LEVEL_21_ID, VOLTAGE_LEVEL_21_V), false, false);
         BusNode bus21Node = BusNode.create(vl21Graph, BUS_21_ID, BUS_21_ID);
         bus21Node.setX(130);
         bus21Node.setY(1100);
@@ -712,8 +712,7 @@ public class TestSVGWriter extends AbstractTestCase {
                 .setVerticalSubstationPadding(50)
                 .setDrawStraightWires(false)
                 .setHorizontalSnakeLinePadding(30)
-                .setVerticalSnakeLinePadding(30)
-                .setShowInductorFor3WT(true);
+                .setVerticalSnakeLinePadding(30);
 
         Map<String, Graph> mapGr = new HashMap<>();
         mapGr.put("/vl1.svg", g1);
@@ -772,8 +771,7 @@ public class TestSVGWriter extends AbstractTestCase {
                 .setVerticalSubstationPadding(50)
                 .setDrawStraightWires(false)
                 .setHorizontalSnakeLinePadding(30)
-                .setVerticalSnakeLinePadding(30)
-                .setShowInductorFor3WT(true);
+                .setVerticalSnakeLinePadding(30);
 
         assertEquals(toString("/zone.svg"), toSVG(zGraph, "/zone.svg", layoutParameters, initValueProvider, styleProvider));
     }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestSerialBlock.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestSerialBlock.java
@@ -40,7 +40,7 @@ public class TestSerialBlock extends AbstractTestCase {
     @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
 
         // detect cells
         new ImplicitCellDetector().detectCells(g);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestSerialParallelBlock.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestSerialParallelBlock.java
@@ -42,7 +42,7 @@ public class TestSerialParallelBlock extends AbstractTestCase {
     @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
 
         // detect cells
         new ImplicitCellDetector().detectCells(g);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestShiftFeedersPosition.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestShiftFeedersPosition.java
@@ -81,8 +81,7 @@ public class TestShiftFeedersPosition extends AbstractTestCase {
                 .setVerticalSubstationPadding(50)
                 .setDrawStraightWires(false)
                 .setHorizontalSnakeLinePadding(30)
-                .setVerticalSnakeLinePadding(30)
-                .setShowInductorFor3WT(false);
+                .setVerticalSnakeLinePadding(30);
 
         // build substation graph
         SubstationGraph g = graphBuilder.buildSubstationGraph(substation.getId(), false);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestTopologyCalculation.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestTopologyCalculation.java
@@ -85,7 +85,7 @@ public class TestTopologyCalculation extends AbstractTestCase {
     @Test
     public void test() {
         // build graph
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
         List<TopologicallyConnectedNodesSet> tcnss = TopologyCalculation.run(g);
         assertTopo(tcnss, 1, 0, 25, 0);
         g.getNode("bA1").setOpen(true);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TestUnicityNodeIdWithMutipleNetwork.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TestUnicityNodeIdWithMutipleNetwork.java
@@ -57,7 +57,7 @@ public class TestUnicityNodeIdWithMutipleNetwork extends AbstractTestCase {
         LayoutParameters layoutParameters = new LayoutParameters();
 
         // Generating json for voltage level in first network
-        Graph graph1 = Graph.create(new VoltageLevelInfos(vl.getId(), vl.getName(), vl.getNominalV()), false, true, false);
+        Graph graph1 = Graph.create(new VoltageLevelInfos(vl.getId(), vl.getName(), vl.getNominalV()), false, true);
         new ImplicitCellDetector().detectCells(graph1);
         new BlockOrganizer().organize(graph1);
         new PositionVoltageLevelLayout(graph1).run(layoutParameters);
@@ -66,7 +66,7 @@ public class TestUnicityNodeIdWithMutipleNetwork extends AbstractTestCase {
         assertEquals(toJson(graph1, "/TestUnicityNodeIdNetWork1.json"), refJson1);
 
         // Generating json for voltage level in second network
-        Graph graph2 = Graph.create(new VoltageLevelInfos(vl2.getId(), vl2.getName(), vl2.getNominalV()), false, true, false);
+        Graph graph2 = Graph.create(new VoltageLevelInfos(vl2.getId(), vl2.getName(), vl2.getNominalV()), false, true);
         new ImplicitCellDetector().detectCells(graph2);
         new BlockOrganizer().organize(graph2);
         new PositionVoltageLevelLayout(graph2).run(layoutParameters);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/TopologicalStyleTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/TopologicalStyleTest.java
@@ -94,9 +94,9 @@ public class TopologicalStyleTest extends AbstractTestCase {
     @Test
     public void test() throws IOException {
         // construction des graphes
-        Graph graph1 = graphBuilder.buildVoltageLevelGraph(vl1.getId(), false, true, false);
-        Graph graph2 = graphBuilder.buildVoltageLevelGraph(vl2.getId(), false, true, false);
-        Graph graph3 = graphBuilder.buildVoltageLevelGraph(vl3.getId(), false, true, false);
+        Graph graph1 = graphBuilder.buildVoltageLevelGraph(vl1.getId(), false, true);
+        Graph graph2 = graphBuilder.buildVoltageLevelGraph(vl2.getId(), false, true);
+        Graph graph3 = graphBuilder.buildVoltageLevelGraph(vl3.getId(), false, true);
 
         Path config = tmpDir.resolve("base-voltages.yml");
         Files.copy(getClass().getResourceAsStream("/base-voltages.yml"), config);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
@@ -38,7 +38,6 @@ public class LayoutParametersTest {
                 .setHorizontalSnakeLinePadding(25)
                 .setVerticalSnakeLinePadding(40)
                 .setArrowDistance(25)
-                .setShowInductorFor3WT(true)
                 .setDiagramName("diag")
                 .setShiftFeedersPosition(false)
                 .setScaleShiftFeedersPosition(2)
@@ -70,7 +69,6 @@ public class LayoutParametersTest {
         assertEquals(layoutParameters.getArrowDistance(), layoutParameters2.getArrowDistance(), 0);
         assertEquals(layoutParameters.isShiftFeedersPosition(), layoutParameters2.isShiftFeedersPosition());
         assertEquals(layoutParameters.getScaleShiftFeedersPosition(), layoutParameters2.getScaleShiftFeedersPosition(), 0);
-        assertEquals(layoutParameters.isShowInductorFor3WT(), layoutParameters2.isShowInductorFor3WT());
         assertEquals(layoutParameters.getDiagramName(), layoutParameters2.getDiagramName());
         assertEquals(layoutParameters.isAvoidSVGComponentsDuplication(), layoutParameters2.isAvoidSVGComponentsDuplication());
         assertEquals(layoutParameters.isAdaptCellHeightToContent(), layoutParameters2.isAdaptCellHeightToContent());

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/InitialValueProviderTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/InitialValueProviderTest.java
@@ -85,7 +85,7 @@ public class InitialValueProviderTest {
     public void test() {
         Network network2 = Network.create("testCase2", "test2");
         DefaultDiagramInitialValueProvider initProvider = new DefaultDiagramInitialValueProvider(network2);
-        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, false, false);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, false);
         InitialValue init = initProvider.getInitialValue(g.getNode("svc"));
         assertFalse(init.getLabel1().isPresent());
         assertFalse(init.getLabel2().isPresent());

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.json
@@ -1064,9 +1064,9 @@
             }
           }, {
             "type" : "FEEDER",
-            "id" : "self4",
-            "name" : "self4",
-            "componentType" : "INDUCTOR",
+            "id" : "trf6_ONE_THREE",
+            "name" : "trf6_ONE_THREE",
+            "componentType" : "LINE",
             "fictitious" : false,
             "x" : 440.0,
             "y" : -19.99999999999998,
@@ -1647,9 +1647,9 @@
             }
           }, {
             "type" : "FEEDER",
-            "id" : "self4",
-            "name" : "self4",
-            "componentType" : "INDUCTOR",
+            "id" : "trf8_ONE_THREE",
+            "name" : "trf8_ONE_THREE",
+            "componentType" : "LINE",
             "fictitious" : false,
             "x" : 920.0,
             "y" : -19.99999999999998,
@@ -2230,9 +2230,9 @@
             }
           }, {
             "type" : "FEEDER",
-            "id" : "self4",
-            "name" : "self4",
-            "componentType" : "INDUCTOR",
+            "id" : "trf7_ONE_THREE",
+            "name" : "trf7_ONE_THREE",
+            "componentType" : "LINE",
             "fictitious" : false,
             "x" : 600.0,
             "y" : 564.9999999999999,
@@ -2680,7 +2680,7 @@
     "node2" : "trf6_ONE_TWO"
   }, {
     "node1" : "FICT_vl1_trf61_fictif",
-    "node2" : "self4"
+    "node2" : "trf6_ONE_THREE"
   }, {
     "node1" : "btrf17",
     "node2" : "FICT_vl1_trf71_fictif"
@@ -2689,7 +2689,7 @@
     "node2" : "trf7_ONE_TWO"
   }, {
     "node1" : "FICT_vl1_trf71_fictif",
-    "node2" : "self4"
+    "node2" : "trf7_ONE_THREE"
   }, {
     "node1" : "btrf18",
     "node2" : "FICT_vl1_trf81_fictif"
@@ -2698,7 +2698,7 @@
     "node2" : "trf8_ONE_TWO"
   }, {
     "node1" : "FICT_vl1_trf81_fictif",
-    "node2" : "self4"
+    "node2" : "trf8_ONE_THREE"
   }, {
     "node1" : "dtrct11",
     "node2" : "FICT_vl1_dsect11Fictif"

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.json
@@ -860,9 +860,9 @@
             }
           }, {
             "type" : "FEEDER",
-            "id" : "self4",
-            "name" : "self4",
-            "componentType" : "INDUCTOR",
+            "id" : "trf7_TWO_THREE",
+            "name" : "trf7_TWO_THREE",
+            "componentType" : "LINE",
             "fictitious" : false,
             "x" : 520.0,
             "y" : -19.99999999999998,
@@ -1589,9 +1589,9 @@
             }
           }, {
             "type" : "FEEDER",
-            "id" : "self4",
-            "name" : "self4",
-            "componentType" : "INDUCTOR",
+            "id" : "trf6_TWO_THREE",
+            "name" : "trf6_TWO_THREE",
+            "componentType" : "LINE",
             "fictitious" : false,
             "x" : 680.0,
             "y" : -19.99999999999998,
@@ -1885,9 +1885,9 @@
             }
           }, {
             "type" : "FEEDER",
-            "id" : "self4",
-            "name" : "self4",
-            "componentType" : "INDUCTOR",
+            "id" : "trf8_TWO_THREE",
+            "name" : "trf8_TWO_THREE",
+            "componentType" : "LINE",
             "fictitious" : false,
             "x" : 840.0,
             "y" : 564.9999999999999,
@@ -2024,7 +2024,7 @@
     "node2" : "trf6_TWO_ONE"
   }, {
     "node1" : "FICT_vl2_trf62_fictif",
-    "node2" : "self4"
+    "node2" : "trf6_TWO_THREE"
   }, {
     "node1" : "btrf27",
     "node2" : "FICT_vl2_trf72_fictif"
@@ -2033,7 +2033,7 @@
     "node2" : "trf7_TWO_ONE"
   }, {
     "node1" : "FICT_vl2_trf72_fictif",
-    "node2" : "self4"
+    "node2" : "trf7_TWO_THREE"
   }, {
     "node1" : "btrf28",
     "node2" : "FICT_vl2_trf82_fictif"
@@ -2042,7 +2042,7 @@
     "node2" : "trf8_TWO_ONE"
   }, {
     "node1" : "FICT_vl2_trf82_fictif",
-    "node2" : "self4"
+    "node2" : "trf8_TWO_THREE"
   }, {
     "node1" : "ddcpl1",
     "node2" : "FICT_vl2_dscpl1Fictif"

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -2626,7 +2626,6 @@
     "horizontalSnakeLinePadding" : 20.0,
     "verticalSnakeLinePadding" : 25.0,
     "arrowDistance" : 20.0,
-    "showInductorFor3WT" : false,
     "diagramName" : null,
     "shiftFeedersPosition" : false,
     "scaleShiftFeedersPosition" : 1.0,

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -162,24 +162,6 @@
     "allowRotation" : true,
     "subComponents" : null
   }, {
-    "type" : "INDUCTOR",
-    "id" : null,
-    "anchorPoints" : [ {
-      "x" : 0.0,
-      "y" : -4.0,
-      "orientation" : "VERTICAL"
-    }, {
-      "x" : 0.0,
-      "y" : 4.0,
-      "orientation" : "VERTICAL"
-    } ],
-    "size" : {
-      "width" : 15.0,
-      "height" : 9.0
-    },
-    "allowRotation" : true,
-    "subComponents" : null
-  }, {
     "type" : "TWO_WINDINGS_TRANSFORMER",
     "id" : null,
     "anchorPoints" : [ {
@@ -254,6 +236,15 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
+    "vlabel" : false
+  }, {
+    "id" : "idtrf6_95_ONE_95_THREE",
+    "vid" : "vl1",
+    "nextVId" : "vl3",
+    "componentType" : "LINE",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "TOP",
     "vlabel" : false
   }, {
     "id" : "iddtrct21",
@@ -517,15 +508,6 @@
     "direction" : "TOP",
     "vlabel" : false
   }, {
-    "id" : "idself4",
-    "vid" : "vl1",
-    "nextVId" : "vl3",
-    "componentType" : "INDUCTOR",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "TOP",
-    "vlabel" : false
-  }, {
     "id" : "idtrf1_95_ONE",
     "vid" : "vl1",
     "nextVId" : "vl2",
@@ -679,6 +661,15 @@
     "direction" : "UNDEFINED",
     "vlabel" : false
   }, {
+    "id" : "idtrf8_95_ONE_95_THREE",
+    "vid" : "vl1",
+    "nextVId" : "vl3",
+    "componentType" : "LINE",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "TOP",
+    "vlabel" : false
+  }, {
     "id" : "iddsect21",
     "vid" : "vl1",
     "nextVId" : null,
@@ -758,6 +749,15 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
+    "vlabel" : false
+  }, {
+    "id" : "idtrf7_95_ONE_95_THREE",
+    "vid" : "vl1",
+    "nextVId" : "vl3",
+    "componentType" : "LINE",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "BOTTOM",
     "vlabel" : false
   }, {
     "id" : "idbload2",
@@ -994,7 +994,7 @@
   }, {
     "id" : "idvl1_95_Wire33",
     "nodeId1" : "idFICT_95_vl1_95_trf81_95_fictif",
-    "nodeId2" : "idself4",
+    "nodeId2" : "idtrf8_95_ONE_95_THREE",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1024,7 +1024,7 @@
   }, {
     "id" : "idvl1_95_Wire30",
     "nodeId1" : "idFICT_95_vl1_95_trf71_95_fictif",
-    "nodeId2" : "idself4",
+    "nodeId2" : "idtrf7_95_ONE_95_THREE",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1060,7 +1060,7 @@
   }, {
     "id" : "idvl1_95_Wire27",
     "nodeId1" : "idFICT_95_vl1_95_trf61_95_fictif",
-    "nodeId2" : "idself4",
+    "nodeId2" : "idtrf6_95_ONE_95_THREE",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1398,7 +1398,6 @@
     "horizontalSnakeLinePadding" : 20.0,
     "verticalSnakeLinePadding" : 25.0,
     "arrowDistance" : 20.0,
-    "showInductorFor3WT" : false,
     "diagramName" : null,
     "shiftFeedersPosition" : false,
     "scaleShiftFeedersPosition" : 1.0,

--- a/single-line-diagram-force-layout/src/test/java/com/powsybl/sld/force/layout/TestCaseSmartSubstationGraph.java
+++ b/single-line-diagram-force-layout/src/test/java/com/powsybl/sld/force/layout/TestCaseSmartSubstationGraph.java
@@ -45,8 +45,7 @@ public class TestCaseSmartSubstationGraph extends TestCase11SubstationGraph {
                 .setVerticalSubstationPadding(50)
                 .setDrawStraightWires(false)
                 .setHorizontalSnakeLinePadding(30)
-                .setVerticalSnakeLinePadding(30)
-                .setShowInductorFor3WT(false);
+                .setVerticalSnakeLinePadding(30);
 
         // write Json and compare to reference (with smart substation layout)
         SubstationGraph g = graphBuilder.buildSubstationGraph(substation.getId(), false);

--- a/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
+++ b/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
@@ -253,8 +253,7 @@ public abstract class AbstractSingleLineDiagramViewer extends Application implem
                 LayoutParameters diagramLayoutParameters = new LayoutParameters(layoutParameters.get()).setDiagramName(dName);
                 diagramLayoutParameters.setComponentsSize(getComponentLibrary().getComponentsSize());
                 if (c.getContainerType() == ContainerType.VOLTAGE_LEVEL) {
-                    VoltageLevelDiagram diagram = VoltageLevelDiagram.build(graphBuilder, c.getId(), getVoltageLevelLayoutFactory(), showNames.isSelected(),
-                            diagramLayoutParameters.isShowInductorFor3WT());
+                    VoltageLevelDiagram diagram = VoltageLevelDiagram.build(graphBuilder, c.getId(), getVoltageLevelLayoutFactory(), showNames.isSelected());
                     diagram.writeSvg("",
                             new DefaultSVGWriter(getComponentLibrary(), diagramLayoutParameters),
                             initProvider,
@@ -712,8 +711,6 @@ public abstract class AbstractSingleLineDiagramViewer extends Application implem
         addPositionLayoutCheckBox("Remove fictitious nodes", rowIndex, PositionVoltageLevelLayoutFactory::isRemoveUnnecessaryFictitiousNodes, PositionVoltageLevelLayoutFactory::setRemoveUnnecessaryFictitiousNodes);
         rowIndex += 1;
         addPositionLayoutCheckBox("Substitute singular fictitious nodes", rowIndex, PositionVoltageLevelLayoutFactory::isSubstituteSingularFictitiousByFeederNode, PositionVoltageLevelLayoutFactory::setSubstituteSingularFictitiousByFeederNode);
-        rowIndex += 1;
-        addCheckBox("Show inductor for three windings transformers", rowIndex, LayoutParameters::isShowInductorFor3WT, LayoutParameters::setShowInductorFor3WT);
         rowIndex += 1;
         addCheckBox("Shift feeders height", rowIndex, LayoutParameters::isShiftFeedersPosition, LayoutParameters::setShiftFeedersPosition);
         rowIndex += 1;


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature removal


**What is the current behavior?** *(You can also link to an open issue here)*
We can aggregate tertiary inductor to the other side voltage level diagram.
 - impl is complex
 - used by anybody
 - does not really work on general data because voltage level at tertiary of 3 windings transformers often are not only composed of one inductor
 - substation diagram (developped since) are a more powerful way to fully show 3 windings transformers.     


**What is the new behavior (if this is a feature change)?**
This feature has been removed.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
