### PR TITLE
Correcting bug displaying fictitious SwitchNode

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramStyleProvider.java
@@ -8,6 +8,7 @@ package com.powsybl.sld.svg;
 
 import com.google.common.collect.ImmutableMap;
 import com.powsybl.sld.library.ComponentSize;
+import com.powsybl.sld.library.ComponentTypeName;
 import com.powsybl.sld.model.*;
 
 import java.util.*;
@@ -32,7 +33,7 @@ public class DefaultDiagramStyleProvider implements DiagramStyleProvider {
     public Optional<String> getCssNodeStyleAttributes(Node node, boolean isShowInternalNodes) {
         Objects.requireNonNull(node);
 
-        if (node instanceof InternalNode && !isShowInternalNodes) {
+        if (node.getComponentType().equals(ComponentTypeName.NODE) && !isShowInternalNodes) {
             StringBuilder style = new StringBuilder();
             String className = escapeId(node.getId());
             style.append(".").append(className)
@@ -126,7 +127,7 @@ public class DefaultDiagramStyleProvider implements DiagramStyleProvider {
                     if (subComponentName.equals(WINDING2)) {
                         color = getNodeColor(((Feeder2WTNode) node).getOtherSideVoltageLevelInfos(), node);
                     }
-                } else if (!isShowInternalNodes && node instanceof InternalNode) {
+                } else if (!isShowInternalNodes && node.getComponentType().equals(ComponentTypeName.NODE)) {
                     attributes.put("stroke-opacity", "0");
                     attributes.put("fill-opacity", "0");
                 }


### PR DESCRIPTION
The fictitious SwitchNodes were displayed even if showInternalNodes was set to false.


**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Fictitious SwitchNodes displayed even if showInternalNodes set to false.


**What is the new behavior (if this is a feature change)?**
Fictitious SwitchNodes not displayed when showInternalNodes set to false.


**Does this PR introduce a breaking change or deprecate an API?**
No
