### PR TITLE
Modified edge color in case one of the extremities is an open switch

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologicalStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologicalStyleProvider.java
@@ -150,6 +150,21 @@ public class TopologicalStyleProvider extends AbstractBaseVoltageDiagramStylePro
     }
 
     @Override
+    protected String getEdgeColor(Node node1, Node node2) {
+        if (node1.getType() == NodeType.SWITCH && node1.isOpen()) {
+            return node2.getVoltageLevelInfos() != null ? getNodeColor(node2.getVoltageLevelInfos(), node2) : null;
+        }
+        if (node2.getType() == NodeType.SWITCH && node2.isOpen()) {
+            return node1.getVoltageLevelInfos() != null ? getNodeColor(node1.getVoltageLevelInfos(), node1) : null;
+        }
+        if (node1.getVoltageLevelInfos() != null) {
+            return getNodeColor(node1.getVoltageLevelInfos(), node1);
+        } else {
+            return getNodeColor(node2.getVoltageLevelInfos(), node2);
+        }
+    }
+
+    @Override
     public String getNodeColor(VoltageLevelInfos voltageLevelInfos, Node node) {
         RGBColor rgbColor = getSmartNodeColor(voltageLevelInfos, node);
         return rgbColor != null ? rgbColor.toString() : disconnectedColor;

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologicalStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologicalStyleProvider.java
@@ -157,11 +157,8 @@ public class TopologicalStyleProvider extends AbstractBaseVoltageDiagramStylePro
         if (node2.getType() == NodeType.SWITCH && node2.isOpen()) {
             return node1.getVoltageLevelInfos() != null ? getNodeColor(node1.getVoltageLevelInfos(), node1) : null;
         }
-        if (node1.getVoltageLevelInfos() != null) {
-            return getNodeColor(node1.getVoltageLevelInfos(), node1);
-        } else {
-            return getNodeColor(node2.getVoltageLevelInfos(), node2);
-        }
+
+        return super.getEdgeColor(node1, node2);
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: NOIR Nicolas ext <nicolas.noir@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR fixes a bug


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, some wires surrounding an open switch are not correctly colored (i.e. are not colored according to their voltage level)


**What is the new behavior (if this is a feature change)?**
Wires surrounding an open switch are now colored according to their voltage level.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
