### PR TITLE
More than one directory for the resources component library

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ResourcesComponentLibrary.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ResourcesComponentLibrary.java
@@ -8,20 +8,19 @@ package com.powsybl.sld.library;
 
 import com.powsybl.sld.svg.SVGLoaderToDocument;
 import org.apache.batik.anim.dom.SVGOMDocument;
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 
 /**
+ * Library of resources components, that is, the SVG image files representing the components, together with the styles
+ * associated to each component
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  * @author Nicolas Duchene
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -37,6 +36,14 @@ public class ResourcesComponentLibrary implements ComponentLibrary {
 
     private final String styleSheet;
 
+    /**
+     * Constructs a new library containing the components in the given directories
+     * @param directory main directory containing the resources components: SVG files, with associated components.xml
+     *                 (containing the list of SVG files) and components.css (containing the style applied to each
+     *                  component)
+     * @param additionalDirectories directories for additional components (each directory containing SVG files,
+     *                              associated components.xml and components.css).
+     */
     public ResourcesComponentLibrary(String directory, String... additionalDirectories) {
         Objects.requireNonNull(directory);
         StringBuilder styleSheetBuilder = new StringBuilder();
@@ -73,8 +80,7 @@ public class ResourcesComponentLibrary implements ComponentLibrary {
 
         try {
             URL cssUrl = getClass().getResource(directory + "/" + "components.css");
-            Path cssPath = Paths.get(URI.create(cssUrl.toString()));
-            styleSheetBuilder.append(new String(Files.readAllBytes(cssPath), StandardCharsets.UTF_8));
+            styleSheetBuilder.append(new String(IOUtils.toByteArray(cssUrl), StandardCharsets.UTF_8));
         } catch (IOException e) {
             throw new UncheckedIOException("Can't read css file from the SVG library!", e);
         }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -29,7 +29,11 @@ import static org.junit.Assert.assertEquals;
  */
 public abstract class AbstractTestCase {
 
-    protected final ResourcesComponentLibrary componentLibrary = new ResourcesComponentLibrary("/ConvergenceLibrary");
+    protected final ResourcesComponentLibrary componentLibrary = getMainResourcesComponentLibrary();
+
+    protected ResourcesComponentLibrary getMainResourcesComponentLibrary() {
+        return new ResourcesComponentLibrary("/ConvergenceLibrary");
+    }
 
     protected static String normalizeLineSeparator(String str) {
         return str.replace("\r\n", "\n")

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -29,9 +29,9 @@ import static org.junit.Assert.assertEquals;
  */
 public abstract class AbstractTestCase {
 
-    protected final ResourcesComponentLibrary componentLibrary = getMainResourcesComponentLibrary();
+    protected final ResourcesComponentLibrary componentLibrary = getResourcesComponentLibrary();
 
-    protected ResourcesComponentLibrary getMainResourcesComponentLibrary() {
+    protected ResourcesComponentLibrary getResourcesComponentLibrary() {
         return new ResourcesComponentLibrary("/ConvergenceLibrary");
     }
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
@@ -6,24 +6,11 @@
  */
 package com.powsybl.sld.iidm;
 
-import com.powsybl.iidm.network.BusbarSection;
-import com.powsybl.iidm.network.Country;
-import com.powsybl.iidm.network.Generator;
-import com.powsybl.iidm.network.Line;
-import com.powsybl.iidm.network.Load;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.ShuntCompensator;
-import com.powsybl.iidm.network.Substation;
-import com.powsybl.iidm.network.SwitchKind;
-import com.powsybl.iidm.network.ThreeWindingsTransformer;
-import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.iidm.network.TwoWindingsTransformer;
-import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.*;
 import com.powsybl.sld.AbstractTestCase;
 import com.powsybl.sld.GraphBuilder;
 import com.powsybl.sld.iidm.extensions.BusbarSectionPosition;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
-import com.powsybl.sld.library.ResourcesComponentLibrary;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
@@ -12,7 +12,6 @@ import com.powsybl.sld.GraphBuilder;
 import com.powsybl.sld.iidm.extensions.BusbarSectionPositionAdder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.iidm.extensions.ConnectablePositionAdder;
-import com.powsybl.sld.library.ResourcesComponentLibrary;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
@@ -38,8 +38,6 @@ public abstract class AbstractTestCaseIidm extends AbstractTestCase {
     protected Substation substation;
     protected GraphBuilder graphBuilder;
 
-    protected final ResourcesComponentLibrary componentLibrary = new ResourcesComponentLibrary("/ConvergenceLibrary");
-
     protected static String normalizeLineSeparator(String str) {
         return str.replace("\r\n", "\n")
                 .replace("\r", "\n");


### PR DESCRIPTION
Signed-off-by: Florian Dupuy <florian.dupuy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The ResourcesComponentLibrary cannot contain components located in more than one folder.
The tests classes extending AbstractTestCase cannot properly specify another ResourcesComponentLibrary than the one in "/ConvergenceLibrary" 


**What is the new behavior (if this is a feature change)?**
The ResourcesComponentLibrary can now contain components located in several folders. This might be useful for node decorators for instance.
The ResourcesComponentLibrary used in tests classes extending AbstractTestCase can be chose by overriding getMainResourcesComponentLibrary() method


**Does this PR introduce a breaking change or deprecate an API?** No
*If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
