### PR TITLE
Open load break switch svg error

### DIFF
--- a/single-line-diagram-core/src/main/resources/ConvergenceLibrary/load-break-switch.svg
+++ b/single-line-diagram-core/src/main/resources/ConvergenceLibrary/load-break-switch.svg
@@ -8,7 +8,7 @@
 	</g>
 	<g id="LOAD_BREAK_SWITCH-open" class="open">
 	    <rect x="0" y="0" width="10" height="10"/>
-	    <line x1="5" y1="5" x2="8" y2="5"/>
+	    <line x1="2" y1="5" x2="8" y2="5"/>
 	    <line x1="0" y1="10" x2="10" y2="0"/>
 	</g>
 </svg>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
On a open load break switch, the horizontal line inside the rectangle is not completely drawn


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
