### PR TITLE
Indentation

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -731,10 +731,8 @@ public class DefaultSVGWriter implements SVGWriter {
         for (int i = 0; i < subComponentChildren.getLength(); i++) {
             org.w3c.dom.Node n = subComponentChildren.item(i).cloneNode(true);
             if (n instanceof Element) {
-                elementAttributesSetter.accept((Element) n, subComponentName);
+                setAttributesAndInsertElement(g, elementAttributesSetter, subComponentName, (Element) n);
             }
-            g.getOwnerDocument().adoptNode(n);
-            g.appendChild(n);
         }
     }
 

--- a/single-line-diagram-core/src/test/resources/substation.svg
+++ b/single-line-diagram-core/src/test/resources/substation.svg
@@ -202,22 +202,22 @@
             <polyline points="60.0,154.0,60.0,240.0"/>
         </g>
         <g class="ARROW1_vl1_95_load1_UP" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_load1_DOWN" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_bload1_95_vl1_95_dload1">
             <polyline points="60.0,260.0,60.0,370.0"/>
@@ -229,22 +229,22 @@
             <polyline points="100.0,570.0,100.0,480.0"/>
         </g>
         <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,545.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,525.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
             <polyline points="100.0,460.0,100.0,370.0"/>
@@ -256,22 +256,22 @@
             <polyline points="420.0,150.0,420.0,240.0"/>
         </g>
         <g class="ARROW1_vl1_95_trf2_95_one_UP" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,415.0,165.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,415.0,185.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2">
             <polyline points="420.0,260.0,420.0,370.0"/>
@@ -280,102 +280,102 @@
             <polyline points="420.0,370.0,410.0,370.0"/>
         </g>
         <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
-    <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_d1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_d1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BREAKER idvl1_95_b1" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-    <g class="closed" id="idvl1_95_b1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_b1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_b1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_b1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_d2" id="idvl1_95_d2" transform="translate(286.0,366.0)">
-    <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_d2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_d2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LOAD idvl1_95_load1" id="idvl1_95_load1" transform="translate(52.0,145.5)">
-    <rect height="9" width="16"/>
-    <line y2="9" x1="0" x2="16" y1="0"/>
-    <line y2="9" x1="16" x2="0" y1="0"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
+            <rect height="9" width="16"/>
+            <line y2="9" x1="0" x2="16" y1="0"/>
+            <line y2="9" x1="16" x2="0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
         </g>
         <g class="BREAKER idvl1_95_bload1" id="idvl1_95_bload1" transform="translate(50.0,240.0)">
-    <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_bload1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_bload1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dload1" id="idvl1_95_dload1" transform="translate(56.0,366.0)">
-    <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dload1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dload1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl1_95_trf1" id="idvl1_95_trf1" transform="translate(100.0,570.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf1__LABEL">vl1_trf1</text>
         </g>
         <g class="BREAKER idvl1_95_btrf1" id="idvl1_95_btrf1" transform="translate(90.0,460.0)">
-    <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_btrf1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_btrf1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dtrf1" id="idvl1_95_dtrf1" transform="translate(96.0,366.0)">
-    <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dtrf1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dtrf1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl1_95_trf2_95_one" id="idvl1_95_trf2_95_one" transform="translate(420.0,150.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf2_one__LABEL">vl1_trf2</text>
         </g>
         <g class="BREAKER idvl1_95_btrf2" id="idvl1_95_btrf2" transform="translate(410.0,240.0)">
-    <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_btrf2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dtrf2" id="idvl1_95_dtrf2" transform="translate(416.0,366.0)">
-    <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dtrf2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BUSBAR_SECTION idvl2_95_bbs1" id="idvl2_95_bbs1" transform="translate(570.0,370.0)">
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_bbs1_NW_LABEL">vl2_bbs1</text>
@@ -384,22 +384,22 @@
             <polyline points="620.0,156.0,620.0,240.0"/>
         </g>
         <g class="ARROW1_vl2_95_gen1_UP" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_gen1_DOWN" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1">
             <polyline points="620.0,260.0,620.0,370.0"/>
@@ -411,22 +411,22 @@
             <polyline points="670.0,570.0,670.0,480.0"/>
         </g>
         <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,665.0,545.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,665.0,525.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1">
             <polyline points="670.0,460.0,670.0,370.0"/>
@@ -438,22 +438,22 @@
             <polyline points="730.0,150.0,730.0,240.0"/>
         </g>
         <g class="ARROW1_vl2_95_trf2_95_one_UP" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,725.0,165.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,725.0,185.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2">
             <polyline points="730.0,260.0,730.0,370.0"/>
@@ -462,74 +462,74 @@
             <polyline points="730.0,370.0,720.0,370.0"/>
         </g>
         <g class="GENERATOR idvl2_95_gen1" id="idvl2_95_gen1" transform="translate(614.0,144.0)">
-    <circle r="6" cx="6" cy="6"/>
-    <path d="M6,6 A 6 40 0 0 0 2,6"/>
-    <path d="M6,6 A 6 40 0 0 0 10,6"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_gen1__LABEL">vl2_gen1</text>
+            <circle r="6" cx="6" cy="6"/>
+            <path d="M6,6 A 6 40 0 0 0 2,6"/>
+            <path d="M6,6 A 6 40 0 0 0 10,6"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_gen1__LABEL">vl2_gen1</text>
         </g>
         <g class="BREAKER idvl2_95_bgen1" id="idvl2_95_bgen1" transform="translate(610.0,240.0)">
-    <g class="closed" id="idvl2_95_bgen1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl2_95_bgen1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_bgen1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl2_95_bgen1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl2_95_dgen1" id="idvl2_95_dgen1" transform="translate(616.0,366.0)">
-    <g class="closed" id="idvl2_95_dgen1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl2_95_dgen1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_dgen1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl2_95_dgen1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl2_95_trf1" id="idvl2_95_trf1" transform="translate(670.0,570.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_trf1__LABEL">vl2_trf1</text>
         </g>
         <g class="BREAKER idvl2_95_btrf1" id="idvl2_95_btrf1" transform="translate(660.0,460.0)">
-    <g class="closed" id="idvl2_95_btrf1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl2_95_btrf1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_btrf1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl2_95_btrf1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl2_95_dtrf1" id="idvl2_95_dtrf1" transform="translate(666.0,366.0)">
-    <g class="closed" id="idvl2_95_dtrf1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl2_95_dtrf1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_dtrf1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl2_95_dtrf1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl2_95_trf2_95_one" id="idvl2_95_trf2_95_one" transform="translate(730.0,150.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_trf2_one__LABEL">vl2_trf2</text>
         </g>
         <g class="BREAKER idvl2_95_btrf2" id="idvl2_95_btrf2" transform="translate(720.0,240.0)">
-    <g class="closed" id="idvl2_95_btrf2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl2_95_btrf2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl2_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl2_95_dtrf2" id="idvl2_95_dtrf2" transform="translate(726.0,366.0)">
-    <g class="closed" id="idvl2_95_dtrf2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl2_95_dtrf2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl2_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BUSBAR_SECTION idvl3_95_bbs1" id="idvl3_95_bbs1" transform="translate(870.0,370.0)">
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_bbs1_NW_LABEL">vl3_bbs1</text>
@@ -538,22 +538,22 @@
             <polyline points="910.0,156.0,910.0,240.0"/>
         </g>
         <g class="ARROW1_vl3_95_capa1_UP" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
-     <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_capa1_DOWN" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
-     <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1">
             <polyline points="910.0,260.0,910.0,370.0"/>
@@ -565,22 +565,22 @@
             <polyline points="1020.0,150.0,1020.0,240.0"/>
         </g>
         <g class="ARROW1_vl3_95_trf2_95_one_UP" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,165.0)">
-     <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,185.0)">
-     <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2">
             <polyline points="1020.0,260.0,1020.0,370.0"/>
