### PR TITLE
Add optional legend for nodes with voltage and angle values

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -71,6 +71,8 @@ public class LayoutParameters {
     private boolean highlightLineState = true;
     private boolean tooltipEnabled = false;
 
+    private boolean addNodesInfos = false;
+
     @JsonIgnore
     private Map<String, ComponentSize> componentsSize;
 
@@ -110,7 +112,8 @@ public class LayoutParameters {
                             @JsonProperty("labelCentered") boolean labelCentered,
                             @JsonProperty("labelDiagonal") boolean labelDiagonal,
                             @JsonProperty("angleLabelShift") double angleLabelShift,
-                            @JsonProperty("highlightLineState") boolean highlightLineState) {
+                            @JsonProperty("highlightLineState") boolean highlightLineState,
+                            @JsonProperty("addNodesInfos") boolean addNodesInfos) {
         this.translateX = translateX;
         this.translateY = translateY;
         this.initialXBus = initialXBus;
@@ -143,6 +146,7 @@ public class LayoutParameters {
         this.labelDiagonal = labelDiagonal;
         this.angleLabelShift = angleLabelShift;
         this.highlightLineState = highlightLineState;
+        this.addNodesInfos = addNodesInfos;
     }
 
     public LayoutParameters(LayoutParameters other) {
@@ -180,6 +184,7 @@ public class LayoutParameters {
         labelDiagonal = other.labelDiagonal;
         labelCentered = other.labelCentered;
         highlightLineState = other.highlightLineState;
+        addNodesInfos = other.addNodesInfos;
     }
 
     public double getTranslateX() {
@@ -475,6 +480,15 @@ public class LayoutParameters {
 
     public LayoutParameters setTooltipEnabled(boolean tooltipEnabled) {
         this.tooltipEnabled = tooltipEnabled;
+        return this;
+    }
+
+    public boolean isAddNodesInfos() {
+        return addNodesInfos;
+    }
+
+    public LayoutParameters setAddNodesInfos(boolean addNodesInfos) {
+        this.addNodesInfos = addNodesInfos;
         return this;
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramStyleProvider.java
@@ -13,7 +13,8 @@ import com.powsybl.sld.model.*;
 
 import java.util.*;
 
-import static com.powsybl.sld.svg.DiagramStyles.*;
+import static com.powsybl.sld.svg.DiagramStyles.escapeClassName;
+import static com.powsybl.sld.svg.DiagramStyles.escapeId;
 
 /**
  * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -112,6 +112,8 @@ public class DefaultSVGWriter implements SVGWriter {
     protected static final String MIDDLE = "middle";
     protected static final int VALUE_MAX_NB_CHARS = 5;
     protected static final int CIRCLE_RADIUS_NODE_INFOS_SIZE = 10;
+    protected static final String FONT_FAMILY_ATTRIBUTE = "font-family";
+    protected static final String FONT_SIZE_ATTRIBUTE = "font-size";
 
     protected final ComponentLibrary componentLibrary;
 
@@ -652,8 +654,8 @@ public class DefaultSVGWriter implements SVGWriter {
         }
         label.setAttribute("x", String.valueOf(xShift));
         label.setAttribute("y", String.valueOf(yShift));
-        label.setAttribute("font-family", FONT_FAMILY);
-        label.setAttribute("font-size", Integer.toString(fontSize));
+        label.setAttribute(FONT_FAMILY_ATTRIBUTE, FONT_FAMILY);
+        label.setAttribute(FONT_SIZE_ATTRIBUTE, Integer.toString(fontSize));
         if (adjustLength) {
             label.setAttribute("xml:space", "preserve");
             label.setAttribute("textLength", Integer.toString(str.length() * (FONT_SIZE - 3)));
@@ -1430,8 +1432,8 @@ public class DefaultSVGWriter implements SVGWriter {
 
         labelV.setAttribute("x", String.valueOf(xShift - circleRadiusSize));
         labelV.setAttribute("y", String.valueOf(yShift + 2.5 * circleRadiusSize));
-        labelV.setAttribute("font-family", FONT_FAMILY);
-        labelV.setAttribute("font-size", Integer.toString(fontSize));
+        labelV.setAttribute(FONT_FAMILY_ATTRIBUTE, FONT_FAMILY);
+        labelV.setAttribute(FONT_SIZE_ATTRIBUTE, Integer.toString(fontSize));
         labelV.setAttribute(CLASS, DiagramStyles.LABEL_STYLE_CLASS);
         Text textV = g.getOwnerDocument().createTextNode(valueV);
         labelV.appendChild(textV);
@@ -1447,8 +1449,8 @@ public class DefaultSVGWriter implements SVGWriter {
 
         labelAngle.setAttribute("x", String.valueOf(xShift - circleRadiusSize));
         labelAngle.setAttribute("y", String.valueOf(yShift + 4 * circleRadiusSize));
-        labelAngle.setAttribute("font-family", FONT_FAMILY);
-        labelAngle.setAttribute("font-size", Integer.toString(fontSize));
+        labelAngle.setAttribute(FONT_FAMILY_ATTRIBUTE, FONT_FAMILY);
+        labelAngle.setAttribute(FONT_SIZE_ATTRIBUTE, Integer.toString(fontSize));
         labelAngle.setAttribute(CLASS, DiagramStyles.LABEL_STYLE_CLASS);
         Text textAngle = g.getOwnerDocument().createTextNode(valueAngle);
         labelAngle.appendChild(textAngle);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -8,9 +8,27 @@ package com.powsybl.sld.svg;
 
 import com.powsybl.commons.exceptions.UncheckedTransformerException;
 import com.powsybl.sld.layout.LayoutParameters;
-import com.powsybl.sld.library.*;
+import com.powsybl.sld.library.AnchorOrientation;
+import com.powsybl.sld.library.AnchorPoint;
+import com.powsybl.sld.library.AnchorPointProvider;
+import com.powsybl.sld.library.ComponentLibrary;
+import com.powsybl.sld.library.ComponentMetadata;
+import com.powsybl.sld.library.ComponentSize;
+import com.powsybl.sld.model.BusCell;
+import com.powsybl.sld.model.BusNode;
+import com.powsybl.sld.model.Cell;
+import com.powsybl.sld.model.Edge;
+import com.powsybl.sld.model.ExternCell;
+import com.powsybl.sld.model.FeederNode;
+import com.powsybl.sld.model.FeederWithSideNode;
+import com.powsybl.sld.model.Graph;
+import com.powsybl.sld.model.LineEdge;
 import com.powsybl.sld.model.Node;
-import com.powsybl.sld.model.*;
+import com.powsybl.sld.model.SubstationGraph;
+import com.powsybl.sld.model.SwitchNode;
+import com.powsybl.sld.model.TwtEdge;
+import com.powsybl.sld.model.VoltageLevelInfos;
+import com.powsybl.sld.model.ZoneGraph;
 import com.powsybl.sld.svg.DiagramLabelProvider.Direction;
 import com.powsybl.sld.svg.GraphMetadata.ArrowMetadata;
 import org.apache.batik.anim.dom.SVGOMDocument;
@@ -19,7 +37,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.util.Precision;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.*;
+import org.w3c.dom.CDATASection;
+import org.w3c.dom.DOMImplementation;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
@@ -33,14 +56,34 @@ import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static com.powsybl.sld.library.ComponentTypeName.*;
-import static com.powsybl.sld.model.Position.Dimension.*;
-import static com.powsybl.sld.svg.DiagramStyles.*;
+import static com.powsybl.sld.library.ComponentTypeName.ARROW;
+import static com.powsybl.sld.library.ComponentTypeName.BREAKER;
+import static com.powsybl.sld.library.ComponentTypeName.BUSBAR_SECTION;
+import static com.powsybl.sld.library.ComponentTypeName.BUSBREAKER_CONNECTION;
+import static com.powsybl.sld.library.ComponentTypeName.DISCONNECTOR;
+import static com.powsybl.sld.library.ComponentTypeName.NODE;
+import static com.powsybl.sld.library.ComponentTypeName.PHASE_SHIFT_TRANSFORMER;
+import static com.powsybl.sld.library.ComponentTypeName.THREE_WINDINGS_TRANSFORMER;
+import static com.powsybl.sld.library.ComponentTypeName.TWO_WINDINGS_TRANSFORMER;
+import static com.powsybl.sld.model.Position.Dimension.H;
+import static com.powsybl.sld.model.Position.Dimension.V;
+import static com.powsybl.sld.svg.DiagramStyles.WIRE_STYLE_CLASS;
+import static com.powsybl.sld.svg.DiagramStyles.escapeClassName;
+import static com.powsybl.sld.svg.DiagramStyles.escapeId;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
@@ -68,6 +111,7 @@ public class DefaultSVGWriter implements SVGWriter {
     protected static final String TEXT_ANCHOR = "text-anchor";
     protected static final String MIDDLE = "middle";
     protected static final int VALUE_MAX_NB_CHARS = 5;
+    protected static final int CIRCLE_RADIUS_NODE_INFOS_SIZE = 10;
 
     protected final ComponentLibrary componentLibrary;
 
@@ -187,7 +231,7 @@ public class DefaultSVGWriter implements SVGWriter {
             root.appendChild(drawGrid(prefixId, graph, document, metadata));
         }
 
-        drawVoltageLevel(prefixId, graph, root, metadata, initProvider, styleProvider);
+        drawVoltageLevel(prefixId, graph, root, metadata, initProvider, styleProvider, true);
 
         document.adoptNode(root);
         document.getDocumentElement().appendChild(root);
@@ -200,7 +244,8 @@ public class DefaultSVGWriter implements SVGWriter {
                                     Element root,
                                     GraphMetadata metadata,
                                     DiagramLabelProvider initProvider,
-                                    DiagramStyleProvider styleProvider) {
+                                    DiagramStyleProvider styleProvider,
+                                    boolean useNodesInfosParam) {
         AnchorPointProvider anchorPointProvider = (type, id) -> {
             if (type.equals(BUSBAR_SECTION)) {
                 BusNode busbarSectionNode = (BusNode) graph.getNode(id);
@@ -233,6 +278,10 @@ public class DefaultSVGWriter implements SVGWriter {
         }
         drawEdges(prefixId, root, graph, remainingEdges, metadata, anchorPointProvider, initProvider, styleProvider);
         drawNodes(prefixId, root, graph, metadata, anchorPointProvider, initProvider, styleProvider, remainingNodes);
+
+        if (useNodesInfosParam && layoutParameters.isAddNodesInfos()) {
+            drawNodesInfos(prefixId, root, graph, styleProvider);
+        }
     }
 
     private List<Edge> drawCell(String prefixId, Element root, Graph graph, Cell cell,
@@ -363,7 +412,7 @@ public class DefaultSVGWriter implements SVGWriter {
                                   DiagramStyleProvider styleProvider) {
         // Drawing the voltageLevel graphs
         for (Graph vlGraph : graph.getNodes()) {
-            drawVoltageLevel(prefixId, vlGraph, root, metadata, initProvider, styleProvider);
+            drawVoltageLevel(prefixId, vlGraph, root, metadata, initProvider, styleProvider, false);
         }
 
         AnchorPointProvider anchorPointProvider = (type, id) -> componentLibrary.getAnchorPoints(type);
@@ -1349,6 +1398,83 @@ public class DefaultSVGWriter implements SVGWriter {
             root.appendChild(g);
 
             setMetadata(metadata, node, nodeId, null, BusCell.Direction.UNDEFINED, anchorPointProvider);
+        });
+    }
+
+   /*
+     * Drawing the voltageLevel nodes infos
+     */
+    private void drawNodeInfos(ElectricalNodeInfo nodeInfo,
+                               double xShift,
+                               double yShift,
+                               Element g,
+                               String idNode,
+                               int fontSize,
+                               double circleRadiusSize) {
+        Element circle = g.getOwnerDocument().createElement("circle");
+
+        circle.setAttribute("id", idNode + "_circle");
+        circle.setAttribute("cx", String.valueOf(xShift));
+        circle.setAttribute("cy", String.valueOf(yShift));
+        circle.setAttribute("r", String.valueOf(circleRadiusSize));
+        circle.setAttribute("fill", nodeInfo.getColor());
+        g.appendChild(circle);
+
+        // v
+        Element labelV = g.getOwnerDocument().createElement("text");
+        labelV.setAttribute("id", idNode + "_v");
+        String valueV = !Double.isNaN(nodeInfo.getV())
+                ? String.valueOf(Precision.round(nodeInfo.getV(), 1))
+                : "\u2014";  // em dash unicode for undefined value
+        valueV += " kV";
+
+        labelV.setAttribute("x", String.valueOf(xShift - circleRadiusSize));
+        labelV.setAttribute("y", String.valueOf(yShift + 2.5 * circleRadiusSize));
+        labelV.setAttribute("font-family", FONT_FAMILY);
+        labelV.setAttribute("font-size", Integer.toString(fontSize));
+        labelV.setAttribute(CLASS, DiagramStyles.LABEL_STYLE_CLASS);
+        Text textV = g.getOwnerDocument().createTextNode(valueV);
+        labelV.appendChild(textV);
+        g.appendChild(labelV);
+
+        // angle
+        Element labelAngle = g.getOwnerDocument().createElement("text");
+        labelAngle.setAttribute("id", idNode + "_angle");
+        String valueAngle = !Double.isNaN(nodeInfo.getAngle())
+                ? String.valueOf(Precision.round(nodeInfo.getAngle(), 1))
+                : "\u2014";  // em dash unicode for undefined value
+        valueAngle += " \u00b0";  // degree sign unicode for degree symbol
+
+        labelAngle.setAttribute("x", String.valueOf(xShift - circleRadiusSize));
+        labelAngle.setAttribute("y", String.valueOf(yShift + 4 * circleRadiusSize));
+        labelAngle.setAttribute("font-family", FONT_FAMILY);
+        labelAngle.setAttribute("font-size", Integer.toString(fontSize));
+        labelAngle.setAttribute(CLASS, DiagramStyles.LABEL_STYLE_CLASS);
+        Text textAngle = g.getOwnerDocument().createTextNode(valueAngle);
+        labelAngle.appendChild(textAngle);
+        g.appendChild(labelAngle);
+    }
+
+    private void drawNodesInfos(String prefixId,
+                                Element root,
+                                Graph graph,
+                                DiagramStyleProvider styleProvider) {
+        double xInitPos = graph.getNodes().stream()
+                .filter(n -> n.getType() == Node.NodeType.BUS)
+                .mapToDouble(Node::getX).min().getAsDouble() + layoutParameters.getTranslateX() + CIRCLE_RADIUS_NODE_INFOS_SIZE;
+
+        double maxY = graph.getNodes().stream().mapToDouble(Node::getY).max().getAsDouble();
+        double yPos = graph.getY() + layoutParameters.getInitialYBus() + maxY - 120;
+
+        List<ElectricalNodeInfo> nodes = styleProvider.getElectricalNodesInfos(graph);
+
+        IntStream.range(0, nodes.size()).forEach(i -> {
+            String idNode = prefixId + "NODE_" + i + "_" + graph.getVoltageLevelInfos().getId();
+            Element gNode = root.getOwnerDocument().createElement("g");
+            gNode.setAttribute("id", idNode);
+
+            drawNodeInfos(nodes.get(i), graph.getX() + xInitPos + (i * (2 * CIRCLE_RADIUS_NODE_INFOS_SIZE + 50)), yPos, gNode, idNode, FONT_SIZE, CIRCLE_RADIUS_NODE_INFOS_SIZE);
+            root.appendChild(gNode);
         });
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DiagramStyleProvider.java
@@ -8,8 +8,11 @@ package com.powsybl.sld.svg;
 
 import com.powsybl.sld.library.ComponentSize;
 import com.powsybl.sld.model.Edge;
+import com.powsybl.sld.model.Graph;
 import com.powsybl.sld.model.Node;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -28,4 +31,8 @@ public interface DiagramStyleProvider {
     Map<String, String> getSvgArrowStyleAttributes(int num);
 
     void reset();
+
+    default List<ElectricalNodeInfo> getElectricalNodesInfos(Graph graph) {
+        return Collections.emptyList();
+    }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/ElectricalNodeInfo.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/ElectricalNodeInfo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.powsybl.sld.svg;
+
+/**
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ */
+public class ElectricalNodeInfo {
+    private double v;
+    private double angle;
+    String color;
+
+    public ElectricalNodeInfo(double v, double angle, String color) {
+        this.v = v;
+        this.angle = angle;
+        this.color = color;
+    }
+
+    public double getV() {
+        return v;
+    }
+
+    public double getAngle() {
+        return angle;
+    }
+
+    public String getColor() {
+        return color;
+    }
+}

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/AbstractBaseVoltageDiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/AbstractBaseVoltageDiagramStyleProvider.java
@@ -133,11 +133,9 @@ public abstract class AbstractBaseVoltageDiagramStyleProvider extends DefaultDia
             b.getConnectedTerminals().forEach(t -> {
                 if (color.get() == null) {
                     feederNodes.forEach(n -> {
-                        if (color.get() == null) {
-                            if (n.getEquipmentId().equals(t.getConnectable().getId())) {
-                                String colorValue = getNodeColor(graph.getVoltageLevelInfos(), n);
-                                color.set(colorValue);
-                            }
+                        if (color.get() == null && n.getEquipmentId().equals(t.getConnectable().getId())) {
+                            String colorValue = getNodeColor(graph.getVoltageLevelInfos(), n);
+                            color.set(colorValue);
                         }
                     });
                 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -16,8 +16,9 @@ import com.powsybl.sld.svg.DefaultSVGWriter;
 import com.powsybl.sld.svg.DiagramLabelProvider;
 import com.powsybl.sld.svg.DiagramStyleProvider;
 
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -51,7 +52,7 @@ public abstract class AbstractTestCase {
     private void writeToFileInHomeDir(String filename, StringWriter content) {
         if (writeFile) {
             try {
-                FileWriter fw = new FileWriter(System.getProperty("user.home") + filename);
+                OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(System.getProperty("user.home") + filename), StandardCharsets.UTF_8);
                 fw.write(content.toString());
                 fw.close();
             } catch (IOException e) {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase12GraphWith3WT.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase12GraphWith3WT.java
@@ -31,7 +31,6 @@ import com.powsybl.sld.util.TopologicalStyleProvider;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -319,10 +318,10 @@ public class TestCase12GraphWith3WT extends AbstractTestCaseIidm {
         DefaultDiagramLabelProvider initProvider = new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters);
 
         // write SVGs and compare to reference
-        assertArrayEquals(toString("/TestCase12GraphWithNodesInfosNominalVoltage.svg").getBytes(),
-                toSVG(g1, "/TestCase12GraphWithNodesInfosNominalVoltage.svg", layoutParameters, initProvider, vNomStyleProvider).getBytes());
+        assertEquals(toString("/TestCase12GraphWithNodesInfosNominalVoltage.svg"),
+                toSVG(g1, "/TestCase12GraphWithNodesInfosNominalVoltage.svg", layoutParameters, initProvider, vNomStyleProvider));
 
-        assertArrayEquals(toString("/TestCase12GraphWithNodesInfosTopological.svg").getBytes(),
-                toSVG(g1, "/TestCase12GraphWithNodesInfosTopological.svg", layoutParameters, initProvider, topoStyleProvider).getBytes());
+        assertEquals(toString("/TestCase12GraphWithNodesInfosTopological.svg"),
+                toSVG(g1, "/TestCase12GraphWithNodesInfosTopological.svg", layoutParameters, initProvider, topoStyleProvider));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
@@ -6,9 +6,9 @@
  */
 package com.powsybl.sld.layout;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
@@ -50,7 +50,9 @@ public class LayoutParametersTest {
                 .setAngleLabelShift(42)
                 .setLabelCentered(true)
                 .setLabelDiagonal(true)
-                .setHighlightLineState(false);
+                .setHighlightLineState(false)
+                .setTooltipEnabled(true)
+                .setAddNodesInfos(true);
         LayoutParameters layoutParameters2 = new LayoutParameters(layoutParameters);
 
         assertEquals(layoutParameters.getTranslateX(), layoutParameters2.getTranslateX(), 0);
@@ -84,5 +86,7 @@ public class LayoutParametersTest {
         assertEquals(layoutParameters.isLabelCentered(), layoutParameters2.isLabelCentered());
         assertEquals(layoutParameters.isLabelDiagonal(), layoutParameters2.isLabelDiagonal());
         assertEquals(layoutParameters.isHighlightLineState(), layoutParameters2.isHighlightLineState());
+        assertEquals(layoutParameters.isTooltipEnabled(), layoutParameters2.isTooltipEnabled());
+        assertEquals(layoutParameters.isAddNodesInfos(), layoutParameters2.isAddNodesInfos());
     }
 }

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -1131,12 +1131,12 @@
         <g id="NODE_0_vl1">
             <circle fill="#ff0000" r="10.0" id="NODE_0_vl1_circle" cx="40.0" cy="595.0"/>
             <text x="30.0" font-size="8" id="NODE_0_vl1_v" y="620.0" class="component-label" font-family="Verdana">392.0 kV</text>
-            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-2.3 ?</text>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-2.3 °</text>
         </g>
         <g id="NODE_1_vl1">
             <circle fill="#ff0000" r="10.0" id="NODE_1_vl1_circle" cx="110.0" cy="595.0"/>
             <text x="100.0" font-size="8" id="NODE_1_vl1_v" y="620.0" class="component-label" font-family="Verdana">403.0 kV</text>
-            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-1.7 ?</text>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-1.7 °</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -1,0 +1,1142 @@
+<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.BUSBAR_SECTION {
+    stroke: rgb(0,0,0);
+    stroke-width: 3;
+}
+
+.BREAKER {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 2;
+    fill: rgb(255, 255, 255);
+}
+
+.DISCONNECTOR {
+    stroke: rgb(0, 0, 0);
+    stroke-width: 3
+}
+
+.GENERATOR {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.LOAD {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.LOAD_BREAK_SWITCH {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill: rgb(255, 255, 255);
+}
+
+.NODE {
+    stroke: rgb(0, 0, 0);
+    fill: rgb(0, 0, 0);
+    fill-opacity: 1;
+}
+
+.CAPACITOR {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.INDUCTOR {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.STATIC_VAR_COMPENSATOR {
+    stroke: rgb(0, 0, 255);
+}
+
+.TWO_WINDINGS_TRANSFORMER {
+    stroke: rgb(0, 0, 255);
+    fill-opacity: 0;
+}
+
+.THREE_WINDINGS_TRANSFORMER {
+    stroke: rgb(0, 0, 255);
+    fill-opacity: 0;
+}
+
+.VSC_CONVERTER_STATION {
+    stroke: rgb(0, 0, 255);
+    font-size: 7.4314661px;
+    line-height: 1.25;
+    font-family: sans-serif;
+    font-variant-ligatures: normal;
+    font-variant-caps: normal;
+    font-variant-numeric: normal;
+    font-feature-settings: normal;
+    text-align: start;
+    letter-spacing: 0px;
+    word-spacing: 0px;
+    writing-mode: lr-tb;
+    text-anchor: start;
+    stroke-miterlimit: 4;
+}
+
+.PHASE_SHIFT_TRANSFORMER {
+    stroke: rgb(0, 0, 255);
+    stroke-linecap: butt;
+    stroke-linejoin: miter;
+    stroke-miterlimit: 4;
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.wire {
+    stroke: rgb(200,0,0);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.grid {
+    stroke: rgb(0,55,0);
+    stroke-width: 1;
+    stroke-dasharray: 1,10;
+}
+
+.component-label {
+    fill: black;
+    color: black;
+    stroke: none;
+    fill-opacity: 1;
+}
+
+.LINE {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+.ARROW1_load1_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_load1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_load1_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_load1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_load1_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_load1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_load1_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_load1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_gen1_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_gen1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_gen1_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_gen1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_gen1_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_gen1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_gen1_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_gen1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_load2_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_load2_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_load2_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_load2_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_load2_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_load2_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_load2_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_load2_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_gen2_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_gen2_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_gen2_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_gen2_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_gen2_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_gen2_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_gen2_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_gen2_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf1_95_ONE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf1_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf1_95_ONE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf1_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf1_95_ONE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf1_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf1_95_ONE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf1_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf2_95_ONE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf2_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf2_95_ONE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf2_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf2_95_ONE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf2_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf2_95_ONE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf2_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf3_95_ONE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf3_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf3_95_ONE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf3_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf3_95_ONE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf3_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf3_95_ONE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf3_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf4_95_ONE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf4_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf4_95_ONE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf4_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf4_95_ONE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf4_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf4_95_ONE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf4_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf5_95_ONE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf5_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf5_95_ONE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf5_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf5_95_ONE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf5_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf5_95_ONE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf5_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf6_95_TWO_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf6_95_TWO_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf6_95_TWO_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf6_95_TWO_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf6_95_TWO_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf6_95_TWO_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf6_95_TWO_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf6_95_TWO_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf6_95_THREE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf6_95_THREE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf6_95_THREE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf6_95_THREE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf6_95_THREE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf6_95_THREE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf6_95_THREE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf6_95_THREE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf7_95_TWO_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf7_95_TWO_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf7_95_TWO_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf7_95_TWO_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf7_95_TWO_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf7_95_TWO_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf7_95_TWO_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf7_95_TWO_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf7_95_THREE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf7_95_THREE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf7_95_THREE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf7_95_THREE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf7_95_THREE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf7_95_THREE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf7_95_THREE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf7_95_THREE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf8_95_TWO_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf8_95_TWO_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf8_95_TWO_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf8_95_TWO_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf8_95_TWO_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf8_95_TWO_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf8_95_TWO_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf8_95_TWO_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf8_95_THREE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf8_95_THREE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf8_95_THREE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf8_95_THREE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf8_95_THREE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf8_95_THREE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf8_95_THREE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf8_95_THREE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.iddsect11 .open { visibility: hidden;}.iddsect11 .closed { visibility: visible;}
+.iddtrct11 .open { visibility: hidden;}.iddtrct11 .closed { visibility: visible;}
+.iddsect12 .open { visibility: hidden;}.iddsect12 .closed { visibility: visible;}
+.iddsect21 .open { visibility: hidden;}.iddsect21 .closed { visibility: visible;}
+.iddtrct21 .open { visibility: hidden;}.iddtrct21 .closed { visibility: visible;}
+.iddsect22 .open { visibility: hidden;}.iddsect22 .closed { visibility: visible;}
+.iddload1 .open { visibility: hidden;}.iddload1 .closed { visibility: visible;}
+.idbload1 .open { visibility: hidden;}.idbload1 .closed { visibility: visible;}
+.iddgen1 .open { visibility: hidden;}.iddgen1 .closed { visibility: visible;}
+.idbgen1 .open { visibility: hidden;}.idbgen1 .closed { visibility: visible;}
+.iddload2 .open { visibility: hidden;}.iddload2 .closed { visibility: visible;}
+.idbload2 .open { visibility: hidden;}.idbload2 .closed { visibility: visible;}
+.iddgen2 .open { visibility: hidden;}.iddgen2 .closed { visibility: visible;}
+.idbgen2 .open { visibility: hidden;}.idbgen2 .closed { visibility: visible;}
+.iddtrf11 .open { visibility: hidden;}.iddtrf11 .closed { visibility: visible;}
+.idbtrf11 .open { visibility: hidden;}.idbtrf11 .closed { visibility: visible;}
+.iddtrf12 .open { visibility: hidden;}.iddtrf12 .closed { visibility: visible;}
+.idbtrf12 .open { visibility: hidden;}.idbtrf12 .closed { visibility: visible;}
+.iddtrf13 .open { visibility: hidden;}.iddtrf13 .closed { visibility: visible;}
+.idbtrf13 .open { visibility: hidden;}.idbtrf13 .closed { visibility: visible;}
+.iddtrf14 .open { visibility: hidden;}.iddtrf14 .closed { visibility: visible;}
+.idbtrf14 .open { visibility: hidden;}.idbtrf14 .closed { visibility: visible;}
+.iddtrf15 .open { visibility: hidden;}.iddtrf15 .closed { visibility: visible;}
+.idbtrf15 .open { visibility: hidden;}.idbtrf15 .closed { visibility: visible;}
+.iddtrf16 .open { visibility: hidden;}.iddtrf16 .closed { visibility: visible;}
+.idbtrf16 .open { visibility: hidden;}.idbtrf16 .closed { visibility: visible;}
+.iddtrf17 .open { visibility: hidden;}.iddtrf17 .closed { visibility: visible;}
+.idbtrf17 .open { visibility: hidden;}.idbtrf17 .closed { visibility: visible;}
+.iddtrf18 .open { visibility: hidden;}.iddtrf18 .closed { visibility: visible;}
+.idbtrf18 .open { visibility: hidden;}.idbtrf18 .closed { visibility: visible;}
+.idFICT_95_vl1_95_dsect11Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dload1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf11Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf15Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf16Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dsect12Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dload2Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf12Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf18Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dsect21Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dgen1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf13Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf17Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dsect22Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dgen2Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf14Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+]]></style>
+    <g>
+        <g class="grid" id="GRID_vl1" transform="translate(20.0,50.0)">
+            <line y2="565.0" x1="0.0" x2="0.0" y1="-20.0"/>
+            <line y2="565.0" x1="80.0" x2="80.0" y1="-20.0"/>
+            <line y2="565.0" x1="160.0" x2="160.0" y1="-20.0"/>
+            <line y2="565.0" x1="240.0" x2="240.0" y1="-20.0"/>
+            <line y2="565.0" x1="320.0" x2="320.0" y1="-20.0"/>
+            <line y2="565.0" x1="400.0" x2="400.0" y1="-20.0"/>
+            <line y2="565.0" x1="480.0" x2="480.0" y1="-20.0"/>
+            <line y2="565.0" x1="560.0" x2="560.0" y1="-20.0"/>
+            <line y2="565.0" x1="640.0" x2="640.0" y1="-20.0"/>
+            <line y2="565.0" x1="720.0" x2="720.0" y1="-20.0"/>
+            <line y2="565.0" x1="800.0" x2="800.0" y1="-20.0"/>
+            <line y2="565.0" x1="880.0" x2="880.0" y1="-20.0"/>
+            <line y2="565.0" x1="960.0" x2="960.0" y1="-20.0"/>
+            <line y2="565.0" x1="1040.0" x2="1040.0" y1="-20.0"/>
+            <line y2="565.0" x1="1120.0" x2="1120.0" y1="-20.0"/>
+            <line y2="565.0" x1="1200.0" x2="1200.0" y1="-20.0"/>
+            <line y2="565.0" x1="1280.0" x2="1280.0" y1="-20.0"/>
+            <line y2="230.0" x1="0.0" x2="1280.0" y1="230.0"/>
+            <line y2="315.0" x1="0.0" x2="1280.0" y1="315.0"/>
+            <line y2="220.0" x1="0.0" x2="1280.0" y1="220.0"/>
+            <line y2="325.0" x1="0.0" x2="1280.0" y1="325.0"/>
+        </g>
+        <g class="BUSBAR_SECTION idbbs1" id="idbbs1" transform="translate(30.0,310.0)">
+            <line y2="0" fill="#ff0000" x1="0" x2="700.0" stroke="#ff0000" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs1_NW_LABEL">bbs1</text>
+        </g>
+        <g class="BUSBAR_SECTION idbbs2" id="idbbs2" transform="translate(830.0,310.0)">
+            <line y2="0" fill="#ff0000" x1="0" x2="460.0" stroke="#ff0000" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs2_NW_LABEL">bbs2</text>
+        </g>
+        <g class="BUSBAR_SECTION idbbs3" id="idbbs3" transform="translate(30.0,335.0)">
+            <line y2="0" fill="#ff0000" x1="0" x2="700.0" stroke="#ff0000" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs3_NW_LABEL">bbs3</text>
+        </g>
+        <g class="BUSBAR_SECTION idbbs4" id="idbbs4" transform="translate(830.0,335.0)">
+            <line y2="0" fill="#ff0000" x1="0" x2="460.0" stroke="#ff0000" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs4_NW_LABEL">bbs4</text>
+        </g>
+        <g class="cell idINTERN_32_0" id="idINTERN_32_0">
+            <g class="NODE idFICT_95_vl1_95_dsect11Fictif" id="idFICT_95_vl1_95_dsect11Fictif" transform="matrix(0.0,1.0,-1.0,0.0,744.0,306.0)">
+                <circle fill-opacity="0" transform="rotate(90.0,4.0,4.0)" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="NODE idFICT_95_vl1_95_dsect12Fictif" id="idFICT_95_vl1_95_dsect12Fictif" transform="matrix(0.0,1.0,-1.0,0.0,824.0,306.0)">
+                <circle fill-opacity="0" transform="rotate(90.0,4.0,4.0)" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs1_95_dsect11">
+                <polyline points="730.0,310.0,740.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dsect11_95_FICT_95_vl1_95_dsect11Fictif">
+                <polyline points="740.0,310.0,740.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrct11_95_FICT_95_vl1_95_dsect11Fictif">
+                <polyline points="770.0,310.0,740.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrct11_95_FICT_95_vl1_95_dsect12Fictif">
+                <polyline points="790.0,310.0,820.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dsect12_95_FICT_95_vl1_95_dsect12Fictif">
+                <polyline points="820.0,310.0,820.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dsect12_95_bbs2">
+                <polyline points="820.0,310.0,830.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="DISCONNECTOR iddsect11" id="iddsect11" transform="translate(736.0,306.0)">
+                <g class="closed" id="iddsect11_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddsect11_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER iddtrct11" id="iddtrct11" transform="matrix(0.0,1.0,-1.0,0.0,790.0,300.0)">
+                <g class="closed" id="iddtrct11_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="iddtrct11_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+            <g class="DISCONNECTOR iddsect12" id="iddsect12" transform="translate(816.0,306.0)">
+                <g class="closed" id="iddsect12_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddsect12_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idINTERN_32_1" id="idINTERN_32_1">
+            <g class="NODE idFICT_95_vl1_95_dsect21Fictif" id="idFICT_95_vl1_95_dsect21Fictif" transform="matrix(0.0,1.0,-1.0,0.0,744.0,331.0)">
+                <circle fill-opacity="0" transform="rotate(90.0,4.0,4.0)" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="NODE idFICT_95_vl1_95_dsect22Fictif" id="idFICT_95_vl1_95_dsect22Fictif" transform="matrix(0.0,1.0,-1.0,0.0,824.0,331.0)">
+                <circle fill-opacity="0" transform="rotate(90.0,4.0,4.0)" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs3_95_dsect21">
+                <polyline points="730.0,335.0,740.0,335.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dsect21_95_FICT_95_vl1_95_dsect21Fictif">
+                <polyline points="740.0,335.0,740.0,335.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect21Fictif">
+                <polyline points="770.0,335.0,740.0,335.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect22Fictif">
+                <polyline points="790.0,335.0,820.0,335.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dsect22_95_FICT_95_vl1_95_dsect22Fictif">
+                <polyline points="820.0,335.0,820.0,335.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dsect22_95_bbs4">
+                <polyline points="820.0,335.0,830.0,335.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="DISCONNECTOR iddsect21" id="iddsect21" transform="translate(736.0,331.0)">
+                <g class="closed" id="iddsect21_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddsect21_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER iddtrct21" id="iddtrct21" transform="matrix(0.0,1.0,-1.0,0.0,790.0,325.0)">
+                <g class="closed" id="iddtrct21_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="iddtrct21_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+            <g class="DISCONNECTOR iddsect22" id="iddsect22" transform="translate(816.0,331.0)">
+                <g class="closed" id="iddsect22_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddsect22_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_2" id="idEXTERN_32_2">
+            <g class="NODE idFICT_95_vl1_95_dload1Fictif" id="idFICT_95_vl1_95_dload1Fictif" transform="translate(56.0,276.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="LOAD idload1" id="idload1" transform="translate(52.0,135.5)">
+                <rect fill="#ff0000" width="16" height="9" stroke="#ff0000"/>
+                <line y2="9" fill="#ff0000" x1="0" x2="16" stroke="#ff0000" y1="0"/>
+                <line y2="9" fill="#ff0000" x1="16" x2="0" stroke="#ff0000" y1="0"/>
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="load1_N_LABEL">load1</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs1_95_dload1">
+                <polyline points="60.0,310.0,60.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dload1_95_FICT_95_vl1_95_dload1Fictif">
+                <polyline points="60.0,310.0,60.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_bload1_95_FICT_95_vl1_95_dload1Fictif">
+                <polyline points="60.0,230.0,60.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_load1_95_bload1">
+                <polyline points="60.0,144.0,60.0,210.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_load1_DOWN" id="_95_vl1_95_load1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,159.0)">
+                <g class="arrow-up" id="_95_vl1_95_load1_95_bload1_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_load1_95_bload1_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_load1_DOWN" id="_95_vl1_95_load1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,179.0)">
+                <g class="arrow-up" id="_95_vl1_95_load1_95_bload1_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_load1_95_bload1_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddload1" id="iddload1" transform="translate(56.0,306.0)">
+                <g class="closed" id="iddload1_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddload1_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbload1" id="idbload1" transform="translate(50.0,210.0)">
+                <g class="closed" id="idbload1_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbload1_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_3" id="idEXTERN_32_3">
+            <g class="NODE idFICT_95_vl1_95_dtrf11Fictif" id="idFICT_95_vl1_95_dtrf11Fictif" transform="translate(136.0,276.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf1_95_ONE" id="idtrf1_95_ONE" transform="translate(135.0,132.5)">
+                <circle fill="#ff0000" r="5" id="idtrf1_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#ff0000"/>
+                <circle fill="#228b22" r="5" id="idtrf1_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#228b22"/>
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf1_ONE_N_LABEL">trf1</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs1_95_dtrf11">
+                <polyline points="140.0,310.0,140.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf11_95_FICT_95_vl1_95_dtrf11Fictif">
+                <polyline points="140.0,310.0,140.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf11_95_FICT_95_vl1_95_dtrf11Fictif">
+                <polyline points="140.0,230.0,140.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf11_95_trf1_95_ONE">
+                <polyline points="140.0,210.0,140.0,148.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_trf1_95_ONE_DOWN" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,135.0,163.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf1_95_ONE_DOWN" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,135.0,183.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf11" id="iddtrf11" transform="translate(136.0,306.0)">
+                <g class="closed" id="iddtrf11_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf11_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf11" id="idbtrf11" transform="translate(130.0,210.0)">
+                <g class="closed" id="idbtrf11_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf11_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_4" id="idEXTERN_32_4">
+            <g class="NODE idFICT_95_vl1_95_dtrf15Fictif" id="idFICT_95_vl1_95_dtrf15Fictif" transform="translate(376.0,276.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf5_95_ONE" id="idtrf5_95_ONE" transform="translate(375.0,132.5)">
+                <circle fill="#ff0000" r="5" id="idtrf5_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#ff0000"/>
+                <circle fill="#a020f0" r="5" id="idtrf5_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#a020f0"/>
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_ONE_N_LABEL">trf5</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs1_95_dtrf15">
+                <polyline points="380.0,310.0,380.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf15_95_FICT_95_vl1_95_dtrf15Fictif">
+                <polyline points="380.0,310.0,380.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf15_95_FICT_95_vl1_95_dtrf15Fictif">
+                <polyline points="380.0,230.0,380.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf15_95_trf5_95_ONE">
+                <polyline points="380.0,210.0,380.0,148.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_trf5_95_ONE_DOWN" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,163.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf5_95_ONE_DOWN" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,183.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf15" id="iddtrf15" transform="translate(376.0,306.0)">
+                <g class="closed" id="iddtrf15_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf15_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf15" id="idbtrf15" transform="translate(370.0,210.0)">
+                <g class="closed" id="idbtrf15_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf15_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_5" id="idEXTERN_32_5">
+            <g class="NODE idFICT_95_vl1_95_dtrf16Fictif" id="idFICT_95_vl1_95_dtrf16Fictif" transform="translate(496.0,276.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_trf6_95_fictif" id="idFICT_95_vl1_95_trf6_95_fictif" transform="translate(492.0,193.0)">
+                <circle fill="#228b22" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5" stroke="#228b22"/>
+                <circle fill="#a020f0" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#a020f0"/>
+                <circle fill="#ff0000" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#ff0000"/>
+            </g>
+            <g class="LINE idtrf6_95_TWO" id="idtrf6_95_TWO" transform="translate(460.0,140.0)">
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf6_TWO_N_LABEL">trf61</text>
+            </g>
+            <g class="LINE idtrf6_95_THREE" id="idtrf6_95_THREE" transform="translate(540.0,140.0)">
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf6_THREE_N_LABEL">trf61</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs1_95_dtrf16">
+                <polyline points="500.0,310.0,500.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf16_95_FICT_95_vl1_95_dtrf16Fictif">
+                <polyline points="500.0,310.0,500.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf16_95_FICT_95_vl1_95_dtrf16Fictif">
+                <polyline points="500.0,250.0,500.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf16_95_FICT_95_vl1_95_trf6_95_fictif">
+                <polyline points="500.0,230.0,500.0,207.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO">
+                <polyline points="493.0,195.0,460.0,195.0,460.0,140.0" stroke-width="1" stroke="#228b22"/>
+            </g>
+            <g class="ARROW1_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,155.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,175.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE">
+                <polyline points="507.0,195.0,540.0,195.0,540.0,140.0" stroke-width="1" stroke="#a020f0"/>
+            </g>
+            <g class="ARROW1_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,155.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,175.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf16" id="iddtrf16" transform="translate(496.0,306.0)">
+                <g class="closed" id="iddtrf16_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf16_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf16" id="idbtrf16" transform="translate(490.0,230.0)">
+                <g class="closed" id="idbtrf16_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf16_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_6" id="idEXTERN_32_6">
+            <g class="NODE idFICT_95_vl1_95_dload2Fictif" id="idFICT_95_vl1_95_dload2Fictif" transform="translate(856.0,276.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="LOAD idload2" id="idload2" transform="translate(852.0,135.5)">
+                <rect fill="#ff0000" width="16" height="9" stroke="#ff0000"/>
+                <line y2="9" fill="#ff0000" x1="0" x2="16" stroke="#ff0000" y1="0"/>
+                <line y2="9" fill="#ff0000" x1="16" x2="0" stroke="#ff0000" y1="0"/>
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="load2_N_LABEL">load2</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs2_95_dload2">
+                <polyline points="860.0,310.0,860.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dload2_95_FICT_95_vl1_95_dload2Fictif">
+                <polyline points="860.0,310.0,860.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_bload2_95_FICT_95_vl1_95_dload2Fictif">
+                <polyline points="860.0,230.0,860.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_load2_95_bload2">
+                <polyline points="860.0,144.0,860.0,210.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_load2_DOWN" id="_95_vl1_95_load2_95_bload2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,159.0)">
+                <g class="arrow-up" id="_95_vl1_95_load2_95_bload2_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_load2_95_bload2_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_load2_DOWN" id="_95_vl1_95_load2_95_bload2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,179.0)">
+                <g class="arrow-up" id="_95_vl1_95_load2_95_bload2_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_load2_95_bload2_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddload2" id="iddload2" transform="translate(856.0,306.0)">
+                <g class="closed" id="iddload2_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddload2_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbload2" id="idbload2" transform="translate(850.0,210.0)">
+                <g class="closed" id="idbload2_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbload2_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_7" id="idEXTERN_32_7">
+            <g class="NODE idFICT_95_vl1_95_dtrf12Fictif" id="idFICT_95_vl1_95_dtrf12Fictif" transform="translate(1176.0,276.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf2_95_ONE" id="idtrf2_95_ONE" transform="translate(1175.0,132.5)">
+                <circle fill="#ff0000" r="5" id="idtrf2_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#ff0000"/>
+                <circle fill="#228b22" r="5" id="idtrf2_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#228b22"/>
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf2_ONE_N_LABEL">trf2</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs2_95_dtrf12">
+                <polyline points="1180.0,310.0,1180.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf12_95_FICT_95_vl1_95_dtrf12Fictif">
+                <polyline points="1180.0,310.0,1180.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf12_95_FICT_95_vl1_95_dtrf12Fictif">
+                <polyline points="1180.0,230.0,1180.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf12_95_trf2_95_ONE">
+                <polyline points="1180.0,210.0,1180.0,148.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_trf2_95_ONE_DOWN" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,163.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf2_95_ONE_DOWN" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,183.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf12" id="iddtrf12" transform="translate(1176.0,306.0)">
+                <g class="closed" id="iddtrf12_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf12_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf12" id="idbtrf12" transform="translate(1170.0,210.0)">
+                <g class="closed" id="idbtrf12_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf12_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_8" id="idEXTERN_32_8">
+            <g class="NODE idFICT_95_vl1_95_dtrf18Fictif" id="idFICT_95_vl1_95_dtrf18Fictif" transform="translate(976.0,276.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_trf8_95_fictif" id="idFICT_95_vl1_95_trf8_95_fictif" transform="translate(972.0,193.0)">
+                <circle fill="#228b22" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5" stroke="#228b22"/>
+                <circle fill="#a020f0" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#a020f0"/>
+                <circle fill="#ff0000" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#ff0000"/>
+            </g>
+            <g class="LINE idtrf8_95_TWO" id="idtrf8_95_TWO" transform="translate(940.0,140.0)">
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf8_TWO_N_LABEL">trf81</text>
+            </g>
+            <g class="LINE idtrf8_95_THREE" id="idtrf8_95_THREE" transform="translate(1020.0,140.0)">
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf8_THREE_N_LABEL">trf81</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs2_95_dtrf18">
+                <polyline points="980.0,310.0,980.0,310.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf18_95_FICT_95_vl1_95_dtrf18Fictif">
+                <polyline points="980.0,310.0,980.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf18_95_FICT_95_vl1_95_dtrf18Fictif">
+                <polyline points="980.0,250.0,980.0,280.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf18_95_FICT_95_vl1_95_trf8_95_fictif">
+                <polyline points="980.0,230.0,980.0,207.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO">
+                <polyline points="973.0,195.0,940.0,195.0,940.0,140.0" stroke-width="1" stroke="#228b22"/>
+            </g>
+            <g class="ARROW1_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,155.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,175.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE">
+                <polyline points="987.0,195.0,1020.0,195.0,1020.0,140.0" stroke-width="1" stroke="#a020f0"/>
+            </g>
+            <g class="ARROW1_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,155.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,175.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf18" id="iddtrf18" transform="translate(976.0,306.0)">
+                <g class="closed" id="iddtrf18_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf18_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf18" id="idbtrf18" transform="translate(970.0,230.0)">
+                <g class="closed" id="idbtrf18_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf18_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_9" id="idEXTERN_32_9">
+            <g class="NODE idFICT_95_vl1_95_dgen1Fictif" id="idFICT_95_vl1_95_dgen1Fictif" transform="translate(216.0,361.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="GENERATOR idgen1" id="idgen1" transform="translate(214.0,499.0)">
+                <circle fill="#ff0000" r="6" cx="6" cy="6" stroke="#ff0000"/>
+                <path fill="#ff0000" d="M6,6 A 6 40 0 0 0 2,6" stroke="#ff0000"/>
+                <path fill="#ff0000" d="M6,6 A 6 40 0 0 0 10,6" stroke="#ff0000"/>
+                <text x="-5.0" font-size="8" y="25.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="gen1_S_LABEL">gen1</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs3_95_dgen1">
+                <polyline points="220.0,335.0,220.0,335.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dgen1_95_FICT_95_vl1_95_dgen1Fictif">
+                <polyline points="220.0,335.0,220.0,365.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_bgen1_95_FICT_95_vl1_95_dgen1Fictif">
+                <polyline points="220.0,415.0,220.0,365.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_gen1_95_bgen1">
+                <polyline points="220.0,499.0,220.0,435.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_gen1_DOWN" id="_95_vl1_95_gen1_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,474.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen1_95_bgen1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_gen1_95_bgen1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_gen1_DOWN" id="_95_vl1_95_gen1_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,454.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen1_95_bgen1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_gen1_95_bgen1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddgen1" id="iddgen1" transform="translate(216.0,331.0)">
+                <g class="closed" id="iddgen1_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddgen1_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbgen1" id="idbgen1" transform="translate(210.0,415.0)">
+                <g class="closed" id="idbgen1_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbgen1_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_10" id="idEXTERN_32_10">
+            <g class="NODE idFICT_95_vl1_95_dtrf13Fictif" id="idFICT_95_vl1_95_dtrf13Fictif" transform="translate(296.0,361.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="translate(295.0,497.5)">
+                <circle transform="rotate(180.0,5.0,7.5)" fill="#ff0000" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#ff0000"/>
+                <circle transform="rotate(180.0,5.0,7.5)" fill="#228b22" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#228b22"/>
+                <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf3_ONE_S_LABEL">trf3</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs3_95_dtrf13">
+                <polyline points="300.0,335.0,300.0,335.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf13_95_FICT_95_vl1_95_dtrf13Fictif">
+                <polyline points="300.0,335.0,300.0,365.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf13_95_FICT_95_vl1_95_dtrf13Fictif">
+                <polyline points="300.0,415.0,300.0,365.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf13_95_trf3_95_ONE">
+                <polyline points="300.0,435.0,300.0,497.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_trf3_95_ONE_DOWN" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,295.0,472.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf3_95_ONE_DOWN" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,295.0,452.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf13" id="iddtrf13" transform="translate(296.0,331.0)">
+                <g class="closed" id="iddtrf13_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf13_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf13" id="idbtrf13" transform="translate(290.0,415.0)">
+                <g class="closed" id="idbtrf13_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf13_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_11" id="idEXTERN_32_11">
+            <g class="NODE idFICT_95_vl1_95_dtrf17Fictif" id="idFICT_95_vl1_95_dtrf17Fictif" transform="translate(656.0,361.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_trf7_95_fictif" id="idFICT_95_vl1_95_trf7_95_fictif" transform="translate(652.0,438.0)">
+                <circle transform="rotate(180.0,8.0,7.0)" fill="#a020f0" r="5" cx="5" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cy="5" stroke="#a020f0"/>
+                <circle transform="rotate(180.0,8.0,7.0)" fill="#228b22" r="5" cx="11" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#228b22"/>
+                <circle transform="rotate(180.0,8.0,7.0)" fill="#ff0000" r="5" cx="8" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cy="9" stroke="#ff0000"/>
+            </g>
+            <g class="LINE idtrf7_95_TWO" id="idtrf7_95_TWO" transform="translate(620.0,505.0)">
+                <text x="-5.0" font-size="8" y="13.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf7_TWO_S_LABEL">trf71</text>
+            </g>
+            <g class="LINE idtrf7_95_THREE" id="idtrf7_95_THREE" transform="translate(700.0,505.0)">
+                <text x="-5.0" font-size="8" y="13.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf7_THREE_S_LABEL">trf71</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs3_95_dtrf17">
+                <polyline points="660.0,335.0,660.0,335.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf17_95_FICT_95_vl1_95_dtrf17Fictif">
+                <polyline points="660.0,335.0,660.0,365.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf17_95_FICT_95_vl1_95_dtrf17Fictif">
+                <polyline points="660.0,395.0,660.0,365.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf17_95_FICT_95_vl1_95_trf7_95_fictif">
+                <polyline points="660.0,415.0,660.0,438.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO">
+                <polyline points="653.0,450.0,620.0,450.0,620.0,505.0" stroke-width="1" stroke="#228b22"/>
+            </g>
+            <g class="ARROW1_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,480.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,460.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE">
+                <polyline points="667.0,450.0,700.0,450.0,700.0,505.0" stroke-width="1" stroke="#a020f0"/>
+            </g>
+            <g class="ARROW1_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,480.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,460.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf17" id="iddtrf17" transform="translate(656.0,331.0)">
+                <g class="closed" id="iddtrf17_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf17_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf17" id="idbtrf17" transform="translate(650.0,395.0)">
+                <g class="closed" id="idbtrf17_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf17_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_12" id="idEXTERN_32_12">
+            <g class="NODE idFICT_95_vl1_95_dgen2Fictif" id="idFICT_95_vl1_95_dgen2Fictif" transform="translate(1256.0,361.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="GENERATOR idgen2" id="idgen2" transform="translate(1254.0,499.0)">
+                <circle fill="#ff0000" r="6" cx="6" cy="6" stroke="#ff0000"/>
+                <path fill="#ff0000" d="M6,6 A 6 40 0 0 0 2,6" stroke="#ff0000"/>
+                <path fill="#ff0000" d="M6,6 A 6 40 0 0 0 10,6" stroke="#ff0000"/>
+                <text x="-5.0" font-size="8" y="25.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="gen2_S_LABEL">gen2</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs4_95_dgen2">
+                <polyline points="1260.0,335.0,1260.0,335.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dgen2_95_FICT_95_vl1_95_dgen2Fictif">
+                <polyline points="1260.0,335.0,1260.0,365.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_bgen2_95_FICT_95_vl1_95_dgen2Fictif">
+                <polyline points="1260.0,415.0,1260.0,365.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_gen2_95_bgen2">
+                <polyline points="1260.0,499.0,1260.0,435.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_gen2_DOWN" id="_95_vl1_95_gen2_95_bgen2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,474.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen2_95_bgen2_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_gen2_95_bgen2_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_gen2_DOWN" id="_95_vl1_95_gen2_95_bgen2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,454.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen2_95_bgen2_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_gen2_95_bgen2_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddgen2" id="iddgen2" transform="translate(1256.0,331.0)">
+                <g class="closed" id="iddgen2_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddgen2_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbgen2" id="idbgen2" transform="translate(1250.0,415.0)">
+                <g class="closed" id="idbgen2_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbgen2_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_13" id="idEXTERN_32_13">
+            <g class="NODE idFICT_95_vl1_95_dtrf14Fictif" id="idFICT_95_vl1_95_dtrf14Fictif" transform="translate(1096.0,361.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="translate(1095.0,497.5)">
+                <circle transform="rotate(180.0,5.0,7.5)" fill="#ff0000" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#ff0000"/>
+                <circle transform="rotate(180.0,5.0,7.5)" fill="#228b22" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#228b22"/>
+                <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_ONE_S_LABEL">trf4</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs4_95_dtrf14">
+                <polyline points="1100.0,335.0,1100.0,335.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf14_95_FICT_95_vl1_95_dtrf14Fictif">
+                <polyline points="1100.0,335.0,1100.0,365.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf14_95_FICT_95_vl1_95_dtrf14Fictif">
+                <polyline points="1100.0,415.0,1100.0,365.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf14_95_trf4_95_ONE">
+                <polyline points="1100.0,435.0,1100.0,497.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_trf4_95_ONE_DOWN" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,472.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf4_95_ONE_DOWN" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,452.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf14" id="iddtrf14" transform="translate(1096.0,331.0)">
+                <g class="closed" id="iddtrf14_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf14_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf14" id="idbtrf14" transform="translate(1090.0,415.0)">
+                <g class="closed" id="idbtrf14_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf14_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g id="NODE_0_vl1">
+            <circle fill="#ff0000" r="10.0" id="NODE_0_vl1_circle" cx="40.0" cy="595.0"/>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_v" y="620.0" class="component-label" font-family="Verdana">392.0 kV</text>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-2.3 ?</text>
+        </g>
+        <g id="NODE_1_vl1">
+            <circle fill="#ff0000" r="10.0" id="NODE_1_vl1_circle" cx="110.0" cy="595.0"/>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_v" y="620.0" class="component-label" font-family="Verdana">403.0 kV</text>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-1.7 ?</text>
+        </g>
+    </g>
+</svg>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -865,7 +865,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf13Fictif" id="idFICT_95_vl1_95_dtrf13Fictif" transform="translate(296.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="matrix(-1.0,0.0,-0.0,-1.0,305.0,512.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="translate(295.0,497.5)">
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#FF0000" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#FF0000"/>
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#218B21" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
                 <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf3_ONE_S_LABEL">trf3</text>
@@ -924,7 +924,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf17Fictif" id="idFICT_95_vl1_95_dtrf17Fictif" transform="translate(656.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_trf7_95_fictif" id="idFICT_95_vl1_95_trf7_95_fictif" transform="matrix(-1.0,0.0,-0.0,-1.0,668.0,452.0)">
+            <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_trf7_95_fictif" id="idFICT_95_vl1_95_trf7_95_fictif" transform="translate(652.0,438.0)">
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#7F0848" r="5" cx="5" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cy="5" stroke="#7F0848"/>
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#218B21" r="5" cx="11" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#FF0000" r="5" cx="8" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cy="9" stroke="#FF0000"/>
@@ -1073,7 +1073,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf14Fictif" id="idFICT_95_vl1_95_dtrf14Fictif" transform="translate(1096.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="matrix(-1.0,0.0,-0.0,-1.0,1105.0,512.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="translate(1095.0,497.5)">
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#FF0000" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#FF0000"/>
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#218B21" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
                 <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_ONE_S_LABEL">trf4</text>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -1,0 +1,1142 @@
+<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.BUSBAR_SECTION {
+    stroke: rgb(0,0,0);
+    stroke-width: 3;
+}
+
+.BREAKER {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 2;
+    fill: rgb(255, 255, 255);
+}
+
+.DISCONNECTOR {
+    stroke: rgb(0, 0, 0);
+    stroke-width: 3
+}
+
+.GENERATOR {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.LOAD {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.LOAD_BREAK_SWITCH {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill: rgb(255, 255, 255);
+}
+
+.NODE {
+    stroke: rgb(0, 0, 0);
+    fill: rgb(0, 0, 0);
+    fill-opacity: 1;
+}
+
+.CAPACITOR {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.INDUCTOR {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.STATIC_VAR_COMPENSATOR {
+    stroke: rgb(0, 0, 255);
+}
+
+.TWO_WINDINGS_TRANSFORMER {
+    stroke: rgb(0, 0, 255);
+    fill-opacity: 0;
+}
+
+.THREE_WINDINGS_TRANSFORMER {
+    stroke: rgb(0, 0, 255);
+    fill-opacity: 0;
+}
+
+.VSC_CONVERTER_STATION {
+    stroke: rgb(0, 0, 255);
+    font-size: 7.4314661px;
+    line-height: 1.25;
+    font-family: sans-serif;
+    font-variant-ligatures: normal;
+    font-variant-caps: normal;
+    font-variant-numeric: normal;
+    font-feature-settings: normal;
+    text-align: start;
+    letter-spacing: 0px;
+    word-spacing: 0px;
+    writing-mode: lr-tb;
+    text-anchor: start;
+    stroke-miterlimit: 4;
+}
+
+.PHASE_SHIFT_TRANSFORMER {
+    stroke: rgb(0, 0, 255);
+    stroke-linecap: butt;
+    stroke-linejoin: miter;
+    stroke-miterlimit: 4;
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.wire {
+    stroke: rgb(200,0,0);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.grid {
+    stroke: rgb(0,55,0);
+    stroke-width: 1;
+    stroke-dasharray: 1,10;
+}
+
+.component-label {
+    fill: black;
+    color: black;
+    stroke: none;
+    fill-opacity: 1;
+}
+
+.LINE {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+.ARROW1_load1_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_load1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_load1_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_load1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_load1_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_load1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_load1_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_load1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_gen1_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_gen1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_gen1_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_gen1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_gen1_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_gen1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_gen1_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_gen1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_load2_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_load2_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_load2_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_load2_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_load2_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_load2_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_load2_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_load2_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_gen2_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_gen2_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_gen2_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_gen2_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_gen2_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_gen2_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_gen2_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_gen2_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf1_95_ONE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf1_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf1_95_ONE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf1_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf1_95_ONE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf1_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf1_95_ONE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf1_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf2_95_ONE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf2_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf2_95_ONE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf2_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf2_95_ONE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf2_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf2_95_ONE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf2_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf3_95_ONE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf3_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf3_95_ONE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf3_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf3_95_ONE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf3_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf3_95_ONE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf3_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf4_95_ONE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf4_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf4_95_ONE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf4_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf4_95_ONE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf4_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf4_95_ONE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf4_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf5_95_ONE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf5_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf5_95_ONE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf5_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf5_95_ONE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf5_95_ONE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf5_95_ONE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf5_95_ONE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf6_95_TWO_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf6_95_TWO_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf6_95_TWO_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf6_95_TWO_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf6_95_TWO_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf6_95_TWO_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf6_95_TWO_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf6_95_TWO_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf6_95_THREE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf6_95_THREE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf6_95_THREE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf6_95_THREE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf6_95_THREE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf6_95_THREE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf6_95_THREE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf6_95_THREE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf7_95_TWO_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf7_95_TWO_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf7_95_TWO_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf7_95_TWO_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf7_95_TWO_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf7_95_TWO_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf7_95_TWO_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf7_95_TWO_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf7_95_THREE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf7_95_THREE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf7_95_THREE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf7_95_THREE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf7_95_THREE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf7_95_THREE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf7_95_THREE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf7_95_THREE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf8_95_TWO_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf8_95_TWO_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf8_95_TWO_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf8_95_TWO_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf8_95_TWO_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf8_95_TWO_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf8_95_TWO_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf8_95_TWO_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.ARROW1_trf8_95_THREE_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_trf8_95_THREE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_trf8_95_THREE_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_trf8_95_THREE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf8_95_THREE_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_trf8_95_THREE_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_trf8_95_THREE_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_trf8_95_THREE_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.iddsect11 .open { visibility: hidden;}.iddsect11 .closed { visibility: visible;}
+.iddtrct11 .open { visibility: hidden;}.iddtrct11 .closed { visibility: visible;}
+.iddsect12 .open { visibility: hidden;}.iddsect12 .closed { visibility: visible;}
+.iddsect21 .open { visibility: hidden;}.iddsect21 .closed { visibility: visible;}
+.iddtrct21 .open { visibility: hidden;}.iddtrct21 .closed { visibility: visible;}
+.iddsect22 .open { visibility: hidden;}.iddsect22 .closed { visibility: visible;}
+.iddload1 .open { visibility: hidden;}.iddload1 .closed { visibility: visible;}
+.idbload1 .open { visibility: hidden;}.idbload1 .closed { visibility: visible;}
+.iddgen1 .open { visibility: hidden;}.iddgen1 .closed { visibility: visible;}
+.idbgen1 .open { visibility: hidden;}.idbgen1 .closed { visibility: visible;}
+.iddload2 .open { visibility: hidden;}.iddload2 .closed { visibility: visible;}
+.idbload2 .open { visibility: hidden;}.idbload2 .closed { visibility: visible;}
+.iddgen2 .open { visibility: hidden;}.iddgen2 .closed { visibility: visible;}
+.idbgen2 .open { visibility: hidden;}.idbgen2 .closed { visibility: visible;}
+.iddtrf11 .open { visibility: hidden;}.iddtrf11 .closed { visibility: visible;}
+.idbtrf11 .open { visibility: hidden;}.idbtrf11 .closed { visibility: visible;}
+.iddtrf12 .open { visibility: hidden;}.iddtrf12 .closed { visibility: visible;}
+.idbtrf12 .open { visibility: hidden;}.idbtrf12 .closed { visibility: visible;}
+.iddtrf13 .open { visibility: hidden;}.iddtrf13 .closed { visibility: visible;}
+.idbtrf13 .open { visibility: hidden;}.idbtrf13 .closed { visibility: visible;}
+.iddtrf14 .open { visibility: hidden;}.iddtrf14 .closed { visibility: visible;}
+.idbtrf14 .open { visibility: hidden;}.idbtrf14 .closed { visibility: visible;}
+.iddtrf15 .open { visibility: hidden;}.iddtrf15 .closed { visibility: visible;}
+.idbtrf15 .open { visibility: hidden;}.idbtrf15 .closed { visibility: visible;}
+.iddtrf16 .open { visibility: hidden;}.iddtrf16 .closed { visibility: visible;}
+.idbtrf16 .open { visibility: hidden;}.idbtrf16 .closed { visibility: visible;}
+.iddtrf17 .open { visibility: hidden;}.iddtrf17 .closed { visibility: visible;}
+.idbtrf17 .open { visibility: hidden;}.idbtrf17 .closed { visibility: visible;}
+.iddtrf18 .open { visibility: hidden;}.iddtrf18 .closed { visibility: visible;}
+.idbtrf18 .open { visibility: hidden;}.idbtrf18 .closed { visibility: visible;}
+.idFICT_95_vl1_95_dsect11Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dload1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf11Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf15Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf16Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dsect12Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dload2Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf12Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf18Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dsect21Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dgen1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf13Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf17Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dsect22Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dgen2Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_dtrf14Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+]]></style>
+    <g>
+        <g class="grid" id="GRID_vl1" transform="translate(20.0,50.0)">
+            <line y2="565.0" x1="0.0" x2="0.0" y1="-20.0"/>
+            <line y2="565.0" x1="80.0" x2="80.0" y1="-20.0"/>
+            <line y2="565.0" x1="160.0" x2="160.0" y1="-20.0"/>
+            <line y2="565.0" x1="240.0" x2="240.0" y1="-20.0"/>
+            <line y2="565.0" x1="320.0" x2="320.0" y1="-20.0"/>
+            <line y2="565.0" x1="400.0" x2="400.0" y1="-20.0"/>
+            <line y2="565.0" x1="480.0" x2="480.0" y1="-20.0"/>
+            <line y2="565.0" x1="560.0" x2="560.0" y1="-20.0"/>
+            <line y2="565.0" x1="640.0" x2="640.0" y1="-20.0"/>
+            <line y2="565.0" x1="720.0" x2="720.0" y1="-20.0"/>
+            <line y2="565.0" x1="800.0" x2="800.0" y1="-20.0"/>
+            <line y2="565.0" x1="880.0" x2="880.0" y1="-20.0"/>
+            <line y2="565.0" x1="960.0" x2="960.0" y1="-20.0"/>
+            <line y2="565.0" x1="1040.0" x2="1040.0" y1="-20.0"/>
+            <line y2="565.0" x1="1120.0" x2="1120.0" y1="-20.0"/>
+            <line y2="565.0" x1="1200.0" x2="1200.0" y1="-20.0"/>
+            <line y2="565.0" x1="1280.0" x2="1280.0" y1="-20.0"/>
+            <line y2="230.0" x1="0.0" x2="1280.0" y1="230.0"/>
+            <line y2="315.0" x1="0.0" x2="1280.0" y1="315.0"/>
+            <line y2="220.0" x1="0.0" x2="1280.0" y1="220.0"/>
+            <line y2="325.0" x1="0.0" x2="1280.0" y1="325.0"/>
+        </g>
+        <g class="BUSBAR_SECTION idbbs1" id="idbbs1" transform="translate(30.0,310.0)">
+            <line y2="0" fill="#7F6C00" x1="0" x2="700.0" stroke="#7F6C00" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs1_NW_LABEL">bbs1</text>
+        </g>
+        <g class="BUSBAR_SECTION idbbs2" id="idbbs2" transform="translate(830.0,310.0)">
+            <line y2="0" fill="#7F6C00" x1="0" x2="460.0" stroke="#7F6C00" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs2_NW_LABEL">bbs2</text>
+        </g>
+        <g class="BUSBAR_SECTION idbbs3" id="idbbs3" transform="translate(30.0,335.0)">
+            <line y2="0" fill="#FF0000" x1="0" x2="700.0" stroke="#FF0000" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs3_NW_LABEL">bbs3</text>
+        </g>
+        <g class="BUSBAR_SECTION idbbs4" id="idbbs4" transform="translate(830.0,335.0)">
+            <line y2="0" fill="#FF0000" x1="0" x2="460.0" stroke="#FF0000" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="bbs4_NW_LABEL">bbs4</text>
+        </g>
+        <g class="cell idINTERN_32_0" id="idINTERN_32_0">
+            <g class="NODE idFICT_95_vl1_95_dsect11Fictif" id="idFICT_95_vl1_95_dsect11Fictif" transform="matrix(0.0,1.0,-1.0,0.0,744.0,306.0)">
+                <circle fill-opacity="0" transform="rotate(90.0,4.0,4.0)" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="NODE idFICT_95_vl1_95_dsect12Fictif" id="idFICT_95_vl1_95_dsect12Fictif" transform="matrix(0.0,1.0,-1.0,0.0,824.0,306.0)">
+                <circle fill-opacity="0" transform="rotate(90.0,4.0,4.0)" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs1_95_dsect11">
+                <polyline points="730.0,310.0,740.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dsect11_95_FICT_95_vl1_95_dsect11Fictif">
+                <polyline points="740.0,310.0,740.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrct11_95_FICT_95_vl1_95_dsect11Fictif">
+                <polyline points="770.0,310.0,740.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrct11_95_FICT_95_vl1_95_dsect12Fictif">
+                <polyline points="790.0,310.0,820.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dsect12_95_FICT_95_vl1_95_dsect12Fictif">
+                <polyline points="820.0,310.0,820.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dsect12_95_bbs2">
+                <polyline points="820.0,310.0,830.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="DISCONNECTOR iddsect11" id="iddsect11" transform="translate(736.0,306.0)">
+                <g class="closed" id="iddsect11_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddsect11_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER iddtrct11" id="iddtrct11" transform="matrix(0.0,1.0,-1.0,0.0,790.0,300.0)">
+                <g class="closed" id="iddtrct11_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="iddtrct11_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+            <g class="DISCONNECTOR iddsect12" id="iddsect12" transform="translate(816.0,306.0)">
+                <g class="closed" id="iddsect12_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddsect12_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idINTERN_32_1" id="idINTERN_32_1">
+            <g class="NODE idFICT_95_vl1_95_dsect21Fictif" id="idFICT_95_vl1_95_dsect21Fictif" transform="matrix(0.0,1.0,-1.0,0.0,744.0,331.0)">
+                <circle fill-opacity="0" transform="rotate(90.0,4.0,4.0)" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
+            </g>
+            <g class="NODE idFICT_95_vl1_95_dsect22Fictif" id="idFICT_95_vl1_95_dsect22Fictif" transform="matrix(0.0,1.0,-1.0,0.0,824.0,331.0)">
+                <circle fill-opacity="0" transform="rotate(90.0,4.0,4.0)" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs3_95_dsect21">
+                <polyline points="730.0,335.0,740.0,335.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dsect21_95_FICT_95_vl1_95_dsect21Fictif">
+                <polyline points="740.0,335.0,740.0,335.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect21Fictif">
+                <polyline points="770.0,335.0,740.0,335.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect22Fictif">
+                <polyline points="790.0,335.0,820.0,335.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dsect22_95_FICT_95_vl1_95_dsect22Fictif">
+                <polyline points="820.0,335.0,820.0,335.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dsect22_95_bbs4">
+                <polyline points="820.0,335.0,830.0,335.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="DISCONNECTOR iddsect21" id="iddsect21" transform="translate(736.0,331.0)">
+                <g class="closed" id="iddsect21_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddsect21_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER iddtrct21" id="iddtrct21" transform="matrix(0.0,1.0,-1.0,0.0,790.0,325.0)">
+                <g class="closed" id="iddtrct21_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="iddtrct21_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+            <g class="DISCONNECTOR iddsect22" id="iddsect22" transform="translate(816.0,331.0)">
+                <g class="closed" id="iddsect22_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddsect22_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_2" id="idEXTERN_32_2">
+            <g class="NODE idFICT_95_vl1_95_dload1Fictif" id="idFICT_95_vl1_95_dload1Fictif" transform="translate(56.0,276.0)">
+                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="LOAD idload1" id="idload1" transform="translate(52.0,135.5)">
+                <rect fill="#7F6C00" width="16" height="9" stroke="#7F6C00"/>
+                <line y2="9" fill="#7F6C00" x1="0" x2="16" stroke="#7F6C00" y1="0"/>
+                <line y2="9" fill="#7F6C00" x1="16" x2="0" stroke="#7F6C00" y1="0"/>
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="load1_N_LABEL">load1</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs1_95_dload1">
+                <polyline points="60.0,310.0,60.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dload1_95_FICT_95_vl1_95_dload1Fictif">
+                <polyline points="60.0,310.0,60.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_bload1_95_FICT_95_vl1_95_dload1Fictif">
+                <polyline points="60.0,230.0,60.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_load1_95_bload1">
+                <polyline points="60.0,144.0,60.0,210.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="ARROW1_load1_DOWN" id="_95_vl1_95_load1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,159.0)">
+                <g class="arrow-up" id="_95_vl1_95_load1_95_bload1_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_load1_95_bload1_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_load1_DOWN" id="_95_vl1_95_load1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,179.0)">
+                <g class="arrow-up" id="_95_vl1_95_load1_95_bload1_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_load1_95_bload1_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddload1" id="iddload1" transform="translate(56.0,306.0)">
+                <g class="closed" id="iddload1_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddload1_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbload1" id="idbload1" transform="translate(50.0,210.0)">
+                <g class="closed" id="idbload1_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbload1_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_3" id="idEXTERN_32_3">
+            <g class="NODE idFICT_95_vl1_95_dtrf11Fictif" id="idFICT_95_vl1_95_dtrf11Fictif" transform="translate(136.0,276.0)">
+                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf1_95_ONE" id="idtrf1_95_ONE" transform="translate(135.0,132.5)">
+                <circle fill="#7F6C00" r="5" id="idtrf1_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#7F6C00"/>
+                <circle fill="#218B21" r="5" id="idtrf1_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#218B21"/>
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf1_ONE_N_LABEL">trf1</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs1_95_dtrf11">
+                <polyline points="140.0,310.0,140.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf11_95_FICT_95_vl1_95_dtrf11Fictif">
+                <polyline points="140.0,310.0,140.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf11_95_FICT_95_vl1_95_dtrf11Fictif">
+                <polyline points="140.0,230.0,140.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf11_95_trf1_95_ONE">
+                <polyline points="140.0,210.0,140.0,148.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="ARROW1_trf1_95_ONE_DOWN" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,135.0,163.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf1_95_ONE_DOWN" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,135.0,183.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf11" id="iddtrf11" transform="translate(136.0,306.0)">
+                <g class="closed" id="iddtrf11_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf11_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf11" id="idbtrf11" transform="translate(130.0,210.0)">
+                <g class="closed" id="idbtrf11_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf11_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_4" id="idEXTERN_32_4">
+            <g class="NODE idFICT_95_vl1_95_dtrf15Fictif" id="idFICT_95_vl1_95_dtrf15Fictif" transform="translate(376.0,276.0)">
+                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf5_95_ONE" id="idtrf5_95_ONE" transform="translate(375.0,132.5)">
+                <circle fill="#7F6C00" r="5" id="idtrf5_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#7F6C00"/>
+                <circle fill="#7F0848" r="5" id="idtrf5_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#7F0848"/>
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_ONE_N_LABEL">trf5</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs1_95_dtrf15">
+                <polyline points="380.0,310.0,380.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf15_95_FICT_95_vl1_95_dtrf15Fictif">
+                <polyline points="380.0,310.0,380.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf15_95_FICT_95_vl1_95_dtrf15Fictif">
+                <polyline points="380.0,230.0,380.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf15_95_trf5_95_ONE">
+                <polyline points="380.0,210.0,380.0,148.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="ARROW1_trf5_95_ONE_DOWN" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,163.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf5_95_ONE_DOWN" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,183.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf15" id="iddtrf15" transform="translate(376.0,306.0)">
+                <g class="closed" id="iddtrf15_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf15_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf15" id="idbtrf15" transform="translate(370.0,210.0)">
+                <g class="closed" id="idbtrf15_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf15_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_5" id="idEXTERN_32_5">
+            <g class="NODE idFICT_95_vl1_95_dtrf16Fictif" id="idFICT_95_vl1_95_dtrf16Fictif" transform="translate(496.0,276.0)">
+                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_trf6_95_fictif" id="idFICT_95_vl1_95_trf6_95_fictif" transform="translate(492.0,193.0)">
+                <circle fill="#218B21" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5" stroke="#218B21"/>
+                <circle fill="#7F0848" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#7F0848"/>
+                <circle fill="#7F6C00" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#7F6C00"/>
+            </g>
+            <g class="LINE idtrf6_95_TWO" id="idtrf6_95_TWO" transform="translate(460.0,140.0)">
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf6_TWO_N_LABEL">trf61</text>
+            </g>
+            <g class="LINE idtrf6_95_THREE" id="idtrf6_95_THREE" transform="translate(540.0,140.0)">
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf6_THREE_N_LABEL">trf61</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs1_95_dtrf16">
+                <polyline points="500.0,310.0,500.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf16_95_FICT_95_vl1_95_dtrf16Fictif">
+                <polyline points="500.0,310.0,500.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf16_95_FICT_95_vl1_95_dtrf16Fictif">
+                <polyline points="500.0,250.0,500.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf16_95_FICT_95_vl1_95_trf6_95_fictif">
+                <polyline points="500.0,230.0,500.0,207.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO">
+                <polyline points="493.0,195.0,460.0,195.0,460.0,140.0" stroke-width="1" stroke="#218B21"/>
+            </g>
+            <g class="ARROW1_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,155.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,175.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE">
+                <polyline points="507.0,195.0,540.0,195.0,540.0,140.0" stroke-width="1" stroke="#7F0848"/>
+            </g>
+            <g class="ARROW1_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,155.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,175.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf16" id="iddtrf16" transform="translate(496.0,306.0)">
+                <g class="closed" id="iddtrf16_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf16_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf16" id="idbtrf16" transform="translate(490.0,230.0)">
+                <g class="closed" id="idbtrf16_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf16_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_6" id="idEXTERN_32_6">
+            <g class="NODE idFICT_95_vl1_95_dload2Fictif" id="idFICT_95_vl1_95_dload2Fictif" transform="translate(856.0,276.0)">
+                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="LOAD idload2" id="idload2" transform="translate(852.0,135.5)">
+                <rect fill="#7F6C00" width="16" height="9" stroke="#7F6C00"/>
+                <line y2="9" fill="#7F6C00" x1="0" x2="16" stroke="#7F6C00" y1="0"/>
+                <line y2="9" fill="#7F6C00" x1="16" x2="0" stroke="#7F6C00" y1="0"/>
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="load2_N_LABEL">load2</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs2_95_dload2">
+                <polyline points="860.0,310.0,860.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dload2_95_FICT_95_vl1_95_dload2Fictif">
+                <polyline points="860.0,310.0,860.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_bload2_95_FICT_95_vl1_95_dload2Fictif">
+                <polyline points="860.0,230.0,860.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_load2_95_bload2">
+                <polyline points="860.0,144.0,860.0,210.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="ARROW1_load2_DOWN" id="_95_vl1_95_load2_95_bload2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,159.0)">
+                <g class="arrow-up" id="_95_vl1_95_load2_95_bload2_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_load2_95_bload2_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_load2_DOWN" id="_95_vl1_95_load2_95_bload2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,179.0)">
+                <g class="arrow-up" id="_95_vl1_95_load2_95_bload2_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_load2_95_bload2_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddload2" id="iddload2" transform="translate(856.0,306.0)">
+                <g class="closed" id="iddload2_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddload2_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbload2" id="idbload2" transform="translate(850.0,210.0)">
+                <g class="closed" id="idbload2_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbload2_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_7" id="idEXTERN_32_7">
+            <g class="NODE idFICT_95_vl1_95_dtrf12Fictif" id="idFICT_95_vl1_95_dtrf12Fictif" transform="translate(1176.0,276.0)">
+                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf2_95_ONE" id="idtrf2_95_ONE" transform="translate(1175.0,132.5)">
+                <circle fill="#7F6C00" r="5" id="idtrf2_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#7F6C00"/>
+                <circle fill="#218B21" r="5" id="idtrf2_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#218B21"/>
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf2_ONE_N_LABEL">trf2</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs2_95_dtrf12">
+                <polyline points="1180.0,310.0,1180.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf12_95_FICT_95_vl1_95_dtrf12Fictif">
+                <polyline points="1180.0,310.0,1180.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf12_95_FICT_95_vl1_95_dtrf12Fictif">
+                <polyline points="1180.0,230.0,1180.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf12_95_trf2_95_ONE">
+                <polyline points="1180.0,210.0,1180.0,148.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="ARROW1_trf2_95_ONE_DOWN" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,163.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf2_95_ONE_DOWN" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,183.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf12" id="iddtrf12" transform="translate(1176.0,306.0)">
+                <g class="closed" id="iddtrf12_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf12_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf12" id="idbtrf12" transform="translate(1170.0,210.0)">
+                <g class="closed" id="idbtrf12_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf12_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_8" id="idEXTERN_32_8">
+            <g class="NODE idFICT_95_vl1_95_dtrf18Fictif" id="idFICT_95_vl1_95_dtrf18Fictif" transform="translate(976.0,276.0)">
+                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_trf8_95_fictif" id="idFICT_95_vl1_95_trf8_95_fictif" transform="translate(972.0,193.0)">
+                <circle fill="#218B21" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5" stroke="#218B21"/>
+                <circle fill="#7F0848" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#7F0848"/>
+                <circle fill="#7F6C00" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#7F6C00"/>
+            </g>
+            <g class="LINE idtrf8_95_TWO" id="idtrf8_95_TWO" transform="translate(940.0,140.0)">
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf8_TWO_N_LABEL">trf81</text>
+            </g>
+            <g class="LINE idtrf8_95_THREE" id="idtrf8_95_THREE" transform="translate(1020.0,140.0)">
+                <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf8_THREE_N_LABEL">trf81</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs2_95_dtrf18">
+                <polyline points="980.0,310.0,980.0,310.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf18_95_FICT_95_vl1_95_dtrf18Fictif">
+                <polyline points="980.0,310.0,980.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf18_95_FICT_95_vl1_95_dtrf18Fictif">
+                <polyline points="980.0,250.0,980.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf18_95_FICT_95_vl1_95_trf8_95_fictif">
+                <polyline points="980.0,230.0,980.0,207.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO">
+                <polyline points="973.0,195.0,940.0,195.0,940.0,140.0" stroke-width="1" stroke="#218B21"/>
+            </g>
+            <g class="ARROW1_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,155.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,175.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE">
+                <polyline points="987.0,195.0,1020.0,195.0,1020.0,140.0" stroke-width="1" stroke="#7F0848"/>
+            </g>
+            <g class="ARROW1_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,155.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,175.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2_ARROW-arrow-up">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2_ARROW-arrow-down">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf18" id="iddtrf18" transform="translate(976.0,306.0)">
+                <g class="closed" id="iddtrf18_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf18_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf18" id="idbtrf18" transform="translate(970.0,230.0)">
+                <g class="closed" id="idbtrf18_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf18_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_9" id="idEXTERN_32_9">
+            <g class="NODE idFICT_95_vl1_95_dgen1Fictif" id="idFICT_95_vl1_95_dgen1Fictif" transform="translate(216.0,361.0)">
+                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
+            </g>
+            <g class="GENERATOR idgen1" id="idgen1" transform="translate(214.0,499.0)">
+                <circle fill="#FF0000" r="6" cx="6" cy="6" stroke="#FF0000"/>
+                <path fill="#FF0000" d="M6,6 A 6 40 0 0 0 2,6" stroke="#FF0000"/>
+                <path fill="#FF0000" d="M6,6 A 6 40 0 0 0 10,6" stroke="#FF0000"/>
+                <text x="-5.0" font-size="8" y="25.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="gen1_S_LABEL">gen1</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs3_95_dgen1">
+                <polyline points="220.0,335.0,220.0,335.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dgen1_95_FICT_95_vl1_95_dgen1Fictif">
+                <polyline points="220.0,335.0,220.0,365.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_bgen1_95_FICT_95_vl1_95_dgen1Fictif">
+                <polyline points="220.0,415.0,220.0,365.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_gen1_95_bgen1">
+                <polyline points="220.0,499.0,220.0,435.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="ARROW1_gen1_DOWN" id="_95_vl1_95_gen1_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,474.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen1_95_bgen1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_gen1_95_bgen1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_gen1_DOWN" id="_95_vl1_95_gen1_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,454.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen1_95_bgen1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_gen1_95_bgen1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddgen1" id="iddgen1" transform="translate(216.0,331.0)">
+                <g class="closed" id="iddgen1_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddgen1_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbgen1" id="idbgen1" transform="translate(210.0,415.0)">
+                <g class="closed" id="idbgen1_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbgen1_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_10" id="idEXTERN_32_10">
+            <g class="NODE idFICT_95_vl1_95_dtrf13Fictif" id="idFICT_95_vl1_95_dtrf13Fictif" transform="translate(296.0,361.0)">
+                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="matrix(-1.0,0.0,-0.0,-1.0,305.0,512.5)">
+                <circle transform="rotate(180.0,5.0,7.5)" fill="#FF0000" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#FF0000"/>
+                <circle transform="rotate(180.0,5.0,7.5)" fill="#218B21" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
+                <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf3_ONE_S_LABEL">trf3</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs3_95_dtrf13">
+                <polyline points="300.0,335.0,300.0,335.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf13_95_FICT_95_vl1_95_dtrf13Fictif">
+                <polyline points="300.0,335.0,300.0,365.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf13_95_FICT_95_vl1_95_dtrf13Fictif">
+                <polyline points="300.0,415.0,300.0,365.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf13_95_trf3_95_ONE">
+                <polyline points="300.0,435.0,300.0,497.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="ARROW1_trf3_95_ONE_DOWN" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,295.0,472.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf3_95_ONE_DOWN" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,295.0,452.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf13" id="iddtrf13" transform="translate(296.0,331.0)">
+                <g class="closed" id="iddtrf13_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf13_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf13" id="idbtrf13" transform="translate(290.0,415.0)">
+                <g class="closed" id="idbtrf13_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf13_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_11" id="idEXTERN_32_11">
+            <g class="NODE idFICT_95_vl1_95_dtrf17Fictif" id="idFICT_95_vl1_95_dtrf17Fictif" transform="translate(656.0,361.0)">
+                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
+            </g>
+            <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_trf7_95_fictif" id="idFICT_95_vl1_95_trf7_95_fictif" transform="matrix(-1.0,0.0,-0.0,-1.0,668.0,452.0)">
+                <circle transform="rotate(180.0,8.0,7.0)" fill="#7F0848" r="5" cx="5" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cy="5" stroke="#7F0848"/>
+                <circle transform="rotate(180.0,8.0,7.0)" fill="#218B21" r="5" cx="11" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
+                <circle transform="rotate(180.0,8.0,7.0)" fill="#FF0000" r="5" cx="8" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cy="9" stroke="#FF0000"/>
+            </g>
+            <g class="LINE idtrf7_95_TWO" id="idtrf7_95_TWO" transform="translate(620.0,505.0)">
+                <text x="-5.0" font-size="8" y="13.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf7_TWO_S_LABEL">trf71</text>
+            </g>
+            <g class="LINE idtrf7_95_THREE" id="idtrf7_95_THREE" transform="translate(700.0,505.0)">
+                <text x="-5.0" font-size="8" y="13.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf7_THREE_S_LABEL">trf71</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs3_95_dtrf17">
+                <polyline points="660.0,335.0,660.0,335.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf17_95_FICT_95_vl1_95_dtrf17Fictif">
+                <polyline points="660.0,335.0,660.0,365.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf17_95_FICT_95_vl1_95_dtrf17Fictif">
+                <polyline points="660.0,395.0,660.0,365.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf17_95_FICT_95_vl1_95_trf7_95_fictif">
+                <polyline points="660.0,415.0,660.0,438.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO">
+                <polyline points="653.0,450.0,620.0,450.0,620.0,505.0" stroke-width="1" stroke="#218B21"/>
+            </g>
+            <g class="ARROW1_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,480.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,460.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE">
+                <polyline points="667.0,450.0,700.0,450.0,700.0,505.0" stroke-width="1" stroke="#7F0848"/>
+            </g>
+            <g class="ARROW1_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,480.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,460.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf17" id="iddtrf17" transform="translate(656.0,331.0)">
+                <g class="closed" id="iddtrf17_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf17_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf17" id="idbtrf17" transform="translate(650.0,395.0)">
+                <g class="closed" id="idbtrf17_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf17_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_12" id="idEXTERN_32_12">
+            <g class="NODE idFICT_95_vl1_95_dgen2Fictif" id="idFICT_95_vl1_95_dgen2Fictif" transform="translate(1256.0,361.0)">
+                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
+            </g>
+            <g class="GENERATOR idgen2" id="idgen2" transform="translate(1254.0,499.0)">
+                <circle fill="#FF0000" r="6" cx="6" cy="6" stroke="#FF0000"/>
+                <path fill="#FF0000" d="M6,6 A 6 40 0 0 0 2,6" stroke="#FF0000"/>
+                <path fill="#FF0000" d="M6,6 A 6 40 0 0 0 10,6" stroke="#FF0000"/>
+                <text x="-5.0" font-size="8" y="25.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="gen2_S_LABEL">gen2</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs4_95_dgen2">
+                <polyline points="1260.0,335.0,1260.0,335.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dgen2_95_FICT_95_vl1_95_dgen2Fictif">
+                <polyline points="1260.0,335.0,1260.0,365.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_bgen2_95_FICT_95_vl1_95_dgen2Fictif">
+                <polyline points="1260.0,415.0,1260.0,365.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_gen2_95_bgen2">
+                <polyline points="1260.0,499.0,1260.0,435.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="ARROW1_gen2_DOWN" id="_95_vl1_95_gen2_95_bgen2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,474.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen2_95_bgen2_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_gen2_95_bgen2_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_gen2_DOWN" id="_95_vl1_95_gen2_95_bgen2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,454.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen2_95_bgen2_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_gen2_95_bgen2_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddgen2" id="iddgen2" transform="translate(1256.0,331.0)">
+                <g class="closed" id="iddgen2_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddgen2_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbgen2" id="idbgen2" transform="translate(1250.0,415.0)">
+                <g class="closed" id="idbgen2_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbgen2_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_13" id="idEXTERN_32_13">
+            <g class="NODE idFICT_95_vl1_95_dtrf14Fictif" id="idFICT_95_vl1_95_dtrf14Fictif" transform="translate(1096.0,361.0)">
+                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="matrix(-1.0,0.0,-0.0,-1.0,1105.0,512.5)">
+                <circle transform="rotate(180.0,5.0,7.5)" fill="#FF0000" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#FF0000"/>
+                <circle transform="rotate(180.0,5.0,7.5)" fill="#218B21" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
+                <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_ONE_S_LABEL">trf4</text>
+            </g>
+            <g class="wire" id="_95_vl1_95_bbs4_95_dtrf14">
+                <polyline points="1100.0,335.0,1100.0,335.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_dtrf14_95_FICT_95_vl1_95_dtrf14Fictif">
+                <polyline points="1100.0,335.0,1100.0,365.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf14_95_FICT_95_vl1_95_dtrf14Fictif">
+                <polyline points="1100.0,415.0,1100.0,365.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="wire" id="_95_vl1_95_btrf14_95_trf4_95_ONE">
+                <polyline points="1100.0,435.0,1100.0,497.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="ARROW1_trf4_95_ONE_DOWN" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,472.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW2_trf4_95_ONE_DOWN" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,452.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="DISCONNECTOR iddtrf14" id="iddtrf14" transform="translate(1096.0,331.0)">
+                <g class="closed" id="iddtrf14_DISCONNECTOR-closed">
+                    <line y2="8" x1="0" x2="8" y1="0"/>
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+                <g class="open" id="iddtrf14_DISCONNECTOR-open">
+                    <line y2="8" x1="8" x2="0" y1="0"/>
+                </g>
+            </g>
+            <g class="BREAKER idbtrf14" id="idbtrf14" transform="translate(1090.0,415.0)">
+                <g class="closed" id="idbtrf14_BREAKER-closed">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="15" x1="10" x2="10" y1="5"/>
+                </g>
+                <g class="open" id="idbtrf14_BREAKER-open">
+                    <rect x="1" width="18" y="1" height="18"/>
+                    <line y2="10" x1="5" x2="15" y1="10"/>
+                </g>
+            </g>
+        </g>
+        <g id="NODE_0_vl1">
+            <circle fill="#7F6C00" r="10.0" id="NODE_0_vl1_circle" cx="40.0" cy="595.0"/>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_v" y="620.0" class="component-label" font-family="Verdana">392.0 kV</text>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-2.3 ?</text>
+        </g>
+        <g id="NODE_1_vl1">
+            <circle fill="#FF0000" r="10.0" id="NODE_1_vl1_circle" cx="110.0" cy="595.0"/>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_v" y="620.0" class="component-label" font-family="Verdana">403.0 kV</text>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-1.7 ?</text>
+        </g>
+    </g>
+</svg>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -865,7 +865,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf13Fictif" id="idFICT_95_vl1_95_dtrf13Fictif" transform="translate(296.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="translate(295.0,497.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="matrix(-1.0,0.0,-0.0,-1.0,305.0,512.5)">
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#FF0000" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#FF0000"/>
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#218B21" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
                 <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf3_ONE_S_LABEL">trf3</text>
@@ -924,7 +924,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf17Fictif" id="idFICT_95_vl1_95_dtrf17Fictif" transform="translate(656.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_trf7_95_fictif" id="idFICT_95_vl1_95_trf7_95_fictif" transform="translate(652.0,438.0)">
+            <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_trf7_95_fictif" id="idFICT_95_vl1_95_trf7_95_fictif" transform="matrix(-1.0,0.0,-0.0,-1.0,668.0,452.0)">
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#7F0848" r="5" cx="5" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING1" cy="5" stroke="#7F0848"/>
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#218B21" r="5" cx="11" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#FF0000" r="5" cx="8" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cy="9" stroke="#FF0000"/>
@@ -1073,7 +1073,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf14Fictif" id="idFICT_95_vl1_95_dtrf14Fictif" transform="translate(1096.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="translate(1095.0,497.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="matrix(-1.0,0.0,-0.0,-1.0,1105.0,512.5)">
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#FF0000" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#FF0000"/>
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#218B21" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
                 <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_ONE_S_LABEL">trf4</text>
@@ -1131,12 +1131,12 @@
         <g id="NODE_0_vl1">
             <circle fill="#7F6C00" r="10.0" id="NODE_0_vl1_circle" cx="40.0" cy="595.0"/>
             <text x="30.0" font-size="8" id="NODE_0_vl1_v" y="620.0" class="component-label" font-family="Verdana">392.0 kV</text>
-            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-2.3 ?</text>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-2.3 °</text>
         </g>
         <g id="NODE_1_vl1">
             <circle fill="#FF0000" r="10.0" id="NODE_1_vl1_circle" cx="110.0" cy="595.0"/>
             <text x="100.0" font-size="8" id="NODE_1_vl1_v" y="620.0" class="component-label" font-family="Verdana">403.0 kV</text>
-            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-1.7 ?</text>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-1.7 °</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -2782,6 +2782,7 @@
     "labelCentered" : false,
     "labelDiagonal" : false,
     "angleLabelShift" : 15.0,
-    "highlightLineState" : true
+    "highlightLineState" : true,
+    "addNodesInfos" : false
   }
 }

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -1470,6 +1470,7 @@
     "labelCentered" : false,
     "labelDiagonal" : false,
     "angleLabelShift" : 15.0,
-    "highlightLineState" : true
+    "highlightLineState" : true,
+    "addNodesInfos" : false
   }
 }

--- a/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
+++ b/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
@@ -744,6 +744,8 @@ public abstract class AbstractSingleLineDiagramViewer extends Application implem
 
         rowIndex += 2;
         addCheckBox("HighLight line state", rowIndex, LayoutParameters::isHighlightLineState, LayoutParameters::setHighlightLineState);
+        rowIndex += 2;
+        addCheckBox("Add nodes infos", rowIndex, LayoutParameters::isAddNodesInfos, LayoutParameters::setAddNodesInfos);
     }
 
     private void setDiagramsNamesContent(Network network, boolean setValues) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
No electrical nodes informations (voltage, angle) are displayed


**What is the new behavior (if this is a feature change)?**
Add optionnally a legend showing the different electrical nodes with their voltage and angle values, at the bottom of the diagram.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
