### PR TITLE
Avoid SVG resizing when power flow values change

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -87,6 +87,7 @@ public class DefaultSVGWriter implements SVGWriter {
     protected static final String POINTS = "points";
     protected static final String TEXT_ANCHOR = "text-anchor";
     protected static final String MIDDLE = "middle";
+    protected static final int VALUE_MAX_NB_CHARS = 5;
 
     protected final ComponentLibrary componentLibrary;
 
@@ -570,7 +571,7 @@ public class DefaultSVGWriter implements SVGWriter {
         for (int i = 0; i < labelsNode.size(); ++i) {
             drawLabel(prefixId + labelsPosition.get(i).getPositionName(), labelsNode.get(i), node.isRotated(),
                     labelsPosition.get(i).getdX(), labelsPosition.get(i).getdY(),
-                    g, FONT_SIZE, labelsPosition.get(i).isCentered(), labelsPosition.get(i).getShiftAngle());
+                    g, FONT_SIZE, labelsPosition.get(i).isCentered(), labelsPosition.get(i).getShiftAngle(), false);
         }
     }
 
@@ -595,7 +596,7 @@ public class DefaultSVGWriter implements SVGWriter {
         drawLabel(null, graph.isUseName()
                         ? graph.getVoltageLevelInfos().getName()
                         : graph.getVoltageLevelInfos().getId(),
-                false, graph.getX(), yPos, gLabel, FONT_VOLTAGE_LEVEL_LABEL_SIZE, false, 0);
+                false, graph.getX(), yPos, gLabel, FONT_VOLTAGE_LEVEL_LABEL_SIZE, false, 0, false);
         root.appendChild(gLabel);
 
         metadata.addNodeMetadata(new GraphMetadata.NodeMetadata(idLabelVoltageLevel,
@@ -634,7 +635,7 @@ public class DefaultSVGWriter implements SVGWriter {
      * Drawing the voltageLevel graph busbar section names and feeder names
      */
     protected void drawLabel(String idLabel, String str, boolean rotated, double xShift, double yShift, Element g,
-                             int fontSize, boolean centered, int shiftAngle) {
+                             int fontSize, boolean centered, int shiftAngle, boolean adjustLength) {
         Element label = g.getOwnerDocument().createElement("text");
         if (!StringUtils.isEmpty(idLabel)) {
             label.setAttribute("id", idLabel);
@@ -643,6 +644,10 @@ public class DefaultSVGWriter implements SVGWriter {
         label.setAttribute("y", String.valueOf(yShift));
         label.setAttribute("font-family", FONT_FAMILY);
         label.setAttribute("font-size", Integer.toString(fontSize));
+        if (adjustLength) {
+            label.setAttribute("xml:space", "preserve");
+            label.setAttribute("textLength", Integer.toString(str.length() * (FONT_SIZE - 3)));
+        }
         label.setAttribute(CLASS, DiagramStyles.LABEL_STYLE_CLASS);
         Text text = g.getOwnerDocument().createTextNode(str);
         label.setAttribute(TRANSFORM, ROTATE + "(" + shiftAngle + "," + 0 + "," + 0 + ")");
@@ -945,7 +950,7 @@ public class DefaultSVGWriter implements SVGWriter {
             } else {
                 insertComponentSVGIntoDocumentSVG(prefixId, arr, g1, n, styleProvider, defsId, true);
             }
-            drawLabel(null, label1.get(), false, shX, shY, g1, FONT_SIZE, false, 0);
+            drawLabel(null, StringUtils.rightPad(label1.get(), VALUE_MAX_NB_CHARS), false, shX, shY, g1, FONT_SIZE, false, 0, true);
 
             if (dir1.isPresent()) {
                 g1.setAttribute(CLASS, "ARROW1_" + escapeClassName(n.getId()) + "_" + dir1.get());
@@ -955,7 +960,7 @@ public class DefaultSVGWriter implements SVGWriter {
             }
 
             Optional<String> label3 = init.getLabel3();
-            label3.ifPresent(s -> drawLabel(null, s, false, -(s.length() * (double) FONT_SIZE / 2 + LABEL_OFFSET), shY, g1, FONT_SIZE, false, 0));
+            label3.ifPresent(s -> drawLabel(null, StringUtils.rightPad(s, VALUE_MAX_NB_CHARS), false, -(s.length() * (double) FONT_SIZE / 2 + LABEL_OFFSET), shY, g1, FONT_SIZE, false, 0, true));
 
             root.appendChild(g1);
             metadata.addArrowMetadata(new ArrowMetadata(arrow1WireId, wireId, layoutParameters.getArrowDistance()));
@@ -979,7 +984,7 @@ public class DefaultSVGWriter implements SVGWriter {
             } else {
                 insertComponentSVGIntoDocumentSVG(prefixId, arr, g2, n, styleProvider, defsId, true);
             }
-            drawLabel(null, label2.get(), false, shX, shY, g2, FONT_SIZE, false, 0);
+            drawLabel(null, StringUtils.rightPad(label2.get(), VALUE_MAX_NB_CHARS), false, shX, shY, g2, FONT_SIZE, false, 0, true);
 
             if (dir2.isPresent()) {
                 g2.setAttribute(CLASS, "ARROW2_" + escapeClassName(n.getId()) + "_" + dir2.get());
@@ -989,7 +994,7 @@ public class DefaultSVGWriter implements SVGWriter {
             }
 
             Optional<String> label4 = init.getLabel4();
-            label4.ifPresent(s -> drawLabel(null, s, false, -(s.length() * (double) FONT_SIZE / 2 + LABEL_OFFSET), shY, g2, FONT_SIZE, false, 0));
+            label4.ifPresent(s -> drawLabel(null, StringUtils.rightPad(s, VALUE_MAX_NB_CHARS), false, -(s.length() * (double) FONT_SIZE / 2 + LABEL_OFFSET), shY, g2, FONT_SIZE, false, 0, true));
 
             root.appendChild(g2);
             metadata.addArrowMetadata(new ArrowMetadata(arrow2WireId, wireId, layoutParameters.getArrowDistance()));

--- a/single-line-diagram-core/src/test/resources/substation.svg
+++ b/single-line-diagram-core/src/test/resources/substation.svg
@@ -197,7 +197,7 @@
      <g class="arrow-down" id="idvl1_95_Wire4_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_load1_DOWN" id="idvl1_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
      <g class="arrow-up" id="idvl1_95_Wire4_ARROW2_ARROW-arrow-up">
@@ -206,7 +206,7 @@
      <g class="arrow-down" id="idvl1_95_Wire4_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="60.0,260.0,60.0,370.0" id="idvl1_95_Wire5"/>
         <polyline class="wire wire_vl1" points="60.0,370.0,50.0,370.0" id="idvl1_95_Wire6"/>
@@ -218,7 +218,7 @@
      <g class="arrow-down" id="idvl1_95_Wire7_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf1_DOWN" id="idvl1_95_Wire7_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,95.0,525.0)">
      <g class="arrow-up" id="idvl1_95_Wire7_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
@@ -227,7 +227,7 @@
      <g class="arrow-down" id="idvl1_95_Wire7_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="100.0,460.0,100.0,370.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="100.0,370.0,90.0,370.0" id="idvl1_95_Wire9"/>
@@ -239,7 +239,7 @@
      <g class="arrow-down" id="idvl1_95_Wire10_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="idvl1_95_Wire10_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,415.0,185.0)">
      <g class="arrow-up" id="idvl1_95_Wire10_ARROW2_ARROW-arrow-up">
@@ -248,7 +248,7 @@
      <g class="arrow-down" id="idvl1_95_Wire10_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="420.0,260.0,420.0,370.0" id="idvl1_95_Wire11"/>
         <polyline class="wire wire_vl1" points="420.0,370.0,410.0,370.0" id="idvl1_95_Wire12"/>
@@ -361,7 +361,7 @@
      <g class="arrow-down" id="idvl2_95_Wire0_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_gen1_DOWN" id="idvl2_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
      <g class="arrow-up" id="idvl2_95_Wire0_ARROW2_ARROW-arrow-up">
@@ -370,7 +370,7 @@
      <g class="arrow-down" id="idvl2_95_Wire0_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="620.0,260.0,620.0,370.0" id="idvl2_95_Wire1"/>
         <polyline class="wire wire_vl2" points="620.0,370.0,600.0,370.0" id="idvl2_95_Wire2"/>
@@ -382,7 +382,7 @@
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf1_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,665.0,525.0)">
      <g class="arrow-up" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
@@ -391,7 +391,7 @@
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="670.0,460.0,670.0,370.0" id="idvl2_95_Wire4"/>
         <polyline class="wire wire_vl2" points="670.0,370.0,680.0,370.0" id="idvl2_95_Wire5"/>
@@ -403,7 +403,7 @@
      <g class="arrow-down" id="idvl2_95_Wire6_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="idvl2_95_Wire6_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,725.0,185.0)">
      <g class="arrow-up" id="idvl2_95_Wire6_ARROW2_ARROW-arrow-up">
@@ -412,7 +412,7 @@
      <g class="arrow-down" id="idvl2_95_Wire6_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="730.0,260.0,730.0,370.0" id="idvl2_95_Wire7"/>
         <polyline class="wire wire_vl2" points="730.0,370.0,720.0,370.0" id="idvl2_95_Wire8"/>
@@ -497,7 +497,7 @@
      <g class="arrow-down" id="idvl3_95_Wire0_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_capa1_DOWN" id="idvl3_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
      <g class="arrow-up" id="idvl3_95_Wire0_ARROW2_ARROW-arrow-up">
@@ -506,7 +506,7 @@
      <g class="arrow-down" id="idvl3_95_Wire0_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl3" points="910.0,260.0,910.0,370.0" id="idvl3_95_Wire1"/>
         <polyline class="wire wire_vl3" points="910.0,370.0,900.0,370.0" id="idvl3_95_Wire2"/>
@@ -518,7 +518,7 @@
      <g class="arrow-down" id="idvl3_95_Wire3_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="idvl3_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,185.0)">
      <g class="arrow-up" id="idvl3_95_Wire3_ARROW2_ARROW-arrow-up">
@@ -527,7 +527,7 @@
      <g class="arrow-down" id="idvl3_95_Wire3_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl3" points="1020.0,260.0,1020.0,370.0" id="idvl3_95_Wire4"/>
         <polyline class="wire wire_vl3" points="1020.0,370.0,1020.0,370.0" id="idvl3_95_Wire5"/>

--- a/single-line-diagram-core/src/test/resources/substation_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/substation_optimized.svg
@@ -222,33 +222,33 @@
         <polyline class="wire wire_vl1" points="60.0,154.0,60.0,240.0" id="idvl1_95_Wire4"/>
         <g class="ARROW1_vl1_95_load1_UP" id="idvl1_95_Wire4_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_load1_DOWN" id="idvl1_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="60.0,260.0,60.0,370.0" id="idvl1_95_Wire5"/>
         <polyline class="wire wire_vl1" points="60.0,370.0,50.0,370.0" id="idvl1_95_Wire6"/>
         <polyline class="wire wire_vl1" points="100.0,570.0,100.0,480.0" id="idvl1_95_Wire7"/>
         <g class="ARROW1_vl1_95_trf1_UP" id="idvl1_95_Wire7_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,95.0,545.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf1_DOWN" id="idvl1_95_Wire7_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,95.0,525.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="100.0,460.0,100.0,370.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="100.0,370.0,90.0,370.0" id="idvl1_95_Wire9"/>
         <polyline class="wire wire_vl1" points="420.0,150.0,420.0,240.0" id="idvl1_95_Wire10"/>
         <g class="ARROW1_vl1_95_trf2_95_one_UP" id="idvl1_95_Wire10_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,415.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="idvl1_95_Wire10_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,415.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="420.0,260.0,420.0,370.0" id="idvl1_95_Wire11"/>
         <polyline class="wire wire_vl1" points="420.0,370.0,410.0,370.0" id="idvl1_95_Wire12"/>
@@ -296,33 +296,33 @@
         <polyline class="wire wire_vl2" points="620.0,156.0,620.0,240.0" id="idvl2_95_Wire0"/>
         <g class="ARROW1_vl2_95_gen1_UP" id="idvl2_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_gen1_DOWN" id="idvl2_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="620.0,260.0,620.0,370.0" id="idvl2_95_Wire1"/>
         <polyline class="wire wire_vl2" points="620.0,370.0,600.0,370.0" id="idvl2_95_Wire2"/>
         <polyline class="wire wire_vl2" points="670.0,570.0,670.0,480.0" id="idvl2_95_Wire3"/>
         <g class="ARROW1_vl2_95_trf1_UP" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,665.0,545.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf1_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,665.0,525.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="670.0,460.0,670.0,370.0" id="idvl2_95_Wire4"/>
         <polyline class="wire wire_vl2" points="670.0,370.0,680.0,370.0" id="idvl2_95_Wire5"/>
         <polyline class="wire wire_vl2" points="730.0,150.0,730.0,240.0" id="idvl2_95_Wire6"/>
         <g class="ARROW1_vl2_95_trf2_95_one_UP" id="idvl2_95_Wire6_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,725.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="idvl2_95_Wire6_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,725.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="730.0,260.0,730.0,370.0" id="idvl2_95_Wire7"/>
         <polyline class="wire wire_vl2" points="730.0,370.0,720.0,370.0" id="idvl2_95_Wire8"/>
@@ -361,22 +361,22 @@
         <polyline class="wire wire_vl3" points="910.0,156.0,910.0,240.0" id="idvl3_95_Wire0"/>
         <g class="ARROW1_vl3_95_capa1_UP" id="idvl3_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_capa1_DOWN" id="idvl3_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl3" points="910.0,260.0,910.0,370.0" id="idvl3_95_Wire1"/>
         <polyline class="wire wire_vl3" points="910.0,370.0,900.0,370.0" id="idvl3_95_Wire2"/>
         <polyline class="wire wire_vl3" points="1020.0,150.0,1020.0,240.0" id="idvl3_95_Wire3"/>
         <g class="ARROW1_vl3_95_trf2_95_one_UP" id="idvl3_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="idvl3_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl3" points="1020.0,260.0,1020.0,370.0" id="idvl3_95_Wire4"/>
         <polyline class="wire wire_vl3" points="1020.0,370.0,1020.0,370.0" id="idvl3_95_Wire5"/>

--- a/single-line-diagram-core/src/test/resources/vl1.svg
+++ b/single-line-diagram-core/src/test/resources/vl1.svg
@@ -163,7 +163,7 @@
      <g class="arrow-down" id="idvl1_95_Wire4_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_load1_DOWN" id="idvl1_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
      <g class="arrow-up" id="idvl1_95_Wire4_ARROW2_ARROW-arrow-up">
@@ -172,7 +172,7 @@
      <g class="arrow-down" id="idvl1_95_Wire4_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="60.0,260.0,60.0,370.0" id="idvl1_95_Wire5"/>
         <polyline class="wire wire_vl1" points="60.0,370.0,50.0,370.0" id="idvl1_95_Wire6"/>
@@ -184,7 +184,7 @@
      <g class="arrow-down" id="idvl1_95_Wire7_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf1_DOWN" id="idvl1_95_Wire7_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,95.0,517.0)">
      <g class="arrow-up" id="idvl1_95_Wire7_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
@@ -193,7 +193,7 @@
      <g class="arrow-down" id="idvl1_95_Wire7_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="100.0,460.0,100.0,370.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="100.0,370.0,90.0,370.0" id="idvl1_95_Wire9"/>
@@ -205,7 +205,7 @@
      <g class="arrow-down" id="idvl1_95_Wire10_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="idvl1_95_Wire10_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
      <g class="arrow-up" id="idvl1_95_Wire10_ARROW2_ARROW-arrow-up">
@@ -214,7 +214,7 @@
      <g class="arrow-down" id="idvl1_95_Wire10_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="460.0,150.0,460.0,205.0,428.0,205.0" id="idvl1_95_Wire11"/>
         <g class="ARROW1_vl1_95_trf2_95_two_UP" id="idvl1_95_Wire11_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
@@ -224,7 +224,7 @@
      <g class="arrow-down" id="idvl1_95_Wire11_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_two_DOWN" id="idvl1_95_Wire11_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
      <g class="arrow-up" id="idvl1_95_Wire11_ARROW2_ARROW-arrow-up">
@@ -233,7 +233,7 @@
      <g class="arrow-down" id="idvl1_95_Wire11_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="420.0,217.0,420.0,240.0" id="idvl1_95_Wire12"/>
         <polyline class="wire wire_vl1" points="420.0,260.0,420.0,370.0" id="idvl1_95_Wire13"/>

--- a/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -191,42 +191,42 @@
         <polyline class="wire wire_vl1" points="60.0,154.0,60.0,240.0" id="idvl1_95_Wire4"/>
         <g class="ARROW1_vl1_95_load1_UP" id="idvl1_95_Wire4_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_load1_DOWN" id="idvl1_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="60.0,260.0,60.0,370.0" id="idvl1_95_Wire5"/>
         <polyline class="wire wire_vl1" points="60.0,370.0,50.0,370.0" id="idvl1_95_Wire6"/>
         <polyline class="wire wire_vl1" points="100.0,562.0,100.0,480.0" id="idvl1_95_Wire7"/>
         <g class="ARROW1_vl1_95_trf1_UP" id="idvl1_95_Wire7_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,95.0,537.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf1_DOWN" id="idvl1_95_Wire7_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,95.0,517.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="100.0,460.0,100.0,370.0" id="idvl1_95_Wire8"/>
         <polyline class="wire wire_vl1" points="100.0,370.0,90.0,370.0" id="idvl1_95_Wire9"/>
         <polyline class="wire wire_vl1" points="380.0,150.0,380.0,205.0,412.0,205.0" id="idvl1_95_Wire10"/>
         <g class="ARROW1_vl1_95_trf2_95_one_UP" id="idvl1_95_Wire10_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="idvl1_95_Wire10_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="460.0,150.0,460.0,205.0,428.0,205.0" id="idvl1_95_Wire11"/>
         <g class="ARROW1_vl1_95_trf2_95_two_UP" id="idvl1_95_Wire11_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_two_DOWN" id="idvl1_95_Wire11_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl1" points="420.0,217.0,420.0,240.0" id="idvl1_95_Wire12"/>
         <polyline class="wire wire_vl1" points="420.0,260.0,420.0,370.0" id="idvl1_95_Wire13"/>

--- a/single-line-diagram-core/src/test/resources/vl2.svg
+++ b/single-line-diagram-core/src/test/resources/vl2.svg
@@ -149,7 +149,7 @@
      <g class="arrow-down" id="idvl2_95_Wire0_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_gen1_DOWN" id="idvl2_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
      <g class="arrow-up" id="idvl2_95_Wire0_ARROW2_ARROW-arrow-up">
@@ -158,7 +158,7 @@
      <g class="arrow-down" id="idvl2_95_Wire0_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="620.0,260.0,620.0,370.0" id="idvl2_95_Wire1"/>
         <polyline class="wire wire_vl2" points="620.0,370.0,600.0,370.0" id="idvl2_95_Wire2"/>
@@ -170,7 +170,7 @@
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf1_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,665.0,517.0)">
      <g class="arrow-up" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
@@ -179,7 +179,7 @@
      <g class="arrow-down" id="idvl2_95_Wire3_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="670.0,460.0,670.0,370.0" id="idvl2_95_Wire4"/>
         <polyline class="wire wire_vl2" points="670.0,370.0,680.0,370.0" id="idvl2_95_Wire5"/>
@@ -191,7 +191,7 @@
      <g class="arrow-down" id="idvl2_95_Wire6_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="idvl2_95_Wire6_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,185.0)">
      <g class="arrow-up" id="idvl2_95_Wire6_ARROW2_ARROW-arrow-up">
@@ -200,7 +200,7 @@
      <g class="arrow-down" id="idvl2_95_Wire6_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="760.0,150.0,760.0,205.0,738.0,205.0" id="idvl2_95_Wire7"/>
         <g class="ARROW1_vl2_95_trf2_95_two_UP" id="idvl2_95_Wire7_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,755.0,165.0)">
@@ -210,7 +210,7 @@
      <g class="arrow-down" id="idvl2_95_Wire7_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf2_95_two_DOWN" id="idvl2_95_Wire7_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,755.0,185.0)">
      <g class="arrow-up" id="idvl2_95_Wire7_ARROW2_ARROW-arrow-up">
@@ -219,7 +219,7 @@
      <g class="arrow-down" id="idvl2_95_Wire7_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="730.0,217.0,730.0,240.0" id="idvl2_95_Wire8"/>
         <polyline class="wire wire_vl2" points="730.0,260.0,730.0,370.0" id="idvl2_95_Wire9"/>

--- a/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -180,42 +180,42 @@
         <polyline class="wire wire_vl2" points="620.0,156.0,620.0,240.0" id="idvl2_95_Wire0"/>
         <g class="ARROW1_vl2_95_gen1_UP" id="idvl2_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_gen1_DOWN" id="idvl2_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="620.0,260.0,620.0,370.0" id="idvl2_95_Wire1"/>
         <polyline class="wire wire_vl2" points="620.0,370.0,600.0,370.0" id="idvl2_95_Wire2"/>
         <polyline class="wire wire_vl2" points="670.0,562.0,670.0,480.0" id="idvl2_95_Wire3"/>
         <g class="ARROW1_vl2_95_trf1_UP" id="idvl2_95_Wire3_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,665.0,537.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf1_DOWN" id="idvl2_95_Wire3_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,665.0,517.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="670.0,460.0,670.0,370.0" id="idvl2_95_Wire4"/>
         <polyline class="wire wire_vl2" points="670.0,370.0,680.0,370.0" id="idvl2_95_Wire5"/>
         <polyline class="wire wire_vl2" points="700.0,150.0,700.0,205.0,722.0,205.0" id="idvl2_95_Wire6"/>
         <g class="ARROW1_vl2_95_trf2_95_one_UP" id="idvl2_95_Wire6_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="idvl2_95_Wire6_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="760.0,150.0,760.0,205.0,738.0,205.0" id="idvl2_95_Wire7"/>
         <g class="ARROW1_vl2_95_trf2_95_two_UP" id="idvl2_95_Wire7_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,755.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf2_95_two_DOWN" id="idvl2_95_Wire7_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,755.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl2" points="730.0,217.0,730.0,240.0" id="idvl2_95_Wire8"/>
         <polyline class="wire wire_vl2" points="730.0,260.0,730.0,370.0" id="idvl2_95_Wire9"/>

--- a/single-line-diagram-core/src/test/resources/vl3.svg
+++ b/single-line-diagram-core/src/test/resources/vl3.svg
@@ -146,7 +146,7 @@
      <g class="arrow-down" id="idvl3_95_Wire0_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_capa1_DOWN" id="idvl3_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
      <g class="arrow-up" id="idvl3_95_Wire0_ARROW2_ARROW-arrow-up">
@@ -155,7 +155,7 @@
      <g class="arrow-down" id="idvl3_95_Wire0_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl3" points="910.0,260.0,910.0,370.0" id="idvl3_95_Wire1"/>
         <polyline class="wire wire_vl3" points="910.0,370.0,900.0,370.0" id="idvl3_95_Wire2"/>
@@ -167,7 +167,7 @@
      <g class="arrow-down" id="idvl3_95_Wire3_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="idvl3_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,975.0,185.0)">
      <g class="arrow-up" id="idvl3_95_Wire3_ARROW2_ARROW-arrow-up">
@@ -176,7 +176,7 @@
      <g class="arrow-down" id="idvl3_95_Wire3_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl3" points="1060.0,150.0,1060.0,205.0,1028.0,205.0" id="idvl3_95_Wire4"/>
         <g class="ARROW1_vl3_95_trf2_95_two_UP" id="idvl3_95_Wire4_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,165.0)">
@@ -186,7 +186,7 @@
      <g class="arrow-down" id="idvl3_95_Wire4_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_trf2_95_two_DOWN" id="idvl3_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,185.0)">
      <g class="arrow-up" id="idvl3_95_Wire4_ARROW2_ARROW-arrow-up">
@@ -195,7 +195,7 @@
      <g class="arrow-down" id="idvl3_95_Wire4_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl3" points="1020.0,217.0,1020.0,240.0" id="idvl3_95_Wire5"/>
         <polyline class="wire wire_vl3" points="1020.0,260.0,1020.0,370.0" id="idvl3_95_Wire6"/>

--- a/single-line-diagram-core/src/test/resources/vl3_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_optimized.svg
@@ -176,31 +176,31 @@
         <polyline class="wire wire_vl3" points="910.0,156.0,910.0,240.0" id="idvl3_95_Wire0"/>
         <g class="ARROW1_vl3_95_capa1_UP" id="idvl3_95_Wire0_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_capa1_DOWN" id="idvl3_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl3" points="910.0,260.0,910.0,370.0" id="idvl3_95_Wire1"/>
         <polyline class="wire wire_vl3" points="910.0,370.0,900.0,370.0" id="idvl3_95_Wire2"/>
         <polyline class="wire wire_vl3" points="980.0,150.0,980.0,205.0,1012.0,205.0" id="idvl3_95_Wire3"/>
         <g class="ARROW1_vl3_95_trf2_95_one_UP" id="idvl3_95_Wire3_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,975.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="idvl3_95_Wire3_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,975.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl3" points="1060.0,150.0,1060.0,205.0,1028.0,205.0" id="idvl3_95_Wire4"/>
         <g class="ARROW1_vl3_95_trf2_95_two_UP" id="idvl3_95_Wire4_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,165.0)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_trf2_95_two_DOWN" id="idvl3_95_Wire4_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,185.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
-            <text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_vl3" points="1020.0,217.0,1020.0,240.0" id="idvl3_95_Wire5"/>
         <polyline class="wire wire_vl3" points="1020.0,260.0,1020.0,370.0" id="idvl3_95_Wire6"/>

--- a/single-line-diagram-core/src/test/resources/zone.svg
+++ b/single-line-diagram-core/src/test/resources/zone.svg
@@ -135,7 +135,7 @@
      <g class="arrow-down" id="idVoltageLevel11_95_Wire0_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_Load_DOWN" id="idVoltageLevel11_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,139.0)">
      <g class="arrow-up" id="idVoltageLevel11_95_Wire0_ARROW2_ARROW-arrow-up">
@@ -144,7 +144,7 @@
      <g class="arrow-down" id="idVoltageLevel11_95_Wire0_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_VoltageLevel11" points="50.0,250.0,70.0,250.0,70.0,350.0" id="idVoltageLevel11_95_Wire1"/>
         <g class="ARROW1_Transformer_95_ONE_UP" id="idVoltageLevel11_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,65.0,325.0)">
@@ -154,7 +154,7 @@
      <g class="arrow-down" id="idVoltageLevel11_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_Transformer_95_ONE_DOWN" id="idVoltageLevel11_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,65.0,305.0)">
      <g class="arrow-up" id="idVoltageLevel11_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
@@ -163,7 +163,7 @@
      <g class="arrow-down" id="idVoltageLevel11_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="LOAD idLoad" id="idLoad" transform="translate(62.0,95.5)">
     <rect height="9" width="16"/>
@@ -186,7 +186,7 @@
      <g class="arrow-down" id="idVoltageLevel12_95_Wire0_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_Transformer_95_TWO_DOWN" id="idVoltageLevel12_95_Wire0_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,485.0)">
      <g class="arrow-up" id="idVoltageLevel12_95_Wire0_ARROW2_ARROW-arrow-up">
@@ -195,7 +195,7 @@
      <g class="arrow-down" id="idVoltageLevel12_95_Wire0_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_VoltageLevel12" points="50.0,550.0,70.0,550.0,70.0,700.0" id="idVoltageLevel12_95_Wire1"/>
         <g class="ARROW1_Line_95_ONE_UP" id="idVoltageLevel12_95_Wire1_ARROW1" transform="matrix(1.0,-0.0,0.0,1.0,65.0,675.0)">
@@ -205,7 +205,7 @@
      <g class="arrow-down" id="idVoltageLevel12_95_Wire1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_Line_95_ONE_DOWN" id="idVoltageLevel12_95_Wire1_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,65.0,655.0)">
      <g class="arrow-up" id="idVoltageLevel12_95_Wire1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
@@ -214,7 +214,7 @@
      <g class="arrow-down" id="idVoltageLevel12_95_Wire1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="LINE idTransformer_95_TWO" id="idTransformer_95_TWO" transform="translate(70.0,450.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Transformer_TWO__LABEL">Transformer</text>
@@ -241,7 +241,7 @@
      <g class="arrow-down" id="idVoltageLevel21_95_Wire0_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_Generator_DOWN" id="idVoltageLevel21_95_Wire0_ARROW2" transform="matrix(1.0,-0.0,0.0,1.0,165.0,1249.0)">
      <g class="arrow-up" id="idVoltageLevel21_95_Wire0_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
@@ -250,7 +250,7 @@
      <g class="arrow-down" id="idVoltageLevel21_95_Wire0_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <polyline class="wire wire_VoltageLevel21" points="150.0,1150.0,170.0,1150.0,170.0,1000.0" id="idVoltageLevel21_95_Wire1"/>
         <g class="ARROW1_Line_95_TWO_UP" id="idVoltageLevel21_95_Wire1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1015.0)">
@@ -260,7 +260,7 @@
      <g class="arrow-down" id="idVoltageLevel21_95_Wire1_ARROW1_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">10</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_Line_95_TWO_DOWN" id="idVoltageLevel21_95_Wire1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1035.0)">
      <g class="arrow-up" id="idVoltageLevel21_95_Wire1_ARROW2_ARROW-arrow-up">
@@ -269,7 +269,7 @@
      <g class="arrow-down" id="idVoltageLevel21_95_Wire1_ARROW2_ARROW-arrow-down">
         <polygon points="0,0 10,0 5,10"/>
      </g>
-<text x="15.0" font-size="8" y="9.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">20</text>
+<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="GENERATOR idGenerator" id="idGenerator" transform="translate(164.0,1294.0)">
     <circle r="6" cx="6" cy="6"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When we run a load flow in Study-app, the change in the power flow values cause a svg resizing.


**What is the new behavior (if this is a feature change)?**
No svg resizing after a load flow.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
