### PR TITLE
Create a viewer profile to not compile by default JavaFX viewer

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
           java-package: jdk+fx
 
       - name: Build with Maven
-        run: mvn --batch-mode package -Pjacoco,checks,viewer
+        run: mvn --batch-mode -Pjacoco,checks,viewer package
 
       - name: Run SonarCloud analysis
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
           java-package: jdk+fx
 
       - name: Build with Maven
-        run: mvn --batch-mode package
+        run: mvn --batch-mode package -Pjacoco,checks,viewer
 
       - name: Run SonarCloud analysis
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
           java-package: jdk+fx
 
       - name: Build with Maven
-        run: mvn --batch-mode -Pjacoco,checks,viewer package
+        run: mvn --batch-mode -P jacoco,checks,viewer package
 
       - name: Run SonarCloud analysis
         if: matrix.os == 'ubuntu-latest'

--- a/pom.xml
+++ b/pom.xml
@@ -53,15 +53,13 @@
         <module>single-line-diagram-core</module>
         <module>single-line-diagram-distribution</module>
         <module>single-line-diagram-iidm-extensions</module>
-        <module>single-line-diagram-view</module>
-        <module>single-line-diagram-view-app</module>
         <module>single-line-diagram-force-layout</module>
     </modules>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <java.version>1.8</java.version>
+        <java.version>8</java.version>
 
         <assertj.version>3.11.0</assertj.version>
         <batik.version>1.9</batik.version>
@@ -103,6 +101,16 @@
     </properties>
 
     <profiles>
+        <profile>
+            <id>viewer</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>single-line-diagram-view</module>
+                <module>single-line-diagram-view-app</module>
+            </modules>
+        </profile>
         <profile>
             <id>release</id>
             <activation>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
JavaFX viewer modules are compiled by default. 


**What is the new behavior (if this is a feature change)?**
A 'viewer' profile has to be activated to compile JavaFX viewer.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