@@ -589,65 +589,62 @@
             <polyline points="1020.0,370.0,1020.0,370.0"/>
         </g>
         <g class="CAPACITOR idvl3_95_capa1" id="idvl3_95_capa1" transform="translate(904.0,144.0)">
-    <line y2="4.5" x1="6" x2="6" y1="0"/>
-    <line y2="4.5" x1="0" x2="12" y1="4.5"/>
-    <line y2="7.5" x1="0" x2="12" y1="7.5"/>
-    <line y2="12" x1="6" x2="6" y1="7.5"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_capa1__LABEL">vl3_capa1</text>
+            <line y2="4.5" x1="6" x2="6" y1="0"/>
+            <line y2="4.5" x1="0" x2="12" y1="4.5"/>
+            <line y2="7.5" x1="0" x2="12" y1="7.5"/>
+            <line y2="12" x1="6" x2="6" y1="7.5"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_capa1__LABEL">vl3_capa1</text>
         </g>
         <g class="BREAKER idvl3_95_bcapa1" id="idvl3_95_bcapa1" transform="translate(900.0,240.0)">
-    <g class="closed" id="idvl3_95_bcapa1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl3_95_bcapa1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl3_95_bcapa1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl3_95_bcapa1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl3_95_dcapa1" id="idvl3_95_dcapa1" transform="translate(906.0,366.0)">
-    <g class="closed" id="idvl3_95_dcapa1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl3_95_dcapa1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl3_95_dcapa1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl3_95_dcapa1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl3_95_trf2_95_one" id="idvl3_95_trf2_95_one" transform="translate(1020.0,150.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_trf2_one__LABEL">vl3_trf2</text>
         </g>
         <g class="BREAKER idvl3_95_btrf2" id="idvl3_95_btrf2" transform="translate(1010.0,240.0)">
-    <g class="closed" id="idvl3_95_btrf2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl3_95_btrf2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl3_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl3_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl3_95_dtrf2" id="idvl3_95_dtrf2" transform="translate(1016.0,366.0)">
-    <g class="closed" id="idvl3_95_dtrf2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl3_95_dtrf2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl3_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl3_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="TWO_WINDINGS_TRANSFORMER idvl1_95_trf1_95_vl2_95_trf1" id="idvl1_95_trf1_95_vl2_95_trf1" transform="translate(380.0,592.5)">
-    <circle r="5" id="idvl1_95_trf1_95_vl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
-
-    <circle r="5" id="idvl1_95_trf1_95_vl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
-</g>
+            <circle r="5" id="idvl1_95_trf1_95_vl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
+            <circle r="5" id="idvl1_95_trf1_95_vl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
+        </g>
         <g class="THREE_WINDINGS_TRANSFORMER idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" transform="translate(722.0,93.0)">
-    <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g class="wire" id="_95_subst_95_vl1_95_trf1_95_vl1_95_trf1_95_vl2_95_trf1">
             <polyline points="100.0,550.0,100.0,600.0,377.0,600.0"/>
         </g>

--- a/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
+++ b/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
@@ -226,102 +226,102 @@
             <polyline points="420.0,370.0,410.0,370.0"/>
         </g>
         <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
-    <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_d1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_d1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BREAKER idvl1_95_b1" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-    <g class="closed" id="idvl1_95_b1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_b1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_b1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_b1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_d2" id="idvl1_95_d2" transform="translate(286.0,366.0)">
-    <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_d2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_d2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LOAD idvl1_95_load1" id="idvl1_95_load1" transform="translate(52.0,145.5)">
-    <rect height="9" width="16"/>
-    <line y2="9" x1="0" x2="16" y1="0"/>
-    <line y2="9" x1="16" x2="0" y1="0"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
+            <rect height="9" width="16"/>
+            <line y2="9" x1="0" x2="16" y1="0"/>
+            <line y2="9" x1="16" x2="0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
         </g>
         <g class="BREAKER idvl1_95_bload1" id="idvl1_95_bload1" transform="translate(50.0,240.0)">
-    <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_bload1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_bload1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dload1" id="idvl1_95_dload1" transform="translate(56.0,366.0)">
-    <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dload1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dload1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl1_95_trf1" id="idvl1_95_trf1" transform="translate(100.0,570.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf1__LABEL">vl1_trf1</text>
         </g>
         <g class="BREAKER idvl1_95_btrf1" id="idvl1_95_btrf1" transform="translate(90.0,460.0)">
-    <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_btrf1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_btrf1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dtrf1" id="idvl1_95_dtrf1" transform="translate(96.0,366.0)">
-    <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dtrf1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dtrf1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl1_95_trf2_95_one" id="idvl1_95_trf2_95_one" transform="translate(420.0,150.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf2_one__LABEL">vl1_trf2</text>
         </g>
         <g class="BREAKER idvl1_95_btrf2" id="idvl1_95_btrf2" transform="translate(410.0,240.0)">
-    <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_btrf2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dtrf2" id="idvl1_95_dtrf2" transform="translate(416.0,366.0)">
-    <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dtrf2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BUSBAR_SECTION idvl2_95_bbs1" id="idvl2_95_bbs1" transform="translate(570.0,370.0)">
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_bbs1_NW_LABEL">vl2_bbs1</text>
@@ -354,74 +354,74 @@
             <polyline points="730.0,370.0,720.0,370.0"/>
         </g>
         <g class="GENERATOR idvl2_95_gen1" id="idvl2_95_gen1" transform="translate(614.0,144.0)">
-    <circle r="6" cx="6" cy="6"/>
-    <path d="M6,6 A 6 40 0 0 0 2,6"/>
-    <path d="M6,6 A 6 40 0 0 0 10,6"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_gen1__LABEL">vl2_gen1</text>
+            <circle r="6" cx="6" cy="6"/>
+            <path d="M6,6 A 6 40 0 0 0 2,6"/>
+            <path d="M6,6 A 6 40 0 0 0 10,6"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_gen1__LABEL">vl2_gen1</text>
         </g>
         <g class="BREAKER idvl2_95_bgen1" id="idvl2_95_bgen1" transform="translate(610.0,240.0)">
-    <g class="closed" id="idvl2_95_bgen1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl2_95_bgen1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_bgen1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl2_95_bgen1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl2_95_dgen1" id="idvl2_95_dgen1" transform="translate(616.0,366.0)">
-    <g class="closed" id="idvl2_95_dgen1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl2_95_dgen1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_dgen1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl2_95_dgen1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl2_95_trf1" id="idvl2_95_trf1" transform="translate(670.0,570.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_trf1__LABEL">vl2_trf1</text>
         </g>
         <g class="BREAKER idvl2_95_btrf1" id="idvl2_95_btrf1" transform="translate(660.0,460.0)">
-    <g class="closed" id="idvl2_95_btrf1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl2_95_btrf1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_btrf1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl2_95_btrf1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl2_95_dtrf1" id="idvl2_95_dtrf1" transform="translate(666.0,366.0)">
-    <g class="closed" id="idvl2_95_dtrf1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl2_95_dtrf1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_dtrf1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl2_95_dtrf1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl2_95_trf2_95_one" id="idvl2_95_trf2_95_one" transform="translate(730.0,150.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_trf2_one__LABEL">vl2_trf2</text>
         </g>
         <g class="BREAKER idvl2_95_btrf2" id="idvl2_95_btrf2" transform="translate(720.0,240.0)">
-    <g class="closed" id="idvl2_95_btrf2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl2_95_btrf2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl2_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl2_95_dtrf2" id="idvl2_95_dtrf2" transform="translate(726.0,366.0)">
-    <g class="closed" id="idvl2_95_dtrf2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl2_95_dtrf2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl2_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BUSBAR_SECTION idvl3_95_bbs1" id="idvl3_95_bbs1" transform="translate(870.0,370.0)">
             <line y2="0" x1="0" x2="200.0" y1="0"/>
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_bbs1_NW_LABEL">vl3_bbs1</text>
@@ -445,65 +445,62 @@
             <polyline points="1020.0,370.0,1020.0,370.0"/>
         </g>
         <g class="CAPACITOR idvl3_95_capa1" id="idvl3_95_capa1" transform="translate(904.0,144.0)">
-    <line y2="4.5" x1="6" x2="6" y1="0"/>
-    <line y2="4.5" x1="0" x2="12" y1="4.5"/>
-    <line y2="7.5" x1="0" x2="12" y1="7.5"/>
-    <line y2="12" x1="6" x2="6" y1="7.5"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_capa1__LABEL">vl3_capa1</text>
+            <line y2="4.5" x1="6" x2="6" y1="0"/>
+            <line y2="4.5" x1="0" x2="12" y1="4.5"/>
+            <line y2="7.5" x1="0" x2="12" y1="7.5"/>
+            <line y2="12" x1="6" x2="6" y1="7.5"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_capa1__LABEL">vl3_capa1</text>
         </g>
         <g class="BREAKER idvl3_95_bcapa1" id="idvl3_95_bcapa1" transform="translate(900.0,240.0)">
-    <g class="closed" id="idvl3_95_bcapa1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl3_95_bcapa1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl3_95_bcapa1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl3_95_bcapa1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl3_95_dcapa1" id="idvl3_95_dcapa1" transform="translate(906.0,366.0)">
-    <g class="closed" id="idvl3_95_dcapa1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl3_95_dcapa1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl3_95_dcapa1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl3_95_dcapa1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl3_95_trf2_95_one" id="idvl3_95_trf2_95_one" transform="translate(1020.0,150.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_trf2_one__LABEL">vl3_trf2</text>
         </g>
         <g class="BREAKER idvl3_95_btrf2" id="idvl3_95_btrf2" transform="translate(1010.0,240.0)">
-    <g class="closed" id="idvl3_95_btrf2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl3_95_btrf2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl3_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl3_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl3_95_dtrf2" id="idvl3_95_dtrf2" transform="translate(1016.0,366.0)">
-    <g class="closed" id="idvl3_95_dtrf2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl3_95_dtrf2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl3_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl3_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="TWO_WINDINGS_TRANSFORMER idvl1_95_trf1_95_vl2_95_trf1" id="idvl1_95_trf1_95_vl2_95_trf1" transform="translate(380.0,592.5)">
-    <circle r="5" id="idvl1_95_trf1_95_vl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
-
-    <circle r="5" id="idvl1_95_trf1_95_vl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
-</g>
+            <circle r="5" id="idvl1_95_trf1_95_vl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
+            <circle r="5" id="idvl1_95_trf1_95_vl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
+        </g>
         <g class="THREE_WINDINGS_TRANSFORMER idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" transform="translate(722.0,93.0)">
-    <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g class="wire" id="_95_subst_95_vl1_95_trf1_95_vl1_95_trf1_95_vl2_95_trf1">
             <polyline points="100.0,550.0,100.0,600.0,369.0,600.0"/>
         </g>

--- a/single-line-diagram-core/src/test/resources/substation_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/substation_optimized.svg
@@ -119,60 +119,57 @@
 ]]></style>
     <defs>
         <g id="GENERATOR">
