### PR TITLE
delete_voltage_level_label_in_voltage_level_diagram

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -243,10 +243,6 @@ public class DefaultSVGWriter implements SVGWriter {
 
         drawVoltageLevel(prefixId, graph, root, metadata, initProvider, styleProvider, nodeLabelConfiguration);
 
-        // the drawing of the voltageLevel graph label is done at the end in order to
-        // facilitate the move of a voltageLevel in the diagram
-        drawGraphLabel(prefixId, root, graph, metadata);
-
         document.adoptNode(root);
         document.getDocumentElement().appendChild(root);
 

--- a/single-line-diagram-core/src/test/resources/vl1.svg
+++ b/single-line-diagram-core/src/test/resources/vl1.svg
@@ -348,8 +348,5 @@
         <line y2="8" x1="8" x2="0" y1="0"/>
     </g>
 </g>
-        <g id="LABEL_VL_vl1">
-            <text x="0.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
-        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -278,8 +278,5 @@
         <g class="DISCONNECTOR idvl1_95_dtrf2" id="idvl1_95_dtrf2" transform="translate(416.0,366.0)">
             <use href="#DISCONNECTOR-closed"/>
         </g>
-        <g id="LABEL_VL_vl1">
-            <text x="0.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
-        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl2.svg
+++ b/single-line-diagram-core/src/test/resources/vl2.svg
@@ -306,8 +306,5 @@
         <line y2="8" x1="8" x2="0" y1="0"/>
     </g>
 </g>
-        <g id="LABEL_VL_vl2">
-            <text x="550.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
-        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -258,8 +258,5 @@
         <g class="DISCONNECTOR idvl2_95_dtrf2" id="idvl2_95_dtrf2" transform="translate(726.0,366.0)">
             <use href="#DISCONNECTOR-closed"/>
         </g>
-        <g id="LABEL_VL_vl2">
-            <text x="550.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
-        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl3.svg
+++ b/single-line-diagram-core/src/test/resources/vl3.svg
@@ -258,8 +258,5 @@
         <line y2="8" x1="8" x2="0" y1="0"/>
     </g>
 </g>
-        <g id="LABEL_VL_vl3">
-            <text x="850.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
-        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl3_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_optimized.svg
@@ -232,8 +232,5 @@
         <g class="DISCONNECTOR idvl3_95_dtrf2" id="idvl3_95_dtrf2" transform="translate(1016.0,366.0)">
             <use href="#DISCONNECTOR-closed"/>
         </g>
-        <g id="LABEL_VL_vl3">
-            <text x="850.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
-        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -715,15 +715,6 @@
     "direction" : "TOP",
     "vlabel" : false
   }, {
-    "id" : "LABEL_VL_vl1",
-    "vid" : "vl1",
-    "nextVId" : null,
-    "componentType" : null,
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : true
-  }, {
     "id" : "idload2",
     "vid" : "vl1",
     "nextVId" : null,


### PR DESCRIPTION
Signed-off-by: Franck LECUYER <franck.lecuyer@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Whe displaying a voltage level diagram, a redundant voltage level label is generated in the svg file


**What is the new behavior (if this is a feature change)?**
The voltage level label is now generated only in substation and zone diagram


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
