### PR TITLE
add unescapedId attribute in metadata

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -443,7 +443,8 @@ public class DefaultSVGWriter implements SVGWriter {
                 null,
                 false,
                 BusCell.Direction.UNDEFINED,
-                false));
+                false,
+                null));
 
         return gridRoot;
     }
@@ -518,7 +519,7 @@ public class DefaultSVGWriter implements SVGWriter {
         metadata.addNodeMetadata(
                 new GraphMetadata.NodeMetadata(nodeId, graph != null ? graph.getVoltageLevelInfos().getId() : "", nextVId,
                         node.getComponentType(), node.getRotationAngle(),
-                        node.isOpen(), direction, false));
+                        node.isOpen(), direction, false, node.getEquipmentId()));
         if (node.getType() == Node.NodeType.BUS) {
             metadata.addComponentMetadata(new ComponentMetadata(BUSBAR_SECTION,
                     nodeId,
@@ -578,7 +579,8 @@ public class DefaultSVGWriter implements SVGWriter {
                 null,
                 false,
                 BusCell.Direction.UNDEFINED,
-                true));
+                true,
+                null));
     }
 
     /*

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/GraphMetadata.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/GraphMetadata.java
@@ -47,6 +47,8 @@ public class GraphMetadata implements AnchorPointProvider {
 
         private final boolean vLabel;
 
+        private final String unescapedId;
+
         @JsonCreator
         public NodeMetadata(@JsonProperty("id") String id,
                             @JsonProperty("vid") String vId,
@@ -55,7 +57,8 @@ public class GraphMetadata implements AnchorPointProvider {
                             @JsonProperty("rotationAngle") Double rotationAngle,
                             @JsonProperty("open") boolean open,
                             @JsonProperty("direction") BusCell.Direction direction,
-                            @JsonProperty("vlabel") boolean vLabel) {
+                            @JsonProperty("vlabel") boolean vLabel,
+                            @JsonProperty("unescapedId") String unescapedId) {
             this.id = Objects.requireNonNull(id);
             this.vId = Objects.requireNonNull(vId);
             this.nextVId = nextVId;
@@ -64,6 +67,7 @@ public class GraphMetadata implements AnchorPointProvider {
             this.open = Objects.requireNonNull(open);
             this.direction = direction;
             this.vLabel = vLabel;
+            this.unescapedId = unescapedId;
         }
 
         public String getId() {
@@ -96,6 +100,10 @@ public class GraphMetadata implements AnchorPointProvider {
 
         public boolean isVLabel() {
             return vLabel;
+        }
+
+        public String getUnescapedId() {
+            return unescapedId;
         }
     }
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/GraphMetadataTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/GraphMetadataTest.java
@@ -65,8 +65,8 @@ public class GraphMetadataTest {
                                                             ImmutableList.of(new AnchorPoint(5, 4, AnchorOrientation.NONE)),
                                                             new ComponentSize(10, 12), true, null));
 
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("id1", "vid1", null, BREAKER, null, false, BusCell.Direction.UNDEFINED, false));
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("id2", "vid2", null, BUSBAR_SECTION, null, false, BusCell.Direction.UNDEFINED, false));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("id1", "vid1", null, BREAKER, null, false, BusCell.Direction.UNDEFINED, false, null));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("id2", "vid2", null, BUSBAR_SECTION, null, false, BusCell.Direction.UNDEFINED, false, null));
         metadata.addWireMetadata(new GraphMetadata.WireMetadata("id3", "id1", "id2", false, false));
         metadata.addArrowMetadata(new ArrowMetadata("id1", "id3", 20));
 
@@ -135,11 +135,11 @@ public class GraphMetadataTest {
     @Test
     public void testGraphMetadataWithLine() throws IOException {
         GraphMetadata metadata = new GraphMetadata();
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("bid1", "vid1", null, BUSBAR_SECTION, null, false, BusCell.Direction.UNDEFINED, false));
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("lid1", "vid1", null, LINE, null, false, BusCell.Direction.UNDEFINED, false));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("bid1", "vid1", null, BUSBAR_SECTION, null, false, BusCell.Direction.UNDEFINED, false, null));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("lid1", "vid1", null, LINE, null, false, BusCell.Direction.UNDEFINED, false, null));
         metadata.addWireMetadata(new GraphMetadata.WireMetadata("wid1", "bid1", "lid1", false, false));
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("bid2", "vid2", null, BUSBAR_SECTION, null, false, BusCell.Direction.UNDEFINED, false));
-        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("lid2", "vid2", null, LINE, null, false, BusCell.Direction.UNDEFINED, false));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("bid2", "vid2", null, BUSBAR_SECTION, null, false, BusCell.Direction.UNDEFINED, false, null));
+        metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("lid2", "vid2", null, LINE, null, false, BusCell.Direction.UNDEFINED, false, null));
         metadata.addWireMetadata(new GraphMetadata.WireMetadata("wid2", "bid2", "lid2", false, false));
         metadata.addLineMetadata(new GraphMetadata.LineMetadata("lid", "lid1", "lid2"));
 

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -228,7 +228,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf7"
   }, {
     "id" : "idtrf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE",
     "vid" : "",
@@ -237,7 +238,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf6_ONE_trf6_TWO_trf6_THREE"
   }, {
     "id" : "iddload4",
     "vid" : "vl3",
@@ -246,7 +248,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dload4"
   }, {
     "id" : "iddload3",
     "vid" : "vl2",
@@ -255,7 +258,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dload3"
   }, {
     "id" : "iddload2",
     "vid" : "vl1",
@@ -264,7 +268,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dload2"
   }, {
     "id" : "idbline11_95_2",
     "vid" : "vl1",
@@ -273,7 +278,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bline11_2"
   }, {
     "id" : "iddload1",
     "vid" : "vl1",
@@ -282,7 +288,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dload1"
   }, {
     "id" : "idFICT_95_vl1_95_dload2Fictif",
     "vid" : "vl1",
@@ -291,7 +298,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dload2Fictif"
   }, {
     "id" : "idbbs4",
     "vid" : "vl1",
@@ -300,7 +308,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bbs4"
   }, {
     "id" : "idbbs5",
     "vid" : "vl2",
@@ -309,7 +318,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bbs5"
   }, {
     "id" : "idbbs6",
     "vid" : "vl2",
@@ -318,7 +328,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bbs6"
   }, {
     "id" : "idbbs7",
     "vid" : "vl3",
@@ -327,7 +338,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bbs7"
   }, {
     "id" : "idbbs1",
     "vid" : "vl1",
@@ -336,7 +348,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bbs1"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf14Fictif",
     "vid" : "vl1",
@@ -345,7 +358,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf14Fictif"
   }, {
     "id" : "idbbs2",
     "vid" : "vl1",
@@ -354,7 +368,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bbs2"
   }, {
     "id" : "idbbs3",
     "vid" : "vl1",
@@ -363,7 +378,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bbs3"
   }, {
     "id" : "idFICT_95_vl2_95_dtrf28Fictif",
     "vid" : "vl2",
@@ -372,7 +388,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf28Fictif"
   }, {
     "id" : "iddscpl1",
     "vid" : "vl2",
@@ -381,7 +398,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dscpl1"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf11Fictif",
     "vid" : "vl1",
@@ -390,7 +408,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf11Fictif"
   }, {
     "id" : "iddscpl2",
     "vid" : "vl2",
@@ -399,7 +418,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dscpl2"
   }, {
     "id" : "iddtrf11",
     "vid" : "vl1",
@@ -408,7 +428,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf11"
   }, {
     "id" : "idtrf6_95_THREE",
     "vid" : "vl3",
@@ -417,7 +438,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf6"
   }, {
     "id" : "idFICT_95_vl2_95_dtrf22Fictif",
     "vid" : "vl2",
@@ -426,7 +448,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf22Fictif"
   }, {
     "id" : "idtrf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE",
     "vid" : "",
@@ -435,7 +458,8 @@
     "rotationAngle" : 180.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf8_ONE_trf8_TWO_trf8_THREE"
   }, {
     "id" : "iddtrf18",
     "vid" : "vl1",
@@ -444,7 +468,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf18"
   }, {
     "id" : "iddtrf17",
     "vid" : "vl1",
@@ -453,7 +478,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf17"
   }, {
     "id" : "iddtrf16",
     "vid" : "vl1",
@@ -462,7 +488,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf16"
   }, {
     "id" : "iddtrf15",
     "vid" : "vl1",
@@ -471,7 +498,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf15"
   }, {
     "id" : "iddtrf14",
     "vid" : "vl1",
@@ -480,7 +508,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf14"
   }, {
     "id" : "iddtrf13",
     "vid" : "vl1",
@@ -489,7 +518,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf13"
   }, {
     "id" : "iddtrf12",
     "vid" : "vl1",
@@ -498,7 +528,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf12"
   }, {
     "id" : "idFICT_95_vl1_95_dgen2Fictif",
     "vid" : "vl1",
@@ -507,7 +538,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dgen2Fictif"
   }, {
     "id" : "idFICT_95_vl2_95_dgen4Fictif",
     "vid" : "vl2",
@@ -516,7 +548,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dgen4Fictif"
   }, {
     "id" : "idddcpl1",
     "vid" : "vl2",
@@ -525,7 +558,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "ddcpl1"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf17Fictif",
     "vid" : "vl1",
@@ -534,7 +568,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf17Fictif"
   }, {
     "id" : "idline1_95_ONE",
     "vid" : "vl1",
@@ -543,7 +578,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "line1"
   }, {
     "id" : "iddtrf22",
     "vid" : "vl2",
@@ -552,7 +588,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf22"
   }, {
     "id" : "idFICT_95_vl3_95_dtrf38Fictif",
     "vid" : "vl3",
@@ -561,7 +598,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf38Fictif"
   }, {
     "id" : "idtrf6_95_TWO",
     "vid" : "vl2",
@@ -570,7 +608,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf6"
   }, {
     "id" : "iddtrf21",
     "vid" : "vl2",
@@ -579,7 +618,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf21"
   }, {
     "id" : "iddsect21",
     "vid" : "vl1",
@@ -588,7 +628,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect21"
   }, {
     "id" : "idFICT_95_vl3_95_dtrf25Fictif",
     "vid" : "vl3",
@@ -597,7 +638,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf25Fictif"
   }, {
     "id" : "iddsect22",
     "vid" : "vl1",
@@ -606,7 +648,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect22"
   }, {
     "id" : "idtrf3_95_ONE_95_trf3_95_TWO",
     "vid" : "",
@@ -615,7 +658,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf3_ONE_trf3_TWO"
   }, {
     "id" : "idtrf2_95_TWO",
     "vid" : "vl2",
@@ -624,7 +668,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf2"
   }, {
     "id" : "iddtrf28",
     "vid" : "vl2",
@@ -633,7 +678,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf28"
   }, {
     "id" : "iddtrf27",
     "vid" : "vl2",
@@ -642,7 +688,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf27"
   }, {
     "id" : "iddtrf26",
     "vid" : "vl2",
@@ -651,7 +698,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf26"
   }, {
     "id" : "idFICT_95_vl2_95_dtrf23Fictif",
     "vid" : "vl2",
@@ -660,7 +708,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf23Fictif"
   }, {
     "id" : "iddtrf25",
     "vid" : "vl3",
@@ -669,7 +718,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf25"
   }, {
     "id" : "iddtrf24",
     "vid" : "vl2",
@@ -678,7 +728,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf24"
   }, {
     "id" : "iddtrf23",
     "vid" : "vl2",
@@ -687,7 +738,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf23"
   }, {
     "id" : "idFICT_95_vl2_95_dscpl1Fictif",
     "vid" : "vl2",
@@ -696,7 +748,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dscpl1Fictif"
   }, {
     "id" : "LABEL_VL_vl1",
     "vid" : "vl1",
@@ -705,7 +758,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : true
+    "vlabel" : true,
+    "unescapedId" : null
   }, {
     "id" : "LABEL_VL_vl3",
     "vid" : "vl3",
@@ -714,7 +768,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : true
+    "vlabel" : true,
+    "unescapedId" : null
   }, {
     "id" : "GRID_vl3",
     "vid" : "vl3",
@@ -723,7 +778,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : null
   }, {
     "id" : "idFICT_95_vl1_95_dtrf16Fictif",
     "vid" : "vl1",
@@ -732,7 +788,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf16Fictif"
   }, {
     "id" : "LABEL_VL_vl2",
     "vid" : "vl2",
@@ -741,7 +798,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : true
+    "vlabel" : true,
+    "unescapedId" : null
   }, {
     "id" : "GRID_vl2",
     "vid" : "vl2",
@@ -750,7 +808,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : null
   }, {
     "id" : "idbload4",
     "vid" : "vl3",
@@ -759,7 +818,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bload4"
   }, {
     "id" : "GRID_vl1",
     "vid" : "vl1",
@@ -768,7 +828,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : null
   }, {
     "id" : "idbload3",
     "vid" : "vl2",
@@ -777,7 +838,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bload3"
   }, {
     "id" : "idFICT_95_vl3_95_dtrf37Fictif",
     "vid" : "vl3",
@@ -786,7 +848,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf37Fictif"
   }, {
     "id" : "idbload2",
     "vid" : "vl1",
@@ -795,7 +858,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bload2"
   }, {
     "id" : "idtrf4_95_ONE_95_trf4_95_TWO",
     "vid" : "",
@@ -804,7 +868,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf4_ONE_trf4_TWO"
   }, {
     "id" : "idbload1",
     "vid" : "vl1",
@@ -813,7 +878,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bload1"
   }, {
     "id" : "idtrf8_95_THREE",
     "vid" : "vl3",
@@ -822,7 +888,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf8"
   }, {
     "id" : "iddsect12",
     "vid" : "vl1",
@@ -831,7 +898,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect12"
   }, {
     "id" : "iddsect11",
     "vid" : "vl1",
@@ -840,7 +908,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect11"
   }, {
     "id" : "idtrf2_95_ONE",
     "vid" : "vl1",
@@ -849,7 +918,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf2"
   }, {
     "id" : "idtrf6_95_ONE",
     "vid" : "vl1",
@@ -858,7 +928,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf6"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf15Fictif",
     "vid" : "vl1",
@@ -867,7 +938,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf15Fictif"
   }, {
     "id" : "iddtrf38",
     "vid" : "vl3",
@@ -876,7 +948,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf38"
   }, {
     "id" : "iddtrf37",
     "vid" : "vl3",
@@ -885,7 +958,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf37"
   }, {
     "id" : "idFICT_95_vl3_95_dtrf36Fictif",
     "vid" : "vl3",
@@ -894,7 +968,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf36Fictif"
   }, {
     "id" : "iddtrf36",
     "vid" : "vl3",
@@ -903,7 +978,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf36"
   }, {
     "id" : "idFICT_95_vl2_95_dtrf24Fictif",
     "vid" : "vl2",
@@ -912,7 +988,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf24Fictif"
   }, {
     "id" : "iddtrct21",
     "vid" : "vl1",
@@ -921,7 +998,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrct21"
   }, {
     "id" : "idFICT_95_vl1_95_dgen1Fictif",
     "vid" : "vl1",
@@ -930,7 +1008,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dgen1Fictif"
   }, {
     "id" : "idbtrf18",
     "vid" : "vl1",
@@ -939,7 +1018,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf18"
   }, {
     "id" : "idtrf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE",
     "vid" : "",
@@ -948,7 +1028,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf7_ONE_trf7_TWO_trf7_THREE"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf12Fictif",
     "vid" : "vl1",
@@ -957,7 +1038,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf12Fictif"
   }, {
     "id" : "idbtrf15",
     "vid" : "vl1",
@@ -966,7 +1048,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf15"
   }, {
     "id" : "idFICT_95_vl2_95_dtrf21Fictif",
     "vid" : "vl2",
@@ -975,7 +1058,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf21Fictif"
   }, {
     "id" : "idbtrf14",
     "vid" : "vl1",
@@ -984,7 +1068,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf14"
   }, {
     "id" : "idbtrf17",
     "vid" : "vl1",
@@ -993,7 +1078,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf17"
   }, {
     "id" : "idbtrf16",
     "vid" : "vl1",
@@ -1002,7 +1088,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf16"
   }, {
     "id" : "idbtrf11",
     "vid" : "vl1",
@@ -1011,7 +1098,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf11"
   }, {
     "id" : "idbtrf13",
     "vid" : "vl1",
@@ -1020,7 +1108,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf13"
   }, {
     "id" : "idbtrf12",
     "vid" : "vl1",
@@ -1029,7 +1118,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf12"
   }, {
     "id" : "idbgen1",
     "vid" : "vl1",
@@ -1038,7 +1128,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bgen1"
   }, {
     "id" : "idbgen2",
     "vid" : "vl1",
@@ -1047,7 +1138,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bgen2"
   }, {
     "id" : "idgen4",
     "vid" : "vl2",
@@ -1056,7 +1148,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "gen4"
   }, {
     "id" : "idtrf3_95_TWO",
     "vid" : "vl2",
@@ -1065,7 +1158,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf3"
   }, {
     "id" : "idgen1",
     "vid" : "vl1",
@@ -1074,7 +1168,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "gen1"
   }, {
     "id" : "idgen2",
     "vid" : "vl1",
@@ -1083,7 +1178,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "gen2"
   }, {
     "id" : "idbgen4",
     "vid" : "vl2",
@@ -1092,7 +1188,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bgen4"
   }, {
     "id" : "idtrf1_95_TWO",
     "vid" : "vl2",
@@ -1101,7 +1198,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf1"
   }, {
     "id" : "idtrf5_95_TWO",
     "vid" : "vl3",
@@ -1110,7 +1208,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf5"
   }, {
     "id" : "idFICT_95_vl2_95_dload3Fictif",
     "vid" : "vl2",
@@ -1119,7 +1218,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dload3Fictif"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf18Fictif",
     "vid" : "vl1",
@@ -1128,7 +1228,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf18Fictif"
   }, {
     "id" : "idFICT_95_vl1_95_dsect12Fictif",
     "vid" : "vl1",
@@ -1137,7 +1238,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect12Fictif"
   }, {
     "id" : "idFICT_95_vl1_95_dload1Fictif",
     "vid" : "vl1",
@@ -1146,7 +1248,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dload1Fictif"
   }, {
     "id" : "idbtrf26",
     "vid" : "vl2",
@@ -1155,7 +1258,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf26"
   }, {
     "id" : "iddline11_95_2",
     "vid" : "vl1",
@@ -1164,7 +1268,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dline11_2"
   }, {
     "id" : "idbtrf25",
     "vid" : "vl3",
@@ -1173,7 +1278,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf25"
   }, {
     "id" : "idbtrf28",
     "vid" : "vl2",
@@ -1182,7 +1288,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf28"
   }, {
     "id" : "idbtrf27",
     "vid" : "vl2",
@@ -1191,7 +1298,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf27"
   }, {
     "id" : "idtrf5_95_ONE_95_trf5_95_TWO",
     "vid" : "",
@@ -1200,7 +1308,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf5_ONE_trf5_TWO"
   }, {
     "id" : "idbtrf22",
     "vid" : "vl2",
@@ -1209,7 +1318,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf22"
   }, {
     "id" : "idbtrf21",
     "vid" : "vl2",
@@ -1218,7 +1328,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf21"
   }, {
     "id" : "idtrf1_95_ONE",
     "vid" : "vl1",
@@ -1227,7 +1338,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf1"
   }, {
     "id" : "idFICT_95_vl2_95_dscpl2Fictif",
     "vid" : "vl2",
@@ -1236,7 +1348,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dscpl2Fictif"
   }, {
     "id" : "idbtrf24",
     "vid" : "vl2",
@@ -1245,7 +1358,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf24"
   }, {
     "id" : "idtrf3_95_ONE",
     "vid" : "vl1",
@@ -1254,7 +1368,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf3"
   }, {
     "id" : "idtrf5_95_ONE",
     "vid" : "vl1",
@@ -1263,7 +1378,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf5"
   }, {
     "id" : "idtrf7_95_ONE",
     "vid" : "vl1",
@@ -1272,7 +1388,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf7"
   }, {
     "id" : "idbtrf23",
     "vid" : "vl2",
@@ -1281,7 +1398,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf23"
   }, {
     "id" : "idtrf1_95_ONE_95_trf1_95_TWO",
     "vid" : "",
@@ -1290,7 +1408,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf1_ONE_trf1_TWO"
   }, {
     "id" : "iddgen4",
     "vid" : "vl2",
@@ -1299,7 +1418,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dgen4"
   }, {
     "id" : "iddgen1",
     "vid" : "vl1",
@@ -1308,7 +1428,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dgen1"
   }, {
     "id" : "iddgen2",
     "vid" : "vl1",
@@ -1317,7 +1438,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dgen2"
   }, {
     "id" : "idtrf2_95_ONE_95_trf2_95_TWO",
     "vid" : "",
@@ -1326,7 +1448,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf2_ONE_trf2_TWO"
   }, {
     "id" : "idtrf8_95_TWO",
     "vid" : "vl2",
@@ -1335,7 +1458,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf8"
   }, {
     "id" : "idtrf7_95_TWO",
     "vid" : "vl2",
@@ -1344,7 +1468,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf7"
   }, {
     "id" : "idFICT_95_vl1_95_dsect21Fictif",
     "vid" : "vl1",
@@ -1353,7 +1478,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect21Fictif"
   }, {
     "id" : "idbtrf37",
     "vid" : "vl3",
@@ -1362,7 +1488,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf37"
   }, {
     "id" : "idbtrf36",
     "vid" : "vl3",
@@ -1371,7 +1498,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf36"
   }, {
     "id" : "idbtrf38",
     "vid" : "vl3",
@@ -1380,7 +1508,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf38"
   }, {
     "id" : "idFICT_95_vl1_95_dsect11Fictif",
     "vid" : "vl1",
@@ -1389,7 +1518,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect11Fictif"
   }, {
     "id" : "idFICT_95_vl2_95_dtrf26Fictif",
     "vid" : "vl2",
@@ -1398,7 +1528,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf26Fictif"
   }, {
     "id" : "iddtrct11",
     "vid" : "vl1",
@@ -1407,7 +1538,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrct11"
   }, {
     "id" : "idtrf4_95_TWO",
     "vid" : "vl2",
@@ -1416,7 +1548,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf4"
   }, {
     "id" : "idload1",
     "vid" : "vl1",
@@ -1425,7 +1558,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "load1"
   }, {
     "id" : "idload2",
     "vid" : "vl1",
@@ -1434,7 +1568,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "load2"
   }, {
     "id" : "idload3",
     "vid" : "vl2",
@@ -1443,7 +1578,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "load3"
   }, {
     "id" : "idload4",
     "vid" : "vl3",
@@ -1452,7 +1588,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "load4"
   }, {
     "id" : "idFICT_95_vl1_95_dline11_95_2Fictif",
     "vid" : "vl1",
@@ -1461,7 +1598,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dline11_2Fictif"
   }, {
     "id" : "idFICT_95_vl3_95_dload4Fictif",
     "vid" : "vl3",
@@ -1470,7 +1608,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dload4Fictif"
   }, {
     "id" : "idFICT_95_vl1_95_dsect22Fictif",
     "vid" : "vl1",
@@ -1479,7 +1618,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect22Fictif"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf13Fictif",
     "vid" : "vl1",
@@ -1488,7 +1628,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf13Fictif"
   }, {
     "id" : "idFICT_95_vl2_95_dtrf27Fictif",
     "vid" : "vl2",
@@ -1497,7 +1638,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf27Fictif"
   }, {
     "id" : "idtrf8_95_ONE",
     "vid" : "vl1",
@@ -1506,7 +1648,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf8"
   }, {
     "id" : "idtrf4_95_ONE",
     "vid" : "vl1",
@@ -1515,7 +1658,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf4"
   } ],
   "wires" : [ {
     "id" : "idvl1_95__95_Wire16",

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -236,7 +236,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf15Fictif"
   }, {
     "id" : "idtrf6_95_ONE_95_THREE",
     "vid" : "vl1",
@@ -245,7 +246,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf6"
   }, {
     "id" : "iddtrct21",
     "vid" : "vl1",
@@ -254,7 +256,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrct21"
   }, {
     "id" : "idFICT_95_vl1_95_dgen1Fictif",
     "vid" : "vl1",
@@ -263,7 +266,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dgen1Fictif"
   }, {
     "id" : "idbtrf18",
     "vid" : "vl1",
@@ -272,7 +276,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf18"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf12Fictif",
     "vid" : "vl1",
@@ -281,7 +286,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf12Fictif"
   }, {
     "id" : "iddload2",
     "vid" : "vl1",
@@ -290,7 +296,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dload2"
   }, {
     "id" : "iddload1",
     "vid" : "vl1",
@@ -299,7 +306,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dload1"
   }, {
     "id" : "idbtrf15",
     "vid" : "vl1",
@@ -308,7 +316,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf15"
   }, {
     "id" : "idbtrf14",
     "vid" : "vl1",
@@ -317,7 +326,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf14"
   }, {
     "id" : "idbtrf17",
     "vid" : "vl1",
@@ -326,7 +336,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf17"
   }, {
     "id" : "idbtrf16",
     "vid" : "vl1",
@@ -335,7 +346,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf16"
   }, {
     "id" : "idbtrf11",
     "vid" : "vl1",
@@ -344,7 +356,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf11"
   }, {
     "id" : "idFICT_95_vl1_95_dload2Fictif",
     "vid" : "vl1",
@@ -353,7 +366,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dload2Fictif"
   }, {
     "id" : "idbtrf13",
     "vid" : "vl1",
@@ -362,7 +376,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf13"
   }, {
     "id" : "idbtrf12",
     "vid" : "vl1",
@@ -371,7 +386,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "btrf12"
   }, {
     "id" : "idbbs4",
     "vid" : "vl1",
@@ -380,7 +396,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bbs4"
   }, {
     "id" : "idbgen1",
     "vid" : "vl1",
@@ -389,7 +406,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bgen1"
   }, {
     "id" : "idbgen2",
     "vid" : "vl1",
@@ -398,7 +416,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bgen2"
   }, {
     "id" : "idgen1",
     "vid" : "vl1",
@@ -407,7 +426,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "gen1"
   }, {
     "id" : "idgen2",
     "vid" : "vl1",
@@ -416,7 +436,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "gen2"
   }, {
     "id" : "idbbs1",
     "vid" : "vl1",
@@ -425,7 +446,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bbs1"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf14Fictif",
     "vid" : "vl1",
@@ -434,7 +456,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf14Fictif"
   }, {
     "id" : "idbbs2",
     "vid" : "vl1",
@@ -443,7 +466,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bbs2"
   }, {
     "id" : "idbbs3",
     "vid" : "vl1",
@@ -452,7 +476,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bbs3"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf11Fictif",
     "vid" : "vl1",
@@ -461,7 +486,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf11Fictif"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf18Fictif",
     "vid" : "vl1",
@@ -470,7 +496,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf18Fictif"
   }, {
     "id" : "idFICT_95_vl1_95_dsect12Fictif",
     "vid" : "vl1",
@@ -479,7 +506,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect12Fictif"
   }, {
     "id" : "idFICT_95_vl1_95_dload1Fictif",
     "vid" : "vl1",
@@ -488,7 +516,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dload1Fictif"
   }, {
     "id" : "iddtrf11",
     "vid" : "vl1",
@@ -497,7 +526,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf11"
   }, {
     "id" : "idtrf6_95_ONE_95_TWO",
     "vid" : "vl1",
@@ -506,7 +536,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf6"
   }, {
     "id" : "idtrf1_95_ONE",
     "vid" : "vl1",
@@ -515,7 +546,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf1"
   }, {
     "id" : "idtrf3_95_ONE",
     "vid" : "vl1",
@@ -524,7 +556,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf3"
   }, {
     "id" : "idtrf5_95_ONE",
     "vid" : "vl1",
@@ -533,7 +566,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf5"
   }, {
     "id" : "idtrf7_95_ONE_95_TWO",
     "vid" : "vl1",
@@ -542,7 +576,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf7"
   }, {
     "id" : "iddtrf18",
     "vid" : "vl1",
@@ -551,7 +586,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf18"
   }, {
     "id" : "iddtrf17",
     "vid" : "vl1",
@@ -560,7 +596,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf17"
   }, {
     "id" : "iddtrf16",
     "vid" : "vl1",
@@ -569,7 +606,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf16"
   }, {
     "id" : "iddtrf15",
     "vid" : "vl1",
@@ -578,7 +616,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf15"
   }, {
     "id" : "iddtrf14",
     "vid" : "vl1",
@@ -587,7 +626,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf14"
   }, {
     "id" : "iddtrf13",
     "vid" : "vl1",
@@ -596,7 +636,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf13"
   }, {
     "id" : "iddtrf12",
     "vid" : "vl1",
@@ -605,7 +646,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf12"
   }, {
     "id" : "idFICT_95_vl1_95_trf81_95_fictif",
     "vid" : "vl1",
@@ -614,7 +656,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf81_fictif"
   }, {
     "id" : "idFICT_95_vl1_95_dgen2Fictif",
     "vid" : "vl1",
@@ -623,7 +666,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dgen2Fictif"
   }, {
     "id" : "iddgen1",
     "vid" : "vl1",
@@ -632,7 +676,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dgen1"
   }, {
     "id" : "iddgen2",
     "vid" : "vl1",
@@ -641,7 +686,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dgen2"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf17Fictif",
     "vid" : "vl1",
@@ -650,7 +696,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf17Fictif"
   }, {
     "id" : "idFICT_95_vl1_95_dsect21Fictif",
     "vid" : "vl1",
@@ -659,7 +706,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect21Fictif"
   }, {
     "id" : "idtrf8_95_ONE_95_THREE",
     "vid" : "vl1",
@@ -668,7 +716,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf8"
   }, {
     "id" : "iddsect21",
     "vid" : "vl1",
@@ -677,7 +726,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect21"
   }, {
     "id" : "iddsect22",
     "vid" : "vl1",
@@ -686,7 +736,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect22"
   }, {
     "id" : "idFICT_95_vl1_95_dsect11Fictif",
     "vid" : "vl1",
@@ -695,7 +746,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect11Fictif"
   }, {
     "id" : "iddtrct11",
     "vid" : "vl1",
@@ -704,7 +756,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrct11"
   }, {
     "id" : "idload1",
     "vid" : "vl1",
@@ -713,7 +766,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "load1"
   }, {
     "id" : "idload2",
     "vid" : "vl1",
@@ -722,7 +776,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "load2"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf16Fictif",
     "vid" : "vl1",
@@ -731,7 +786,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf16Fictif"
   }, {
     "id" : "GRID_vl1",
     "vid" : "vl1",
@@ -740,7 +796,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : null
   }, {
     "id" : "idtrf7_95_ONE_95_THREE",
     "vid" : "vl1",
@@ -749,7 +806,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf7"
   }, {
     "id" : "idbload2",
     "vid" : "vl1",
@@ -758,7 +816,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bload2"
   }, {
     "id" : "idFICT_95_vl1_95_trf61_95_fictif",
     "vid" : "vl1",
@@ -767,7 +826,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf61_fictif"
   }, {
     "id" : "idbload1",
     "vid" : "vl1",
@@ -776,7 +836,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "bload1"
   }, {
     "id" : "idFICT_95_vl1_95_dsect22Fictif",
     "vid" : "vl1",
@@ -785,7 +846,8 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect22Fictif"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf13Fictif",
     "vid" : "vl1",
@@ -794,7 +856,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dtrf13Fictif"
   }, {
     "id" : "iddsect12",
     "vid" : "vl1",
@@ -803,7 +866,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect12"
   }, {
     "id" : "idtrf8_95_ONE_95_TWO",
     "vid" : "vl1",
@@ -812,7 +876,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf8"
   }, {
     "id" : "iddsect11",
     "vid" : "vl1",
@@ -821,7 +886,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "dsect11"
   }, {
     "id" : "idtrf2_95_ONE",
     "vid" : "vl1",
@@ -830,7 +896,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "TOP",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf2"
   }, {
     "id" : "idtrf4_95_ONE",
     "vid" : "vl1",
@@ -839,7 +906,8 @@
     "rotationAngle" : null,
     "open" : false,
     "direction" : "BOTTOM",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf4"
   }, {
     "id" : "idFICT_95_vl1_95_trf71_95_fictif",
     "vid" : "vl1",
@@ -848,7 +916,8 @@
     "rotationAngle" : 180.0,
     "open" : false,
     "direction" : "UNDEFINED",
-    "vlabel" : false
+    "vlabel" : false,
+    "unescapedId" : "trf71_fictif"
   } ],
   "wires" : [ {
     "id" : "idvl1_95_Wire47",


### PR DESCRIPTION
Signed-off-by: AbdelHedhili <abdelsalem.hedhili@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
add the attribute "unescapedId" for the switches in metadata


**What is the current behavior?** *(You can also link to an open issue here)*
no attribute unescapedId


**What is the new behavior (if this is a feature change)?**
attribute unescapedId