-    <circle r="6" cx="6" cy="6"/>
-    <path d="M6,6 A 6 40 0 0 0 2,6"/>
-    <path d="M6,6 A 6 40 0 0 0 10,6"/>
-</g>
+            <circle r="6" cx="6" cy="6"/>
+            <path d="M6,6 A 6 40 0 0 0 2,6"/>
+            <path d="M6,6 A 6 40 0 0 0 10,6"/>
+        </g>
         <g id="ARROW">
-     <g class="arrow-up" id="ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-</g>
+            <g class="arrow-up" id="ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+        </g>
         <g id="LOAD">
-    <rect height="9" width="16"/>
-    <line y2="9" x1="0" x2="16" y1="0"/>
-    <line y2="9" x1="16" x2="0" y1="0"/>
-</g>
+            <rect height="9" width="16"/>
+            <line y2="9" x1="0" x2="16" y1="0"/>
+            <line y2="9" x1="16" x2="0" y1="0"/>
+        </g>
         <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g id="CAPACITOR">
-    <line y2="4.5" x1="6" x2="6" y1="0"/>
-    <line y2="4.5" x1="0" x2="12" y1="4.5"/>
-    <line y2="7.5" x1="0" x2="12" y1="7.5"/>
-    <line y2="12" x1="6" x2="6" y1="7.5"/>
-</g>
+            <line y2="4.5" x1="6" x2="6" y1="0"/>
+            <line y2="4.5" x1="0" x2="12" y1="4.5"/>
+            <line y2="7.5" x1="0" x2="12" y1="7.5"/>
+            <line y2="12" x1="6" x2="6" y1="7.5"/>
+        </g>
         <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
-
-    <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
-</g>
+            <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
+            <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
+        </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
     </defs>
     <g>
         <g class="grid" id="GRID_vl1" transform="translate(20.0,50.0)">

--- a/single-line-diagram-core/src/test/resources/vl1.svg
+++ b/single-line-diagram-core/src/test/resources/vl1.svg
@@ -168,22 +168,22 @@
             <polyline points="60.0,154.0,60.0,240.0"/>
         </g>
         <g class="ARROW1_vl1_95_load1_UP" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_load1_DOWN" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_bload1_95_vl1_95_dload1">
             <polyline points="60.0,260.0,60.0,370.0"/>
@@ -195,22 +195,22 @@
             <polyline points="100.0,562.0,100.0,480.0"/>
         </g>
         <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
             <polyline points="100.0,460.0,100.0,370.0"/>
@@ -222,43 +222,43 @@
             <polyline points="380.0,150.0,380.0,205.0,412.0,205.0"/>
         </g>
         <g class="ARROW1_vl1_95_trf2_95_one_UP" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2">
             <polyline points="460.0,150.0,460.0,205.0,428.0,205.0"/>
         </g>
         <g class="ARROW1_vl1_95_trf2_95_two_UP" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_two_DOWN" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
             <polyline points="420.0,217.0,420.0,240.0"/>
@@ -270,83 +270,82 @@
             <polyline points="420.0,370.0,410.0,370.0"/>
         </g>
         <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
-    <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_d1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_d1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BREAKER idvl1_95_b1" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-    <g class="closed" id="idvl1_95_b1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_b1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_b1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_b1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_d2" id="idvl1_95_d2" transform="translate(286.0,366.0)">
-    <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_d2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_d2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LOAD idvl1_95_load1" id="idvl1_95_load1" transform="translate(52.0,145.5)">
-    <rect height="9" width="16"/>
-    <line y2="9" x1="0" x2="16" y1="0"/>
-    <line y2="9" x1="16" x2="0" y1="0"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
+            <rect height="9" width="16"/>
+            <line y2="9" x1="0" x2="16" y1="0"/>
+            <line y2="9" x1="16" x2="0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
         </g>
         <g class="BREAKER idvl1_95_bload1" id="idvl1_95_bload1" transform="translate(50.0,240.0)">
-    <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_bload1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_bload1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dload1" id="idvl1_95_dload1" transform="translate(56.0,366.0)">
-    <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dload1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dload1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="TWO_WINDINGS_TRANSFORMER idvl1_95_trf1" id="idvl1_95_trf1" transform="translate(95.0,562.5)">
-    <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
-
-    <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf1__LABEL">vl1_trf1</text>
+            <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
+            <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf1__LABEL">vl1_trf1</text>
         </g>
         <g class="BREAKER idvl1_95_btrf1" id="idvl1_95_btrf1" transform="translate(90.0,460.0)">
