### PR TITLE
Fix wire style class name unicity issue

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DiagramStyleProvider.java
@@ -19,15 +19,13 @@ import java.util.Optional;
  */
 public interface DiagramStyleProvider {
 
-    Optional<String> getNodeStyle(Node node, boolean avoidSVGComponentsDuplication, boolean isShowInternalNodes);
+    Optional<String> getCssNodeStyleAttributes(Node node, boolean isShowInternalNodes);
 
-    String getIdWireStyle(Edge edge);
+    Map<String, String> getCssWireStyleAttributes(Edge edge, boolean isHighLightLineState);
 
-    Optional<String> getWireStyle(Edge edge, String id, int index, boolean isHighLightLineState);
+    Map<String, String> getSvgNodeStyleAttributes(Node node, ComponentSize size, String subComponentName, boolean isShowInternalNodes);
 
-    Map<String, String> getNodeSVGStyle(Node node, ComponentSize size, String nameSubComponent, boolean isShowInternalNodes);
-
-    Map<String, String> getAttributesArrow(int num);
+    Map<String, String> getSvgArrowStyleAttributes(int num);
 
     void reset();
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/AbstractBaseVoltageDiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/AbstractBaseVoltageDiagramStyleProvider.java
@@ -16,7 +16,6 @@ import com.powsybl.sld.model.FeederType;
 import com.powsybl.sld.model.FeederWithSideNode;
 import com.powsybl.sld.model.Node;
 import com.powsybl.sld.svg.DefaultDiagramStyleProvider;
-import com.powsybl.sld.svg.DiagramStyles;
 
 import java.util.EnumMap;
 import java.util.Map;
@@ -36,7 +35,7 @@ public abstract class AbstractBaseVoltageDiagramStyleProvider extends DefaultDia
     protected final Network network;
 
     protected static final String BLACK_COLOR = "black";
-    protected static final String STROKE_DASHARRAY = "stroke-dasharray:3,3";
+    protected static final String STROKE_DASHARRAY = "3,3";
 
     protected AbstractBaseVoltageDiagramStyleProvider(BaseVoltageColor baseVoltageColor, Network network) {
         this.baseVoltageColor = Objects.requireNonNull(baseVoltageColor);
@@ -71,13 +70,11 @@ public abstract class AbstractBaseVoltageDiagramStyleProvider extends DefaultDia
         return res;
     }
 
-    protected Optional<String> buildWireStyle(Edge edge, String id, int index, String color) {
+    protected Optional<String> buildWireStyle(Edge edge, Map<String, String> style, String color) {
         Node n1 = edge.getNode1();
         Node n2 = edge.getNode2();
 
         if (n1 instanceof FeederWithSideNode || n2 instanceof FeederWithSideNode) {
-            String wireId = DiagramStyles.escapeId(id + "_Wire" + index);
-
             FeederWithSideNode n = n1 instanceof FeederWithSideNode ? (FeederWithSideNode) n1 : (FeederWithSideNode) n2;
             Map<FeederWithSideNode.Side, Boolean> connectionStatus = connectionStatus(n);
             FeederWithSideNode.Side side = null;
@@ -103,11 +100,13 @@ public abstract class AbstractBaseVoltageDiagramStyleProvider extends DefaultDia
 
             if (side != null && otherSide != null) {
                 if (Boolean.FALSE.equals(connectionStatus.get(side)) && Boolean.FALSE.equals(connectionStatus.get(otherSide))) {  // disconnected on both ends
-                    return Optional.of(" #" + wireId + " {stroke:" + BLACK_COLOR + ";stroke-width:1}");
+                    style.put("stroke", BLACK_COLOR);
                 } else if (Boolean.TRUE.equals(connectionStatus.get(side)) && Boolean.FALSE.equals(connectionStatus.get(otherSide))) {  // connected on side and disconnected on other side
-                    return Optional.of(" #" + wireId + " {stroke:" + color + ";stroke-width:1;" + STROKE_DASHARRAY + "}");
+                    style.put("stroke", color);
+                    style.put("stroke-dasharray", STROKE_DASHARRAY);
                 } else if (Boolean.FALSE.equals(connectionStatus.get(side)) && Boolean.TRUE.equals(connectionStatus.get(otherSide))) {  // disconnected on side and connected on other side
-                    return Optional.of(" #" + wireId + " {stroke:" + BLACK_COLOR + ";stroke-width:1;" + STROKE_DASHARRAY + "}");
+                    style.put("stroke", BLACK_COLOR);
+                    style.put("stroke-dasharray", STROKE_DASHARRAY);
                 }
             }
         }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/NominalVoltageDiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/NominalVoltageDiagramStyleProvider.java
@@ -7,12 +7,14 @@
 package com.powsybl.sld.util;
 
 import com.powsybl.iidm.network.Network;
-import com.powsybl.sld.model.*;
 import com.powsybl.sld.color.BaseVoltageColor;
+import com.powsybl.sld.model.*;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
-import static com.powsybl.sld.svg.DiagramStyles.*;
+import static com.powsybl.sld.svg.DiagramStyles.escapeId;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -34,8 +36,8 @@ public class NominalVoltageDiagramStyleProvider extends AbstractBaseVoltageDiagr
     }
 
     @Override
-    public Optional<String> getNodeStyle(Node node, boolean avoidSVGComponentsDuplication, boolean isShowInternalNodes) {
-        Optional<String> defaultStyle = super.getNodeStyle(node, avoidSVGComponentsDuplication, isShowInternalNodes);
+    public Optional<String> getCssNodeStyleAttributes(Node node, boolean isShowInternalNodes) {
+        Optional<String> defaultStyle = super.getCssNodeStyleAttributes(node, isShowInternalNodes);
 
         String color = getBaseColor(node.getGraph().getVoltageLevelInfos().getNominalVoltage());
         if (node.getType() == Node.NodeType.SWITCH) {
@@ -60,24 +62,19 @@ public class NominalVoltageDiagramStyleProvider extends AbstractBaseVoltageDiagr
     }
 
     @Override
-    public String getIdWireStyle(Edge edge) {
-        VoltageLevelInfos voltageLevelInfos = getVoltageLevelInfos(edge);
-        return WIRE_STYLE_CLASS + "_" + escapeClassName(voltageLevelInfos.getId());
-    }
+    public Map<String, String> getCssWireStyleAttributes(Edge edge, boolean isHighLightLineState) {
+        Map<String, String> style = new HashMap<>();
 
-    @Override
-    public Optional<String> getWireStyle(Edge edge, String id, int index, boolean isHighLightLineState) {
         VoltageLevelInfos voltageLevelInfos = getVoltageLevelInfos(edge);
         String color = getBaseColor(voltageLevelInfos.getNominalVoltage());
 
+        style.put("stroke", color);
+        style.put("stroke-width", "1");
+
         if (isHighLightLineState && network != null) {
-            Optional<String> style = buildWireStyle(edge, id, index, color);
-            if (style.isPresent()) {
-                return style;
-            }
+            buildWireStyle(edge, style, color);
         }
 
-        String style = "." + WIRE_STYLE_CLASS + "_" + escapeClassName(voltageLevelInfos.getId()) + " {stroke:" + color + ";stroke-width:1;}";
-        return Optional.of(style);
+        return style;
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologicalStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologicalStyleProvider.java
@@ -13,7 +13,6 @@ import com.powsybl.sld.model.Edge;
 import com.powsybl.sld.model.Node;
 import com.powsybl.sld.model.Node.NodeType;
 import com.powsybl.sld.model.TwtEdge;
-import com.powsybl.sld.svg.DiagramStyles;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -114,8 +113,8 @@ public class TopologicalStyleProvider extends AbstractBaseVoltageDiagramStylePro
     }
 
     @Override
-    public Optional<String> getNodeStyle(Node node, boolean avoidSVGComponentsDuplication, boolean isShowInternalNodes) {
-        Optional<String> defaultStyle = super.getNodeStyle(node, avoidSVGComponentsDuplication, isShowInternalNodes);
+    public Optional<String> getCssNodeStyleAttributes(Node node, boolean isShowInternalNodes) {
+        Optional<String> defaultStyle = super.getCssNodeStyleAttributes(node, isShowInternalNodes);
         if (node.getType() == NodeType.SWITCH) {
             return defaultStyle;
         }
@@ -130,8 +129,9 @@ public class TopologicalStyleProvider extends AbstractBaseVoltageDiagramStylePro
     }
 
     @Override
-    public Optional<String> getWireStyle(Edge edge, String id, int index, boolean isHighLightLineState) {
-        String wireId = DiagramStyles.escapeId(id + "_Wire" + index);
+    public Map<String, String> getCssWireStyleAttributes(Edge edge, boolean isHighLightLineState) {
+        Map<String, String> style = new HashMap<>();
+
         Node bus;
         if (!(edge instanceof TwtEdge)) {
             bus = edge.getNode1().getType() == NodeType.BUS ? edge.getNode1() : findConnectedBus(edge.getNode1(), new ArrayList<>());
@@ -156,14 +156,14 @@ public class TopologicalStyleProvider extends AbstractBaseVoltageDiagramStylePro
             }
         }
 
+        style.put("stroke", color);
+        style.put("stroke-width", "1");
+
         if (isHighLightLineState && network != null) {
-            Optional<String> style = buildWireStyle(edge, id, index, color);
-            if (style.isPresent()) {
-                return style;
-            }
+            buildWireStyle(edge, style, color);
         }
 
-        return Optional.of(" #" + wireId + " {stroke:" + color + ";stroke-width:1;fill-opacity:0;}");
+        return style;
     }
 
     private Node findConnectedBus(Node node, List<Node> visitedNodes) {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/util/NominalVoltageStyleTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/util/NominalVoltageStyleTest.java
@@ -6,18 +6,15 @@
  */
 package com.powsybl.sld.util;
 
+import com.google.common.collect.ImmutableMap;
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.iidm.AbstractTestCaseIidm;
 import com.powsybl.sld.NetworkGraphBuilder;
 import com.powsybl.sld.color.BaseVoltageColor;
+import com.powsybl.sld.iidm.AbstractTestCaseIidm;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.library.ComponentSize;
-import com.powsybl.sld.model.BusNode;
-import com.powsybl.sld.model.Edge;
-import com.powsybl.sld.model.FeederNode;
-import com.powsybl.sld.model.Graph;
-import com.powsybl.sld.model.Node;
+import com.powsybl.sld.model.*;
 import com.powsybl.sld.svg.DiagramInitialValueProvider;
 import com.powsybl.sld.svg.InitialValue;
 import org.junit.Before;
@@ -97,39 +94,32 @@ public class NominalVoltageStyleTest extends AbstractTestCaseIidm {
         NominalVoltageDiagramStyleProvider styleProvider = new NominalVoltageDiagramStyleProvider(baseVoltageColor, network);
 
         Node node1 = graph1.getNode("bbs1");
-        Optional<String> nodeStyle1 = styleProvider.getNodeStyle(node1, false, false);
+        Optional<String> nodeStyle1 = styleProvider.getCssNodeStyleAttributes(node1, false);
         assertTrue(nodeStyle1.isPresent());
         assertEquals(" .idbbs1 {stroke:#ff0000;}", nodeStyle1.get());
 
         Node node2 = graph2.getNode("bbs2");
-        Optional<String> nodeStyle2 = styleProvider.getNodeStyle(node2, false, false);
+        Optional<String> nodeStyle2 = styleProvider.getCssNodeStyleAttributes(node2, false);
         assertTrue(nodeStyle2.isPresent());
         assertEquals(" .idbbs2 {stroke:#228b22;}", nodeStyle2.get());
 
         Node node3 = graph3.getNode("bbs3");
-        Optional<String> nodeStyle3 = styleProvider.getNodeStyle(node3, false, false);
+        Optional<String> nodeStyle3 = styleProvider.getCssNodeStyleAttributes(node3, false);
         assertTrue(nodeStyle3.isPresent());
         assertEquals(" .idbbs3 {stroke:#a020f0;}", nodeStyle3.get());
 
-        Edge edge = graph1.getEdges().get(0);
-        String idWireStyle = styleProvider.getIdWireStyle(edge);
-        assertEquals("wire_vl2", idWireStyle);
-        edge = graph1.getEdges().get(12);
-        idWireStyle = styleProvider.getIdWireStyle(edge);
-        assertEquals("wire_vl1", idWireStyle);
-
-        Optional<String> wireStyle = styleProvider.getWireStyle(edge, vl1.getId(), 12, false);
-        assertTrue(wireStyle.isPresent());
-        assertEquals(".wire_vl1 {stroke:#ff0000;stroke-width:1;}", wireStyle.get());
+        Edge edge = graph1.getEdges().get(12);
+        Map<String, String> wireStyle = styleProvider.getCssWireStyleAttributes(edge, false);
+        assertEquals(ImmutableMap.of("stroke", "#ff0000", "stroke-width", "1"), wireStyle);
 
         Node fict3WTNode = graph1.getNode("FICT_vl1_3WT_fictif");
-        Map<String, String> node3WTStyle = styleProvider.getNodeSVGStyle(fict3WTNode, new ComponentSize(14, 12), "WINDING1", true);
+        Map<String, String> node3WTStyle = styleProvider.getSvgNodeStyleAttributes(fict3WTNode, new ComponentSize(14, 12), "WINDING1", true);
         assertFalse(node3WTStyle.isEmpty());
         assertTrue(node3WTStyle.containsKey("stroke"));
         assertEquals("#a020f0", node3WTStyle.get("stroke"));
 
         Node f2WTNode = graph1.getNode("2WT_ONE");
-        Map<String, String> node2WTStyle = styleProvider.getNodeSVGStyle(f2WTNode, new ComponentSize(13, 8), "WINDING1", true);
+        Map<String, String> node2WTStyle = styleProvider.getSvgNodeStyleAttributes(f2WTNode, new ComponentSize(13, 8), "WINDING1", true);
         assertFalse(node2WTStyle.isEmpty());
         assertTrue(node2WTStyle.containsKey("stroke"));
         assertEquals("#ff0000", node2WTStyle.get("stroke"));
@@ -138,7 +128,7 @@ public class NominalVoltageStyleTest extends AbstractTestCaseIidm {
         assertTrue(color.isPresent());
         assertEquals("#ff0000", color.get());
 
-        Map<String, String> attributesArrow = styleProvider.getAttributesArrow(1);
+        Map<String, String> attributesArrow = styleProvider.getSvgArrowStyleAttributes(1);
         assertEquals(3, attributesArrow.size());
         assertTrue(attributesArrow.containsKey("fill"));
         assertEquals("black", attributesArrow.get("fill"));
@@ -147,7 +137,7 @@ public class NominalVoltageStyleTest extends AbstractTestCaseIidm {
         assertTrue(attributesArrow.containsKey("fill-opacity"));
         assertEquals("1", attributesArrow.get("fill-opacity"));
 
-        attributesArrow = styleProvider.getAttributesArrow(2);
+        attributesArrow = styleProvider.getSvgArrowStyleAttributes(2);
         assertEquals(3, attributesArrow.size());
         assertTrue(attributesArrow.containsKey("fill"));
         assertEquals("blue", attributesArrow.get("fill"));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
@@ -6,12 +6,13 @@
  */
 package com.powsybl.sld.util;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.iidm.AbstractTestCaseIidm;
 import com.powsybl.sld.NetworkGraphBuilder;
 import com.powsybl.sld.color.BaseVoltageColor;
+import com.powsybl.sld.iidm.AbstractTestCaseIidm;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.library.ComponentSize;
 import com.powsybl.sld.model.Edge;
@@ -101,43 +102,37 @@ public class TopologicalStyleTest extends AbstractTestCaseIidm {
         TopologicalStyleProvider styleProvider = new TopologicalStyleProvider(baseVoltageColor, network);
 
         Node node1 = graph1.getNode("bbs1");
-        Optional<String> nodeStyle1 = styleProvider.getNodeStyle(node1, false, false);
+        Optional<String> nodeStyle1 = styleProvider.getCssNodeStyleAttributes(node1, false);
         assertTrue(nodeStyle1.isPresent());
         assertEquals(" #idbbs1 {stroke:#FF0000;}", nodeStyle1.get());
 
         Node node2 = graph2.getNode("bbs2");
-        Optional<String> nodeStyle2 = styleProvider.getNodeStyle(node2, false, false);
+        Optional<String> nodeStyle2 = styleProvider.getCssNodeStyleAttributes(node2, false);
         assertTrue(nodeStyle2.isPresent());
         assertEquals(" #idbbs2 {stroke:#808080;}", nodeStyle2.get());
 
         Node node3 = graph3.getNode("bbs3");
-        Optional<String> nodeStyle3 = styleProvider.getNodeStyle(node3, false, false);
+        Optional<String> nodeStyle3 = styleProvider.getCssNodeStyleAttributes(node3, false);
         assertTrue(nodeStyle3.isPresent());
         assertEquals(" #idbbs3 {stroke:#A020EF;}", nodeStyle3.get());
 
-        Edge edge = graph1.getEdges().get(0);
-        String idWireStyle = styleProvider.getIdWireStyle(edge);
-        assertEquals("wire_vl1", idWireStyle);
-        edge = graph1.getEdges().get(12);
-        idWireStyle = styleProvider.getIdWireStyle(edge);
-        assertEquals("wire_vl1", idWireStyle);
+        Edge edge = graph1.getEdges().get(12);
 
-        Optional<String> wireStyle = styleProvider.getWireStyle(edge, vl1.getId(), 12, false);
-        assertTrue(wireStyle.isPresent());
-        assertEquals(" #idvl1_95_Wire12 {stroke:#FF0000;stroke-width:1;fill-opacity:0;}", wireStyle.get());
+        Map<String, String> wireStyle = styleProvider.getCssWireStyleAttributes(edge, false);
+        assertEquals(ImmutableMap.of("stroke-width", "1", "stroke", "#FF0000"), wireStyle);
 
         Node fict3WTNode = graph1.getNode("FICT_vl1_3WT_fictif");
-        Map<String, String> node3WTStyle = styleProvider.getNodeSVGStyle(fict3WTNode, new ComponentSize(14, 12), "WINDING1", true);
+        Map<String, String> node3WTStyle = styleProvider.getSvgNodeStyleAttributes(fict3WTNode, new ComponentSize(14, 12), "WINDING1", true);
         assertTrue(node3WTStyle.isEmpty());
 
         Node f2WTNode = graph1.getNode("2WT_ONE");
-        Map<String, String> node2WTStyle = styleProvider.getNodeSVGStyle(f2WTNode, new ComponentSize(13, 8), "WINDING1", true);
+        Map<String, String> node2WTStyle = styleProvider.getSvgNodeStyleAttributes(f2WTNode, new ComponentSize(13, 8), "WINDING1", true);
         assertTrue(node2WTStyle.isEmpty());
 
         Optional<String> color = styleProvider.getColor(400, null);
         assertFalse(color.isPresent());
 
-        Map<String, String> attributesArrow = styleProvider.getAttributesArrow(1);
+        Map<String, String> attributesArrow = styleProvider.getSvgArrowStyleAttributes(1);
         assertEquals(3, attributesArrow.size());
         assertTrue(attributesArrow.containsKey("fill"));
         assertEquals("black", attributesArrow.get("fill"));
@@ -146,7 +141,7 @@ public class TopologicalStyleTest extends AbstractTestCaseIidm {
         assertTrue(attributesArrow.containsKey("fill-opacity"));
         assertEquals("1", attributesArrow.get("fill-opacity"));
 
-        attributesArrow = styleProvider.getAttributesArrow(2);
+        attributesArrow = styleProvider.getSvgArrowStyleAttributes(2);
         assertEquals(3, attributesArrow.size());
         assertTrue(attributesArrow.containsKey("fill"));
         assertEquals("blue", attributesArrow.get("fill"));

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -1662,1092 +1662,1092 @@
     "equipmentId" : "trf4"
   } ],
   "wires" : [ {
-    "id" : "idvl1_95__95_Wire16",
-    "nodeId1" : "idtrf8_95_ONE",
-    "nodeId2" : "idtrf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl2_95_Wire21",
-    "nodeId1" : "iddscpl1",
-    "nodeId2" : "idFICT_95_vl2_95_dscpl1Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire20",
-    "nodeId1" : "idddcpl1",
-    "nodeId2" : "idFICT_95_vl2_95_dscpl1Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire23",
-    "nodeId1" : "iddload3",
-    "nodeId2" : "idFICT_95_vl2_95_dload3Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire22",
-    "nodeId1" : "idbload3",
-    "nodeId2" : "idFICT_95_vl2_95_dload3Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire25",
-    "nodeId1" : "iddtrf21",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf21Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire24",
-    "nodeId1" : "idbtrf21",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf21Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire27",
-    "nodeId1" : "iddtrf24",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf24Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire26",
-    "nodeId1" : "idbtrf24",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf24Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire29",
-    "nodeId1" : "iddtrf27",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf27Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire28",
-    "nodeId1" : "idbtrf27",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf27Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95__95_Wire13",
-    "nodeId1" : "idtrf7_95_ONE",
-    "nodeId2" : "idtrf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl1_95__95_Wire10",
-    "nodeId1" : "idtrf6_95_ONE",
-    "nodeId2" : "idtrf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl2_95_Wire10",
-    "nodeId1" : "idbbs6",
-    "nodeId2" : "iddtrf23",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire12",
-    "nodeId1" : "idbbs5",
-    "nodeId2" : "iddtrf24",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire11",
-    "nodeId1" : "idbtrf23",
-    "nodeId2" : "idtrf3_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire14",
-    "nodeId1" : "idbbs6",
-    "nodeId2" : "iddtrf26",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire13",
-    "nodeId1" : "idbtrf24",
-    "nodeId2" : "idtrf4_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire16",
-    "nodeId1" : "idbbs5",
-    "nodeId2" : "iddtrf27",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire15",
-    "nodeId1" : "idbtrf26",
-    "nodeId2" : "idtrf6_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire18",
-    "nodeId1" : "idbbs6",
-    "nodeId2" : "iddtrf28",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire17",
-    "nodeId1" : "idbtrf27",
-    "nodeId2" : "idtrf7_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "id_95_vl3_95_Wire9",
-    "nodeId1" : "idtrf5_95_ONE_95_trf5_95_TWO",
-    "nodeId2" : "idtrf5_95_TWO",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl2_95_Wire19",
-    "nodeId1" : "idbtrf28",
-    "nodeId2" : "idtrf8_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire41",
-    "nodeId1" : "iddtrf28",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf28Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire40",
-    "nodeId1" : "idbtrf28",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf28Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "id_95_vl3_95_Wire12",
-    "nodeId1" : "idtrf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE",
-    "nodeId2" : "idtrf6_95_THREE",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "id_95_vl3_95_Wire15",
-    "nodeId1" : "idtrf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE",
-    "nodeId2" : "idtrf7_95_THREE",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl1_95_Wire29",
+    "id" : "_95_vl1_95_bline11_95_2_95_line1_95_ONE",
     "nodeId1" : "idbline11_95_2",
     "nodeId2" : "idline1_95_ONE",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "id_95_vl3_95_Wire18",
-    "nodeId1" : "idtrf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE",
-    "nodeId2" : "idtrf8_95_THREE",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl1_95_Wire25",
-    "nodeId1" : "idbtrf17",
-    "nodeId2" : "idtrf7_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire26",
-    "nodeId1" : "idbbs2",
-    "nodeId2" : "iddtrf18",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire27",
-    "nodeId1" : "idbtrf18",
-    "nodeId2" : "idtrf8_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire28",
-    "nodeId1" : "idbbs1",
-    "nodeId2" : "iddline11_95_2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire21",
-    "nodeId1" : "idbtrf15",
-    "nodeId2" : "idtrf5_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire22",
-    "nodeId1" : "idbbs1",
-    "nodeId2" : "iddtrf16",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire23",
-    "nodeId1" : "idbtrf16",
-    "nodeId2" : "idtrf6_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire24",
-    "nodeId1" : "idbbs3",
-    "nodeId2" : "iddtrf17",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire20",
-    "nodeId1" : "idbbs1",
-    "nodeId2" : "iddtrf15",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95__95_Wire0",
-    "nodeId1" : "idtrf1_95_ONE",
-    "nodeId2" : "idtrf1_95_ONE_95_trf1_95_TWO",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl1_95__95_Wire4",
-    "nodeId1" : "idtrf3_95_ONE",
-    "nodeId2" : "idtrf3_95_ONE_95_trf3_95_TWO",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl2_95_Wire30",
-    "nodeId1" : "idddcpl1",
-    "nodeId2" : "idFICT_95_vl2_95_dscpl2Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95__95_Wire2",
-    "nodeId1" : "idtrf2_95_ONE",
-    "nodeId2" : "idtrf2_95_ONE_95_trf2_95_TWO",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl2_95_Wire32",
-    "nodeId1" : "idbgen4",
-    "nodeId2" : "idFICT_95_vl2_95_dgen4Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire31",
-    "nodeId1" : "iddscpl2",
-    "nodeId2" : "idFICT_95_vl2_95_dscpl2Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95__95_Wire8",
-    "nodeId1" : "idtrf5_95_ONE",
-    "nodeId2" : "idtrf5_95_ONE_95_trf5_95_TWO",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl2_95_Wire34",
-    "nodeId1" : "idbtrf22",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf22Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire33",
-    "nodeId1" : "iddgen4",
-    "nodeId2" : "idFICT_95_vl2_95_dgen4Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95__95_Wire6",
-    "nodeId1" : "idtrf4_95_ONE",
-    "nodeId2" : "idtrf4_95_ONE_95_trf4_95_TWO",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl1_95_Wire18",
-    "nodeId1" : "idbbs4",
-    "nodeId2" : "iddtrf14",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire36",
-    "nodeId1" : "idbtrf23",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf23Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire19",
-    "nodeId1" : "idbtrf14",
-    "nodeId2" : "idtrf4_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire35",
-    "nodeId1" : "iddtrf22",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf22Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire38",
-    "nodeId1" : "idbtrf26",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf26Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire37",
-    "nodeId1" : "iddtrf23",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf23Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire14",
-    "nodeId1" : "idbbs2",
-    "nodeId2" : "iddtrf12",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire15",
-    "nodeId1" : "idbtrf12",
-    "nodeId2" : "idtrf2_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire39",
-    "nodeId1" : "iddtrf26",
-    "nodeId2" : "idFICT_95_vl2_95_dtrf26Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire16",
-    "nodeId1" : "idbbs3",
-    "nodeId2" : "iddtrf13",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire17",
-    "nodeId1" : "idbtrf13",
-    "nodeId2" : "idtrf3_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire10",
-    "nodeId1" : "idbbs4",
-    "nodeId2" : "iddgen2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire11",
-    "nodeId1" : "idgen2",
-    "nodeId2" : "idbgen2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire12",
-    "nodeId1" : "idbbs1",
-    "nodeId2" : "iddtrf11",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire13",
-    "nodeId1" : "idbtrf11",
-    "nodeId2" : "idtrf1_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire47",
-    "nodeId1" : "iddtrf12",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf12Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire48",
-    "nodeId1" : "idbtrf18",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf18Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "id_95_vl2_95_Wire17",
-    "nodeId1" : "idtrf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE",
-    "nodeId2" : "idtrf8_95_TWO",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl1_95_Wire49",
-    "nodeId1" : "iddtrf18",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf18Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire43",
-    "nodeId1" : "iddsect12",
-    "nodeId2" : "idFICT_95_vl1_95_dsect12Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "id_95_vl2_95_Wire14",
-    "nodeId1" : "idtrf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE",
-    "nodeId2" : "idtrf7_95_TWO",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl1_95_Wire44",
+    "id" : "_95_vl1_95_bload2_95_FICT_95_vl1_95_dload2Fictif",
     "nodeId1" : "idbload2",
     "nodeId2" : "idFICT_95_vl1_95_dload2Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire45",
-    "nodeId1" : "iddload2",
-    "nodeId2" : "idFICT_95_vl1_95_dload2Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire46",
-    "nodeId1" : "idbtrf12",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf12Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire40",
-    "nodeId1" : "idbline11_95_2",
-    "nodeId2" : "idFICT_95_vl1_95_dline11_95_2Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire41",
-    "nodeId1" : "iddline11_95_2",
-    "nodeId2" : "idFICT_95_vl1_95_dline11_95_2Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire42",
-    "nodeId1" : "iddtrct11",
-    "nodeId2" : "idFICT_95_vl1_95_dsect12Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "id_95_vl2_95_Wire11",
-    "nodeId1" : "idtrf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE",
-    "nodeId2" : "idtrf6_95_TWO",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl2_95_Wire0",
-    "nodeId1" : "idbbs5",
-    "nodeId2" : "iddscpl1",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire1",
+    "id" : "_95_vl2_95_dscpl2_95_FICT_95_vl2_95_dscpl2Fictif",
     "nodeId1" : "iddscpl2",
-    "nodeId2" : "idbbs6",
+    "nodeId2" : "idFICT_95_vl2_95_dscpl2Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "id_95_vl2_95_Wire7",
-    "nodeId1" : "idtrf4_95_ONE_95_trf4_95_TWO",
-    "nodeId2" : "idtrf4_95_TWO",
+    "id" : "_95_vl2_95_dtrf24_95_FICT_95_vl2_95_dtrf24Fictif",
+    "nodeId1" : "iddtrf24",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf24Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf4_95_ONE_95_trf4_95_ONE_95_trf4_95_TWO",
+    "nodeId1" : "idtrf4_95_ONE",
+    "nodeId2" : "idtrf4_95_ONE_95_trf4_95_TWO",
     "straight" : false,
     "snakeLine" : true
   }, {
-    "id" : "idvl2_95_Wire8",
-    "nodeId1" : "idbbs6",
-    "nodeId2" : "iddtrf22",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire9",
-    "nodeId1" : "idbtrf22",
-    "nodeId2" : "idtrf2_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire6",
-    "nodeId1" : "idbbs5",
-    "nodeId2" : "iddtrf21",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire7",
-    "nodeId1" : "idbtrf21",
-    "nodeId2" : "idtrf1_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire9",
-    "nodeId1" : "idload2",
-    "nodeId2" : "idbload2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire4",
-    "nodeId1" : "idbbs6",
-    "nodeId2" : "iddgen4",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire5",
+    "id" : "_95_vl2_95_gen4_95_bgen4",
     "nodeId1" : "idgen4",
     "nodeId2" : "idbgen4",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl2_95_Wire2",
-    "nodeId1" : "idbbs5",
-    "nodeId2" : "iddload3",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl2_95_Wire3",
-    "nodeId1" : "idload3",
-    "nodeId2" : "idbload3",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire5",
-    "nodeId1" : "idload1",
-    "nodeId2" : "idbload1",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire36",
-    "nodeId1" : "idbtrf15",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf15Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire37",
-    "nodeId1" : "iddtrf15",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf15Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire6",
-    "nodeId1" : "idbbs3",
-    "nodeId2" : "iddgen1",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire38",
-    "nodeId1" : "idbtrf16",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf16Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire7",
-    "nodeId1" : "idgen1",
-    "nodeId2" : "idbgen1",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire39",
-    "nodeId1" : "iddtrf16",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf16Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire8",
-    "nodeId1" : "idbbs2",
-    "nodeId2" : "iddload2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire1",
-    "nodeId1" : "iddsect12",
-    "nodeId2" : "idbbs2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire32",
+    "id" : "_95_vl1_95_bload1_95_FICT_95_vl1_95_dload1Fictif",
     "nodeId1" : "idbload1",
     "nodeId2" : "idFICT_95_vl1_95_dload1Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire2",
-    "nodeId1" : "idbbs3",
-    "nodeId2" : "iddsect21",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire33",
-    "nodeId1" : "iddload1",
-    "nodeId2" : "idFICT_95_vl1_95_dload1Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire3",
-    "nodeId1" : "iddsect22",
-    "nodeId2" : "idbbs4",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire34",
-    "nodeId1" : "idbtrf11",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf11Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire4",
-    "nodeId1" : "idbbs1",
-    "nodeId2" : "iddload1",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire35",
-    "nodeId1" : "iddtrf11",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf11Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "id_95_vl2_95_Wire5",
-    "nodeId1" : "idtrf3_95_ONE_95_trf3_95_TWO",
-    "nodeId2" : "idtrf3_95_TWO",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl1_95_Wire30",
-    "nodeId1" : "iddtrct11",
-    "nodeId2" : "idFICT_95_vl1_95_dsect11Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire0",
-    "nodeId1" : "idbbs1",
-    "nodeId2" : "iddsect11",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire31",
-    "nodeId1" : "iddsect11",
-    "nodeId2" : "idFICT_95_vl1_95_dsect11Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "id_95_vl2_95_Wire3",
-    "nodeId1" : "idtrf2_95_ONE_95_trf2_95_TWO",
-    "nodeId2" : "idtrf2_95_TWO",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "id_95_vl2_95_Wire1",
-    "nodeId1" : "idtrf1_95_ONE_95_trf1_95_TWO",
-    "nodeId2" : "idtrf1_95_TWO",
-    "straight" : false,
-    "snakeLine" : true
-  }, {
-    "id" : "idvl3_95_Wire9",
-    "nodeId1" : "idbtrf38",
+    "id" : "_95_subst_95_trf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE_95_trf8_95_THREE",
+    "nodeId1" : "idtrf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE",
     "nodeId2" : "idtrf8_95_THREE",
     "straight" : false,
-    "snakeLine" : false
+    "snakeLine" : true
   }, {
-    "id" : "idvl3_95_Wire8",
-    "nodeId1" : "idbbs7",
-    "nodeId2" : "iddtrf38",
+    "id" : "_95_vl1_95_btrf12_95_FICT_95_vl1_95_dtrf12Fictif",
+    "nodeId1" : "idbtrf12",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf12Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl3_95_Wire7",
-    "nodeId1" : "idbtrf37",
-    "nodeId2" : "idtrf7_95_THREE",
+    "id" : "_95_vl1_95_bbs3_95_dtrf17",
+    "nodeId1" : "idbbs3",
+    "nodeId2" : "iddtrf17",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl3_95_Wire6",
-    "nodeId1" : "idbbs7",
-    "nodeId2" : "iddtrf37",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire5",
-    "nodeId1" : "idbtrf36",
-    "nodeId2" : "idtrf6_95_THREE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire4",
-    "nodeId1" : "idbbs7",
-    "nodeId2" : "iddtrf36",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire3",
-    "nodeId1" : "idbtrf25",
-    "nodeId2" : "idtrf5_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire2",
-    "nodeId1" : "idbbs7",
-    "nodeId2" : "iddtrf25",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire14",
-    "nodeId1" : "idbtrf36",
-    "nodeId2" : "idFICT_95_vl3_95_dtrf36Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire1",
-    "nodeId1" : "idbload4",
-    "nodeId2" : "idload4",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire15",
-    "nodeId1" : "iddtrf36",
-    "nodeId2" : "idFICT_95_vl3_95_dtrf36Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire0",
-    "nodeId1" : "idbbs7",
-    "nodeId2" : "iddload4",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire12",
-    "nodeId1" : "idbtrf25",
-    "nodeId2" : "idFICT_95_vl3_95_dtrf25Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire13",
-    "nodeId1" : "iddtrf25",
-    "nodeId2" : "idFICT_95_vl3_95_dtrf25Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire10",
-    "nodeId1" : "idbload4",
-    "nodeId2" : "idFICT_95_vl3_95_dload4Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire11",
-    "nodeId1" : "iddload4",
-    "nodeId2" : "idFICT_95_vl3_95_dload4Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire18",
-    "nodeId1" : "idbtrf38",
-    "nodeId2" : "idFICT_95_vl3_95_dtrf38Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire19",
-    "nodeId1" : "iddtrf38",
-    "nodeId2" : "idFICT_95_vl3_95_dtrf38Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire16",
-    "nodeId1" : "idbtrf37",
-    "nodeId2" : "idFICT_95_vl3_95_dtrf37Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl3_95_Wire17",
-    "nodeId1" : "iddtrf37",
-    "nodeId2" : "idFICT_95_vl3_95_dtrf37Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire61",
-    "nodeId1" : "iddgen2",
-    "nodeId2" : "idFICT_95_vl1_95_dgen2Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire62",
-    "nodeId1" : "idbtrf14",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf14Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire63",
-    "nodeId1" : "iddtrf14",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf14Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire60",
-    "nodeId1" : "idbgen2",
-    "nodeId2" : "idFICT_95_vl1_95_dgen2Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire58",
-    "nodeId1" : "iddtrct21",
-    "nodeId2" : "idFICT_95_vl1_95_dsect22Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire59",
-    "nodeId1" : "iddsect22",
-    "nodeId2" : "idFICT_95_vl1_95_dsect22Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire54",
-    "nodeId1" : "idbtrf13",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf13Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire55",
-    "nodeId1" : "iddtrf13",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf13Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire56",
-    "nodeId1" : "idbtrf17",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf17Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire57",
-    "nodeId1" : "iddtrf17",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf17Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire50",
-    "nodeId1" : "iddtrct21",
-    "nodeId2" : "idFICT_95_vl1_95_dsect21Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire51",
+    "id" : "_95_vl1_95_dsect21_95_FICT_95_vl1_95_dsect21Fictif",
     "nodeId1" : "iddsect21",
     "nodeId2" : "idFICT_95_vl1_95_dsect21Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire52",
+    "id" : "_95_vl1_95_btrf14_95_FICT_95_vl1_95_dtrf14Fictif",
+    "nodeId1" : "idbtrf14",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf14Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_dtrf26_95_FICT_95_vl2_95_dtrf26Fictif",
+    "nodeId1" : "iddtrf26",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf26Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_btrf37_95_trf7_95_THREE",
+    "nodeId1" : "idbtrf37",
+    "nodeId2" : "idtrf7_95_THREE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs1_95_dload1",
+    "nodeId1" : "idbbs1",
+    "nodeId2" : "iddload1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf13_95_FICT_95_vl1_95_dtrf13Fictif",
+    "nodeId1" : "idbtrf13",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf13Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_dtrf27_95_FICT_95_vl2_95_dtrf27Fictif",
+    "nodeId1" : "iddtrf27",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf27Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_dtrf25_95_FICT_95_vl3_95_dtrf25Fictif",
+    "nodeId1" : "iddtrf25",
+    "nodeId2" : "idFICT_95_vl3_95_dtrf25Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs1_95_dline11_95_2",
+    "nodeId1" : "idbbs1",
+    "nodeId2" : "iddline11_95_2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_btrf27_95_trf7_95_TWO",
+    "nodeId1" : "idbtrf27",
+    "nodeId2" : "idtrf7_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf12_95_trf2_95_ONE",
+    "nodeId1" : "idbtrf12",
+    "nodeId2" : "idtrf2_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs3_95_dtrf13",
+    "nodeId1" : "idbbs3",
+    "nodeId2" : "iddtrf13",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_gen1_95_bgen1",
+    "nodeId1" : "idgen1",
+    "nodeId2" : "idbgen1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_dtrf21_95_FICT_95_vl2_95_dtrf21Fictif",
+    "nodeId1" : "iddtrf21",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf21Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf17_95_FICT_95_vl1_95_dtrf17Fictif",
+    "nodeId1" : "iddtrf17",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf17Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf2_95_ONE_95_trf2_95_TWO_95_trf2_95_TWO",
+    "nodeId1" : "idtrf2_95_ONE_95_trf2_95_TWO",
+    "nodeId2" : "idtrf2_95_TWO",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl1_95_bbs1_95_dsect11",
+    "nodeId1" : "idbbs1",
+    "nodeId2" : "iddsect11",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf15_95_trf5_95_ONE",
+    "nodeId1" : "idbtrf15",
+    "nodeId2" : "idtrf5_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf16_95_FICT_95_vl1_95_dtrf16Fictif",
+    "nodeId1" : "idbtrf16",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf16Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_bbs6_95_dgen4",
+    "nodeId1" : "idbbs6",
+    "nodeId2" : "iddgen4",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_dtrf28_95_FICT_95_vl2_95_dtrf28Fictif",
+    "nodeId1" : "iddtrf28",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf28Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf1_95_ONE_95_trf1_95_ONE_95_trf1_95_TWO",
+    "nodeId1" : "idtrf1_95_ONE",
+    "nodeId2" : "idtrf1_95_ONE_95_trf1_95_TWO",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_subst_95_trf5_95_ONE_95_trf5_95_TWO_95_trf5_95_TWO",
+    "nodeId1" : "idtrf5_95_ONE_95_trf5_95_TWO",
+    "nodeId2" : "idtrf5_95_TWO",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl1_95_btrf11_95_FICT_95_vl1_95_dtrf11Fictif",
+    "nodeId1" : "idbtrf11",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf11Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_btrf22_95_FICT_95_vl2_95_dtrf22Fictif",
+    "nodeId1" : "idbtrf22",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf22Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_dload4_95_FICT_95_vl3_95_dload4Fictif",
+    "nodeId1" : "iddload4",
+    "nodeId2" : "idFICT_95_vl3_95_dload4Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs3_95_dgen1",
+    "nodeId1" : "idbbs3",
+    "nodeId2" : "iddgen1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dgen2_95_FICT_95_vl1_95_dgen2Fictif",
+    "nodeId1" : "iddgen2",
+    "nodeId2" : "idFICT_95_vl1_95_dgen2Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs4_95_dtrf14",
+    "nodeId1" : "idbbs4",
+    "nodeId2" : "iddtrf14",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_dscpl1_95_FICT_95_vl2_95_dscpl1Fictif",
+    "nodeId1" : "iddscpl1",
+    "nodeId2" : "idFICT_95_vl2_95_dscpl1Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf7_95_ONE_95_trf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE",
+    "nodeId1" : "idtrf7_95_ONE",
+    "nodeId2" : "idtrf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl2_95_dtrf23_95_FICT_95_vl2_95_dtrf23Fictif",
+    "nodeId1" : "iddtrf23",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf23Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_btrf23_95_FICT_95_vl2_95_dtrf23Fictif",
+    "nodeId1" : "idbtrf23",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf23Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf18_95_trf8_95_ONE",
+    "nodeId1" : "idbtrf18",
+    "nodeId2" : "idtrf8_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf18_95_FICT_95_vl1_95_dtrf18Fictif",
+    "nodeId1" : "idbtrf18",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf18Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs1_95_dtrf16",
+    "nodeId1" : "idbbs1",
+    "nodeId2" : "iddtrf16",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs1_95_dtrf15",
+    "nodeId1" : "idbbs1",
+    "nodeId2" : "iddtrf15",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_bbs7_95_dtrf36",
+    "nodeId1" : "idbbs7",
+    "nodeId2" : "iddtrf36",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf2_95_ONE_95_trf2_95_ONE_95_trf2_95_TWO",
+    "nodeId1" : "idtrf2_95_ONE",
+    "nodeId2" : "idtrf2_95_ONE_95_trf2_95_TWO",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl3_95_bbs7_95_dtrf37",
+    "nodeId1" : "idbbs7",
+    "nodeId2" : "iddtrf37",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs1_95_dtrf11",
+    "nodeId1" : "idbbs1",
+    "nodeId2" : "iddtrf11",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_bbs7_95_dtrf38",
+    "nodeId1" : "idbbs7",
+    "nodeId2" : "iddtrf38",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_btrf26_95_trf6_95_TWO",
+    "nodeId1" : "idbtrf26",
+    "nodeId2" : "idtrf6_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_btrf38_95_trf8_95_THREE",
+    "nodeId1" : "idbtrf38",
+    "nodeId2" : "idtrf8_95_THREE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_dtrf37_95_FICT_95_vl3_95_dtrf37Fictif",
+    "nodeId1" : "iddtrf37",
+    "nodeId2" : "idFICT_95_vl3_95_dtrf37Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf15_95_FICT_95_vl1_95_dtrf15Fictif",
+    "nodeId1" : "iddtrf15",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf15Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf13_95_trf3_95_ONE",
+    "nodeId1" : "idbtrf13",
+    "nodeId2" : "idtrf3_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf4_95_ONE_95_trf4_95_TWO_95_trf4_95_TWO",
+    "nodeId1" : "idtrf4_95_ONE_95_trf4_95_TWO",
+    "nodeId2" : "idtrf4_95_TWO",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_subst_95_trf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE_95_trf8_95_TWO",
+    "nodeId1" : "idtrf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE",
+    "nodeId2" : "idtrf8_95_TWO",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl2_95_btrf24_95_FICT_95_vl2_95_dtrf24Fictif",
+    "nodeId1" : "idbtrf24",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf24Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf16_95_FICT_95_vl1_95_dtrf16Fictif",
+    "nodeId1" : "iddtrf16",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf16Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_load1_95_bload1",
+    "nodeId1" : "idload1",
+    "nodeId2" : "idbload1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_bgen4_95_FICT_95_vl2_95_dgen4Fictif",
+    "nodeId1" : "idbgen4",
+    "nodeId2" : "idFICT_95_vl2_95_dgen4Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_bbs5_95_dtrf24",
+    "nodeId1" : "idbbs5",
+    "nodeId2" : "iddtrf24",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_dtrf38_95_FICT_95_vl3_95_dtrf38Fictif",
+    "nodeId1" : "iddtrf38",
+    "nodeId2" : "idFICT_95_vl3_95_dtrf38Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_ddcpl1_95_FICT_95_vl2_95_dscpl1Fictif",
+    "nodeId1" : "idddcpl1",
+    "nodeId2" : "idFICT_95_vl2_95_dscpl1Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_bbs5_95_dtrf27",
+    "nodeId1" : "idbbs5",
+    "nodeId2" : "iddtrf27",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf11_95_FICT_95_vl1_95_dtrf11Fictif",
+    "nodeId1" : "iddtrf11",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf11Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bgen2_95_FICT_95_vl1_95_dgen2Fictif",
+    "nodeId1" : "idbgen2",
+    "nodeId2" : "idFICT_95_vl1_95_dgen2Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_bbs5_95_dtrf21",
+    "nodeId1" : "idbbs5",
+    "nodeId2" : "iddtrf21",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_dtrf22_95_FICT_95_vl2_95_dtrf22Fictif",
+    "nodeId1" : "iddtrf22",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf22Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf3_95_ONE_95_trf3_95_ONE_95_trf3_95_TWO",
+    "nodeId1" : "idtrf3_95_ONE",
+    "nodeId2" : "idtrf3_95_ONE_95_trf3_95_TWO",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_subst_95_trf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE_95_trf6_95_TWO",
+    "nodeId1" : "idtrf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE",
+    "nodeId2" : "idtrf6_95_TWO",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl1_95_dsect12_95_bbs2",
+    "nodeId1" : "iddsect12",
+    "nodeId2" : "idbbs2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_bload3_95_FICT_95_vl2_95_dload3Fictif",
+    "nodeId1" : "idbload3",
+    "nodeId2" : "idFICT_95_vl2_95_dload3Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf8_95_ONE_95_trf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE",
+    "nodeId1" : "idtrf8_95_ONE",
+    "nodeId2" : "idtrf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl2_95_btrf28_95_FICT_95_vl2_95_dtrf28Fictif",
+    "nodeId1" : "idbtrf28",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf28Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_btrf36_95_trf6_95_THREE",
+    "nodeId1" : "idbtrf36",
+    "nodeId2" : "idtrf6_95_THREE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE_95_trf7_95_THREE",
+    "nodeId1" : "idtrf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE",
+    "nodeId2" : "idtrf7_95_THREE",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl1_95_dload2_95_FICT_95_vl1_95_dload2Fictif",
+    "nodeId1" : "iddload2",
+    "nodeId2" : "idFICT_95_vl1_95_dload2Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_btrf21_95_trf1_95_TWO",
+    "nodeId1" : "idbtrf21",
+    "nodeId2" : "idtrf1_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf14_95_trf4_95_ONE",
+    "nodeId1" : "idbtrf14",
+    "nodeId2" : "idtrf4_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf17_95_FICT_95_vl1_95_dtrf17Fictif",
+    "nodeId1" : "idbtrf17",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf17Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf17_95_trf7_95_ONE",
+    "nodeId1" : "idbtrf17",
+    "nodeId2" : "idtrf7_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dgen1_95_FICT_95_vl1_95_dgen1Fictif",
+    "nodeId1" : "iddgen1",
+    "nodeId2" : "idFICT_95_vl1_95_dgen1Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf3_95_ONE_95_trf3_95_TWO_95_trf3_95_TWO",
+    "nodeId1" : "idtrf3_95_ONE_95_trf3_95_TWO",
+    "nodeId2" : "idtrf3_95_TWO",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl2_95_btrf22_95_trf2_95_TWO",
+    "nodeId1" : "idbtrf22",
+    "nodeId2" : "idtrf2_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_bbs5_95_dload3",
+    "nodeId1" : "idbbs5",
+    "nodeId2" : "iddload3",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_bbs5_95_dscpl1",
+    "nodeId1" : "idbbs5",
+    "nodeId2" : "iddscpl1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_btrf36_95_FICT_95_vl3_95_dtrf36Fictif",
+    "nodeId1" : "idbtrf36",
+    "nodeId2" : "idFICT_95_vl3_95_dtrf36Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_ddcpl1_95_FICT_95_vl2_95_dscpl2Fictif",
+    "nodeId1" : "idddcpl1",
+    "nodeId2" : "idFICT_95_vl2_95_dscpl2Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_btrf27_95_FICT_95_vl2_95_dtrf27Fictif",
+    "nodeId1" : "idbtrf27",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf27Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_load3_95_bload3",
+    "nodeId1" : "idload3",
+    "nodeId2" : "idbload3",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_bbs7_95_dtrf25",
+    "nodeId1" : "idbbs7",
+    "nodeId2" : "iddtrf25",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs4_95_dgen2",
+    "nodeId1" : "idbbs4",
+    "nodeId2" : "iddgen2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_bload4_95_load4",
+    "nodeId1" : "idbload4",
+    "nodeId2" : "idload4",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf12_95_FICT_95_vl1_95_dtrf12Fictif",
+    "nodeId1" : "iddtrf12",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf12Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dload1_95_FICT_95_vl1_95_dload1Fictif",
+    "nodeId1" : "iddload1",
+    "nodeId2" : "idFICT_95_vl1_95_dload1Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_btrf25_95_trf5_95_TWO",
+    "nodeId1" : "idbtrf25",
+    "nodeId2" : "idtrf5_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_dscpl2_95_bbs6",
+    "nodeId1" : "iddscpl2",
+    "nodeId2" : "idbbs6",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_btrf38_95_FICT_95_vl3_95_dtrf38Fictif",
+    "nodeId1" : "idbtrf38",
+    "nodeId2" : "idFICT_95_vl3_95_dtrf38Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bgen1_95_FICT_95_vl1_95_dgen1Fictif",
     "nodeId1" : "idbgen1",
     "nodeId2" : "idFICT_95_vl1_95_dgen1Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire53",
-    "nodeId1" : "iddgen1",
-    "nodeId2" : "idFICT_95_vl1_95_dgen1Fictif",
+    "id" : "_95_vl3_95_bbs7_95_dload4",
+    "nodeId1" : "idbbs7",
+    "nodeId2" : "iddload4",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrct11_95_FICT_95_vl1_95_dsect12Fictif",
+    "nodeId1" : "iddtrct11",
+    "nodeId2" : "idFICT_95_vl1_95_dsect12Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_gen2_95_bgen2",
+    "nodeId1" : "idgen2",
+    "nodeId2" : "idbgen2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf6_95_ONE_95_trf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE",
+    "nodeId1" : "idtrf6_95_ONE",
+    "nodeId2" : "idtrf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect22Fictif",
+    "nodeId1" : "iddtrct21",
+    "nodeId2" : "idFICT_95_vl1_95_dsect22Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs2_95_dload2",
+    "nodeId1" : "idbbs2",
+    "nodeId2" : "iddload2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf13_95_FICT_95_vl1_95_dtrf13Fictif",
+    "nodeId1" : "iddtrf13",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf13Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf11_95_trf1_95_ONE",
+    "nodeId1" : "idbtrf11",
+    "nodeId2" : "idtrf1_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_bload4_95_FICT_95_vl3_95_dload4Fictif",
+    "nodeId1" : "idbload4",
+    "nodeId2" : "idFICT_95_vl3_95_dload4Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_btrf28_95_trf8_95_TWO",
+    "nodeId1" : "idbtrf28",
+    "nodeId2" : "idtrf8_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf1_95_ONE_95_trf1_95_TWO_95_trf1_95_TWO",
+    "nodeId1" : "idtrf1_95_ONE_95_trf1_95_TWO",
+    "nodeId2" : "idtrf1_95_TWO",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl3_95_dtrf36_95_FICT_95_vl3_95_dtrf36Fictif",
+    "nodeId1" : "iddtrf36",
+    "nodeId2" : "idFICT_95_vl3_95_dtrf36Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf14_95_FICT_95_vl1_95_dtrf14Fictif",
+    "nodeId1" : "iddtrf14",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf14Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dline11_95_2_95_FICT_95_vl1_95_dline11_95_2Fictif",
+    "nodeId1" : "iddline11_95_2",
+    "nodeId2" : "idFICT_95_vl1_95_dline11_95_2Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_dload3_95_FICT_95_vl2_95_dload3Fictif",
+    "nodeId1" : "iddload3",
+    "nodeId2" : "idFICT_95_vl2_95_dload3Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_btrf23_95_trf3_95_TWO",
+    "nodeId1" : "idbtrf23",
+    "nodeId2" : "idtrf3_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf16_95_trf6_95_ONE",
+    "nodeId1" : "idbtrf16",
+    "nodeId2" : "idtrf6_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE_95_trf7_95_TWO",
+    "nodeId1" : "idtrf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE",
+    "nodeId2" : "idtrf7_95_TWO",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl1_95_bline11_95_2_95_FICT_95_vl1_95_dline11_95_2Fictif",
+    "nodeId1" : "idbline11_95_2",
+    "nodeId2" : "idFICT_95_vl1_95_dline11_95_2Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_dgen4_95_FICT_95_vl2_95_dgen4Fictif",
+    "nodeId1" : "iddgen4",
+    "nodeId2" : "idFICT_95_vl2_95_dgen4Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_bbs6_95_dtrf22",
+    "nodeId1" : "idbbs6",
+    "nodeId2" : "iddtrf22",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_bbs6_95_dtrf23",
+    "nodeId1" : "idbbs6",
+    "nodeId2" : "iddtrf23",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_bbs6_95_dtrf26",
+    "nodeId1" : "idbbs6",
+    "nodeId2" : "iddtrf26",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf5_95_ONE_95_trf5_95_ONE_95_trf5_95_TWO",
+    "nodeId1" : "idtrf5_95_ONE",
+    "nodeId2" : "idtrf5_95_ONE_95_trf5_95_TWO",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl2_95_bbs6_95_dtrf28",
+    "nodeId1" : "idbbs6",
+    "nodeId2" : "iddtrf28",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_btrf25_95_FICT_95_vl3_95_dtrf25Fictif",
+    "nodeId1" : "idbtrf25",
+    "nodeId2" : "idFICT_95_vl3_95_dtrf25Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_subst_95_trf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE_95_trf6_95_THREE",
+    "nodeId1" : "idtrf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE",
+    "nodeId2" : "idtrf6_95_THREE",
+    "straight" : false,
+    "snakeLine" : true
+  }, {
+    "id" : "_95_vl1_95_dtrct11_95_FICT_95_vl1_95_dsect11Fictif",
+    "nodeId1" : "iddtrct11",
+    "nodeId2" : "idFICT_95_vl1_95_dsect11Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dsect12_95_FICT_95_vl1_95_dsect12Fictif",
+    "nodeId1" : "iddsect12",
+    "nodeId2" : "idFICT_95_vl1_95_dsect12Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dsect22_95_FICT_95_vl1_95_dsect22Fictif",
+    "nodeId1" : "iddsect22",
+    "nodeId2" : "idFICT_95_vl1_95_dsect22Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs3_95_dsect21",
+    "nodeId1" : "idbbs3",
+    "nodeId2" : "iddsect21",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf15_95_FICT_95_vl1_95_dtrf15Fictif",
+    "nodeId1" : "idbtrf15",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf15Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dsect11_95_FICT_95_vl1_95_dsect11Fictif",
+    "nodeId1" : "iddsect11",
+    "nodeId2" : "idFICT_95_vl1_95_dsect11Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_btrf24_95_trf4_95_TWO",
+    "nodeId1" : "idbtrf24",
+    "nodeId2" : "idtrf4_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_btrf26_95_FICT_95_vl2_95_dtrf26Fictif",
+    "nodeId1" : "idbtrf26",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf26Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect21Fictif",
+    "nodeId1" : "iddtrct21",
+    "nodeId2" : "idFICT_95_vl1_95_dsect21Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_btrf37_95_FICT_95_vl3_95_dtrf37Fictif",
+    "nodeId1" : "idbtrf37",
+    "nodeId2" : "idFICT_95_vl3_95_dtrf37Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs2_95_dtrf12",
+    "nodeId1" : "idbbs2",
+    "nodeId2" : "iddtrf12",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dsect22_95_bbs4",
+    "nodeId1" : "iddsect22",
+    "nodeId2" : "idbbs4",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf18_95_FICT_95_vl1_95_dtrf18Fictif",
+    "nodeId1" : "iddtrf18",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf18Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_load2_95_bload2",
+    "nodeId1" : "idload2",
+    "nodeId2" : "idbload2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs2_95_dtrf18",
+    "nodeId1" : "idbbs2",
+    "nodeId2" : "iddtrf18",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_btrf21_95_FICT_95_vl2_95_dtrf21Fictif",
+    "nodeId1" : "idbtrf21",
+    "nodeId2" : "idFICT_95_vl2_95_dtrf21Fictif",
     "straight" : false,
     "snakeLine" : false
   } ],
   "lines" : [ ],
   "arrows" : [ {
-    "id" : "idvl2_95_Wire11_ARROW1",
-    "wireId" : "idvl2_95_Wire11",
+    "id" : "_95_vl1_95_bline11_95_2_95_line1_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_bline11_95_2_95_line1_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire7_ARROW1",
-    "wireId" : "idvl1_95_Wire7",
+    "id" : "_95_vl3_95_btrf38_95_trf8_95_THREE_ARROW1",
+    "wireId" : "_95_vl3_95_btrf38_95_trf8_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire7_ARROW2",
-    "wireId" : "idvl1_95_Wire7",
+    "id" : "_95_vl2_95_btrf22_95_trf2_95_TWO_ARROW1",
+    "wireId" : "_95_vl2_95_btrf22_95_trf2_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire9_ARROW2",
-    "wireId" : "idvl1_95_Wire9",
+    "id" : "_95_vl3_95_btrf38_95_trf8_95_THREE_ARROW2",
+    "wireId" : "_95_vl3_95_btrf38_95_trf8_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire13_ARROW2",
-    "wireId" : "idvl2_95_Wire13",
+    "id" : "_95_vl1_95_bline11_95_2_95_line1_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_bline11_95_2_95_line1_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire11_ARROW2",
-    "wireId" : "idvl2_95_Wire11",
+    "id" : "_95_vl1_95_gen2_95_bgen2_ARROW1",
+    "wireId" : "_95_vl1_95_gen2_95_bgen2",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire13_ARROW1",
-    "wireId" : "idvl2_95_Wire13",
+    "id" : "_95_vl2_95_btrf23_95_trf3_95_TWO_ARROW1",
+    "wireId" : "_95_vl2_95_btrf23_95_trf3_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire5_ARROW2",
-    "wireId" : "idvl1_95_Wire5",
+    "id" : "_95_vl1_95_gen2_95_bgen2_ARROW2",
+    "wireId" : "_95_vl1_95_gen2_95_bgen2",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire9_ARROW1",
-    "wireId" : "idvl1_95_Wire9",
+    "id" : "_95_vl2_95_btrf23_95_trf3_95_TWO_ARROW2",
+    "wireId" : "_95_vl2_95_btrf23_95_trf3_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire5_ARROW1",
-    "wireId" : "idvl1_95_Wire5",
+    "id" : "_95_vl1_95_btrf17_95_trf7_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf17_95_trf7_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire3_ARROW1",
-    "wireId" : "idvl2_95_Wire3",
+    "id" : "_95_vl2_95_gen4_95_bgen4_ARROW2",
+    "wireId" : "_95_vl2_95_gen4_95_bgen4",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire3_ARROW2",
-    "wireId" : "idvl2_95_Wire3",
+    "id" : "_95_vl2_95_gen4_95_bgen4_ARROW1",
+    "wireId" : "_95_vl2_95_gen4_95_bgen4",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire19_ARROW1",
-    "wireId" : "idvl1_95_Wire19",
+    "id" : "_95_vl1_95_btrf16_95_trf6_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf16_95_trf6_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire19_ARROW2",
-    "wireId" : "idvl1_95_Wire19",
+    "id" : "_95_vl1_95_btrf16_95_trf6_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf16_95_trf6_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire15_ARROW1",
-    "wireId" : "idvl1_95_Wire15",
+    "id" : "_95_vl2_95_btrf22_95_trf2_95_TWO_ARROW2",
+    "wireId" : "_95_vl2_95_btrf22_95_trf2_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire17_ARROW1",
-    "wireId" : "idvl1_95_Wire17",
+    "id" : "_95_vl3_95_btrf25_95_trf5_95_TWO_ARROW2",
+    "wireId" : "_95_vl3_95_btrf25_95_trf5_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire15_ARROW2",
-    "wireId" : "idvl1_95_Wire15",
+    "id" : "_95_vl3_95_btrf25_95_trf5_95_TWO_ARROW1",
+    "wireId" : "_95_vl3_95_btrf25_95_trf5_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire17_ARROW2",
-    "wireId" : "idvl1_95_Wire17",
+    "id" : "_95_vl2_95_load3_95_bload3_ARROW2",
+    "wireId" : "_95_vl2_95_load3_95_bload3",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire13_ARROW2",
-    "wireId" : "idvl1_95_Wire13",
+    "id" : "_95_vl3_95_btrf37_95_trf7_95_THREE_ARROW2",
+    "wireId" : "_95_vl3_95_btrf37_95_trf7_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire13_ARROW1",
-    "wireId" : "idvl1_95_Wire13",
+    "id" : "_95_vl3_95_btrf37_95_trf7_95_THREE_ARROW1",
+    "wireId" : "_95_vl3_95_btrf37_95_trf7_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire11_ARROW2",
-    "wireId" : "idvl1_95_Wire11",
+    "id" : "_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf15_95_trf5_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire11_ARROW1",
-    "wireId" : "idvl1_95_Wire11",
+    "id" : "_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf15_95_trf5_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl3_95_Wire1_ARROW1",
-    "wireId" : "idvl3_95_Wire1",
+    "id" : "_95_vl2_95_load3_95_bload3_ARROW1",
+    "wireId" : "_95_vl2_95_load3_95_bload3",
     "distance" : 20.0
   }, {
-    "id" : "idvl3_95_Wire1_ARROW2",
-    "wireId" : "idvl3_95_Wire1",
+    "id" : "_95_vl1_95_load2_95_bload2_ARROW2",
+    "wireId" : "_95_vl1_95_load2_95_bload2",
     "distance" : 20.0
   }, {
-    "id" : "idvl3_95_Wire3_ARROW2",
-    "wireId" : "idvl3_95_Wire3",
+    "id" : "_95_vl1_95_load2_95_bload2_ARROW1",
+    "wireId" : "_95_vl1_95_load2_95_bload2",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire21_ARROW2",
-    "wireId" : "idvl1_95_Wire21",
+    "id" : "_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf14_95_trf4_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire7_ARROW1",
-    "wireId" : "idvl2_95_Wire7",
+    "id" : "_95_vl2_95_btrf21_95_trf1_95_TWO_ARROW2",
+    "wireId" : "_95_vl2_95_btrf21_95_trf1_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire7_ARROW2",
-    "wireId" : "idvl2_95_Wire7",
+    "id" : "_95_vl2_95_btrf21_95_trf1_95_TWO_ARROW1",
+    "wireId" : "_95_vl2_95_btrf21_95_trf1_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire5_ARROW1",
-    "wireId" : "idvl2_95_Wire5",
+    "id" : "_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf14_95_trf4_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire9_ARROW2",
-    "wireId" : "idvl2_95_Wire9",
+    "id" : "_95_vl1_95_load1_95_bload1_ARROW1",
+    "wireId" : "_95_vl1_95_load1_95_bload1",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire5_ARROW2",
-    "wireId" : "idvl2_95_Wire5",
+    "id" : "_95_vl1_95_load1_95_bload1_ARROW2",
+    "wireId" : "_95_vl1_95_load1_95_bload1",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire9_ARROW1",
-    "wireId" : "idvl2_95_Wire9",
+    "id" : "_95_vl2_95_btrf28_95_trf8_95_TWO_ARROW1",
+    "wireId" : "_95_vl2_95_btrf28_95_trf8_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire29_ARROW2",
-    "wireId" : "idvl1_95_Wire29",
+    "id" : "_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf12_95_trf2_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire25_ARROW2",
-    "wireId" : "idvl1_95_Wire25",
+    "id" : "_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf13_95_trf3_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire23_ARROW2",
-    "wireId" : "idvl1_95_Wire23",
+    "id" : "_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf12_95_trf2_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire27_ARROW2",
-    "wireId" : "idvl1_95_Wire27",
+    "id" : "_95_vl2_95_btrf28_95_trf8_95_TWO_ARROW2",
+    "wireId" : "_95_vl2_95_btrf28_95_trf8_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire29_ARROW1",
-    "wireId" : "idvl1_95_Wire29",
+    "id" : "_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf13_95_trf3_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire23_ARROW1",
-    "wireId" : "idvl1_95_Wire23",
+    "id" : "_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf11_95_trf1_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire27_ARROW1",
-    "wireId" : "idvl1_95_Wire27",
+    "id" : "_95_vl3_95_btrf36_95_trf6_95_THREE_ARROW1",
+    "wireId" : "_95_vl3_95_btrf36_95_trf6_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire25_ARROW1",
-    "wireId" : "idvl1_95_Wire25",
+    "id" : "_95_vl3_95_btrf36_95_trf6_95_THREE_ARROW2",
+    "wireId" : "_95_vl3_95_btrf36_95_trf6_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire21_ARROW1",
-    "wireId" : "idvl1_95_Wire21",
+    "id" : "_95_vl2_95_btrf27_95_trf7_95_TWO_ARROW1",
+    "wireId" : "_95_vl2_95_btrf27_95_trf7_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire19_ARROW2",
-    "wireId" : "idvl2_95_Wire19",
+    "id" : "_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf11_95_trf1_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl3_95_Wire7_ARROW2",
-    "wireId" : "idvl3_95_Wire7",
+    "id" : "_95_vl2_95_btrf27_95_trf7_95_TWO_ARROW2",
+    "wireId" : "_95_vl2_95_btrf27_95_trf7_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire17_ARROW1",
-    "wireId" : "idvl2_95_Wire17",
+    "id" : "_95_vl2_95_btrf26_95_trf6_95_TWO_ARROW1",
+    "wireId" : "_95_vl2_95_btrf26_95_trf6_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire19_ARROW1",
-    "wireId" : "idvl2_95_Wire19",
+    "id" : "_95_vl2_95_btrf26_95_trf6_95_TWO_ARROW2",
+    "wireId" : "_95_vl2_95_btrf26_95_trf6_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl3_95_Wire5_ARROW2",
-    "wireId" : "idvl3_95_Wire5",
+    "id" : "_95_vl1_95_gen1_95_bgen1_ARROW2",
+    "wireId" : "_95_vl1_95_gen1_95_bgen1",
     "distance" : 20.0
   }, {
-    "id" : "idvl3_95_Wire9_ARROW2",
-    "wireId" : "idvl3_95_Wire9",
+    "id" : "_95_vl1_95_gen1_95_bgen1_ARROW1",
+    "wireId" : "_95_vl1_95_gen1_95_bgen1",
     "distance" : 20.0
   }, {
-    "id" : "idvl3_95_Wire5_ARROW1",
-    "wireId" : "idvl3_95_Wire5",
+    "id" : "_95_vl3_95_bload4_95_load4_ARROW1",
+    "wireId" : "_95_vl3_95_bload4_95_load4",
     "distance" : 20.0
   }, {
-    "id" : "idvl3_95_Wire7_ARROW1",
-    "wireId" : "idvl3_95_Wire7",
+    "id" : "_95_vl3_95_bload4_95_load4_ARROW2",
+    "wireId" : "_95_vl3_95_bload4_95_load4",
     "distance" : 20.0
   }, {
-    "id" : "idvl3_95_Wire9_ARROW1",
-    "wireId" : "idvl3_95_Wire9",
+    "id" : "_95_vl1_95_btrf17_95_trf7_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf17_95_trf7_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire15_ARROW2",
-    "wireId" : "idvl2_95_Wire15",
+    "id" : "_95_vl2_95_btrf24_95_trf4_95_TWO_ARROW2",
+    "wireId" : "_95_vl2_95_btrf24_95_trf4_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl3_95_Wire3_ARROW1",
-    "wireId" : "idvl3_95_Wire3",
+    "id" : "_95_vl2_95_btrf24_95_trf4_95_TWO_ARROW1",
+    "wireId" : "_95_vl2_95_btrf24_95_trf4_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire15_ARROW1",
-    "wireId" : "idvl2_95_Wire15",
+    "id" : "_95_vl1_95_btrf18_95_trf8_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf18_95_trf8_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl2_95_Wire17_ARROW2",
-    "wireId" : "idvl2_95_Wire17",
+    "id" : "_95_vl1_95_btrf18_95_trf8_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf18_95_trf8_95_ONE",
     "distance" : 20.0
   } ],
   "layoutParams" : {

--- a/single-line-diagram-core/src/test/resources/substation.svg
+++ b/single-line-diagram-core/src/test/resources/substation.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -185,73 +186,73 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_bbs2_NW_LABEL">vl1_bbs2</text>
         </g>
-        <polyline class="wire wire_vl1" points="220.0,370.0,240.0,370.0" id="idvl1_95_Wire0"/>
-        <polyline class="wire wire_vl1" points="240.0,370.0,255.0,370.0" id="idvl1_95_Wire1"/>
-        <polyline class="wire wire_vl1" points="275.0,370.0,290.0,370.0" id="idvl1_95_Wire2"/>
-        <polyline class="wire wire_vl1" points="290.0,370.0,300.0,370.0" id="idvl1_95_Wire3"/>
-        <polyline class="wire wire_vl1" points="60.0,154.0,60.0,240.0" id="idvl1_95_Wire4"/>
-        <g class="ARROW1_vl1_95_load1_UP" id="idvl1_95_Wire4_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
-     <g class="arrow-up" id="idvl1_95_Wire4_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl1_95_vl1_95_bbs1_95_vl1_95_d1" points="220.0,370.0,240.0,370.0" id="_95_vl1_95_vl1_95_bbs1_95_vl1_95_d1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_d1_95_vl1_95_b1" points="240.0,370.0,255.0,370.0" id="_95_vl1_95_vl1_95_d1_95_vl1_95_b1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_b1_95_vl1_95_d2" points="275.0,370.0,290.0,370.0" id="_95_vl1_95_vl1_95_b1_95_vl1_95_d2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_d2_95_vl1_95_bbs2" points="290.0,370.0,300.0,370.0" id="_95_vl1_95_vl1_95_d2_95_vl1_95_bbs2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_load1_95_vl1_95_bload1" points="60.0,154.0,60.0,240.0" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1"/>
+        <g class="ARROW1_vl1_95_load1_UP" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire4_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_load1_DOWN" id="idvl1_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
-     <g class="arrow-up" id="idvl1_95_Wire4_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl1_95_load1_DOWN" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire4_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="60.0,260.0,60.0,370.0" id="idvl1_95_Wire5"/>
-        <polyline class="wire wire_vl1" points="60.0,370.0,50.0,370.0" id="idvl1_95_Wire6"/>
-        <polyline class="wire wire_vl1" points="100.0,570.0,100.0,480.0" id="idvl1_95_Wire7"/>
-        <g class="ARROW1_vl1_95_trf1_UP" id="idvl1_95_Wire7_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,95.0,545.0)">
-     <g class="arrow-up" id="idvl1_95_Wire7_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polyline class="wire wire__95_vl1_95_vl1_95_bload1_95_vl1_95_dload1" points="60.0,260.0,60.0,370.0" id="_95_vl1_95_vl1_95_bload1_95_vl1_95_dload1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1" points="60.0,370.0,50.0,370.0" id="_95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1" points="100.0,570.0,100.0,480.0" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1"/>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,95.0,545.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire7_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_trf1_DOWN" id="idvl1_95_Wire7_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,95.0,525.0)">
-     <g class="arrow-up" id="idvl1_95_Wire7_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,95.0,525.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire7_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="100.0,460.0,100.0,370.0" id="idvl1_95_Wire8"/>
-        <polyline class="wire wire_vl1" points="100.0,370.0,90.0,370.0" id="idvl1_95_Wire9"/>
-        <polyline class="wire wire_vl1" points="420.0,150.0,420.0,240.0" id="idvl1_95_Wire10"/>
-        <g class="ARROW1_vl1_95_trf2_95_one_UP" id="idvl1_95_Wire10_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,415.0,165.0)">
-     <g class="arrow-up" id="idvl1_95_Wire10_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1" points="100.0,460.0,100.0,370.0" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1" points="100.0,370.0,90.0,370.0" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2" points="420.0,150.0,420.0,240.0" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2"/>
+        <g class="ARROW1_vl1_95_trf2_95_one_UP" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,415.0,165.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire10_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="idvl1_95_Wire10_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,415.0,185.0)">
-     <g class="arrow-up" id="idvl1_95_Wire10_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,415.0,185.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire10_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="420.0,260.0,420.0,370.0" id="idvl1_95_Wire11"/>
-        <polyline class="wire wire_vl1" points="420.0,370.0,410.0,370.0" id="idvl1_95_Wire12"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2" points="420.0,260.0,420.0,370.0" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2" points="420.0,370.0,410.0,370.0" id="_95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2"/>
         <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
     <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
@@ -353,69 +354,69 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_bbs1_NW_LABEL">vl2_bbs1</text>
         </g>
-        <polyline class="wire wire_vl2" points="620.0,156.0,620.0,240.0" id="idvl2_95_Wire0"/>
-        <g class="ARROW1_vl2_95_gen1_UP" id="idvl2_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
-     <g class="arrow-up" id="idvl2_95_Wire0_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1" points="620.0,156.0,620.0,240.0" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1"/>
+        <g class="ARROW1_vl2_95_gen1_UP" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire0_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_gen1_DOWN" id="idvl2_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
-     <g class="arrow-up" id="idvl2_95_Wire0_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl2_95_gen1_DOWN" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire0_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="620.0,260.0,620.0,370.0" id="idvl2_95_Wire1"/>
-        <polyline class="wire wire_vl2" points="620.0,370.0,600.0,370.0" id="idvl2_95_Wire2"/>
-        <polyline class="wire wire_vl2" points="670.0,570.0,670.0,480.0" id="idvl2_95_Wire3"/>
-        <g class="ARROW1_vl2_95_trf1_UP" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,665.0,545.0)">
-     <g class="arrow-up" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polyline class="wire wire__95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1" points="620.0,260.0,620.0,370.0" id="_95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dgen1_95_vl2_95_bbs1" points="620.0,370.0,600.0,370.0" id="_95_vl2_95_vl2_95_dgen1_95_vl2_95_bbs1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1" points="670.0,570.0,670.0,480.0" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1"/>
+        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,665.0,545.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_trf1_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,665.0,525.0)">
-     <g class="arrow-up" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,665.0,525.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="670.0,460.0,670.0,370.0" id="idvl2_95_Wire4"/>
-        <polyline class="wire wire_vl2" points="670.0,370.0,680.0,370.0" id="idvl2_95_Wire5"/>
-        <polyline class="wire wire_vl2" points="730.0,150.0,730.0,240.0" id="idvl2_95_Wire6"/>
-        <g class="ARROW1_vl2_95_trf2_95_one_UP" id="idvl2_95_Wire6_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,725.0,165.0)">
-     <g class="arrow-up" id="idvl2_95_Wire6_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1" points="670.0,460.0,670.0,370.0" id="_95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1" points="670.0,370.0,680.0,370.0" id="_95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2" points="730.0,150.0,730.0,240.0" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2"/>
+        <g class="ARROW1_vl2_95_trf2_95_one_UP" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,725.0,165.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire6_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="idvl2_95_Wire6_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,725.0,185.0)">
-     <g class="arrow-up" id="idvl2_95_Wire6_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,725.0,185.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire6_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="730.0,260.0,730.0,370.0" id="idvl2_95_Wire7"/>
-        <polyline class="wire wire_vl2" points="730.0,370.0,720.0,370.0" id="idvl2_95_Wire8"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2" points="730.0,260.0,730.0,370.0" id="_95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dtrf2_95_vl2_95_bbs1" points="730.0,370.0,720.0,370.0" id="_95_vl2_95_vl2_95_dtrf2_95_vl2_95_bbs1"/>
         <g class="GENERATOR idvl2_95_gen1" id="idvl2_95_gen1" transform="translate(614.0,144.0)">
     <circle r="6" cx="6" cy="6"/>
     <path d="M6,6 A 6 40 0 0 0 2,6"/>
@@ -489,48 +490,48 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_bbs1_NW_LABEL">vl3_bbs1</text>
         </g>
-        <polyline class="wire wire_vl3" points="910.0,156.0,910.0,240.0" id="idvl3_95_Wire0"/>
-        <g class="ARROW1_vl3_95_capa1_UP" id="idvl3_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
-     <g class="arrow-up" id="idvl3_95_Wire0_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1" points="910.0,156.0,910.0,240.0" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1"/>
+        <g class="ARROW1_vl3_95_capa1_UP" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
+     <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl3_95_Wire0_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl3_95_capa1_DOWN" id="idvl3_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
-     <g class="arrow-up" id="idvl3_95_Wire0_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl3_95_capa1_DOWN" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
+     <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl3_95_Wire0_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl3" points="910.0,260.0,910.0,370.0" id="idvl3_95_Wire1"/>
-        <polyline class="wire wire_vl3" points="910.0,370.0,900.0,370.0" id="idvl3_95_Wire2"/>
-        <polyline class="wire wire_vl3" points="1020.0,150.0,1020.0,240.0" id="idvl3_95_Wire3"/>
-        <g class="ARROW1_vl3_95_trf2_95_one_UP" id="idvl3_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,165.0)">
-     <g class="arrow-up" id="idvl3_95_Wire3_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1" points="910.0,260.0,910.0,370.0" id="_95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1" points="910.0,370.0,900.0,370.0" id="_95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2" points="1020.0,150.0,1020.0,240.0" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2"/>
+        <g class="ARROW1_vl3_95_trf2_95_one_UP" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,165.0)">
+     <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl3_95_Wire3_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="idvl3_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,185.0)">
-     <g class="arrow-up" id="idvl3_95_Wire3_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,185.0)">
+     <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl3_95_Wire3_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl3" points="1020.0,260.0,1020.0,370.0" id="idvl3_95_Wire4"/>
-        <polyline class="wire wire_vl3" points="1020.0,370.0,1020.0,370.0" id="idvl3_95_Wire5"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2" points="1020.0,260.0,1020.0,370.0" id="_95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_dtrf2_95_vl3_95_bbs1" points="1020.0,370.0,1020.0,370.0" id="_95_vl3_95_vl3_95_dtrf2_95_vl3_95_bbs1"/>
         <g class="CAPACITOR idvl3_95_capa1" id="idvl3_95_capa1" transform="translate(904.0,144.0)">
     <line y2="4.5" x1="6" x2="6" y1="0"/>
     <line y2="4.5" x1="0" x2="12" y1="4.5"/>
@@ -591,11 +592,11 @@
 
     <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
 </g>
-        <polyline class="wire wire_vl1" points="100.0,550.0,100.0,600.0,377.0,600.0" id="idvl1_95__95_Wire0"/>
-        <polyline class="wire wire_vl2" points="393.0,600.0,670.0,600.0,670.0,550.0" id="id_95_vl2_95_Wire1"/>
-        <polyline class="wire wire_vl1" points="420.0,130.0,420.0,95.0,722.0,95.0" id="idvl1_95__95_Wire2"/>
-        <polyline class="wire wire_vl2" points="730.0,107.0,730.0,130.0" id="id_95_vl2_95_Wire3"/>
-        <polyline class="wire wire_vl3" points="738.0,95.0,1020.0,95.0,1020.0,130.0" id="id_95_vl3_95_Wire4"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf1_95_vl1_95_trf1_95_vl2_95_trf1" points="100.0,550.0,100.0,600.0,377.0,600.0" id="_95_subst_95_vl1_95_trf1_95_vl1_95_trf1_95_vl2_95_trf1"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf1_95_vl2_95_trf1_95_vl2_95_trf1" points="393.0,600.0,670.0,600.0,670.0,550.0" id="_95_subst_95_vl1_95_trf1_95_vl2_95_trf1_95_vl2_95_trf1"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf2_95_one_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" points="420.0,130.0,420.0,95.0,722.0,95.0" id="_95_subst_95_vl1_95_trf2_95_one_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl2_95_trf2_95_one" points="730.0,107.0,730.0,130.0" id="_95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl2_95_trf2_95_one"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl3_95_trf2_95_one" points="738.0,95.0,1020.0,95.0,1020.0,130.0" id="_95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl3_95_trf2_95_one"/>
         <g id="LABEL_VL_vl1">
             <text x="0.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
+++ b/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -185,19 +186,19 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_bbs2_NW_LABEL">vl1_bbs2</text>
         </g>
-        <polyline class="wire wire_vl1" points="220.0,370.0,240.0,370.0" id="idvl1_95_Wire0"/>
-        <polyline class="wire wire_vl1" points="240.0,370.0,255.0,370.0" id="idvl1_95_Wire1"/>
-        <polyline class="wire wire_vl1" points="275.0,370.0,290.0,370.0" id="idvl1_95_Wire2"/>
-        <polyline class="wire wire_vl1" points="290.0,370.0,300.0,370.0" id="idvl1_95_Wire3"/>
-        <polyline class="wire wire_vl1" points="60.0,154.0,60.0,240.0" id="idvl1_95_Wire4"/>
-        <polyline class="wire wire_vl1" points="60.0,260.0,60.0,370.0" id="idvl1_95_Wire5"/>
-        <polyline class="wire wire_vl1" points="60.0,370.0,50.0,370.0" id="idvl1_95_Wire6"/>
-        <polyline class="wire wire_vl1" points="100.0,570.0,100.0,480.0" id="idvl1_95_Wire7"/>
-        <polyline class="wire wire_vl1" points="100.0,460.0,100.0,370.0" id="idvl1_95_Wire8"/>
-        <polyline class="wire wire_vl1" points="100.0,370.0,90.0,370.0" id="idvl1_95_Wire9"/>
-        <polyline class="wire wire_vl1" points="420.0,150.0,420.0,240.0" id="idvl1_95_Wire10"/>
-        <polyline class="wire wire_vl1" points="420.0,260.0,420.0,370.0" id="idvl1_95_Wire11"/>
-        <polyline class="wire wire_vl1" points="420.0,370.0,410.0,370.0" id="idvl1_95_Wire12"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_bbs1_95_vl1_95_d1" points="220.0,370.0,240.0,370.0" id="_95_vl1_95_vl1_95_bbs1_95_vl1_95_d1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_d1_95_vl1_95_b1" points="240.0,370.0,255.0,370.0" id="_95_vl1_95_vl1_95_d1_95_vl1_95_b1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_b1_95_vl1_95_d2" points="275.0,370.0,290.0,370.0" id="_95_vl1_95_vl1_95_b1_95_vl1_95_d2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_d2_95_vl1_95_bbs2" points="290.0,370.0,300.0,370.0" id="_95_vl1_95_vl1_95_d2_95_vl1_95_bbs2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_load1_95_vl1_95_bload1" points="60.0,154.0,60.0,240.0" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_bload1_95_vl1_95_dload1" points="60.0,260.0,60.0,370.0" id="_95_vl1_95_vl1_95_bload1_95_vl1_95_dload1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1" points="60.0,370.0,50.0,370.0" id="_95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1" points="100.0,570.0,100.0,480.0" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1" points="100.0,460.0,100.0,370.0" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1" points="100.0,370.0,90.0,370.0" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2" points="420.0,150.0,420.0,240.0" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2" points="420.0,260.0,420.0,370.0" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2" points="420.0,370.0,410.0,370.0" id="_95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2"/>
         <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
     <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
@@ -299,15 +300,15 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_bbs1_NW_LABEL">vl2_bbs1</text>
         </g>
-        <polyline class="wire wire_vl2" points="620.0,156.0,620.0,240.0" id="idvl2_95_Wire0"/>
-        <polyline class="wire wire_vl2" points="620.0,260.0,620.0,370.0" id="idvl2_95_Wire1"/>
-        <polyline class="wire wire_vl2" points="620.0,370.0,600.0,370.0" id="idvl2_95_Wire2"/>
-        <polyline class="wire wire_vl2" points="670.0,570.0,670.0,480.0" id="idvl2_95_Wire3"/>
-        <polyline class="wire wire_vl2" points="670.0,460.0,670.0,370.0" id="idvl2_95_Wire4"/>
-        <polyline class="wire wire_vl2" points="670.0,370.0,680.0,370.0" id="idvl2_95_Wire5"/>
-        <polyline class="wire wire_vl2" points="730.0,150.0,730.0,240.0" id="idvl2_95_Wire6"/>
-        <polyline class="wire wire_vl2" points="730.0,260.0,730.0,370.0" id="idvl2_95_Wire7"/>
-        <polyline class="wire wire_vl2" points="730.0,370.0,720.0,370.0" id="idvl2_95_Wire8"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1" points="620.0,156.0,620.0,240.0" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1" points="620.0,260.0,620.0,370.0" id="_95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dgen1_95_vl2_95_bbs1" points="620.0,370.0,600.0,370.0" id="_95_vl2_95_vl2_95_dgen1_95_vl2_95_bbs1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1" points="670.0,570.0,670.0,480.0" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1" points="670.0,460.0,670.0,370.0" id="_95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1" points="670.0,370.0,680.0,370.0" id="_95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2" points="730.0,150.0,730.0,240.0" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2" points="730.0,260.0,730.0,370.0" id="_95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dtrf2_95_vl2_95_bbs1" points="730.0,370.0,720.0,370.0" id="_95_vl2_95_vl2_95_dtrf2_95_vl2_95_bbs1"/>
         <g class="GENERATOR idvl2_95_gen1" id="idvl2_95_gen1" transform="translate(614.0,144.0)">
     <circle r="6" cx="6" cy="6"/>
     <path d="M6,6 A 6 40 0 0 0 2,6"/>
@@ -381,12 +382,12 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_bbs1_NW_LABEL">vl3_bbs1</text>
         </g>
-        <polyline class="wire wire_vl3" points="910.0,156.0,910.0,240.0" id="idvl3_95_Wire0"/>
-        <polyline class="wire wire_vl3" points="910.0,260.0,910.0,370.0" id="idvl3_95_Wire1"/>
-        <polyline class="wire wire_vl3" points="910.0,370.0,900.0,370.0" id="idvl3_95_Wire2"/>
-        <polyline class="wire wire_vl3" points="1020.0,150.0,1020.0,240.0" id="idvl3_95_Wire3"/>
-        <polyline class="wire wire_vl3" points="1020.0,260.0,1020.0,370.0" id="idvl3_95_Wire4"/>
-        <polyline class="wire wire_vl3" points="1020.0,370.0,1020.0,370.0" id="idvl3_95_Wire5"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1" points="910.0,156.0,910.0,240.0" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1" points="910.0,260.0,910.0,370.0" id="_95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1" points="910.0,370.0,900.0,370.0" id="_95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2" points="1020.0,150.0,1020.0,240.0" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2" points="1020.0,260.0,1020.0,370.0" id="_95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_dtrf2_95_vl3_95_bbs1" points="1020.0,370.0,1020.0,370.0" id="_95_vl3_95_vl3_95_dtrf2_95_vl3_95_bbs1"/>
         <g class="CAPACITOR idvl3_95_capa1" id="idvl3_95_capa1" transform="translate(904.0,144.0)">
     <line y2="4.5" x1="6" x2="6" y1="0"/>
     <line y2="4.5" x1="0" x2="12" y1="4.5"/>
@@ -447,11 +448,11 @@
 
     <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
 </g>
-        <polyline class="wire wire_vl1" points="100.0,550.0,100.0,600.0,369.0,600.0" id="idvl1_95__95_Wire0"/>
-        <polyline class="wire wire_vl2" points="401.0,600.0,670.0,600.0,670.0,550.0" id="id_95_vl2_95_Wire1"/>
-        <polyline class="wire wire_vl1" points="420.0,130.0,420.0,90.0,714.0,90.0" id="idvl1_95__95_Wire2"/>
-        <polyline class="wire wire_vl2" points="730.0,114.0,730.0,130.0" id="id_95_vl2_95_Wire3"/>
-        <polyline class="wire wire_vl3" points="746.0,90.0,1020.0,90.0,1020.0,130.0" id="id_95_vl3_95_Wire4"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf1_95_vl1_95_trf1_95_vl2_95_trf1" points="100.0,550.0,100.0,600.0,369.0,600.0" id="_95_subst_95_vl1_95_trf1_95_vl1_95_trf1_95_vl2_95_trf1"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf1_95_vl2_95_trf1_95_vl2_95_trf1" points="401.0,600.0,670.0,600.0,670.0,550.0" id="_95_subst_95_vl1_95_trf1_95_vl2_95_trf1_95_vl2_95_trf1"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf2_95_one_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" points="420.0,130.0,420.0,90.0,714.0,90.0" id="_95_subst_95_vl1_95_trf2_95_one_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl2_95_trf2_95_one" points="730.0,114.0,730.0,130.0" id="_95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl2_95_trf2_95_one"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl3_95_trf2_95_one" points="746.0,90.0,1020.0,90.0,1020.0,130.0" id="_95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl3_95_trf2_95_one"/>
         <g id="LABEL_VL_vl1">
             <text x="0.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/substation_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/substation_optimized.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -215,43 +216,43 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_bbs2_NW_LABEL">vl1_bbs2</text>
         </g>
-        <polyline class="wire wire_vl1" points="220.0,370.0,240.0,370.0" id="idvl1_95_Wire0"/>
-        <polyline class="wire wire_vl1" points="240.0,370.0,255.0,370.0" id="idvl1_95_Wire1"/>
-        <polyline class="wire wire_vl1" points="275.0,370.0,290.0,370.0" id="idvl1_95_Wire2"/>
-        <polyline class="wire wire_vl1" points="290.0,370.0,300.0,370.0" id="idvl1_95_Wire3"/>
-        <polyline class="wire wire_vl1" points="60.0,154.0,60.0,240.0" id="idvl1_95_Wire4"/>
-        <g class="ARROW1_vl1_95_load1_UP" id="idvl1_95_Wire4_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
+        <polyline class="wire wire__95_vl1_95_vl1_95_bbs1_95_vl1_95_d1" points="220.0,370.0,240.0,370.0" id="_95_vl1_95_vl1_95_bbs1_95_vl1_95_d1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_d1_95_vl1_95_b1" points="240.0,370.0,255.0,370.0" id="_95_vl1_95_vl1_95_d1_95_vl1_95_b1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_b1_95_vl1_95_d2" points="275.0,370.0,290.0,370.0" id="_95_vl1_95_vl1_95_b1_95_vl1_95_d2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_d2_95_vl1_95_bbs2" points="290.0,370.0,300.0,370.0" id="_95_vl1_95_vl1_95_d2_95_vl1_95_bbs2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_load1_95_vl1_95_bload1" points="60.0,154.0,60.0,240.0" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1"/>
+        <g class="ARROW1_vl1_95_load1_UP" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_load1_DOWN" id="idvl1_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
+        <g class="ARROW2_vl1_95_load1_DOWN" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="60.0,260.0,60.0,370.0" id="idvl1_95_Wire5"/>
-        <polyline class="wire wire_vl1" points="60.0,370.0,50.0,370.0" id="idvl1_95_Wire6"/>
-        <polyline class="wire wire_vl1" points="100.0,570.0,100.0,480.0" id="idvl1_95_Wire7"/>
-        <g class="ARROW1_vl1_95_trf1_UP" id="idvl1_95_Wire7_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,95.0,545.0)">
+        <polyline class="wire wire__95_vl1_95_vl1_95_bload1_95_vl1_95_dload1" points="60.0,260.0,60.0,370.0" id="_95_vl1_95_vl1_95_bload1_95_vl1_95_dload1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1" points="60.0,370.0,50.0,370.0" id="_95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1" points="100.0,570.0,100.0,480.0" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1"/>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,95.0,545.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_trf1_DOWN" id="idvl1_95_Wire7_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,95.0,525.0)">
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,95.0,525.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="100.0,460.0,100.0,370.0" id="idvl1_95_Wire8"/>
-        <polyline class="wire wire_vl1" points="100.0,370.0,90.0,370.0" id="idvl1_95_Wire9"/>
-        <polyline class="wire wire_vl1" points="420.0,150.0,420.0,240.0" id="idvl1_95_Wire10"/>
-        <g class="ARROW1_vl1_95_trf2_95_one_UP" id="idvl1_95_Wire10_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,415.0,165.0)">
+        <polyline class="wire wire__95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1" points="100.0,460.0,100.0,370.0" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1" points="100.0,370.0,90.0,370.0" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2" points="420.0,150.0,420.0,240.0" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2"/>
+        <g class="ARROW1_vl1_95_trf2_95_one_UP" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,415.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="idvl1_95_Wire10_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,415.0,185.0)">
+        <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,415.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="420.0,260.0,420.0,370.0" id="idvl1_95_Wire11"/>
-        <polyline class="wire wire_vl1" points="420.0,370.0,410.0,370.0" id="idvl1_95_Wire12"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2" points="420.0,260.0,420.0,370.0" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2" points="420.0,370.0,410.0,370.0" id="_95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2"/>
         <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
             <use href="#DISCONNECTOR-closed"/>
         </g>
@@ -293,39 +294,39 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_bbs1_NW_LABEL">vl2_bbs1</text>
         </g>
-        <polyline class="wire wire_vl2" points="620.0,156.0,620.0,240.0" id="idvl2_95_Wire0"/>
-        <g class="ARROW1_vl2_95_gen1_UP" id="idvl2_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
+        <polyline class="wire wire__95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1" points="620.0,156.0,620.0,240.0" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1"/>
+        <g class="ARROW1_vl2_95_gen1_UP" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_gen1_DOWN" id="idvl2_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
+        <g class="ARROW2_vl2_95_gen1_DOWN" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="620.0,260.0,620.0,370.0" id="idvl2_95_Wire1"/>
-        <polyline class="wire wire_vl2" points="620.0,370.0,600.0,370.0" id="idvl2_95_Wire2"/>
-        <polyline class="wire wire_vl2" points="670.0,570.0,670.0,480.0" id="idvl2_95_Wire3"/>
-        <g class="ARROW1_vl2_95_trf1_UP" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,665.0,545.0)">
+        <polyline class="wire wire__95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1" points="620.0,260.0,620.0,370.0" id="_95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dgen1_95_vl2_95_bbs1" points="620.0,370.0,600.0,370.0" id="_95_vl2_95_vl2_95_dgen1_95_vl2_95_bbs1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1" points="670.0,570.0,670.0,480.0" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1"/>
+        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,665.0,545.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_trf1_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,665.0,525.0)">
+        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,665.0,525.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="670.0,460.0,670.0,370.0" id="idvl2_95_Wire4"/>
-        <polyline class="wire wire_vl2" points="670.0,370.0,680.0,370.0" id="idvl2_95_Wire5"/>
-        <polyline class="wire wire_vl2" points="730.0,150.0,730.0,240.0" id="idvl2_95_Wire6"/>
-        <g class="ARROW1_vl2_95_trf2_95_one_UP" id="idvl2_95_Wire6_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,725.0,165.0)">
+        <polyline class="wire wire__95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1" points="670.0,460.0,670.0,370.0" id="_95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1" points="670.0,370.0,680.0,370.0" id="_95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2" points="730.0,150.0,730.0,240.0" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2"/>
+        <g class="ARROW1_vl2_95_trf2_95_one_UP" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,725.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="idvl2_95_Wire6_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,725.0,185.0)">
+        <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,725.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="730.0,260.0,730.0,370.0" id="idvl2_95_Wire7"/>
-        <polyline class="wire wire_vl2" points="730.0,370.0,720.0,370.0" id="idvl2_95_Wire8"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2" points="730.0,260.0,730.0,370.0" id="_95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dtrf2_95_vl2_95_bbs1" points="730.0,370.0,720.0,370.0" id="_95_vl2_95_vl2_95_dtrf2_95_vl2_95_bbs1"/>
         <g class="GENERATOR idvl2_95_gen1" id="idvl2_95_gen1" transform="translate(614.0,144.0)">
             <use href="#GENERATOR"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_gen1__LABEL">vl2_gen1</text>
@@ -358,28 +359,28 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_bbs1_NW_LABEL">vl3_bbs1</text>
         </g>
-        <polyline class="wire wire_vl3" points="910.0,156.0,910.0,240.0" id="idvl3_95_Wire0"/>
-        <g class="ARROW1_vl3_95_capa1_UP" id="idvl3_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
+        <polyline class="wire wire__95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1" points="910.0,156.0,910.0,240.0" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1"/>
+        <g class="ARROW1_vl3_95_capa1_UP" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl3_95_capa1_DOWN" id="idvl3_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
+        <g class="ARROW2_vl3_95_capa1_DOWN" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl3" points="910.0,260.0,910.0,370.0" id="idvl3_95_Wire1"/>
-        <polyline class="wire wire_vl3" points="910.0,370.0,900.0,370.0" id="idvl3_95_Wire2"/>
-        <polyline class="wire wire_vl3" points="1020.0,150.0,1020.0,240.0" id="idvl3_95_Wire3"/>
-        <g class="ARROW1_vl3_95_trf2_95_one_UP" id="idvl3_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,165.0)">
+        <polyline class="wire wire__95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1" points="910.0,260.0,910.0,370.0" id="_95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1" points="910.0,370.0,900.0,370.0" id="_95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2" points="1020.0,150.0,1020.0,240.0" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2"/>
+        <g class="ARROW1_vl3_95_trf2_95_one_UP" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="idvl3_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,185.0)">
+        <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl3" points="1020.0,260.0,1020.0,370.0" id="idvl3_95_Wire4"/>
-        <polyline class="wire wire_vl3" points="1020.0,370.0,1020.0,370.0" id="idvl3_95_Wire5"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2" points="1020.0,260.0,1020.0,370.0" id="_95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_dtrf2_95_vl3_95_bbs1" points="1020.0,370.0,1020.0,370.0" id="_95_vl3_95_vl3_95_dtrf2_95_vl3_95_bbs1"/>
         <g class="CAPACITOR idvl3_95_capa1" id="idvl3_95_capa1" transform="translate(904.0,144.0)">
             <use href="#CAPACITOR"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_capa1__LABEL">vl3_capa1</text>
@@ -408,11 +409,11 @@
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING2"/>
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING3"/>
         </g>
-        <polyline class="wire wire_vl1" points="100.0,550.0,100.0,600.0,361.0,600.0" id="idvl1_95__95_Wire0"/>
-        <polyline class="wire wire_vl2" points="409.0,600.0,670.0,600.0,670.0,550.0" id="id_95_vl2_95_Wire1"/>
-        <polyline class="wire wire_vl1" points="420.0,130.0,420.0,85.0,706.0,85.0" id="idvl1_95__95_Wire2"/>
-        <polyline class="wire wire_vl2" points="730.0,121.0,730.0,130.0" id="id_95_vl2_95_Wire3"/>
-        <polyline class="wire wire_vl3" points="754.0,85.0,1020.0,85.0,1020.0,130.0" id="id_95_vl3_95_Wire4"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf1_95_vl1_95_trf1_95_vl2_95_trf1" points="100.0,550.0,100.0,600.0,361.0,600.0" id="_95_subst_95_vl1_95_trf1_95_vl1_95_trf1_95_vl2_95_trf1"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf1_95_vl2_95_trf1_95_vl2_95_trf1" points="409.0,600.0,670.0,600.0,670.0,550.0" id="_95_subst_95_vl1_95_trf1_95_vl2_95_trf1_95_vl2_95_trf1"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf2_95_one_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" points="420.0,130.0,420.0,85.0,706.0,85.0" id="_95_subst_95_vl1_95_trf2_95_one_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl2_95_trf2_95_one" points="730.0,121.0,730.0,130.0" id="_95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl2_95_trf2_95_one"/>
+        <polyline class="wire wire__95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl3_95_trf2_95_one" points="754.0,85.0,1020.0,85.0,1020.0,130.0" id="_95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl3_95_trf2_95_one"/>
         <g id="LABEL_VL_vl1">
             <text x="0.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
         </g>

--- a/single-line-diagram-core/src/test/resources/vl1.svg
+++ b/single-line-diagram-core/src/test/resources/vl1.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -151,93 +152,93 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_bbs2_NW_LABEL">vl1_bbs2</text>
         </g>
-        <polyline class="wire wire_vl1" points="220.0,370.0,240.0,370.0" id="idvl1_95_Wire0"/>
-        <polyline class="wire wire_vl1" points="240.0,370.0,255.0,370.0" id="idvl1_95_Wire1"/>
-        <polyline class="wire wire_vl1" points="275.0,370.0,290.0,370.0" id="idvl1_95_Wire2"/>
-        <polyline class="wire wire_vl1" points="290.0,370.0,300.0,370.0" id="idvl1_95_Wire3"/>
-        <polyline class="wire wire_vl1" points="60.0,154.0,60.0,240.0" id="idvl1_95_Wire4"/>
-        <g class="ARROW1_vl1_95_load1_UP" id="idvl1_95_Wire4_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
-     <g class="arrow-up" id="idvl1_95_Wire4_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl1_95_vl1_95_bbs1_95_vl1_95_d1" points="220.0,370.0,240.0,370.0" id="_95_vl1_95_vl1_95_bbs1_95_vl1_95_d1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_d1_95_vl1_95_b1" points="240.0,370.0,255.0,370.0" id="_95_vl1_95_vl1_95_d1_95_vl1_95_b1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_b1_95_vl1_95_d2" points="275.0,370.0,290.0,370.0" id="_95_vl1_95_vl1_95_b1_95_vl1_95_d2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_d2_95_vl1_95_bbs2" points="290.0,370.0,300.0,370.0" id="_95_vl1_95_vl1_95_d2_95_vl1_95_bbs2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_load1_95_vl1_95_bload1" points="60.0,154.0,60.0,240.0" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1"/>
+        <g class="ARROW1_vl1_95_load1_UP" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire4_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_load1_DOWN" id="idvl1_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
-     <g class="arrow-up" id="idvl1_95_Wire4_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl1_95_load1_DOWN" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire4_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="60.0,260.0,60.0,370.0" id="idvl1_95_Wire5"/>
-        <polyline class="wire wire_vl1" points="60.0,370.0,50.0,370.0" id="idvl1_95_Wire6"/>
-        <polyline class="wire wire_vl1" points="100.0,562.0,100.0,480.0" id="idvl1_95_Wire7"/>
-        <g class="ARROW1_vl1_95_trf1_UP" id="idvl1_95_Wire7_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,95.0,537.0)">
-     <g class="arrow-up" id="idvl1_95_Wire7_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polyline class="wire wire__95_vl1_95_vl1_95_bload1_95_vl1_95_dload1" points="60.0,260.0,60.0,370.0" id="_95_vl1_95_vl1_95_bload1_95_vl1_95_dload1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1" points="60.0,370.0,50.0,370.0" id="_95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1" points="100.0,562.0,100.0,480.0" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1"/>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,95.0,537.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire7_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_trf1_DOWN" id="idvl1_95_Wire7_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,95.0,517.0)">
-     <g class="arrow-up" id="idvl1_95_Wire7_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,95.0,517.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire7_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="100.0,460.0,100.0,370.0" id="idvl1_95_Wire8"/>
-        <polyline class="wire wire_vl1" points="100.0,370.0,90.0,370.0" id="idvl1_95_Wire9"/>
-        <polyline class="wire wire_vl1" points="380.0,150.0,380.0,205.0,412.0,205.0" id="idvl1_95_Wire10"/>
-        <g class="ARROW1_vl1_95_trf2_95_one_UP" id="idvl1_95_Wire10_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
-     <g class="arrow-up" id="idvl1_95_Wire10_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1" points="100.0,460.0,100.0,370.0" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1" points="100.0,370.0,90.0,370.0" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2" points="380.0,150.0,380.0,205.0,412.0,205.0" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2"/>
+        <g class="ARROW1_vl1_95_trf2_95_one_UP" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire10_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="idvl1_95_Wire10_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
-     <g class="arrow-up" id="idvl1_95_Wire10_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire10_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="460.0,150.0,460.0,205.0,428.0,205.0" id="idvl1_95_Wire11"/>
-        <g class="ARROW1_vl1_95_trf2_95_two_UP" id="idvl1_95_Wire11_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
-     <g class="arrow-up" id="idvl1_95_Wire11_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2" points="460.0,150.0,460.0,205.0,428.0,205.0" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2"/>
+        <g class="ARROW1_vl1_95_trf2_95_two_UP" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire11_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_trf2_95_two_DOWN" id="idvl1_95_Wire11_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
-     <g class="arrow-up" id="idvl1_95_Wire11_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl1_95_trf2_95_two_DOWN" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
+     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl1_95_Wire11_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="420.0,217.0,420.0,240.0" id="idvl1_95_Wire12"/>
-        <polyline class="wire wire_vl1" points="420.0,260.0,420.0,370.0" id="idvl1_95_Wire13"/>
-        <polyline class="wire wire_vl1" points="420.0,370.0,410.0,370.0" id="idvl1_95_Wire14"/>
+        <polyline class="wire wire__95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2" points="420.0,217.0,420.0,240.0" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2" points="420.0,260.0,420.0,370.0" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2" points="420.0,370.0,410.0,370.0" id="_95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2"/>
         <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
     <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>

--- a/single-line-diagram-core/src/test/resources/vl1_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_nominal_voltage_style.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -130,40 +131,98 @@
 .idFICT_95_vl1_95_6 {stroke-opacity:0; fill-opacity:0; visibility: hidden;} .idFICT_95_vl1_95_6 {stroke:#ff0000;}
 .idd3WT_95_1 .open { visibility: hidden;}.idd3WT_95_1 .closed { visibility: visible;}
 .idb3WT_95_1 .open { visibility: visible;}.idb3WT_95_1 .closed { visibility: hidden;}
- #idvl1_95_Wire0 {stroke:black;stroke-width:1;stroke-dasharray:3,3}
- #idvl1_95_Wire1 {stroke:black;stroke-width:1}
-.wire_vl1 {stroke:#ff0000;stroke-width:1;}
-.wire_vl1 {stroke:#ff0000;stroke-width:1;}
-.wire_vl1 {stroke:#ff0000;stroke-width:1;}
-.wire_vl1 {stroke:#ff0000;stroke-width:1;}
-.wire_vl1 {stroke:#ff0000;stroke-width:1;}
-.wire_vl1 {stroke:#ff0000;stroke-width:1;}
- #idvl1_95_Wire8 {stroke:#ff0000;stroke-width:1;stroke-dasharray:3,3}
-.wire_vl1 {stroke:#ff0000;stroke-width:1;}
-.wire_vl1 {stroke:#ff0000;stroke-width:1;}
-.wire_vl1 {stroke:#ff0000;stroke-width:1;}
-.wire_vl1 {stroke:#ff0000;stroke-width:1;}
-.wire_vl1 {stroke:#ff0000;stroke-width:1;}
+.wire__95_vl1_95_FICT_95_vl1_95_3WT_95_fictif_95_3WT_95_TWO {
+    stroke-dasharray: 3,3;
+    stroke-width: 1;
+    stroke: black;
+}
+
+.wire__95_vl1_95_FICT_95_vl1_95_3WT_95_fictif_95_3WT_95_THREE {
+    stroke-width: 1;
+    stroke: black;
+}
+
+.wire__95_vl1_95_bbs1_95_d {
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
+.wire__95_vl1_95_d_95_FICT_95_vl1_95_1 {
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
+.wire__95_vl1_95_FICT_95_vl1_95_1_95_b {
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
+.wire__95_vl1_95_b_95_l {
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
+.wire__95_vl1_95_bbs1_95_d2WT_95_1 {
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
+.wire__95_vl1_95_d2WT_95_1_95_FICT_95_vl1_95_4 {
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
+.wire__95_vl1_95_2WT_95_ONE_95_b2WT_95_1 {
+    stroke-dasharray: 3,3;
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
+.wire__95_vl1_95_b2WT_95_1_95_FICT_95_vl1_95_4 {
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
+.wire__95_vl1_95_bbs1_95_d3WT_95_1 {
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
+.wire__95_vl1_95_d3WT_95_1_95_FICT_95_vl1_95_6 {
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
+.wire__95_vl1_95_FICT_95_vl1_95_3WT_95_fictif_95_b3WT_95_1 {
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
+.wire__95_vl1_95_b3WT_95_1_95_FICT_95_vl1_95_6 {
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
 ]]></style>
     <g>
         <g class="BUSBAR_SECTION idbbs1" id="idbbs1" transform="translate(19.0,49.0)">
             <line y2="0" x1="0" x2="1.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs1_NW_LABEL">bbs1</text>
         </g>
-        <polyline class="wire wire_vl2" points="19.0,56.0,19.0,49.0" id="idvl1_95_Wire0"/>
-        <polyline class="wire wire_vl3" points="19.0,56.0,19.0,49.0" id="idvl1_95_Wire1"/>
-        <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="idvl1_95_Wire2"/>
-        <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="idvl1_95_Wire3"/>
-        <polyline class="wire wire_vl1" points="19.0,49.0,19.0,39.0" id="idvl1_95_Wire4"/>
-        <polyline class="wire wire_vl1" points="19.0,39.0,19.0,45.0" id="idvl1_95_Wire5"/>
-        <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="idvl1_95_Wire6"/>
-        <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="idvl1_95_Wire7"/>
-        <polyline class="wire wire_vl1" points="19.0,41.0,19.0,39.0" id="idvl1_95_Wire8"/>
-        <polyline class="wire wire_vl1" points="19.0,39.0,19.0,49.0" id="idvl1_95_Wire9"/>
-        <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="idvl1_95_Wire10"/>
-        <polyline class="wire wire_vl1" points="19.0,49.0,19.0,49.0" id="idvl1_95_Wire11"/>
-        <polyline class="wire wire_vl1" points="19.0,56.0,19.0,59.0" id="idvl1_95_Wire12"/>
-        <polyline class="wire wire_vl1" points="19.0,39.0,19.0,49.0" id="idvl1_95_Wire13"/>
+        <polyline class="wire wire__95_vl1_95_FICT_95_vl1_95_3WT_95_fictif_95_3WT_95_TWO" points="19.0,56.0,19.0,49.0" id="_95_vl1_95_FICT_95_vl1_95_3WT_95_fictif_95_3WT_95_TWO"/>
+        <polyline class="wire wire__95_vl1_95_FICT_95_vl1_95_3WT_95_fictif_95_3WT_95_THREE" points="19.0,56.0,19.0,49.0" id="_95_vl1_95_FICT_95_vl1_95_3WT_95_fictif_95_3WT_95_THREE"/>
+        <polyline class="wire wire__95_vl1_95_bbs1_95_d" points="19.0,49.0,19.0,49.0" id="_95_vl1_95_bbs1_95_d"/>
+        <polyline class="wire wire__95_vl1_95_d_95_FICT_95_vl1_95_1" points="19.0,49.0,19.0,49.0" id="_95_vl1_95_d_95_FICT_95_vl1_95_1"/>
+        <polyline class="wire wire__95_vl1_95_FICT_95_vl1_95_1_95_b" points="19.0,49.0,19.0,39.0" id="_95_vl1_95_FICT_95_vl1_95_1_95_b"/>
+        <polyline class="wire wire__95_vl1_95_b_95_l" points="19.0,39.0,19.0,45.0" id="_95_vl1_95_b_95_l"/>
+        <polyline class="wire wire__95_vl1_95_bbs1_95_d2WT_95_1" points="19.0,49.0,19.0,49.0" id="_95_vl1_95_bbs1_95_d2WT_95_1"/>
+        <polyline class="wire wire__95_vl1_95_d2WT_95_1_95_FICT_95_vl1_95_4" points="19.0,49.0,19.0,49.0" id="_95_vl1_95_d2WT_95_1_95_FICT_95_vl1_95_4"/>
+        <polyline class="wire wire__95_vl1_95_2WT_95_ONE_95_b2WT_95_1" points="19.0,41.0,19.0,39.0" id="_95_vl1_95_2WT_95_ONE_95_b2WT_95_1"/>
+        <polyline class="wire wire__95_vl1_95_b2WT_95_1_95_FICT_95_vl1_95_4" points="19.0,39.0,19.0,49.0" id="_95_vl1_95_b2WT_95_1_95_FICT_95_vl1_95_4"/>
+        <polyline class="wire wire__95_vl1_95_bbs1_95_d3WT_95_1" points="19.0,49.0,19.0,49.0" id="_95_vl1_95_bbs1_95_d3WT_95_1"/>
+        <polyline class="wire wire__95_vl1_95_d3WT_95_1_95_FICT_95_vl1_95_6" points="19.0,49.0,19.0,49.0" id="_95_vl1_95_d3WT_95_1_95_FICT_95_vl1_95_6"/>
+        <polyline class="wire wire__95_vl1_95_FICT_95_vl1_95_3WT_95_fictif_95_b3WT_95_1" points="19.0,56.0,19.0,59.0" id="_95_vl1_95_FICT_95_vl1_95_3WT_95_fictif_95_b3WT_95_1"/>
+        <polyline class="wire wire__95_vl1_95_b3WT_95_1_95_FICT_95_vl1_95_6" points="19.0,39.0,19.0,49.0" id="_95_vl1_95_b3WT_95_1_95_FICT_95_vl1_95_6"/>
         <g class="LOAD idl" id="idl" transform="translate(11.0,44.5)">
     <rect height="9" width="16"/>
     <line y2="9" x1="0" x2="16" y1="0"/>

--- a/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -184,53 +185,53 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_bbs2_NW_LABEL">vl1_bbs2</text>
         </g>
-        <polyline class="wire wire_vl1" points="220.0,370.0,240.0,370.0" id="idvl1_95_Wire0"/>
-        <polyline class="wire wire_vl1" points="240.0,370.0,255.0,370.0" id="idvl1_95_Wire1"/>
-        <polyline class="wire wire_vl1" points="275.0,370.0,290.0,370.0" id="idvl1_95_Wire2"/>
-        <polyline class="wire wire_vl1" points="290.0,370.0,300.0,370.0" id="idvl1_95_Wire3"/>
-        <polyline class="wire wire_vl1" points="60.0,154.0,60.0,240.0" id="idvl1_95_Wire4"/>
-        <g class="ARROW1_vl1_95_load1_UP" id="idvl1_95_Wire4_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
+        <polyline class="wire wire__95_vl1_95_vl1_95_bbs1_95_vl1_95_d1" points="220.0,370.0,240.0,370.0" id="_95_vl1_95_vl1_95_bbs1_95_vl1_95_d1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_d1_95_vl1_95_b1" points="240.0,370.0,255.0,370.0" id="_95_vl1_95_vl1_95_d1_95_vl1_95_b1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_b1_95_vl1_95_d2" points="275.0,370.0,290.0,370.0" id="_95_vl1_95_vl1_95_b1_95_vl1_95_d2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_d2_95_vl1_95_bbs2" points="290.0,370.0,300.0,370.0" id="_95_vl1_95_vl1_95_d2_95_vl1_95_bbs2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_load1_95_vl1_95_bload1" points="60.0,154.0,60.0,240.0" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1"/>
+        <g class="ARROW1_vl1_95_load1_UP" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_load1_DOWN" id="idvl1_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
+        <g class="ARROW2_vl1_95_load1_DOWN" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="60.0,260.0,60.0,370.0" id="idvl1_95_Wire5"/>
-        <polyline class="wire wire_vl1" points="60.0,370.0,50.0,370.0" id="idvl1_95_Wire6"/>
-        <polyline class="wire wire_vl1" points="100.0,562.0,100.0,480.0" id="idvl1_95_Wire7"/>
-        <g class="ARROW1_vl1_95_trf1_UP" id="idvl1_95_Wire7_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,95.0,537.0)">
+        <polyline class="wire wire__95_vl1_95_vl1_95_bload1_95_vl1_95_dload1" points="60.0,260.0,60.0,370.0" id="_95_vl1_95_vl1_95_bload1_95_vl1_95_dload1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1" points="60.0,370.0,50.0,370.0" id="_95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1" points="100.0,562.0,100.0,480.0" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1"/>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,95.0,537.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_trf1_DOWN" id="idvl1_95_Wire7_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,95.0,517.0)">
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,95.0,517.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="100.0,460.0,100.0,370.0" id="idvl1_95_Wire8"/>
-        <polyline class="wire wire_vl1" points="100.0,370.0,90.0,370.0" id="idvl1_95_Wire9"/>
-        <polyline class="wire wire_vl1" points="380.0,150.0,380.0,205.0,412.0,205.0" id="idvl1_95_Wire10"/>
-        <g class="ARROW1_vl1_95_trf2_95_one_UP" id="idvl1_95_Wire10_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
+        <polyline class="wire wire__95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1" points="100.0,460.0,100.0,370.0" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1" points="100.0,370.0,90.0,370.0" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2" points="380.0,150.0,380.0,205.0,412.0,205.0" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2"/>
+        <g class="ARROW1_vl1_95_trf2_95_one_UP" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="idvl1_95_Wire10_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
+        <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="460.0,150.0,460.0,205.0,428.0,205.0" id="idvl1_95_Wire11"/>
-        <g class="ARROW1_vl1_95_trf2_95_two_UP" id="idvl1_95_Wire11_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
+        <polyline class="wire wire__95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2" points="460.0,150.0,460.0,205.0,428.0,205.0" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2"/>
+        <g class="ARROW1_vl1_95_trf2_95_two_UP" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl1_95_trf2_95_two_DOWN" id="idvl1_95_Wire11_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
+        <g class="ARROW2_vl1_95_trf2_95_two_DOWN" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl1" points="420.0,217.0,420.0,240.0" id="idvl1_95_Wire12"/>
-        <polyline class="wire wire_vl1" points="420.0,260.0,420.0,370.0" id="idvl1_95_Wire13"/>
-        <polyline class="wire wire_vl1" points="420.0,370.0,410.0,370.0" id="idvl1_95_Wire14"/>
+        <polyline class="wire wire__95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2" points="420.0,217.0,420.0,240.0" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2" points="420.0,260.0,420.0,370.0" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2"/>
+        <polyline class="wire wire__95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2" points="420.0,370.0,410.0,370.0" id="_95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2"/>
         <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
             <use href="#DISCONNECTOR-closed"/>
         </g>

--- a/single-line-diagram-core/src/test/resources/vl2.svg
+++ b/single-line-diagram-core/src/test/resources/vl2.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -141,89 +142,89 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_bbs1_NW_LABEL">vl2_bbs1</text>
         </g>
-        <polyline class="wire wire_vl2" points="620.0,156.0,620.0,240.0" id="idvl2_95_Wire0"/>
-        <g class="ARROW1_vl2_95_gen1_UP" id="idvl2_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
-     <g class="arrow-up" id="idvl2_95_Wire0_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1" points="620.0,156.0,620.0,240.0" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1"/>
+        <g class="ARROW1_vl2_95_gen1_UP" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire0_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_gen1_DOWN" id="idvl2_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
-     <g class="arrow-up" id="idvl2_95_Wire0_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl2_95_gen1_DOWN" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire0_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="620.0,260.0,620.0,370.0" id="idvl2_95_Wire1"/>
-        <polyline class="wire wire_vl2" points="620.0,370.0,600.0,370.0" id="idvl2_95_Wire2"/>
-        <polyline class="wire wire_vl2" points="670.0,562.0,670.0,480.0" id="idvl2_95_Wire3"/>
-        <g class="ARROW1_vl2_95_trf1_UP" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,665.0,537.0)">
-     <g class="arrow-up" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polyline class="wire wire__95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1" points="620.0,260.0,620.0,370.0" id="_95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dgen1_95_vl2_95_bbs1" points="620.0,370.0,600.0,370.0" id="_95_vl2_95_vl2_95_dgen1_95_vl2_95_bbs1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1" points="670.0,562.0,670.0,480.0" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1"/>
+        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,665.0,537.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_trf1_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,665.0,517.0)">
-     <g class="arrow-up" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,665.0,517.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="670.0,460.0,670.0,370.0" id="idvl2_95_Wire4"/>
-        <polyline class="wire wire_vl2" points="670.0,370.0,680.0,370.0" id="idvl2_95_Wire5"/>
-        <polyline class="wire wire_vl2" points="700.0,150.0,700.0,205.0,722.0,205.0" id="idvl2_95_Wire6"/>
-        <g class="ARROW1_vl2_95_trf2_95_one_UP" id="idvl2_95_Wire6_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,165.0)">
-     <g class="arrow-up" id="idvl2_95_Wire6_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1" points="670.0,460.0,670.0,370.0" id="_95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1" points="670.0,370.0,680.0,370.0" id="_95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2" points="700.0,150.0,700.0,205.0,722.0,205.0" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2"/>
+        <g class="ARROW1_vl2_95_trf2_95_one_UP" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,165.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire6_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="idvl2_95_Wire6_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,185.0)">
-     <g class="arrow-up" id="idvl2_95_Wire6_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,185.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire6_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="760.0,150.0,760.0,205.0,738.0,205.0" id="idvl2_95_Wire7"/>
-        <g class="ARROW1_vl2_95_trf2_95_two_UP" id="idvl2_95_Wire7_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,755.0,165.0)">
-     <g class="arrow-up" id="idvl2_95_Wire7_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2" points="760.0,150.0,760.0,205.0,738.0,205.0" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2"/>
+        <g class="ARROW1_vl2_95_trf2_95_two_UP" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,755.0,165.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire7_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_trf2_95_two_DOWN" id="idvl2_95_Wire7_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,755.0,185.0)">
-     <g class="arrow-up" id="idvl2_95_Wire7_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl2_95_trf2_95_two_DOWN" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,755.0,185.0)">
+     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl2_95_Wire7_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="730.0,217.0,730.0,240.0" id="idvl2_95_Wire8"/>
-        <polyline class="wire wire_vl2" points="730.0,260.0,730.0,370.0" id="idvl2_95_Wire9"/>
-        <polyline class="wire wire_vl2" points="730.0,370.0,720.0,370.0" id="idvl2_95_Wire10"/>
+        <polyline class="wire wire__95_vl2_95_FICT_95_vl2_95_vl2_95_trf2_95_vl2_95_btrf2" points="730.0,217.0,730.0,240.0" id="_95_vl2_95_FICT_95_vl2_95_vl2_95_trf2_95_vl2_95_btrf2"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2" points="730.0,260.0,730.0,370.0" id="_95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dtrf2_95_vl2_95_bbs1" points="730.0,370.0,720.0,370.0" id="_95_vl2_95_vl2_95_dtrf2_95_vl2_95_bbs1"/>
         <g class="GENERATOR idvl2_95_gen1" id="idvl2_95_gen1" transform="translate(614.0,144.0)">
     <circle r="6" cx="6" cy="6"/>
     <path d="M6,6 A 6 40 0 0 0 2,6"/>

--- a/single-line-diagram-core/src/test/resources/vl2_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_nominal_voltage_style.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -126,32 +127,75 @@
 .idFICT_95_vl2_95_4 {stroke-opacity:0; fill-opacity:0; visibility: hidden;} .idFICT_95_vl2_95_4 {stroke:#228b22;}
 .idd3WT_95_2 .open { visibility: hidden;}.idd3WT_95_2 .closed { visibility: visible;}
 .idb3WT_95_2 .open { visibility: hidden;}.idb3WT_95_2 .closed { visibility: visible;}
- #idvl2_95_Wire0 {stroke:#ff0000;stroke-width:1;stroke-dasharray:3,3}
- #idvl2_95_Wire1 {stroke:#a020f0;stroke-width:1;stroke-dasharray:3,3}
-.wire_vl2 {stroke:#228b22;stroke-width:1;}
-.wire_vl2 {stroke:#228b22;stroke-width:1;}
- #idvl2_95_Wire4 {stroke:black;stroke-width:1;stroke-dasharray:3,3}
-.wire_vl2 {stroke:#228b22;stroke-width:1;}
-.wire_vl2 {stroke:#228b22;stroke-width:1;}
-.wire_vl2 {stroke:#228b22;stroke-width:1;}
-.wire_vl2 {stroke:#228b22;stroke-width:1;}
-.wire_vl2 {stroke:#228b22;stroke-width:1;}
+.wire__95_vl2_95_FICT_95_vl2_95_3WT_95_fictif_95_3WT_95_ONE {
+    stroke-dasharray: 3,3;
+    stroke-width: 1;
+    stroke: #ff0000;
+}
+
+.wire__95_vl2_95_FICT_95_vl2_95_3WT_95_fictif_95_3WT_95_THREE {
+    stroke-dasharray: 3,3;
+    stroke-width: 1;
+    stroke: #a020f0;
+}
+
+.wire__95_vl2_95_bbs2_95_d2WT_95_2 {
+    stroke-width: 1;
+    stroke: #228b22;
+}
+
+.wire__95_vl2_95_d2WT_95_2_95_FICT_95_vl2_95_2 {
+    stroke-width: 1;
+    stroke: #228b22;
+}
+
+.wire__95_vl2_95_2WT_95_TWO_95_b2WT_95_2 {
+    stroke-dasharray: 3,3;
+    stroke-width: 1;
+    stroke: black;
+}
+
+.wire__95_vl2_95_b2WT_95_2_95_FICT_95_vl2_95_2 {
+    stroke-width: 1;
+    stroke: #228b22;
+}
+
+.wire__95_vl2_95_bbs2_95_d3WT_95_2 {
+    stroke-width: 1;
+    stroke: #228b22;
+}
+
+.wire__95_vl2_95_d3WT_95_2_95_FICT_95_vl2_95_4 {
+    stroke-width: 1;
+    stroke: #228b22;
+}
+
+.wire__95_vl2_95_FICT_95_vl2_95_3WT_95_fictif_95_b3WT_95_2 {
+    stroke-width: 1;
+    stroke: #228b22;
+}
+
+.wire__95_vl2_95_b3WT_95_2_95_FICT_95_vl2_95_4 {
+    stroke-width: 1;
+    stroke: #228b22;
+}
+
 ]]></style>
     <g>
         <g class="BUSBAR_SECTION idbbs2" id="idbbs2" transform="translate(19.0,49.0)">
             <line y2="0" x1="0" x2="1.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs2_NW_LABEL">bbs2</text>
         </g>
-        <polyline class="wire wire_vl1" points="19.0,56.0,19.0,49.0" id="idvl2_95_Wire0"/>
-        <polyline class="wire wire_vl3" points="19.0,56.0,19.0,49.0" id="idvl2_95_Wire1"/>
-        <polyline class="wire wire_vl2" points="19.0,49.0,19.0,49.0" id="idvl2_95_Wire2"/>
-        <polyline class="wire wire_vl2" points="19.0,49.0,19.0,49.0" id="idvl2_95_Wire3"/>
-        <polyline class="wire wire_vl2" points="19.0,41.0,19.0,39.0" id="idvl2_95_Wire4"/>
-        <polyline class="wire wire_vl2" points="19.0,39.0,19.0,49.0" id="idvl2_95_Wire5"/>
-        <polyline class="wire wire_vl2" points="19.0,49.0,19.0,49.0" id="idvl2_95_Wire6"/>
-        <polyline class="wire wire_vl2" points="19.0,49.0,19.0,49.0" id="idvl2_95_Wire7"/>
-        <polyline class="wire wire_vl2" points="19.0,56.0,19.0,59.0" id="idvl2_95_Wire8"/>
-        <polyline class="wire wire_vl2" points="19.0,39.0,19.0,49.0" id="idvl2_95_Wire9"/>
+        <polyline class="wire wire__95_vl2_95_FICT_95_vl2_95_3WT_95_fictif_95_3WT_95_ONE" points="19.0,56.0,19.0,49.0" id="_95_vl2_95_FICT_95_vl2_95_3WT_95_fictif_95_3WT_95_ONE"/>
+        <polyline class="wire wire__95_vl2_95_FICT_95_vl2_95_3WT_95_fictif_95_3WT_95_THREE" points="19.0,56.0,19.0,49.0" id="_95_vl2_95_FICT_95_vl2_95_3WT_95_fictif_95_3WT_95_THREE"/>
+        <polyline class="wire wire__95_vl2_95_bbs2_95_d2WT_95_2" points="19.0,49.0,19.0,49.0" id="_95_vl2_95_bbs2_95_d2WT_95_2"/>
+        <polyline class="wire wire__95_vl2_95_d2WT_95_2_95_FICT_95_vl2_95_2" points="19.0,49.0,19.0,49.0" id="_95_vl2_95_d2WT_95_2_95_FICT_95_vl2_95_2"/>
+        <polyline class="wire wire__95_vl2_95_2WT_95_TWO_95_b2WT_95_2" points="19.0,41.0,19.0,39.0" id="_95_vl2_95_2WT_95_TWO_95_b2WT_95_2"/>
+        <polyline class="wire wire__95_vl2_95_b2WT_95_2_95_FICT_95_vl2_95_2" points="19.0,39.0,19.0,49.0" id="_95_vl2_95_b2WT_95_2_95_FICT_95_vl2_95_2"/>
+        <polyline class="wire wire__95_vl2_95_bbs2_95_d3WT_95_2" points="19.0,49.0,19.0,49.0" id="_95_vl2_95_bbs2_95_d3WT_95_2"/>
+        <polyline class="wire wire__95_vl2_95_d3WT_95_2_95_FICT_95_vl2_95_4" points="19.0,49.0,19.0,49.0" id="_95_vl2_95_d3WT_95_2_95_FICT_95_vl2_95_4"/>
+        <polyline class="wire wire__95_vl2_95_FICT_95_vl2_95_3WT_95_fictif_95_b3WT_95_2" points="19.0,56.0,19.0,59.0" id="_95_vl2_95_FICT_95_vl2_95_3WT_95_fictif_95_b3WT_95_2"/>
+        <polyline class="wire wire__95_vl2_95_b3WT_95_2_95_FICT_95_vl2_95_4" points="19.0,39.0,19.0,49.0" id="_95_vl2_95_b3WT_95_2_95_FICT_95_vl2_95_4"/>
         <g class="TWO_WINDINGS_TRANSFORMER id2WT_95_TWO" id="id2WT_95_TWO" transform="translate(14.0,41.5)">
     <circle r="5" id="id2WT_95_TWO_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#228b22"/>
 

--- a/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -177,49 +178,49 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_bbs1_NW_LABEL">vl2_bbs1</text>
         </g>
-        <polyline class="wire wire_vl2" points="620.0,156.0,620.0,240.0" id="idvl2_95_Wire0"/>
-        <g class="ARROW1_vl2_95_gen1_UP" id="idvl2_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
+        <polyline class="wire wire__95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1" points="620.0,156.0,620.0,240.0" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1"/>
+        <g class="ARROW1_vl2_95_gen1_UP" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_gen1_DOWN" id="idvl2_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
+        <g class="ARROW2_vl2_95_gen1_DOWN" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="620.0,260.0,620.0,370.0" id="idvl2_95_Wire1"/>
-        <polyline class="wire wire_vl2" points="620.0,370.0,600.0,370.0" id="idvl2_95_Wire2"/>
-        <polyline class="wire wire_vl2" points="670.0,562.0,670.0,480.0" id="idvl2_95_Wire3"/>
-        <g class="ARROW1_vl2_95_trf1_UP" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,665.0,537.0)">
+        <polyline class="wire wire__95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1" points="620.0,260.0,620.0,370.0" id="_95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dgen1_95_vl2_95_bbs1" points="620.0,370.0,600.0,370.0" id="_95_vl2_95_vl2_95_dgen1_95_vl2_95_bbs1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1" points="670.0,562.0,670.0,480.0" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1"/>
+        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,665.0,537.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_trf1_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,665.0,517.0)">
+        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,665.0,517.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="670.0,460.0,670.0,370.0" id="idvl2_95_Wire4"/>
-        <polyline class="wire wire_vl2" points="670.0,370.0,680.0,370.0" id="idvl2_95_Wire5"/>
-        <polyline class="wire wire_vl2" points="700.0,150.0,700.0,205.0,722.0,205.0" id="idvl2_95_Wire6"/>
-        <g class="ARROW1_vl2_95_trf2_95_one_UP" id="idvl2_95_Wire6_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,165.0)">
+        <polyline class="wire wire__95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1" points="670.0,460.0,670.0,370.0" id="_95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1" points="670.0,370.0,680.0,370.0" id="_95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2" points="700.0,150.0,700.0,205.0,722.0,205.0" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2"/>
+        <g class="ARROW1_vl2_95_trf2_95_one_UP" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="idvl2_95_Wire6_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,185.0)">
+        <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="760.0,150.0,760.0,205.0,738.0,205.0" id="idvl2_95_Wire7"/>
-        <g class="ARROW1_vl2_95_trf2_95_two_UP" id="idvl2_95_Wire7_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,755.0,165.0)">
+        <polyline class="wire wire__95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2" points="760.0,150.0,760.0,205.0,738.0,205.0" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2"/>
+        <g class="ARROW1_vl2_95_trf2_95_two_UP" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,755.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl2_95_trf2_95_two_DOWN" id="idvl2_95_Wire7_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,755.0,185.0)">
+        <g class="ARROW2_vl2_95_trf2_95_two_DOWN" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,755.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl2" points="730.0,217.0,730.0,240.0" id="idvl2_95_Wire8"/>
-        <polyline class="wire wire_vl2" points="730.0,260.0,730.0,370.0" id="idvl2_95_Wire9"/>
-        <polyline class="wire wire_vl2" points="730.0,370.0,720.0,370.0" id="idvl2_95_Wire10"/>
+        <polyline class="wire wire__95_vl2_95_FICT_95_vl2_95_vl2_95_trf2_95_vl2_95_btrf2" points="730.0,217.0,730.0,240.0" id="_95_vl2_95_FICT_95_vl2_95_vl2_95_trf2_95_vl2_95_btrf2"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2" points="730.0,260.0,730.0,370.0" id="_95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2"/>
+        <polyline class="wire wire__95_vl2_95_vl2_95_dtrf2_95_vl2_95_bbs1" points="730.0,370.0,720.0,370.0" id="_95_vl2_95_vl2_95_dtrf2_95_vl2_95_bbs1"/>
         <g class="GENERATOR idvl2_95_gen1" id="idvl2_95_gen1" transform="translate(614.0,144.0)">
             <use href="#GENERATOR"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_gen1__LABEL">vl2_gen1</text>

--- a/single-line-diagram-core/src/test/resources/vl3.svg
+++ b/single-line-diagram-core/src/test/resources/vl3.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -138,68 +139,68 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_bbs1_NW_LABEL">vl3_bbs1</text>
         </g>
-        <polyline class="wire wire_vl3" points="910.0,156.0,910.0,240.0" id="idvl3_95_Wire0"/>
-        <g class="ARROW1_vl3_95_capa1_UP" id="idvl3_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
-     <g class="arrow-up" id="idvl3_95_Wire0_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1" points="910.0,156.0,910.0,240.0" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1"/>
+        <g class="ARROW1_vl3_95_capa1_UP" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
+     <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl3_95_Wire0_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl3_95_capa1_DOWN" id="idvl3_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
-     <g class="arrow-up" id="idvl3_95_Wire0_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl3_95_capa1_DOWN" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
+     <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl3_95_Wire0_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl3" points="910.0,260.0,910.0,370.0" id="idvl3_95_Wire1"/>
-        <polyline class="wire wire_vl3" points="910.0,370.0,900.0,370.0" id="idvl3_95_Wire2"/>
-        <polyline class="wire wire_vl3" points="980.0,150.0,980.0,205.0,1012.0,205.0" id="idvl3_95_Wire3"/>
-        <g class="ARROW1_vl3_95_trf2_95_one_UP" id="idvl3_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,975.0,165.0)">
-     <g class="arrow-up" id="idvl3_95_Wire3_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1" points="910.0,260.0,910.0,370.0" id="_95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1" points="910.0,370.0,900.0,370.0" id="_95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2" points="980.0,150.0,980.0,205.0,1012.0,205.0" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2"/>
+        <g class="ARROW1_vl3_95_trf2_95_one_UP" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,975.0,165.0)">
+     <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl3_95_Wire3_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="idvl3_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,975.0,185.0)">
-     <g class="arrow-up" id="idvl3_95_Wire3_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,975.0,185.0)">
+     <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl3_95_Wire3_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl3" points="1060.0,150.0,1060.0,205.0,1028.0,205.0" id="idvl3_95_Wire4"/>
-        <g class="ARROW1_vl3_95_trf2_95_two_UP" id="idvl3_95_Wire4_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,165.0)">
-     <g class="arrow-up" id="idvl3_95_Wire4_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2" points="1060.0,150.0,1060.0,205.0,1028.0,205.0" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2"/>
+        <g class="ARROW1_vl3_95_trf2_95_two_UP" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,165.0)">
+     <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl3_95_Wire4_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl3_95_trf2_95_two_DOWN" id="idvl3_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,185.0)">
-     <g class="arrow-up" id="idvl3_95_Wire4_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_vl3_95_trf2_95_two_DOWN" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,185.0)">
+     <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idvl3_95_Wire4_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl3" points="1020.0,217.0,1020.0,240.0" id="idvl3_95_Wire5"/>
-        <polyline class="wire wire_vl3" points="1020.0,260.0,1020.0,370.0" id="idvl3_95_Wire6"/>
-        <polyline class="wire wire_vl3" points="1020.0,370.0,1020.0,370.0" id="idvl3_95_Wire7"/>
+        <polyline class="wire wire__95_vl3_95_FICT_95_vl3_95_vl3_95_trf2_95_vl3_95_btrf2" points="1020.0,217.0,1020.0,240.0" id="_95_vl3_95_FICT_95_vl3_95_vl3_95_trf2_95_vl3_95_btrf2"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2" points="1020.0,260.0,1020.0,370.0" id="_95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_dtrf2_95_vl3_95_bbs1" points="1020.0,370.0,1020.0,370.0" id="_95_vl3_95_vl3_95_dtrf2_95_vl3_95_bbs1"/>
         <g class="CAPACITOR idvl3_95_capa1" id="idvl3_95_capa1" transform="translate(904.0,144.0)">
     <line y2="4.5" x1="6" x2="6" y1="0"/>
     <line y2="4.5" x1="0" x2="12" y1="4.5"/>

--- a/single-line-diagram-core/src/test/resources/vl3_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_nominal_voltage_style.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -122,24 +123,49 @@
 .idFICT_95_vl3_95_2 {stroke-opacity:0; fill-opacity:0; visibility: hidden;} .idFICT_95_vl3_95_2 {stroke:#a020f0;}
 .idd3WT_95_3 .open { visibility: hidden;}.idd3WT_95_3 .closed { visibility: visible;}
 .idb3WT_95_3 .open { visibility: visible;}.idb3WT_95_3 .closed { visibility: hidden;}
- #idvl3_95_Wire0 {stroke:black;stroke-width:1}
- #idvl3_95_Wire1 {stroke:black;stroke-width:1;stroke-dasharray:3,3}
-.wire_vl3 {stroke:#a020f0;stroke-width:1;}
-.wire_vl3 {stroke:#a020f0;stroke-width:1;}
-.wire_vl3 {stroke:#a020f0;stroke-width:1;}
-.wire_vl3 {stroke:#a020f0;stroke-width:1;}
+.wire__95_vl3_95_FICT_95_vl3_95_3WT_95_fictif_95_3WT_95_ONE {
+    stroke-width: 1;
+    stroke: black;
+}
+
+.wire__95_vl3_95_FICT_95_vl3_95_3WT_95_fictif_95_3WT_95_TWO {
+    stroke-dasharray: 3,3;
+    stroke-width: 1;
+    stroke: black;
+}
+
+.wire__95_vl3_95_bbs3_95_d3WT_95_3 {
+    stroke-width: 1;
+    stroke: #a020f0;
+}
+
+.wire__95_vl3_95_d3WT_95_3_95_FICT_95_vl3_95_2 {
+    stroke-width: 1;
+    stroke: #a020f0;
+}
+
+.wire__95_vl3_95_FICT_95_vl3_95_3WT_95_fictif_95_b3WT_95_3 {
+    stroke-width: 1;
+    stroke: #a020f0;
+}
+
+.wire__95_vl3_95_b3WT_95_3_95_FICT_95_vl3_95_2 {
+    stroke-width: 1;
+    stroke: #a020f0;
+}
+
 ]]></style>
     <g>
         <g class="BUSBAR_SECTION idbbs3" id="idbbs3" transform="translate(19.0,49.0)">
             <line y2="0" x1="0" x2="1.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs3_NW_LABEL">bbs3</text>
         </g>
-        <polyline class="wire wire_vl1" points="19.0,56.0,19.0,49.0" id="idvl3_95_Wire0"/>
-        <polyline class="wire wire_vl2" points="19.0,56.0,19.0,49.0" id="idvl3_95_Wire1"/>
-        <polyline class="wire wire_vl3" points="19.0,49.0,19.0,49.0" id="idvl3_95_Wire2"/>
-        <polyline class="wire wire_vl3" points="19.0,49.0,19.0,49.0" id="idvl3_95_Wire3"/>
-        <polyline class="wire wire_vl3" points="19.0,56.0,19.0,59.0" id="idvl3_95_Wire4"/>
-        <polyline class="wire wire_vl3" points="19.0,39.0,19.0,49.0" id="idvl3_95_Wire5"/>
+        <polyline class="wire wire__95_vl3_95_FICT_95_vl3_95_3WT_95_fictif_95_3WT_95_ONE" points="19.0,56.0,19.0,49.0" id="_95_vl3_95_FICT_95_vl3_95_3WT_95_fictif_95_3WT_95_ONE"/>
+        <polyline class="wire wire__95_vl3_95_FICT_95_vl3_95_3WT_95_fictif_95_3WT_95_TWO" points="19.0,56.0,19.0,49.0" id="_95_vl3_95_FICT_95_vl3_95_3WT_95_fictif_95_3WT_95_TWO"/>
+        <polyline class="wire wire__95_vl3_95_bbs3_95_d3WT_95_3" points="19.0,49.0,19.0,49.0" id="_95_vl3_95_bbs3_95_d3WT_95_3"/>
+        <polyline class="wire wire__95_vl3_95_d3WT_95_3_95_FICT_95_vl3_95_2" points="19.0,49.0,19.0,49.0" id="_95_vl3_95_d3WT_95_3_95_FICT_95_vl3_95_2"/>
+        <polyline class="wire wire__95_vl3_95_FICT_95_vl3_95_3WT_95_fictif_95_b3WT_95_3" points="19.0,56.0,19.0,59.0" id="_95_vl3_95_FICT_95_vl3_95_3WT_95_fictif_95_b3WT_95_3"/>
+        <polyline class="wire wire__95_vl3_95_b3WT_95_3_95_FICT_95_vl3_95_2" points="19.0,39.0,19.0,49.0" id="_95_vl3_95_b3WT_95_3_95_FICT_95_vl3_95_2"/>
         <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl3_95_3WT_95_fictif" id="idFICT_95_vl3_95_3WT_95_fictif" transform="translate(11.0,42.0)">
     <circle r="5" id="idFICT_95_vl3_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5" stroke="#228b22"/>
 

--- a/single-line-diagram-core/src/test/resources/vl3_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_optimized.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -173,38 +174,38 @@
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_bbs1_NW_LABEL">vl3_bbs1</text>
         </g>
-        <polyline class="wire wire_vl3" points="910.0,156.0,910.0,240.0" id="idvl3_95_Wire0"/>
-        <g class="ARROW1_vl3_95_capa1_UP" id="idvl3_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
+        <polyline class="wire wire__95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1" points="910.0,156.0,910.0,240.0" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1"/>
+        <g class="ARROW1_vl3_95_capa1_UP" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl3_95_capa1_DOWN" id="idvl3_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
+        <g class="ARROW2_vl3_95_capa1_DOWN" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl3" points="910.0,260.0,910.0,370.0" id="idvl3_95_Wire1"/>
-        <polyline class="wire wire_vl3" points="910.0,370.0,900.0,370.0" id="idvl3_95_Wire2"/>
-        <polyline class="wire wire_vl3" points="980.0,150.0,980.0,205.0,1012.0,205.0" id="idvl3_95_Wire3"/>
-        <g class="ARROW1_vl3_95_trf2_95_one_UP" id="idvl3_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,975.0,165.0)">
+        <polyline class="wire wire__95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1" points="910.0,260.0,910.0,370.0" id="_95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1" points="910.0,370.0,900.0,370.0" id="_95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2" points="980.0,150.0,980.0,205.0,1012.0,205.0" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2"/>
+        <g class="ARROW1_vl3_95_trf2_95_one_UP" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,975.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="idvl3_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,975.0,185.0)">
+        <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,975.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl3" points="1060.0,150.0,1060.0,205.0,1028.0,205.0" id="idvl3_95_Wire4"/>
-        <g class="ARROW1_vl3_95_trf2_95_two_UP" id="idvl3_95_Wire4_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,165.0)">
+        <polyline class="wire wire__95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2" points="1060.0,150.0,1060.0,205.0,1028.0,205.0" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2"/>
+        <g class="ARROW1_vl3_95_trf2_95_two_UP" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_vl3_95_trf2_95_two_DOWN" id="idvl3_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,185.0)">
+        <g class="ARROW2_vl3_95_trf2_95_two_DOWN" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_vl3" points="1020.0,217.0,1020.0,240.0" id="idvl3_95_Wire5"/>
-        <polyline class="wire wire_vl3" points="1020.0,260.0,1020.0,370.0" id="idvl3_95_Wire6"/>
-        <polyline class="wire wire_vl3" points="1020.0,370.0,1020.0,370.0" id="idvl3_95_Wire7"/>
+        <polyline class="wire wire__95_vl3_95_FICT_95_vl3_95_vl3_95_trf2_95_vl3_95_btrf2" points="1020.0,217.0,1020.0,240.0" id="_95_vl3_95_FICT_95_vl3_95_vl3_95_trf2_95_vl3_95_btrf2"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2" points="1020.0,260.0,1020.0,370.0" id="_95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2"/>
+        <polyline class="wire wire__95_vl3_95_vl3_95_dtrf2_95_vl3_95_bbs1" points="1020.0,370.0,1020.0,370.0" id="_95_vl3_95_vl3_95_dtrf2_95_vl3_95_bbs1"/>
         <g class="CAPACITOR idvl3_95_capa1" id="idvl3_95_capa1" transform="translate(904.0,144.0)">
             <use href="#CAPACITOR"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_capa1__LABEL">vl3_capa1</text>

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -920,522 +920,522 @@
     "equipmentId" : "trf4"
   } ],
   "wires" : [ {
-    "id" : "idvl1_95_Wire47",
-    "nodeId1" : "iddload2",
-    "nodeId2" : "idFICT_95_vl1_95_dload2Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire48",
-    "nodeId1" : "idbtrf12",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf12Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire49",
-    "nodeId1" : "iddtrf12",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf12Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire43",
-    "nodeId1" : "iddtrf16",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf16Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire44",
-    "nodeId1" : "iddtrct11",
-    "nodeId2" : "idFICT_95_vl1_95_dsect12Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire45",
-    "nodeId1" : "iddsect12",
-    "nodeId2" : "idFICT_95_vl1_95_dsect12Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire46",
+    "id" : "_95_vl1_95_bload2_95_FICT_95_vl1_95_dload2Fictif",
     "nodeId1" : "idbload2",
     "nodeId2" : "idFICT_95_vl1_95_dload2Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire40",
-    "nodeId1" : "idbtrf15",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf15Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire41",
-    "nodeId1" : "iddtrf15",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf15Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire42",
-    "nodeId1" : "idbtrf16",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf16Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire9",
-    "nodeId1" : "iddsect22",
-    "nodeId2" : "idbbs4",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire36",
-    "nodeId1" : "idbload1",
-    "nodeId2" : "idFICT_95_vl1_95_dload1Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire5",
-    "nodeId1" : "idFICT_95_vl1_95_trf8_95_fictif",
-    "nodeId2" : "idtrf8_95_THREE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire6",
-    "nodeId1" : "idbbs1",
-    "nodeId2" : "iddsect11",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire37",
-    "nodeId1" : "iddload1",
-    "nodeId2" : "idFICT_95_vl1_95_dload1Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire7",
-    "nodeId1" : "iddsect12",
-    "nodeId2" : "idbbs2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire38",
-    "nodeId1" : "idbtrf11",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf11Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire8",
-    "nodeId1" : "idbbs3",
-    "nodeId2" : "iddsect21",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire39",
-    "nodeId1" : "iddtrf11",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf11Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire1",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE",
     "nodeId1" : "idFICT_95_vl1_95_trf6_95_fictif",
     "nodeId2" : "idtrf6_95_THREE",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire32",
-    "nodeId1" : "idbbs2",
-    "nodeId2" : "iddtrf18",
+    "id" : "_95_vl1_95_bload1_95_FICT_95_vl1_95_dload1Fictif",
+    "nodeId1" : "idbload1",
+    "nodeId2" : "idFICT_95_vl1_95_dload1Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire33",
-    "nodeId1" : "idbtrf18",
-    "nodeId2" : "idFICT_95_vl1_95_trf8_95_fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire2",
-    "nodeId1" : "idFICT_95_vl1_95_trf7_95_fictif",
-    "nodeId2" : "idtrf7_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire34",
-    "nodeId1" : "iddtrct11",
-    "nodeId2" : "idFICT_95_vl1_95_dsect11Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire3",
-    "nodeId1" : "idFICT_95_vl1_95_trf7_95_fictif",
-    "nodeId2" : "idtrf7_95_THREE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire35",
-    "nodeId1" : "iddsect11",
-    "nodeId2" : "idFICT_95_vl1_95_dsect11Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire4",
-    "nodeId1" : "idFICT_95_vl1_95_trf8_95_fictif",
-    "nodeId2" : "idtrf8_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire30",
-    "nodeId1" : "idbbs3",
-    "nodeId2" : "iddtrf17",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire0",
-    "nodeId1" : "idFICT_95_vl1_95_trf6_95_fictif",
-    "nodeId2" : "idtrf6_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire31",
-    "nodeId1" : "idbtrf17",
-    "nodeId2" : "idFICT_95_vl1_95_trf7_95_fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire29",
-    "nodeId1" : "idbtrf16",
-    "nodeId2" : "idFICT_95_vl1_95_trf6_95_fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire25",
-    "nodeId1" : "idbtrf14",
-    "nodeId2" : "idtrf4_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire26",
-    "nodeId1" : "idbbs1",
-    "nodeId2" : "iddtrf15",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire27",
-    "nodeId1" : "idbtrf15",
-    "nodeId2" : "idtrf5_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire28",
-    "nodeId1" : "idbbs1",
-    "nodeId2" : "iddtrf16",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire21",
-    "nodeId1" : "idbtrf12",
-    "nodeId2" : "idtrf2_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire65",
-    "nodeId1" : "iddtrf14",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf14Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire22",
-    "nodeId1" : "idbbs3",
-    "nodeId2" : "iddtrf13",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire23",
-    "nodeId1" : "idbtrf13",
-    "nodeId2" : "idtrf3_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire24",
-    "nodeId1" : "idbbs4",
-    "nodeId2" : "iddtrf14",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire61",
-    "nodeId1" : "iddsect22",
-    "nodeId2" : "idFICT_95_vl1_95_dsect22Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire62",
-    "nodeId1" : "idbgen2",
-    "nodeId2" : "idFICT_95_vl1_95_dgen2Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire63",
-    "nodeId1" : "iddgen2",
-    "nodeId2" : "idFICT_95_vl1_95_dgen2Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire20",
-    "nodeId1" : "idbbs2",
-    "nodeId2" : "iddtrf12",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire64",
-    "nodeId1" : "idbtrf14",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf14Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire60",
-    "nodeId1" : "iddtrct21",
-    "nodeId2" : "idFICT_95_vl1_95_dsect22Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire18",
-    "nodeId1" : "idbbs1",
-    "nodeId2" : "iddtrf11",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire19",
-    "nodeId1" : "idbtrf11",
-    "nodeId2" : "idtrf1_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire14",
-    "nodeId1" : "idbbs2",
-    "nodeId2" : "iddload2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire58",
-    "nodeId1" : "idbtrf17",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf17Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire15",
-    "nodeId1" : "idload2",
-    "nodeId2" : "idbload2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire59",
-    "nodeId1" : "iddtrf17",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf17Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire16",
-    "nodeId1" : "idbbs4",
-    "nodeId2" : "iddgen2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire17",
-    "nodeId1" : "idgen2",
-    "nodeId2" : "idbgen2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire10",
-    "nodeId1" : "idbbs1",
-    "nodeId2" : "iddload1",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire54",
-    "nodeId1" : "idbgen1",
-    "nodeId2" : "idFICT_95_vl1_95_dgen1Fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire11",
-    "nodeId1" : "idload1",
-    "nodeId2" : "idbload1",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "idvl1_95_Wire55",
+    "id" : "_95_vl1_95_dgen1_95_FICT_95_vl1_95_dgen1Fictif",
     "nodeId1" : "iddgen1",
     "nodeId2" : "idFICT_95_vl1_95_dgen1Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire12",
-    "nodeId1" : "idbbs3",
-    "nodeId2" : "iddgen1",
+    "id" : "_95_vl1_95_btrf12_95_FICT_95_vl1_95_dtrf12Fictif",
+    "nodeId1" : "idbtrf12",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf12Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire56",
+    "id" : "_95_vl1_95_btrf17_95_FICT_95_vl1_95_trf7_95_fictif",
+    "nodeId1" : "idbtrf17",
+    "nodeId2" : "idFICT_95_vl1_95_trf7_95_fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs3_95_dtrf17",
+    "nodeId1" : "idbbs3",
+    "nodeId2" : "iddtrf17",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dsect21_95_FICT_95_vl1_95_dsect21Fictif",
+    "nodeId1" : "iddsect21",
+    "nodeId2" : "idFICT_95_vl1_95_dsect21Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf14_95_FICT_95_vl1_95_dtrf14Fictif",
+    "nodeId1" : "idbtrf14",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf14Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs1_95_dload1",
+    "nodeId1" : "idbbs1",
+    "nodeId2" : "iddload1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf13_95_FICT_95_vl1_95_dtrf13Fictif",
     "nodeId1" : "idbtrf13",
     "nodeId2" : "idFICT_95_vl1_95_dtrf13Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire13",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO",
+    "nodeId1" : "idFICT_95_vl1_95_trf7_95_fictif",
+    "nodeId2" : "idtrf7_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf12_95_trf2_95_ONE",
+    "nodeId1" : "idbtrf12",
+    "nodeId2" : "idtrf2_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs3_95_dtrf13",
+    "nodeId1" : "idbbs3",
+    "nodeId2" : "iddtrf13",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_gen1_95_bgen1",
     "nodeId1" : "idgen1",
     "nodeId2" : "idbgen1",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire57",
+    "id" : "_95_vl1_95_dtrf17_95_FICT_95_vl1_95_dtrf17Fictif",
+    "nodeId1" : "iddtrf17",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf17Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs1_95_dsect11",
+    "nodeId1" : "idbbs1",
+    "nodeId2" : "iddsect11",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO",
+    "nodeId1" : "idFICT_95_vl1_95_trf6_95_fictif",
+    "nodeId2" : "idtrf6_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf15_95_trf5_95_ONE",
+    "nodeId1" : "idbtrf15",
+    "nodeId2" : "idtrf5_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf16_95_FICT_95_vl1_95_dtrf16Fictif",
+    "nodeId1" : "idbtrf16",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf16Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs4_95_dgen2",
+    "nodeId1" : "idbbs4",
+    "nodeId2" : "iddgen2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf12_95_FICT_95_vl1_95_dtrf12Fictif",
+    "nodeId1" : "iddtrf12",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf12Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dload1_95_FICT_95_vl1_95_dload1Fictif",
+    "nodeId1" : "iddload1",
+    "nodeId2" : "idFICT_95_vl1_95_dload1Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf18_95_FICT_95_vl1_95_trf8_95_fictif",
+    "nodeId1" : "idbtrf18",
+    "nodeId2" : "idFICT_95_vl1_95_trf8_95_fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf11_95_FICT_95_vl1_95_dtrf11Fictif",
+    "nodeId1" : "idbtrf11",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf11Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs3_95_dgen1",
+    "nodeId1" : "idbbs3",
+    "nodeId2" : "iddgen1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dgen2_95_FICT_95_vl1_95_dgen2Fictif",
+    "nodeId1" : "iddgen2",
+    "nodeId2" : "idFICT_95_vl1_95_dgen2Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs4_95_dtrf14",
+    "nodeId1" : "idbbs4",
+    "nodeId2" : "iddtrf14",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bgen1_95_FICT_95_vl1_95_dgen1Fictif",
+    "nodeId1" : "idbgen1",
+    "nodeId2" : "idFICT_95_vl1_95_dgen1Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrct11_95_FICT_95_vl1_95_dsect12Fictif",
+    "nodeId1" : "iddtrct11",
+    "nodeId2" : "idFICT_95_vl1_95_dsect12Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_gen2_95_bgen2",
+    "nodeId1" : "idgen2",
+    "nodeId2" : "idbgen2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect22Fictif",
+    "nodeId1" : "iddtrct21",
+    "nodeId2" : "idFICT_95_vl1_95_dsect22Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs2_95_dload2",
+    "nodeId1" : "idbbs2",
+    "nodeId2" : "iddload2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf13_95_FICT_95_vl1_95_dtrf13Fictif",
     "nodeId1" : "iddtrf13",
     "nodeId2" : "idFICT_95_vl1_95_dtrf13Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire50",
+    "id" : "_95_vl1_95_btrf11_95_trf1_95_ONE",
+    "nodeId1" : "idbtrf11",
+    "nodeId2" : "idtrf1_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf18_95_FICT_95_vl1_95_dtrf18Fictif",
     "nodeId1" : "idbtrf18",
     "nodeId2" : "idFICT_95_vl1_95_dtrf18Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire51",
-    "nodeId1" : "iddtrf18",
-    "nodeId2" : "idFICT_95_vl1_95_dtrf18Fictif",
+    "id" : "_95_vl1_95_bbs1_95_dtrf16",
+    "nodeId1" : "idbbs1",
+    "nodeId2" : "iddtrf16",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire52",
+    "id" : "_95_vl1_95_bbs1_95_dtrf15",
+    "nodeId1" : "idbbs1",
+    "nodeId2" : "iddtrf15",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf14_95_FICT_95_vl1_95_dtrf14Fictif",
+    "nodeId1" : "iddtrf14",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf14Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs1_95_dtrf11",
+    "nodeId1" : "idbbs1",
+    "nodeId2" : "iddtrf11",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE",
+    "nodeId1" : "idFICT_95_vl1_95_trf8_95_fictif",
+    "nodeId2" : "idtrf8_95_THREE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf15_95_FICT_95_vl1_95_dtrf15Fictif",
+    "nodeId1" : "iddtrf15",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf15Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf13_95_trf3_95_ONE",
+    "nodeId1" : "idbtrf13",
+    "nodeId2" : "idtrf3_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO",
+    "nodeId1" : "idFICT_95_vl1_95_trf8_95_fictif",
+    "nodeId2" : "idtrf8_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf16_95_FICT_95_vl1_95_dtrf16Fictif",
+    "nodeId1" : "iddtrf16",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf16Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_load1_95_bload1",
+    "nodeId1" : "idload1",
+    "nodeId2" : "idbload1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf11_95_FICT_95_vl1_95_dtrf11Fictif",
+    "nodeId1" : "iddtrf11",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf11Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bgen2_95_FICT_95_vl1_95_dgen2Fictif",
+    "nodeId1" : "idbgen2",
+    "nodeId2" : "idFICT_95_vl1_95_dgen2Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrct11_95_FICT_95_vl1_95_dsect11Fictif",
+    "nodeId1" : "iddtrct11",
+    "nodeId2" : "idFICT_95_vl1_95_dsect11Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dsect12_95_FICT_95_vl1_95_dsect12Fictif",
+    "nodeId1" : "iddsect12",
+    "nodeId2" : "idFICT_95_vl1_95_dsect12Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dsect22_95_FICT_95_vl1_95_dsect22Fictif",
+    "nodeId1" : "iddsect22",
+    "nodeId2" : "idFICT_95_vl1_95_dsect22Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs3_95_dsect21",
+    "nodeId1" : "idbbs3",
+    "nodeId2" : "iddsect21",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf15_95_FICT_95_vl1_95_dtrf15Fictif",
+    "nodeId1" : "idbtrf15",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf15Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf16_95_FICT_95_vl1_95_trf6_95_fictif",
+    "nodeId1" : "idbtrf16",
+    "nodeId2" : "idFICT_95_vl1_95_trf6_95_fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dsect11_95_FICT_95_vl1_95_dsect11Fictif",
+    "nodeId1" : "iddsect11",
+    "nodeId2" : "idFICT_95_vl1_95_dsect11Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dsect12_95_bbs2",
+    "nodeId1" : "iddsect12",
+    "nodeId2" : "idbbs2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect21Fictif",
     "nodeId1" : "iddtrct21",
     "nodeId2" : "idFICT_95_vl1_95_dsect21Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "idvl1_95_Wire53",
-    "nodeId1" : "iddsect21",
-    "nodeId2" : "idFICT_95_vl1_95_dsect21Fictif",
+    "id" : "_95_vl1_95_bbs2_95_dtrf12",
+    "nodeId1" : "idbbs2",
+    "nodeId2" : "iddtrf12",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dsect22_95_bbs4",
+    "nodeId1" : "iddsect22",
+    "nodeId2" : "idbbs4",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf18_95_FICT_95_vl1_95_dtrf18Fictif",
+    "nodeId1" : "iddtrf18",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf18Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dload2_95_FICT_95_vl1_95_dload2Fictif",
+    "nodeId1" : "iddload2",
+    "nodeId2" : "idFICT_95_vl1_95_dload2Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_load2_95_bload2",
+    "nodeId1" : "idload2",
+    "nodeId2" : "idbload2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs2_95_dtrf18",
+    "nodeId1" : "idbbs2",
+    "nodeId2" : "iddtrf18",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf14_95_trf4_95_ONE",
+    "nodeId1" : "idbtrf14",
+    "nodeId2" : "idtrf4_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE",
+    "nodeId1" : "idFICT_95_vl1_95_trf7_95_fictif",
+    "nodeId2" : "idtrf7_95_THREE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf17_95_FICT_95_vl1_95_dtrf17Fictif",
+    "nodeId1" : "idbtrf17",
+    "nodeId2" : "idFICT_95_vl1_95_dtrf17Fictif",
     "straight" : false,
     "snakeLine" : false
   } ],
   "lines" : [ ],
   "arrows" : [ {
-    "id" : "idvl1_95_Wire4_ARROW2",
-    "wireId" : "idvl1_95_Wire4",
+    "id" : "_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf12_95_trf2_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire4_ARROW1",
-    "wireId" : "idvl1_95_Wire4",
+    "id" : "_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf13_95_trf3_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire3_ARROW1",
-    "wireId" : "idvl1_95_Wire3",
+    "id" : "_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf12_95_trf2_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire5_ARROW2",
-    "wireId" : "idvl1_95_Wire5",
+    "id" : "_95_vl1_95_gen2_95_bgen2_ARROW1",
+    "wireId" : "_95_vl1_95_gen2_95_bgen2",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire3_ARROW2",
-    "wireId" : "idvl1_95_Wire3",
+    "id" : "_95_vl1_95_gen2_95_bgen2_ARROW2",
+    "wireId" : "_95_vl1_95_gen2_95_bgen2",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire2_ARROW1",
-    "wireId" : "idvl1_95_Wire2",
+    "id" : "_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf13_95_trf3_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire5_ARROW1",
-    "wireId" : "idvl1_95_Wire5",
+    "id" : "_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf11_95_trf1_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire2_ARROW2",
-    "wireId" : "idvl1_95_Wire2",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1",
+    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire1_ARROW1",
-    "wireId" : "idvl1_95_Wire1",
+    "id" : "_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf11_95_trf1_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire21_ARROW2",
-    "wireId" : "idvl1_95_Wire21",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2",
+    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire19_ARROW1",
-    "wireId" : "idvl1_95_Wire19",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2",
+    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire19_ARROW2",
-    "wireId" : "idvl1_95_Wire19",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1",
+    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire25_ARROW2",
-    "wireId" : "idvl1_95_Wire25",
+    "id" : "_95_vl1_95_gen1_95_bgen1_ARROW2",
+    "wireId" : "_95_vl1_95_gen1_95_bgen1",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire15_ARROW1",
-    "wireId" : "idvl1_95_Wire15",
+    "id" : "_95_vl1_95_gen1_95_bgen1_ARROW1",
+    "wireId" : "_95_vl1_95_gen1_95_bgen1",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire17_ARROW1",
-    "wireId" : "idvl1_95_Wire17",
+    "id" : "_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf15_95_trf5_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire15_ARROW2",
-    "wireId" : "idvl1_95_Wire15",
+    "id" : "_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf15_95_trf5_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire17_ARROW2",
-    "wireId" : "idvl1_95_Wire17",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1",
+    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire27_ARROW2",
-    "wireId" : "idvl1_95_Wire27",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2",
+    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire23_ARROW2",
-    "wireId" : "idvl1_95_Wire23",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2",
+    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire27_ARROW1",
-    "wireId" : "idvl1_95_Wire27",
+    "id" : "_95_vl1_95_load2_95_bload2_ARROW2",
+    "wireId" : "_95_vl1_95_load2_95_bload2",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire23_ARROW1",
-    "wireId" : "idvl1_95_Wire23",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1",
+    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire25_ARROW1",
-    "wireId" : "idvl1_95_Wire25",
+    "id" : "_95_vl1_95_load2_95_bload2_ARROW1",
+    "wireId" : "_95_vl1_95_load2_95_bload2",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire0_ARROW1",
-    "wireId" : "idvl1_95_Wire0",
+    "id" : "_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2",
+    "wireId" : "_95_vl1_95_btrf14_95_trf4_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire21_ARROW1",
-    "wireId" : "idvl1_95_Wire21",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2",
+    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire13_ARROW2",
-    "wireId" : "idvl1_95_Wire13",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1",
+    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire0_ARROW2",
-    "wireId" : "idvl1_95_Wire0",
+    "id" : "_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1",
+    "wireId" : "_95_vl1_95_btrf14_95_trf4_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire1_ARROW2",
-    "wireId" : "idvl1_95_Wire1",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1",
+    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire13_ARROW1",
-    "wireId" : "idvl1_95_Wire13",
+    "id" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2",
+    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire11_ARROW2",
-    "wireId" : "idvl1_95_Wire11",
+    "id" : "_95_vl1_95_load1_95_bload1_ARROW1",
+    "wireId" : "_95_vl1_95_load1_95_bload1",
     "distance" : 20.0
   }, {
-    "id" : "idvl1_95_Wire11_ARROW1",
-    "wireId" : "idvl1_95_Wire11",
+    "id" : "_95_vl1_95_load1_95_bload1_ARROW2",
+    "wireId" : "_95_vl1_95_load1_95_bload1",
     "distance" : 20.0
   } ],
   "layoutParams" : {

--- a/single-line-diagram-core/src/test/resources/zone.svg
+++ b/single-line-diagram-core/src/test/resources/zone.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
-    <style><![CDATA[.BUSBAR_SECTION {
+    <style><![CDATA[
+.BUSBAR_SECTION {
     stroke: rgb(0,0,0);
     stroke-width: 3;
 }
@@ -127,40 +128,40 @@
             <line y2="0" x1="0" x2="40.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Bus11_NW_LABEL">Bus11</text>
         </g>
-        <polyline class="wire wire_VoltageLevel11" points="50.0,250.0,70.0,250.0,70.0,104.0" id="idVoltageLevel11_95_Wire0"/>
-        <g class="ARROW1_Load_UP" id="idVoltageLevel11_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,119.0)">
-     <g class="arrow-up" id="idVoltageLevel11_95_Wire0_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_VoltageLevel11_95_Bus11_95_Load" points="50.0,250.0,70.0,250.0,70.0,104.0" id="_95_VoltageLevel11_95_Bus11_95_Load"/>
+        <g class="ARROW1_Load_UP" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,119.0)">
+     <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idVoltageLevel11_95_Wire0_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_Load_DOWN" id="idVoltageLevel11_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,139.0)">
-     <g class="arrow-up" id="idVoltageLevel11_95_Wire0_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_Load_DOWN" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,139.0)">
+     <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idVoltageLevel11_95_Wire0_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_VoltageLevel11" points="50.0,250.0,70.0,250.0,70.0,350.0" id="idVoltageLevel11_95_Wire1"/>
-        <g class="ARROW1_Transformer_95_ONE_UP" id="idVoltageLevel11_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,65.0,325.0)">
-     <g class="arrow-up" id="idVoltageLevel11_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polyline class="wire wire__95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE" points="50.0,250.0,70.0,250.0,70.0,350.0" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE"/>
+        <g class="ARROW1_Transformer_95_ONE_UP" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,65.0,325.0)">
+     <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idVoltageLevel11_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_Transformer_95_ONE_DOWN" id="idVoltageLevel11_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,65.0,305.0)">
-     <g class="arrow-up" id="idVoltageLevel11_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <g class="ARROW2_Transformer_95_ONE_DOWN" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,65.0,305.0)">
+     <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idVoltageLevel11_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
@@ -178,40 +179,40 @@
             <line y2="0" x1="0" x2="40.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Bus12_NW_LABEL">Bus12</text>
         </g>
-        <polyline class="wire wire_VoltageLevel12" points="50.0,550.0,70.0,550.0,70.0,450.0" id="idVoltageLevel12_95_Wire0"/>
-        <g class="ARROW1_Transformer_95_TWO_UP" id="idVoltageLevel12_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,465.0)">
-     <g class="arrow-up" id="idVoltageLevel12_95_Wire0_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO" points="50.0,550.0,70.0,550.0,70.0,450.0" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO"/>
+        <g class="ARROW1_Transformer_95_TWO_UP" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,465.0)">
+     <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idVoltageLevel12_95_Wire0_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_Transformer_95_TWO_DOWN" id="idVoltageLevel12_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,485.0)">
-     <g class="arrow-up" id="idVoltageLevel12_95_Wire0_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_Transformer_95_TWO_DOWN" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,485.0)">
+     <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idVoltageLevel12_95_Wire0_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_VoltageLevel12" points="50.0,550.0,70.0,550.0,70.0,700.0" id="idVoltageLevel12_95_Wire1"/>
-        <g class="ARROW1_Line_95_ONE_UP" id="idVoltageLevel12_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,65.0,675.0)">
-     <g class="arrow-up" id="idVoltageLevel12_95_Wire1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polyline class="wire wire__95_VoltageLevel12_95_Bus12_95_Line_95_ONE" points="50.0,550.0,70.0,550.0,70.0,700.0" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE"/>
+        <g class="ARROW1_Line_95_ONE_UP" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,65.0,675.0)">
+     <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idVoltageLevel12_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_Line_95_ONE_DOWN" id="idVoltageLevel12_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,65.0,655.0)">
-     <g class="arrow-up" id="idVoltageLevel12_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <g class="ARROW2_Line_95_ONE_DOWN" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,65.0,655.0)">
+     <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idVoltageLevel12_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
@@ -227,46 +228,46 @@
 
     <circle r="5" id="idTransformer_95_ONE_95_Transformer_95_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" transform="rotate(180.0,5.0,7.5)" cy="5"/>
 </g>
-        <polyline class="wire wire_VoltageLevel11" points="70.0,350.0,70.0,370.0,70.0,392.0" id="idVoltageLevel11_95__95_Wire0"/>
-        <polyline class="wire wire_VoltageLevel12" points="70.0,408.0,70.0,430.0,70.0,450.0" id="id_95_VoltageLevel12_95_Wire1"/>
+        <polyline class="wire wire__95_Substation1_95_Transformer_95_ONE_95_Transformer_95_ONE_95_Transformer_95_TWO" points="70.0,350.0,70.0,370.0,70.0,392.0" id="_95_Substation1_95_Transformer_95_ONE_95_Transformer_95_ONE_95_Transformer_95_TWO"/>
+        <polyline class="wire wire__95_Substation1_95_Transformer_95_ONE_95_Transformer_95_TWO_95_Transformer_95_TWO" points="70.0,408.0,70.0,430.0,70.0,450.0" id="_95_Substation1_95_Transformer_95_ONE_95_Transformer_95_TWO_95_Transformer_95_TWO"/>
         <g class="BUSBAR_SECTION idBus21" id="idBus21" transform="translate(150.0,1150.0)">
             <line y2="0" x1="0" x2="40.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Bus21_NW_LABEL">Bus21</text>
         </g>
-        <polyline class="wire wire_VoltageLevel21" points="150.0,1150.0,170.0,1150.0,170.0,1294.0" id="idVoltageLevel21_95_Wire0"/>
-        <g class="ARROW1_Generator_UP" id="idVoltageLevel21_95_Wire0_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,165.0,1269.0)">
-     <g class="arrow-up" id="idVoltageLevel21_95_Wire0_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <polyline class="wire wire__95_VoltageLevel21_95_Bus21_95_Generator" points="150.0,1150.0,170.0,1150.0,170.0,1294.0" id="_95_VoltageLevel21_95_Bus21_95_Generator"/>
+        <g class="ARROW1_Generator_UP" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,165.0,1269.0)">
+     <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idVoltageLevel21_95_Wire0_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_Generator_DOWN" id="idVoltageLevel21_95_Wire0_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,165.0,1249.0)">
-     <g class="arrow-up" id="idVoltageLevel21_95_Wire0_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <g class="ARROW2_Generator_DOWN" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,165.0,1249.0)">
+     <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idVoltageLevel21_95_Wire0_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+     <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
         </g>
-        <polyline class="wire wire_VoltageLevel21" points="150.0,1150.0,170.0,1150.0,170.0,1000.0" id="idVoltageLevel21_95_Wire1"/>
-        <g class="ARROW1_Line_95_TWO_UP" id="idVoltageLevel21_95_Wire1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1015.0)">
-     <g class="arrow-up" id="idVoltageLevel21_95_Wire1_ARROW1_ARROW-arrow-up">
+        <polyline class="wire wire__95_VoltageLevel21_95_Bus21_95_Line_95_TWO" points="150.0,1150.0,170.0,1150.0,170.0,1000.0" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO"/>
+        <g class="ARROW1_Line_95_TWO_UP" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1015.0)">
+     <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idVoltageLevel21_95_Wire1_ARROW1_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
         </g>
-        <g class="ARROW2_Line_95_TWO_DOWN" id="idVoltageLevel21_95_Wire1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1035.0)">
-     <g class="arrow-up" id="idVoltageLevel21_95_Wire1_ARROW2_ARROW-arrow-up">
+        <g class="ARROW2_Line_95_TWO_DOWN" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1035.0)">
+     <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW2_ARROW-arrow-up">
         <polygon points="5,0 10,10 0,10"/>
      </g>
-     <g class="arrow-down" id="idVoltageLevel21_95_Wire1_ARROW2_ARROW-arrow-down">
+     <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
 <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Wire class names are not unique and are responsible for for coloration issue. 


**What is the new behavior (if this is a feature change)?**
Wire class names are unique, derived from prefixId + containerId + node 1 id + node 2 ide 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
