### PR TITLE
Add tooltip with equipment name

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -69,6 +69,7 @@ public class LayoutParameters {
     private boolean labelDiagonal = false;
 
     private boolean highlightLineState = true;
+    private boolean tooltipEnabled = false;
 
     @JsonIgnore
     private Map<String, ComponentSize> componentsSize;
@@ -89,6 +90,7 @@ public class LayoutParameters {
                             @JsonProperty("internCellHeight") double internCellHeight,
                             @JsonProperty("stackHeight") double stackHeight,
                             @JsonProperty("showGrid") boolean showGrid,
+                            @JsonProperty("tooltipEnabled") boolean tooltipEnabled,
                             @JsonProperty("showInternalNodes") boolean showInternalNodes,
                             @JsonProperty("scaleFactor") double scaleFactor,
                             @JsonProperty("horizontalSubstationPadding") double horizontalSubstationPadding,
@@ -120,6 +122,7 @@ public class LayoutParameters {
         this.internCellHeight = internCellHeight;
         this.stackHeight = stackHeight;
         this.showGrid = showGrid;
+        this.tooltipEnabled = tooltipEnabled;
         this.showInternalNodes = showInternalNodes;
         this.scaleFactor = scaleFactor;
         this.horizontalSubstationPadding = horizontalSubstationPadding;
@@ -155,6 +158,7 @@ public class LayoutParameters {
         internCellHeight = other.internCellHeight;
         stackHeight = other.stackHeight;
         showGrid = other.showGrid;
+        tooltipEnabled = other.tooltipEnabled;
         showInternalNodes = other.showInternalNodes;
         scaleFactor = other.scaleFactor;
         horizontalSubstationPadding = other.horizontalSubstationPadding;
@@ -462,6 +466,15 @@ public class LayoutParameters {
 
     public LayoutParameters setHighlightLineState(boolean highlightLineState) {
         this.highlightLineState = highlightLineState;
+        return this;
+    }
+
+    public boolean isTooltipEnabled() {
+        return tooltipEnabled;
+    }
+
+    public LayoutParameters setTooltipEnabled(boolean tooltipEnabled) {
+        this.tooltipEnabled = tooltipEnabled;
         return this;
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -681,7 +681,7 @@ public class DefaultSVGWriter implements SVGWriter {
         handleNodeRotation(node);
         BiConsumer<Element, String> elementAttributesSetter
                 = (elt, subComponent) -> setComponentAttributes(prefixId, g, node, styleProvider, elt, subComponent);
-        insertSVGIntoDocumentSVG(componentType, g, componentDefsId, elementAttributesSetter);
+        insertSVGIntoDocumentSVG(node.getName(), componentType, g, componentDefsId, elementAttributesSetter);
     }
 
     protected void insertArrowSVGIntoDocumentSVG(String prefixId,
@@ -690,7 +690,7 @@ public class DefaultSVGWriter implements SVGWriter {
                                                  String componentDefsId) {
         BiConsumer<Element, String> elementAttributesSetter
                 = (e, subComponent) -> setArrowAttributes(prefixId, g, e, angle, componentSize);
-        insertSVGIntoDocumentSVG(ARROW, g, componentDefsId, elementAttributesSetter);
+        insertSVGIntoDocumentSVG("", ARROW, g, componentDefsId, elementAttributesSetter);
     }
 
     private void setArrowAttributes(String prefixId, Element g, Element e,
@@ -709,13 +709,18 @@ public class DefaultSVGWriter implements SVGWriter {
                                                      DiagramStyleProvider styleProvider) {
         BiConsumer<Element, String> elementAttributesSetter
                 = (elt, subComponent) -> setDecoratorAttributes(prefixId, g, node, nodeDecorator, styleProvider, elt, subComponent);
-        insertSVGIntoDocumentSVG(nodeDecorator.getType(), g, nodeDecorator.getType(), elementAttributesSetter);
+        String nodeDecoratorType = nodeDecorator.getType();
+        insertSVGIntoDocumentSVG(nodeDecoratorType, nodeDecoratorType, g, nodeDecoratorType, elementAttributesSetter);
     }
 
-    protected void insertSVGIntoDocumentSVG(String componentType, Element g, String componentDefsId,
+    protected void insertSVGIntoDocumentSVG(String name, String componentType, Element g, String componentDefsId,
                                             BiConsumer<Element, String> elementAttributesSetter) {
 
         Map<String, SVGOMDocument> subComponents = componentLibrary.getSvgDocument(componentType);
+
+        if (layoutParameters.isTooltipEnabled() && !name.isEmpty()) {
+            addToolTip(name, g);
+        }
 
         if (!layoutParameters.isAvoidSVGComponentsDuplication()) {
             // The following code work correctly considering SVG part describing the component is the first child of the SVGDocument.
@@ -747,6 +752,14 @@ public class DefaultSVGWriter implements SVGWriter {
                 });
             }
         }
+    }
+
+    private void addToolTip(String tooltip, Element g) {
+        Document doc = g.getOwnerDocument();
+        Element title = doc.createElement("title");
+        title.appendChild(doc.createTextNode(tooltip));
+        doc.adoptNode(title);
+        g.appendChild(title);
     }
 
     private void setComponentAttributes(String prefixId, Element g, Node node, DiagramStyleProvider styleProvider,

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
@@ -15,7 +15,9 @@ import com.powsybl.sld.svg.*;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -757,10 +759,16 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
     }
 
     @Test
-    public void testStraightWires() {
+    public void testLayoutParameters() {
         DiagramStyleProvider styleProvider = new DefaultDiagramStyleProvider();
         layoutParameters.setDrawStraightWires(true);
-        assertEquals(toString("/vl1_straightWires.svg"), toSVG(g1, "/vl1_straightWires.svg", layoutParameters, initValueProvider, styleProvider));
+        layoutParameters.setTooltipEnabled(true);
+        assertEquals(toString("/vl1_lpChanged.svg"),
+            toSVG(g1, "/vl1_lpChanged.svg", layoutParameters, initValueProvider, styleProvider));
+
+        layoutParameters.setAvoidSVGComponentsDuplication(true);
+        assertEquals(toString("/vl1_lpChanged_opt.svg"),
+            toSVG(g1, "/vl1_lpChanged_opt.svg", layoutParameters, initValueProvider, styleProvider));
     }
 
 }

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -2762,6 +2762,7 @@
     "internCellHeight" : 40.0,
     "stackHeight" : 30.0,
     "showGrid" : false,
+    "tooltipEnabled" : false,
     "showInternalNodes" : false,
     "scaleFactor" : 1.0,
     "horizontalSubstationPadding" : 50.0,

--- a/single-line-diagram-core/src/test/resources/vl1_lpChanged.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_lpChanged.svg
@@ -270,6 +270,7 @@
             <polyline points="420.0,370.0,410.0,370.0"/>
         </g>
         <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
+            <title>vl1_d1</title>
     <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
         <line y2="8" x1="8" x2="0" y1="0"/>
@@ -279,6 +280,7 @@
     </g>
 </g>
         <g class="BREAKER idvl1_95_b1" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
+            <title>vl1_b1</title>
     <g class="closed" id="idvl1_95_b1_BREAKER-closed">
         <rect x="1" width="18" y="1" height="18"/>
         <line y2="15" x1="10" x2="10" y1="5"/>
@@ -289,6 +291,7 @@
     </g>
 </g>
         <g class="DISCONNECTOR idvl1_95_d2" id="idvl1_95_d2" transform="translate(286.0,366.0)">
+            <title>vl1_d2</title>
     <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
         <line y2="8" x1="8" x2="0" y1="0"/>
@@ -298,12 +301,14 @@
     </g>
 </g>
         <g class="LOAD idvl1_95_load1" id="idvl1_95_load1" transform="translate(52.0,145.5)">
+            <title>vl1_load1</title>
     <rect height="9" width="16"/>
     <line y2="9" x1="0" x2="16" y1="0"/>
     <line y2="9" x1="16" x2="0" y1="0"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
         </g>
         <g class="BREAKER idvl1_95_bload1" id="idvl1_95_bload1" transform="translate(50.0,240.0)">
+            <title>vl1_bload1</title>
     <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
         <rect x="1" width="18" y="1" height="18"/>
         <line y2="15" x1="10" x2="10" y1="5"/>
@@ -314,6 +319,7 @@
     </g>
 </g>
         <g class="DISCONNECTOR idvl1_95_dload1" id="idvl1_95_dload1" transform="translate(56.0,366.0)">
+            <title>vl1_dload1</title>
     <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
         <line y2="8" x1="8" x2="0" y1="0"/>
@@ -323,12 +329,14 @@
     </g>
 </g>
         <g class="TWO_WINDINGS_TRANSFORMER idvl1_95_trf1" id="idvl1_95_trf1" transform="translate(95.0,562.5)">
+            <title>vl1_trf1</title>
     <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
 
     <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf1__LABEL">vl1_trf1</text>
         </g>
         <g class="BREAKER idvl1_95_btrf1" id="idvl1_95_btrf1" transform="translate(90.0,460.0)">
+            <title>vl1_btrf1</title>
     <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
         <rect x="1" width="18" y="1" height="18"/>
         <line y2="15" x1="10" x2="10" y1="5"/>
@@ -339,6 +347,7 @@
     </g>
 </g>
         <g class="DISCONNECTOR idvl1_95_dtrf1" id="idvl1_95_dtrf1" transform="translate(96.0,366.0)">
+            <title>vl1_dtrf1</title>
     <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
         <line y2="8" x1="8" x2="0" y1="0"/>
@@ -354,6 +363,7 @@
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf2_two__LABEL">vl1_trf2</text>
         </g>
         <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_vl1_95_trf2" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,203.0)">
+            <title>vl1_trf2</title>
     <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
 
     <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
@@ -361,6 +371,7 @@
     <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
 </g>
         <g class="BREAKER idvl1_95_btrf2" id="idvl1_95_btrf2" transform="translate(410.0,240.0)">
+            <title>vl1_btrf2</title>
     <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
         <rect x="1" width="18" y="1" height="18"/>
         <line y2="15" x1="10" x2="10" y1="5"/>
@@ -371,6 +382,7 @@
     </g>
 </g>
         <g class="DISCONNECTOR idvl1_95_dtrf2" id="idvl1_95_dtrf2" transform="translate(416.0,366.0)">
+            <title>vl1_dtrf2</title>
     <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
         <line y2="8" x1="0" x2="8" y1="0"/>
         <line y2="8" x1="8" x2="0" y1="0"/>

--- a/single-line-diagram-core/src/test/resources/vl1_lpChanged_opt.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_lpChanged_opt.svg
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.BUSBAR_SECTION {
+    stroke: rgb(0,0,0);
+    stroke-width: 3;
+}
+
+.BREAKER {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 2;
+    fill: rgb(255, 255, 255);
+}
+
+.DISCONNECTOR {
+    stroke: rgb(0, 0, 0);
+    stroke-width: 3
+}
+
+.GENERATOR {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.LOAD {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.LOAD_BREAK_SWITCH {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill: rgb(255, 255, 255);
+}
+
+.NODE {
+    stroke: rgb(0, 0, 0);
+    fill: rgb(0, 0, 0);
+    fill-opacity: 1;
+}
+
+.CAPACITOR {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.INDUCTOR {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.STATIC_VAR_COMPENSATOR {
+    stroke: rgb(0, 0, 255);
+}
+
+.TWO_WINDINGS_TRANSFORMER {
+    stroke: rgb(0, 0, 255);
+    fill-opacity: 0;
+}
+
+.THREE_WINDINGS_TRANSFORMER {
+    stroke: rgb(0, 0, 255);
+    fill-opacity: 0;
+}
+
+.VSC_CONVERTER_STATION {
+    stroke: rgb(0, 0, 255);
+    font-size: 7.4314661px;
+    line-height: 1.25;
+    font-family: sans-serif;
+    font-variant-ligatures: normal;
+    font-variant-caps: normal;
+    font-variant-numeric: normal;
+    font-feature-settings: normal;
+    text-align: start;
+    letter-spacing: 0px;
+    word-spacing: 0px;
+    writing-mode: lr-tb;
+    text-anchor: start;
+    stroke-miterlimit: 4;
+}
+
+.PHASE_SHIFT_TRANSFORMER {
+    stroke: rgb(0, 0, 255);
+    stroke-linecap: butt;
+    stroke-linejoin: miter;
+    stroke-miterlimit: 4;
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.wire {
+    stroke: rgb(200,0,0);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.grid {
+    stroke: rgb(0,55,0);
+    stroke-width: 1;
+    stroke-dasharray: 1,10;
+}
+
+.component-label {
+    fill: black;
+    color: black;
+    stroke: none;
+    fill-opacity: 1;
+}
+
+.LINE {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+]]></style>
+    <defs>
+        <g id="ARROW">
+     <g class="arrow-up" id="ARROW-arrow-up">
+        <polygon points="5,0 10,10 0,10"/>
+     </g>
+     <g class="arrow-down" id="ARROW-arrow-down">
+        <polygon points="0,0 10,0 5,10"/>
+     </g>
+</g>
+        <g id="LOAD">
+    <rect height="9" width="16"/>
+    <line y2="9" x1="0" x2="16" y1="0"/>
+    <line y2="9" x1="16" x2="0" y1="0"/>
+</g>
+        <g id="DISCONNECTOR">
+    <g class="closed" id="DISCONNECTOR-closed">
+        <line y2="8" x1="0" x2="8" y1="0"/>
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+    <g class="open" id="DISCONNECTOR-open">
+        <line y2="8" x1="8" x2="0" y1="0"/>
+    </g>
+</g>
+        <g id="TWO_WINDINGS_TRANSFORMER">
+    <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
+
+    <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
+</g>
+        <g id="THREE_WINDINGS_TRANSFORMER">
+    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+
+    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+
+    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+</g>
+        <g id="BREAKER">
+    <g class="closed" id="BREAKER-closed">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="15" x1="10" x2="10" y1="5"/>
+    </g>
+    <g class="open" id="BREAKER-open">
+        <rect x="1" width="18" y="1" height="18"/>
+        <line y2="10" x1="5" x2="15" y1="10"/>
+    </g>
+</g>
+    </defs>
+    <g>
+        <g class="grid" id="GRID_vl1" transform="translate(20.0,50.0)">
+            <line y2="560.0" x1="0.0" x2="0.0" y1="0.0"/>
+            <line y2="560.0" x1="80.0" x2="80.0" y1="0.0"/>
+            <line y2="560.0" x1="160.0" x2="160.0" y1="0.0"/>
+            <line y2="560.0" x1="240.0" x2="240.0" y1="0.0"/>
+            <line y2="560.0" x1="320.0" x2="320.0" y1="0.0"/>
+            <line y2="560.0" x1="400.0" x2="400.0" y1="0.0"/>
+            <line y2="560.0" x1="480.0" x2="480.0" y1="0.0"/>
+            <line y2="250.0" x1="0.0" x2="480.0" y1="250.0"/>
+            <line y2="310.0" x1="0.0" x2="480.0" y1="310.0"/>
+            <line y2="240.0" x1="0.0" x2="480.0" y1="240.0"/>
+            <line y2="320.0" x1="0.0" x2="480.0" y1="320.0"/>
+        </g>
+        <g class="BUSBAR_SECTION idvl1_95_bbs1" id="idvl1_95_bbs1" transform="translate(20.0,370.0)">
+            <line y2="0" x1="0" x2="200.0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_bbs1_NW_LABEL">vl1_bbs1</text>
+        </g>
+        <g class="BUSBAR_SECTION idvl1_95_bbs2" id="idvl1_95_bbs2" transform="translate(300.0,370.0)">
+            <line y2="0" x1="0" x2="200.0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_bbs2_NW_LABEL">vl1_bbs2</text>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_bbs1_95_vl1_95_d1">
+            <polyline points="220.0,370.0,240.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_d1_95_vl1_95_b1">
+            <polyline points="240.0,370.0,255.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_b1_95_vl1_95_d2">
+            <polyline points="275.0,370.0,290.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_d2_95_vl1_95_bbs2">
+            <polyline points="290.0,370.0,300.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
+            <polyline points="60.0,154.0,60.0,240.0"/>
+        </g>
+        <g class="ARROW1_vl1_95_load1_UP" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+        </g>
+        <g class="ARROW2_vl1_95_load1_DOWN" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
+            <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_bload1_95_vl1_95_dload1">
+            <polyline points="60.0,260.0,60.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1">
+            <polyline points="60.0,370.0,50.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
+            <polyline points="100.0,562.0,100.0,480.0"/>
+        </g>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+        </g>
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+            <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
+            <polyline points="100.0,460.0,100.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1">
+            <polyline points="100.0,370.0,90.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2">
+            <polyline points="380.0,150.0,412.0,205.0"/>
+        </g>
+        <g class="ARROW1_vl1_95_trf2_95_one_UP" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(0.8643,-0.5029,0.5029,0.8643,383.2217,165.4797)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+        </g>
+        <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(0.8643,-0.5029,0.5029,0.8643,393.2795,182.7667)">
+            <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2">
+            <polyline points="460.0,150.0,428.0,205.0"/>
+        </g>
+        <g class="ARROW1_vl1_95_trf2_95_two_UP" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(0.8643,0.5029,-0.5029,0.8643,448.1349,160.4508)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+        </g>
+        <g class="ARROW2_vl1_95_trf2_95_two_DOWN" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(0.8643,0.5029,-0.5029,0.8643,438.077,177.7377)">
+            <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
+            <polyline points="420.0,217.0,420.0,240.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2">
+            <polyline points="420.0,260.0,420.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2">
+            <polyline points="420.0,370.0,410.0,370.0"/>
+        </g>
+        <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
+            <title>vl1_d1</title>
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="BREAKER idvl1_95_b1" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
+            <title>vl1_b1</title>
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR idvl1_95_d2" id="idvl1_95_d2" transform="translate(286.0,366.0)">
+            <title>vl1_d2</title>
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="LOAD idvl1_95_load1" id="idvl1_95_load1" transform="translate(52.0,145.5)">
+            <title>vl1_load1</title>
+            <use href="#LOAD"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
+        </g>
+        <g class="BREAKER idvl1_95_bload1" id="idvl1_95_bload1" transform="translate(50.0,240.0)">
+            <title>vl1_bload1</title>
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR idvl1_95_dload1" id="idvl1_95_dload1" transform="translate(56.0,366.0)">
+            <title>vl1_dload1</title>
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="TWO_WINDINGS_TRANSFORMER idvl1_95_trf1" id="idvl1_95_trf1" transform="translate(95.0,562.5)">
+            <title>vl1_trf1</title>
+            <use href="#TWO_WINDINGS_TRANSFORMER-WINDING1"/>
+            <use href="#TWO_WINDINGS_TRANSFORMER-WINDING2"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf1__LABEL">vl1_trf1</text>
+        </g>
+        <g class="BREAKER idvl1_95_btrf1" id="idvl1_95_btrf1" transform="translate(90.0,460.0)">
+            <title>vl1_btrf1</title>
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR idvl1_95_dtrf1" id="idvl1_95_dtrf1" transform="translate(96.0,366.0)">
+            <title>vl1_dtrf1</title>
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+        <g class="LINE idvl1_95_trf2_95_one" id="idvl1_95_trf2_95_one" transform="translate(380.0,150.0)">
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf2_one__LABEL">vl1_trf2</text>
+        </g>
+        <g class="LINE idvl1_95_trf2_95_two" id="idvl1_95_trf2_95_two" transform="translate(460.0,150.0)">
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf2_two__LABEL">vl1_trf2</text>
+        </g>
+        <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_vl1_95_trf2" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,203.0)">
+            <title>vl1_trf2</title>
+            <use href="#THREE_WINDINGS_TRANSFORMER-WINDING1"/>
+            <use href="#THREE_WINDINGS_TRANSFORMER-WINDING2"/>
+            <use href="#THREE_WINDINGS_TRANSFORMER-WINDING3"/>
+        </g>
+        <g class="BREAKER idvl1_95_btrf2" id="idvl1_95_btrf2" transform="translate(410.0,240.0)">
+            <title>vl1_btrf2</title>
+            <use href="#BREAKER-closed"/>
+        </g>
+        <g class="DISCONNECTOR idvl1_95_dtrf2" id="idvl1_95_dtrf2" transform="translate(416.0,366.0)">
+            <title>vl1_dtrf2</title>
+            <use href="#DISCONNECTOR-closed"/>
+        </g>
+    </g>
+</svg>

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -1450,6 +1450,7 @@
     "internCellHeight" : 40.0,
     "stackHeight" : 30.0,
     "showGrid" : false,
+    "tooltipEnabled" : false,
     "showInternalNodes" : false,
     "scaleFactor" : 1.0,
     "horizontalSubstationPadding" : 50.0,

--- a/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
+++ b/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
@@ -704,6 +704,8 @@ public abstract class AbstractSingleLineDiagramViewer extends Application implem
         rowIndex += 2;
         addCheckBox("Show grid", rowIndex, LayoutParameters::isShowGrid, LayoutParameters::setShowGrid);
         rowIndex += 1;
+        addCheckBox("Add svg tooltip", rowIndex, LayoutParameters::isTooltipEnabled, LayoutParameters::setTooltipEnabled);
+        rowIndex += 1;
         addCheckBox("Show internal nodes", rowIndex, LayoutParameters::isShowInternalNodes, LayoutParameters::setShowInternalNodes);
         rowIndex += 1;
         addCheckBox("Draw straight wires", rowIndex, LayoutParameters::isDrawStraightWires, LayoutParameters::setDrawStraightWires);

--- a/single-line-diagram-view/src/main/java/com/powsybl/sld/view/AbstractContainerDiagramView.java
+++ b/single-line-diagram-view/src/main/java/com/powsybl/sld/view/AbstractContainerDiagramView.java
@@ -131,11 +131,12 @@ public abstract class AbstractContainerDiagramView extends BorderPane {
                                             SwitchPositionChangeListener listener,
                                             DisplayVoltageLevel displayVL) {
         if (!nodeMetadata.isVLabel()) {
-            NodeHandler nodeHandler = new NodeHandler(node, nodeMetadata.getComponentType(),
-                                                      nodeMetadata.getRotationAngle(),
-                                                      metadata,
-                                                      nodeMetadata.getVId(), nodeMetadata.getNextVId(),
-                                                      nodeMetadata.getDirection());
+            NodeHandler nodeHandler = new NodeHandler(node,
+                nodeMetadata.getEquipmentId(), nodeMetadata.getComponentType(),
+                nodeMetadata.getRotationAngle(),
+                metadata,
+                nodeMetadata.getVId(), nodeMetadata.getNextVId(),
+                nodeMetadata.getDirection());
             nodeHandler.setDisplayVL(displayVL);
             if (nodeMetadata.getComponentType() != null
                     && (nodeMetadata.getComponentType().equals(BREAKER)


### PR DESCRIPTION
Signed-off-by: Florian Dupuy <florian.dupuy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Not so easy to get the equipment name...


**What is the new behavior (if this is a feature change)?**
Mouse over to get the equipment name

firefox:
![tooltip_firefox](https://user-images.githubusercontent.com/66690739/93102666-fa747c80-f6ab-11ea-94f5-1cffe1ef5a72.png)


**Does this PR introduce a breaking change or deprecate an API?** 
No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