-    <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_btrf1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_btrf1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dtrf1" id="idvl1_95_dtrf1" transform="translate(96.0,366.0)">
-    <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dtrf1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dtrf1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl1_95_trf2_95_one" id="idvl1_95_trf2_95_one" transform="translate(380.0,150.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf2_one__LABEL">vl1_trf2</text>
         </g>
@@ -354,30 +353,28 @@
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf2_two__LABEL">vl1_trf2</text>
         </g>
         <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_vl1_95_trf2" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,203.0)">
-    <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g class="BREAKER idvl1_95_btrf2" id="idvl1_95_btrf2" transform="translate(410.0,240.0)">
-    <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_btrf2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dtrf2" id="idvl1_95_dtrf2" transform="translate(416.0,366.0)">
-    <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dtrf2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl1_decorated.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_decorated.svg
@@ -180,22 +180,22 @@
             <polyline points="60.0,154.0,60.0,240.0"/>
         </g>
         <g class="ARROW1_vl1_95_load1_UP" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_load1_DOWN" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_bload1_95_vl1_95_dload1">
             <polyline points="60.0,260.0,60.0,370.0"/>
@@ -207,22 +207,22 @@
             <polyline points="100.0,562.0,100.0,480.0"/>
         </g>
         <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
             <polyline points="100.0,460.0,100.0,370.0"/>
@@ -234,43 +234,43 @@
             <polyline points="380.0,150.0,380.0,205.0,412.0,205.0"/>
         </g>
         <g class="ARROW1_vl1_95_trf2_95_one_UP" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2">
             <polyline points="460.0,150.0,460.0,205.0,428.0,205.0"/>
         </g>
         <g class="ARROW1_vl1_95_trf2_95_two_UP" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_two_DOWN" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
             <polyline points="420.0,217.0,420.0,240.0"/>
@@ -282,97 +282,89 @@
             <polyline points="420.0,370.0,410.0,370.0"/>
         </g>
         <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
-    <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_d1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-
-  <path class="LOCK" d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(9.0,0.0)"/>
-</g>
+            <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_d1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <path class="LOCK" d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(9.0,0.0)"/>
+        </g>
         <g class="BREAKER idvl1_95_b1" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-    <g class="closed" id="idvl1_95_b1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_b1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-
-  <path class="FLASH" d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="matrix(0.0,-1.0,1.0,0.0,0.0,-1.0)"/>
-</g>
+            <g class="closed" id="idvl1_95_b1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_b1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+            <path class="FLASH" d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="matrix(0.0,-1.0,1.0,0.0,0.0,-1.0)"/>
+        </g>
         <g class="DISCONNECTOR idvl1_95_d2" id="idvl1_95_d2" transform="translate(286.0,366.0)">
-    <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_d2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-
-  <path class="LOCK" d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(9.0,0.0)"/>
-</g>
+            <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_d2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <path class="LOCK" d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(9.0,0.0)"/>
+        </g>
         <g class="LOAD idvl1_95_load1" id="idvl1_95_load1" transform="translate(52.0,145.5)">
-    <rect height="9" width="16"/>
-    <line y2="9" x1="0" x2="16" y1="0"/>
-    <line y2="9" x1="16" x2="0" y1="0"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
+            <rect height="9" width="16"/>
+            <line y2="9" x1="0" x2="16" y1="0"/>
+            <line y2="9" x1="16" x2="0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
         </g>
         <g class="BREAKER idvl1_95_bload1" id="idvl1_95_bload1" transform="translate(50.0,240.0)">
-    <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_bload1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-
-  <path class="FLASH" d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(21.0,0.0)"/>
-</g>
+            <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_bload1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+            <path class="FLASH" d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(21.0,0.0)"/>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dload1" id="idvl1_95_dload1" transform="translate(56.0,366.0)">
-    <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dload1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-
-  <path class="LOCK" d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(9.0,0.0)"/>
-</g>
+            <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dload1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <path class="LOCK" d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(9.0,0.0)"/>
+        </g>
         <g class="TWO_WINDINGS_TRANSFORMER idvl1_95_trf1" id="idvl1_95_trf1" transform="translate(95.0,562.5)">
-    <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
-
-    <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf1__LABEL">vl1_trf1</text>
+            <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
+            <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf1__LABEL">vl1_trf1</text>
         </g>
         <g class="BREAKER idvl1_95_btrf1" id="idvl1_95_btrf1" transform="translate(90.0,460.0)">
-    <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_btrf1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-
-  <path class="FLASH" d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(21.0,0.0)"/>
-</g>
+            <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_btrf1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+            <path class="FLASH" d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(21.0,0.0)"/>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dtrf1" id="idvl1_95_dtrf1" transform="translate(96.0,366.0)">
-    <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dtrf1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-
-  <path class="LOCK" d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(9.0,0.0)"/>
-</g>
+            <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dtrf1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <path class="LOCK" d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(9.0,0.0)"/>
+        </g>
         <g class="LINE idvl1_95_trf2_95_one" id="idvl1_95_trf2_95_one" transform="translate(380.0,150.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf2_one__LABEL">vl1_trf2</text>
         </g>
@@ -380,34 +372,30 @@
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf2_two__LABEL">vl1_trf2</text>
         </g>
         <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_vl1_95_trf2" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,203.0)">
-    <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g class="BREAKER idvl1_95_btrf2" id="idvl1_95_btrf2" transform="translate(410.0,240.0)">
-    <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_btrf2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-
-  <path class="FLASH" d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(21.0,0.0)"/>
-</g>
+            <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+            <path class="FLASH" d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(21.0,0.0)"/>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dtrf2" id="idvl1_95_dtrf2" transform="translate(416.0,366.0)">
-    <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dtrf2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-
-  <path class="LOCK" d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(9.0,0.0)"/>
-</g>
+            <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <path class="LOCK" d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(9.0,0.0)"/>
+        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl1_decorated_opt.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_decorated_opt.svg
@@ -131,55 +131,52 @@
 ]]></style>
     <defs>
         <g id="ARROW">
-     <g class="arrow-up" id="ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-</g>
+            <g class="arrow-up" id="ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+        </g>
         <g id="LOAD">
-    <rect height="9" width="16"/>
-    <line y2="9" x1="0" x2="16" y1="0"/>
-    <line y2="9" x1="16" x2="0" y1="0"/>
-</g>
+            <rect height="9" width="16"/>
+            <line y2="9" x1="0" x2="16" y1="0"/>
+            <line y2="9" x1="16" x2="0" y1="0"/>
+        </g>
         <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g id="LOCK">
-  <path class="LOCK" d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z"/>
-</g>
+            <path class="LOCK" d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z"/>
+        </g>
         <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
-
-    <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
-</g>
+            <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
+            <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
+        </g>
         <g id="FLASH">
-  <path class="FLASH" d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z"/>
-</g>
+            <path class="FLASH" d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z"/>
+        </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
     </defs>
     <g>
         <g class="grid" id="GRID_vl1" transform="translate(20.0,50.0)">

--- a/single-line-diagram-core/src/test/resources/vl1_lpChanged.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_lpChanged.svg
@@ -168,22 +168,22 @@
             <polyline points="60.0,154.0,60.0,240.0"/>
         </g>
         <g class="ARROW1_vl1_95_load1_UP" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_load1_DOWN" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_bload1_95_vl1_95_dload1">
             <polyline points="60.0,260.0,60.0,370.0"/>
@@ -195,22 +195,22 @@
             <polyline points="100.0,562.0,100.0,480.0"/>
         </g>
         <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
             <polyline points="100.0,460.0,100.0,370.0"/>
@@ -222,43 +222,43 @@
             <polyline points="380.0,150.0,412.0,205.0"/>
         </g>
         <g class="ARROW1_vl1_95_trf2_95_one_UP" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(0.8643,-0.5029,0.5029,0.8643,383.2217,165.4797)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(0.8643,-0.5029,0.5029,0.8643,393.2795,182.7667)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2">
             <polyline points="460.0,150.0,428.0,205.0"/>
         </g>
         <g class="ARROW1_vl1_95_trf2_95_two_UP" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(0.8643,0.5029,-0.5029,0.8643,448.1349,160.4508)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl1_95_trf2_95_two_DOWN" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(0.8643,0.5029,-0.5029,0.8643,438.077,177.7377)">
-     <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
             <polyline points="420.0,217.0,420.0,240.0"/>
@@ -271,91 +271,90 @@
         </g>
         <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
             <title>vl1_d1</title>
-    <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_d1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_d1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BREAKER idvl1_95_b1" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
             <title>vl1_b1</title>
-    <g class="closed" id="idvl1_95_b1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_b1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_b1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_b1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_d2" id="idvl1_95_d2" transform="translate(286.0,366.0)">
             <title>vl1_d2</title>
-    <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_d2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_d2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LOAD idvl1_95_load1" id="idvl1_95_load1" transform="translate(52.0,145.5)">
             <title>vl1_load1</title>
-    <rect height="9" width="16"/>
-    <line y2="9" x1="0" x2="16" y1="0"/>
-    <line y2="9" x1="16" x2="0" y1="0"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
+            <rect height="9" width="16"/>
+            <line y2="9" x1="0" x2="16" y1="0"/>
+            <line y2="9" x1="16" x2="0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
         </g>
         <g class="BREAKER idvl1_95_bload1" id="idvl1_95_bload1" transform="translate(50.0,240.0)">
             <title>vl1_bload1</title>
-    <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_bload1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_bload1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dload1" id="idvl1_95_dload1" transform="translate(56.0,366.0)">
             <title>vl1_dload1</title>
-    <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dload1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dload1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="TWO_WINDINGS_TRANSFORMER idvl1_95_trf1" id="idvl1_95_trf1" transform="translate(95.0,562.5)">
             <title>vl1_trf1</title>
-    <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
-
-    <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf1__LABEL">vl1_trf1</text>
+            <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
+            <circle r="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf1__LABEL">vl1_trf1</text>
         </g>
         <g class="BREAKER idvl1_95_btrf1" id="idvl1_95_btrf1" transform="translate(90.0,460.0)">
             <title>vl1_btrf1</title>
-    <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_btrf1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_btrf1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dtrf1" id="idvl1_95_dtrf1" transform="translate(96.0,366.0)">
             <title>vl1_dtrf1</title>
-    <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dtrf1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dtrf1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl1_95_trf2_95_one" id="idvl1_95_trf2_95_one" transform="translate(380.0,150.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf2_one__LABEL">vl1_trf2</text>
         </g>
@@ -364,32 +363,30 @@
         </g>
         <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_vl1_95_trf2" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,203.0)">
             <title>vl1_trf2</title>
-    <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g class="BREAKER idvl1_95_btrf2" id="idvl1_95_btrf2" transform="translate(410.0,240.0)">
             <title>vl1_btrf2</title>
-    <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl1_95_btrf2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl1_95_dtrf2" id="idvl1_95_dtrf2" transform="translate(416.0,366.0)">
             <title>vl1_dtrf2</title>
-    <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl1_95_dtrf2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl1_lpChanged_opt.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_lpChanged_opt.svg
@@ -119,49 +119,46 @@
 ]]></style>
     <defs>
         <g id="ARROW">
-     <g class="arrow-up" id="ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-</g>
+            <g class="arrow-up" id="ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+        </g>
         <g id="LOAD">
-    <rect height="9" width="16"/>
-    <line y2="9" x1="0" x2="16" y1="0"/>
-    <line y2="9" x1="16" x2="0" y1="0"/>
-</g>
+            <rect height="9" width="16"/>
+            <line y2="9" x1="0" x2="16" y1="0"/>
+            <line y2="9" x1="16" x2="0" y1="0"/>
+        </g>
         <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
-
-    <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
-</g>
+            <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
+            <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
+        </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
     </defs>
     <g>
         <g class="grid" id="GRID_vl1" transform="translate(20.0,50.0)">

--- a/single-line-diagram-core/src/test/resources/vl1_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_nominal_voltage_style.svg
@@ -178,24 +178,21 @@
             <polyline points="19.0,39.0,19.0,49.0" stroke-width="1" stroke="#ff0000"/>
         </g>
         <g class="LOAD idl" id="idl" transform="translate(11.0,44.5)">
-    <rect fill="#ff0000" width="16" height="9" stroke="#ff0000"/>
-    <line y2="9" fill="#ff0000" x1="0" x2="16" stroke="#ff0000" y1="0"/>
-    <line y2="9" fill="#ff0000" x1="16" x2="0" stroke="#ff0000" y1="0"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="l__LABEL">l</text>
+            <rect fill="#ff0000" width="16" height="9" stroke="#ff0000"/>
+            <line y2="9" fill="#ff0000" x1="0" x2="16" stroke="#ff0000" y1="0"/>
+            <line y2="9" fill="#ff0000" x1="16" x2="0" stroke="#ff0000" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="l__LABEL">l</text>
         </g>
         <g class="TWO_WINDINGS_TRANSFORMER id2WT_95_ONE" id="id2WT_95_ONE" transform="translate(14.0,41.5)">
-    <circle fill="#ff0000" r="5" id="id2WT_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#ff0000"/>
-
-    <circle fill="#228b22" r="5" id="id2WT_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#228b22"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="2WT_ONE__LABEL">2WT_1</text>
+            <circle fill="#ff0000" r="5" id="id2WT_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#ff0000"/>
+            <circle fill="#228b22" r="5" id="id2WT_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#228b22"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="2WT_ONE__LABEL">2WT_1</text>
         </g>
         <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_3WT_95_fictif" id="idFICT_95_vl1_95_3WT_95_fictif" transform="translate(11.0,42.0)">
-    <circle fill="#a020f0" r="5" id="idFICT_95_vl1_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5" stroke="#a020f0"/>
-
-    <circle fill="#228b22" r="5" id="idFICT_95_vl1_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#228b22"/>
-
-    <circle fill="#ff0000" r="5" id="idFICT_95_vl1_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#ff0000"/>
-</g>
+            <circle fill="#a020f0" r="5" id="idFICT_95_vl1_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5" stroke="#a020f0"/>
+            <circle fill="#228b22" r="5" id="idFICT_95_vl1_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#228b22"/>
+            <circle fill="#ff0000" r="5" id="idFICT_95_vl1_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#ff0000"/>
+        </g>
         <g class="LINE id3WT_95_TWO" id="id3WT_95_TWO" transform="translate(19.0,49.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="3WT_TWO__LABEL">3WT_1</text>
         </g>
@@ -203,70 +200,70 @@
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="3WT_THREE__LABEL">3WT_1</text>
         </g>
         <g class="NODE idFICT_95_vl1_95_1" id="idFICT_95_vl1_95_1" transform="translate(15.0,45.0)">
-    <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
-</g>
+            <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+        </g>
         <g class="DISCONNECTOR idd" id="idd" transform="translate(15.0,45.0)">
-    <g class="closed" id="idd_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idd_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idd_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idd_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BREAKER idb" id="idb" transform="translate(9.0,39.0)">
-    <g class="closed" id="idb_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idb_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idb_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idb_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="NODE idFICT_95_vl1_95_4" id="idFICT_95_vl1_95_4" transform="translate(15.0,45.0)">
-    <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
-</g>
+            <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+        </g>
         <g class="DISCONNECTOR idd2WT_95_1" id="idd2WT_95_1" transform="translate(15.0,45.0)">
-    <g class="closed" id="idd2WT_95_1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idd2WT_95_1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idd2WT_95_1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idd2WT_95_1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BREAKER idb2WT_95_1" id="idb2WT_95_1" transform="translate(9.0,39.0)">
-    <g class="closed" id="idb2WT_95_1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idb2WT_95_1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idb2WT_95_1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idb2WT_95_1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="NODE idFICT_95_vl1_95_6" id="idFICT_95_vl1_95_6" transform="translate(15.0,45.0)">
-    <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
-</g>
+            <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+        </g>
         <g class="DISCONNECTOR idd3WT_95_1" id="idd3WT_95_1" transform="translate(15.0,45.0)">
-    <g class="closed" id="idd3WT_95_1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idd3WT_95_1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idd3WT_95_1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idd3WT_95_1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BREAKER idb3WT_95_1" id="idb3WT_95_1" transform="translate(9.0,39.0)">
-    <g class="closed" id="idb3WT_95_1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idb3WT_95_1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idb3WT_95_1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idb3WT_95_1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -119,49 +119,46 @@
 ]]></style>
     <defs>
         <g id="ARROW">
-     <g class="arrow-up" id="ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-</g>
+            <g class="arrow-up" id="ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+        </g>
         <g id="LOAD">
-    <rect height="9" width="16"/>
-    <line y2="9" x1="0" x2="16" y1="0"/>
-    <line y2="9" x1="16" x2="0" y1="0"/>
-</g>
+            <rect height="9" width="16"/>
+            <line y2="9" x1="0" x2="16" y1="0"/>
+            <line y2="9" x1="16" x2="0" y1="0"/>
+        </g>
         <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
-
-    <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
-</g>
+            <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
+            <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
+        </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
     </defs>
     <g>
         <g class="grid" id="GRID_vl1" transform="translate(20.0,50.0)">

--- a/single-line-diagram-core/src/test/resources/vl2.svg
+++ b/single-line-diagram-core/src/test/resources/vl2.svg
@@ -146,22 +146,22 @@
             <polyline points="620.0,156.0,620.0,240.0"/>
         </g>
         <g class="ARROW1_vl2_95_gen1_UP" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_gen1_DOWN" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1">
             <polyline points="620.0,260.0,620.0,370.0"/>
@@ -173,22 +173,22 @@
             <polyline points="670.0,562.0,670.0,480.0"/>
         </g>
         <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,665.0,537.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,665.0,517.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1">
             <polyline points="670.0,460.0,670.0,370.0"/>
@@ -200,43 +200,43 @@
             <polyline points="700.0,150.0,700.0,205.0,722.0,205.0"/>
         </g>
         <g class="ARROW1_vl2_95_trf2_95_one_UP" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,165.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,185.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2">
             <polyline points="760.0,150.0,760.0,205.0,738.0,205.0"/>
         </g>
         <g class="ARROW1_vl2_95_trf2_95_two_UP" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,755.0,165.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl2_95_trf2_95_two_DOWN" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,755.0,185.0)">
-     <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl2_95_FICT_95_vl2_95_vl2_95_trf2_95_vl2_95_btrf2">
             <polyline points="730.0,217.0,730.0,240.0"/>
@@ -248,55 +248,54 @@
             <polyline points="730.0,370.0,720.0,370.0"/>
         </g>
         <g class="GENERATOR idvl2_95_gen1" id="idvl2_95_gen1" transform="translate(614.0,144.0)">
-    <circle r="6" cx="6" cy="6"/>
-    <path d="M6,6 A 6 40 0 0 0 2,6"/>
-    <path d="M6,6 A 6 40 0 0 0 10,6"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_gen1__LABEL">vl2_gen1</text>
+            <circle r="6" cx="6" cy="6"/>
+            <path d="M6,6 A 6 40 0 0 0 2,6"/>
+            <path d="M6,6 A 6 40 0 0 0 10,6"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_gen1__LABEL">vl2_gen1</text>
         </g>
         <g class="BREAKER idvl2_95_bgen1" id="idvl2_95_bgen1" transform="translate(610.0,240.0)">
-    <g class="closed" id="idvl2_95_bgen1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl2_95_bgen1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_bgen1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl2_95_bgen1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl2_95_dgen1" id="idvl2_95_dgen1" transform="translate(616.0,366.0)">
-    <g class="closed" id="idvl2_95_dgen1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl2_95_dgen1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_dgen1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl2_95_dgen1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="TWO_WINDINGS_TRANSFORMER idvl2_95_trf1" id="idvl2_95_trf1" transform="translate(665.0,562.5)">
-    <circle r="5" id="idvl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
-
-    <circle r="5" id="idvl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_trf1__LABEL">vl2_trf1</text>
+            <circle r="5" id="idvl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
+            <circle r="5" id="idvl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_trf1__LABEL">vl2_trf1</text>
         </g>
         <g class="BREAKER idvl2_95_btrf1" id="idvl2_95_btrf1" transform="translate(660.0,460.0)">
-    <g class="closed" id="idvl2_95_btrf1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl2_95_btrf1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_btrf1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl2_95_btrf1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl2_95_dtrf1" id="idvl2_95_dtrf1" transform="translate(666.0,366.0)">
-    <g class="closed" id="idvl2_95_dtrf1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl2_95_dtrf1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_dtrf1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl2_95_dtrf1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl2_95_trf2_95_one" id="idvl2_95_trf2_95_one" transform="translate(700.0,150.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_trf2_one__LABEL">vl2_trf2</text>
         </g>
@@ -304,30 +303,28 @@
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_trf2_two__LABEL">vl2_trf2</text>
         </g>
         <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl2_95_vl2_95_trf2" id="idFICT_95_vl2_95_vl2_95_trf2" transform="translate(722.0,203.0)">
-    <circle r="5" id="idFICT_95_vl2_95_vl2_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="idFICT_95_vl2_95_vl2_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="idFICT_95_vl2_95_vl2_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="idFICT_95_vl2_95_vl2_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="idFICT_95_vl2_95_vl2_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="idFICT_95_vl2_95_vl2_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g class="BREAKER idvl2_95_btrf2" id="idvl2_95_btrf2" transform="translate(720.0,240.0)">
-    <g class="closed" id="idvl2_95_btrf2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl2_95_btrf2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl2_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl2_95_dtrf2" id="idvl2_95_dtrf2" transform="translate(726.0,366.0)">
-    <g class="closed" id="idvl2_95_dtrf2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl2_95_dtrf2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl2_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl2_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl2_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_nominal_voltage_style.svg
@@ -162,18 +162,15 @@
             <polyline points="19.0,39.0,19.0,49.0" stroke-width="1" stroke="#228b22"/>
         </g>
         <g class="TWO_WINDINGS_TRANSFORMER id2WT_95_TWO" id="id2WT_95_TWO" transform="translate(14.0,41.5)">
-    <circle fill="#228b22" r="5" id="id2WT_95_TWO_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#228b22"/>
-
-    <circle fill="#ff0000" r="5" id="id2WT_95_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#ff0000"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="2WT_TWO__LABEL">2WT_2</text>
+            <circle fill="#228b22" r="5" id="id2WT_95_TWO_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#228b22"/>
+            <circle fill="#ff0000" r="5" id="id2WT_95_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#ff0000"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="2WT_TWO__LABEL">2WT_2</text>
         </g>
         <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl2_95_3WT_95_fictif" id="idFICT_95_vl2_95_3WT_95_fictif" transform="translate(11.0,42.0)">
-    <circle fill="#a020f0" r="5" id="idFICT_95_vl2_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5" stroke="#a020f0"/>
-
-    <circle fill="#ff0000" r="5" id="idFICT_95_vl2_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#ff0000"/>
-
-    <circle fill="#228b22" r="5" id="idFICT_95_vl2_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#228b22"/>
-</g>
+            <circle fill="#a020f0" r="5" id="idFICT_95_vl2_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5" stroke="#a020f0"/>
+            <circle fill="#ff0000" r="5" id="idFICT_95_vl2_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#ff0000"/>
+            <circle fill="#228b22" r="5" id="idFICT_95_vl2_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#228b22"/>
+        </g>
         <g class="LINE id3WT_95_ONE" id="id3WT_95_ONE" transform="translate(19.0,49.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="3WT_ONE__LABEL">3WT_2</text>
         </g>
@@ -181,48 +178,48 @@
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="3WT_THREE__LABEL">3WT_2</text>
         </g>
         <g class="NODE idFICT_95_vl2_95_2" id="idFICT_95_vl2_95_2" transform="translate(15.0,45.0)">
-    <circle fill-opacity="0" fill="#228b22" r="4" cx="4" cy="4" stroke="#228b22" stroke-opacity="0"/>
-</g>
+            <circle fill-opacity="0" fill="#228b22" r="4" cx="4" cy="4" stroke="#228b22" stroke-opacity="0"/>
+        </g>
         <g class="DISCONNECTOR idd2WT_95_2" id="idd2WT_95_2" transform="translate(15.0,45.0)">
-    <g class="closed" id="idd2WT_95_2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idd2WT_95_2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idd2WT_95_2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idd2WT_95_2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BREAKER idb2WT_95_2" id="idb2WT_95_2" transform="translate(9.0,39.0)">
-    <g class="closed" id="idb2WT_95_2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idb2WT_95_2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idb2WT_95_2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idb2WT_95_2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="NODE idFICT_95_vl2_95_4" id="idFICT_95_vl2_95_4" transform="translate(15.0,45.0)">
-    <circle fill-opacity="0" fill="#228b22" r="4" cx="4" cy="4" stroke="#228b22" stroke-opacity="0"/>
-</g>
+            <circle fill-opacity="0" fill="#228b22" r="4" cx="4" cy="4" stroke="#228b22" stroke-opacity="0"/>
+        </g>
         <g class="DISCONNECTOR idd3WT_95_2" id="idd3WT_95_2" transform="translate(15.0,45.0)">
-    <g class="closed" id="idd3WT_95_2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idd3WT_95_2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idd3WT_95_2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idd3WT_95_2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BREAKER idb3WT_95_2" id="idb3WT_95_2" transform="translate(9.0,39.0)">
-    <g class="closed" id="idb3WT_95_2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idb3WT_95_2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idb3WT_95_2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idb3WT_95_2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -119,49 +119,46 @@
 ]]></style>
     <defs>
         <g id="GENERATOR">
-    <circle r="6" cx="6" cy="6"/>
-    <path d="M6,6 A 6 40 0 0 0 2,6"/>
-    <path d="M6,6 A 6 40 0 0 0 10,6"/>
-</g>
+            <circle r="6" cx="6" cy="6"/>
+            <path d="M6,6 A 6 40 0 0 0 2,6"/>
+            <path d="M6,6 A 6 40 0 0 0 10,6"/>
+        </g>
         <g id="ARROW">
-     <g class="arrow-up" id="ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-</g>
+            <g class="arrow-up" id="ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+        </g>
         <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g id="TWO_WINDINGS_TRANSFORMER">
-    <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
-
-    <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
-</g>
+            <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10"/>
+            <circle r="5" id="TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5"/>
+        </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
     </defs>
     <g>
         <g class="grid" id="GRID_vl2" transform="translate(20.0,50.0)">

--- a/single-line-diagram-core/src/test/resources/vl3.svg
+++ b/single-line-diagram-core/src/test/resources/vl3.svg
@@ -143,22 +143,22 @@
             <polyline points="910.0,156.0,910.0,240.0"/>
         </g>
         <g class="ARROW1_vl3_95_capa1_UP" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
-     <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_capa1_DOWN" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
-     <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1">
             <polyline points="910.0,260.0,910.0,370.0"/>
@@ -170,43 +170,43 @@
             <polyline points="980.0,150.0,980.0,205.0,1012.0,205.0"/>
         </g>
         <g class="ARROW1_vl3_95_trf2_95_one_UP" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,975.0,165.0)">
-     <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,975.0,185.0)">
-     <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2">
             <polyline points="1060.0,150.0,1060.0,205.0,1028.0,205.0"/>
         </g>
         <g class="ARROW1_vl3_95_trf2_95_two_UP" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,165.0)">
-     <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_vl3_95_trf2_95_two_DOWN" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,185.0)">
-     <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_vl3_95_FICT_95_vl3_95_vl3_95_trf2_95_vl3_95_btrf2">
             <polyline points="1020.0,217.0,1020.0,240.0"/>
@@ -218,31 +218,31 @@
             <polyline points="1020.0,370.0,1020.0,370.0"/>
         </g>
         <g class="CAPACITOR idvl3_95_capa1" id="idvl3_95_capa1" transform="translate(904.0,144.0)">
-    <line y2="4.5" x1="6" x2="6" y1="0"/>
-    <line y2="4.5" x1="0" x2="12" y1="4.5"/>
-    <line y2="7.5" x1="0" x2="12" y1="7.5"/>
-    <line y2="12" x1="6" x2="6" y1="7.5"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_capa1__LABEL">vl3_capa1</text>
+            <line y2="4.5" x1="6" x2="6" y1="0"/>
+            <line y2="4.5" x1="0" x2="12" y1="4.5"/>
+            <line y2="7.5" x1="0" x2="12" y1="7.5"/>
+            <line y2="12" x1="6" x2="6" y1="7.5"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_capa1__LABEL">vl3_capa1</text>
         </g>
         <g class="BREAKER idvl3_95_bcapa1" id="idvl3_95_bcapa1" transform="translate(900.0,240.0)">
-    <g class="closed" id="idvl3_95_bcapa1_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl3_95_bcapa1_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl3_95_bcapa1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl3_95_bcapa1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl3_95_dcapa1" id="idvl3_95_dcapa1" transform="translate(906.0,366.0)">
-    <g class="closed" id="idvl3_95_dcapa1_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl3_95_dcapa1_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl3_95_dcapa1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl3_95_dcapa1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="LINE idvl3_95_trf2_95_one" id="idvl3_95_trf2_95_one" transform="translate(980.0,150.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_trf2_one__LABEL">vl3_trf2</text>
         </g>
@@ -250,30 +250,28 @@
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_trf2_two__LABEL">vl3_trf2</text>
         </g>
         <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl3_95_vl3_95_trf2" id="idFICT_95_vl3_95_vl3_95_trf2" transform="translate(1012.0,203.0)">
-    <circle r="5" id="idFICT_95_vl3_95_vl3_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="idFICT_95_vl3_95_vl3_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="idFICT_95_vl3_95_vl3_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="idFICT_95_vl3_95_vl3_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="idFICT_95_vl3_95_vl3_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="idFICT_95_vl3_95_vl3_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g class="BREAKER idvl3_95_btrf2" id="idvl3_95_btrf2" transform="translate(1010.0,240.0)">
-    <g class="closed" id="idvl3_95_btrf2_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idvl3_95_btrf2_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idvl3_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl3_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
         <g class="DISCONNECTOR idvl3_95_dtrf2" id="idvl3_95_dtrf2" transform="translate(1016.0,366.0)">
-    <g class="closed" id="idvl3_95_dtrf2_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idvl3_95_dtrf2_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idvl3_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl3_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl3_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_nominal_voltage_style.svg
@@ -146,12 +146,10 @@
             <polyline points="19.0,39.0,19.0,49.0" stroke-width="1" stroke="#a020f0"/>
         </g>
         <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl3_95_3WT_95_fictif" id="idFICT_95_vl3_95_3WT_95_fictif" transform="translate(11.0,42.0)">
-    <circle fill="#228b22" r="5" id="idFICT_95_vl3_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5" stroke="#228b22"/>
-
-    <circle fill="#ff0000" r="5" id="idFICT_95_vl3_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#ff0000"/>
-
-    <circle fill="#a020f0" r="5" id="idFICT_95_vl3_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#a020f0"/>
-</g>
+            <circle fill="#228b22" r="5" id="idFICT_95_vl3_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5" stroke="#228b22"/>
+            <circle fill="#ff0000" r="5" id="idFICT_95_vl3_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#ff0000"/>
+            <circle fill="#a020f0" r="5" id="idFICT_95_vl3_95_3WT_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#a020f0"/>
+        </g>
         <g class="LINE id3WT_95_ONE" id="id3WT_95_ONE" transform="translate(19.0,49.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="3WT_ONE__LABEL">3WT_3</text>
         </g>
@@ -159,26 +157,26 @@
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="3WT_TWO__LABEL">3WT_3</text>
         </g>
         <g class="NODE idFICT_95_vl3_95_2" id="idFICT_95_vl3_95_2" transform="translate(15.0,45.0)">
-    <circle fill-opacity="0" fill="#a020f0" r="4" cx="4" cy="4" stroke="#a020f0" stroke-opacity="0"/>
-</g>
+            <circle fill-opacity="0" fill="#a020f0" r="4" cx="4" cy="4" stroke="#a020f0" stroke-opacity="0"/>
+        </g>
         <g class="DISCONNECTOR idd3WT_95_3" id="idd3WT_95_3" transform="translate(15.0,45.0)">
-    <g class="closed" id="idd3WT_95_3_DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="idd3WT_95_3_DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="idd3WT_95_3_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idd3WT_95_3_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g class="BREAKER idb3WT_95_3" id="idb3WT_95_3" transform="translate(9.0,39.0)">
-    <g class="closed" id="idb3WT_95_3_BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="idb3WT_95_3_BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="idb3WT_95_3_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idb3WT_95_3_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/vl3_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_optimized.svg
@@ -119,45 +119,43 @@
 ]]></style>
     <defs>
         <g id="ARROW">
-     <g class="arrow-up" id="ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-</g>
+            <g class="arrow-up" id="ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+        </g>
         <g id="CAPACITOR">
-    <line y2="4.5" x1="6" x2="6" y1="0"/>
-    <line y2="4.5" x1="0" x2="12" y1="4.5"/>
-    <line y2="7.5" x1="0" x2="12" y1="7.5"/>
-    <line y2="12" x1="6" x2="6" y1="7.5"/>
-</g>
+            <line y2="4.5" x1="6" x2="6" y1="0"/>
+            <line y2="4.5" x1="0" x2="12" y1="4.5"/>
+            <line y2="7.5" x1="0" x2="12" y1="7.5"/>
+            <line y2="12" x1="6" x2="6" y1="7.5"/>
+        </g>
         <g id="DISCONNECTOR">
-    <g class="closed" id="DISCONNECTOR-closed">
-        <line y2="8" x1="0" x2="8" y1="0"/>
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-    <g class="open" id="DISCONNECTOR-open">
-        <line y2="8" x1="8" x2="0" y1="0"/>
-    </g>
-</g>
+            <g class="closed" id="DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
         <g id="THREE_WINDINGS_TRANSFORMER">
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
-
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
-
-    <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
-</g>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
         <g id="BREAKER">
-    <g class="closed" id="BREAKER-closed">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="15" x1="10" x2="10" y1="5"/>
-    </g>
-    <g class="open" id="BREAKER-open">
-        <rect x="1" width="18" y="1" height="18"/>
-        <line y2="10" x1="5" x2="15" y1="10"/>
-    </g>
-</g>
+            <g class="closed" id="BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
     </defs>
     <g>
         <g class="grid" id="GRID_vl3" transform="translate(20.0,50.0)">

--- a/single-line-diagram-core/src/test/resources/zone.svg
+++ b/single-line-diagram-core/src/test/resources/zone.svg
@@ -132,49 +132,49 @@
             <polyline points="50.0,250.0,70.0,250.0,70.0,104.0"/>
         </g>
         <g class="ARROW1_Load_UP" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,119.0)">
-     <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_Load_DOWN" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,139.0)">
-     <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE">
             <polyline points="50.0,250.0,70.0,250.0,70.0,350.0"/>
         </g>
         <g class="ARROW1_Transformer_95_ONE_UP" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,325.0)">
-     <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_Transformer_95_ONE_DOWN" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,305.0)">
-     <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="LOAD idLoad" id="idLoad" transform="translate(62.0,95.5)">
-    <rect height="9" width="16"/>
-    <line y2="9" x1="0" x2="16" y1="0"/>
-    <line y2="9" x1="16" x2="0" y1="0"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Load__LABEL">Load</text>
+            <rect height="9" width="16"/>
+            <line y2="9" x1="0" x2="16" y1="0"/>
+            <line y2="9" x1="16" x2="0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Load__LABEL">Load</text>
         </g>
         <g class="LINE idTransformer_95_ONE" id="idTransformer_95_ONE" transform="translate(70.0,350.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Transformer_ONE__LABEL">Transformer</text>
@@ -187,43 +187,43 @@
             <polyline points="50.0,550.0,70.0,550.0,70.0,450.0"/>
         </g>
         <g class="ARROW1_Transformer_95_TWO_UP" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,465.0)">
-     <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_Transformer_95_TWO_DOWN" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,485.0)">
-     <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE">
             <polyline points="50.0,550.0,70.0,550.0,70.0,700.0"/>
         </g>
         <g class="ARROW1_Line_95_ONE_UP" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,675.0)">
-     <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_Line_95_ONE_DOWN" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,655.0)">
-     <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="LINE idTransformer_95_TWO" id="idTransformer_95_TWO" transform="translate(70.0,450.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Transformer_TWO__LABEL">Transformer</text>
@@ -232,10 +232,9 @@
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Line_ONE__LABEL">Line</text>
         </g>
         <g class="TWO_WINDINGS_TRANSFORMER idTransformer_95_ONE_95_Transformer_95_TWO" id="idTransformer_95_ONE_95_Transformer_95_TWO" transform="translate(65.0,392.5)">
-    <circle r="5" id="idTransformer_95_ONE_95_Transformer_95_TWO_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" transform="rotate(180.0,5.0,7.5)" cy="10"/>
-
-    <circle r="5" id="idTransformer_95_ONE_95_Transformer_95_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" transform="rotate(180.0,5.0,7.5)" cy="5"/>
-</g>
+            <circle r="5" id="idTransformer_95_ONE_95_Transformer_95_TWO_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" transform="rotate(180.0,5.0,7.5)" cy="10"/>
+            <circle r="5" id="idTransformer_95_ONE_95_Transformer_95_TWO_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" transform="rotate(180.0,5.0,7.5)" cy="5"/>
+        </g>
         <g class="wire" id="_95_Substation1_95_Transformer_95_ONE_95_Transformer_95_ONE_95_Transformer_95_TWO">
             <polyline points="70.0,350.0,70.0,370.0,70.0,392.0"/>
         </g>
@@ -250,49 +249,49 @@
             <polyline points="150.0,1150.0,170.0,1150.0,170.0,1294.0"/>
         </g>
         <g class="ARROW1_Generator_UP" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1269.0)">
-     <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_Generator_DOWN" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1249.0)">
-     <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="wire" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO">
             <polyline points="150.0,1150.0,170.0,1150.0,170.0,1000.0"/>
         </g>
         <g class="ARROW1_Line_95_TWO_UP" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1015.0)">
-     <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+            <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="ARROW2_Line_95_TWO_DOWN" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1035.0)">
-     <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW2_ARROW-arrow-up">
-        <polygon points="5,0 10,10 0,10"/>
-     </g>
-     <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW2_ARROW-arrow-down">
-        <polygon points="0,0 10,0 5,10"/>
-     </g>
-<text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+            <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
         <g class="GENERATOR idGenerator" id="idGenerator" transform="translate(164.0,1294.0)">
-    <circle r="6" cx="6" cy="6"/>
-    <path d="M6,6 A 6 40 0 0 0 2,6"/>
-    <path d="M6,6 A 6 40 0 0 0 10,6"/>
-<text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Generator__LABEL">Generator</text>
+            <circle r="6" cx="6" cy="6"/>
+            <path d="M6,6 A 6 40 0 0 0 2,6"/>
+            <path d="M6,6 A 6 40 0 0 0 10,6"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Generator__LABEL">Generator</text>
         </g>
         <g class="LINE idLine_95_TWO" id="idLine_95_TWO" transform="translate(170.0,1000.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Line_TWO__LABEL">Line</text>


### PR DESCRIPTION
Wrong indentation in svg diagram was because of the text nodes in the svg basic components. Indeed, empty text nodes were kept and the transformer does not manage them. This PR looks for empty nodes and delete them after loading each component. Another way would have been to validate the content of the svg component while loading it.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Wrong indentation in produced svg


**What is the new behavior (if this is a feature change)?**
Correct indentation


**Does this PR introduce a breaking change or deprecate an API?** 
No


**Other information**:
Note that the high number of lines modified is because of the svg test files.