### PR TITLE
Write svg in json tests for debug

### DIFF
--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -29,7 +29,31 @@ public abstract class AbstractTestCase {
     protected boolean writeFile = false;
 
     protected final ResourcesComponentLibrary componentLibrary = getResourcesComponentLibrary();
-    protected LayoutParameters layoutParameters;
+
+    protected abstract LayoutParameters getLayoutParameters();
+
+    protected static LayoutParameters createDefaultLayoutParameters() {
+        return new LayoutParameters()
+            .setTranslateX(20)
+            .setTranslateY(50)
+            .setInitialXBus(0)
+            .setInitialYBus(260)
+            .setVerticalSpaceBus(25)
+            .setHorizontalBusPadding(20)
+            .setCellWidth(50)
+            .setExternCellHeight(250)
+            .setInternCellHeight(40)
+            .setStackHeight(30)
+            .setShowGrid(true)
+            .setShowInternalNodes(true)
+            .setScaleFactor(1)
+            .setHorizontalSubstationPadding(50)
+            .setVerticalSubstationPadding(50)
+            .setArrowDistance(20)
+            .setDrawStraightWires(false)
+            .setHorizontalSnakeLinePadding(30)
+            .setVerticalSnakeLinePadding(30);
+    }
 
     protected ResourcesComponentLibrary getResourcesComponentLibrary() {
         return new ResourcesComponentLibrary("/ConvergenceLibrary");

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -7,14 +7,14 @@
 package com.powsybl.sld;
 
 import com.google.common.io.ByteStreams;
-import com.powsybl.iidm.network.Network;
 import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.library.ResourcesComponentLibrary;
 import com.powsybl.sld.model.Graph;
 import com.powsybl.sld.model.SubstationGraph;
 import com.powsybl.sld.model.ZoneGraph;
-import com.powsybl.sld.svg.*;
-import com.powsybl.sld.util.NominalVoltageDiagramStyleProvider;
+import com.powsybl.sld.svg.DefaultSVGWriter;
+import com.powsybl.sld.svg.DiagramLabelProvider;
+import com.powsybl.sld.svg.DiagramStyleProvider;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -50,7 +50,7 @@ public abstract class AbstractTestCase {
         if (writeFile) {
             File homeFolder = new File(System.getProperty("user.home"));
             File file = new File(homeFolder, filename);
-            try (OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)){
+            try (OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {
                 fw.write(content.toString());
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
@@ -59,7 +59,9 @@ public abstract class AbstractTestCase {
     }
 
     public abstract void toSVG(Graph g, String filename);
+
     public abstract void toSVG(SubstationGraph g, String filename);
+
     public abstract void toSVG(ZoneGraph g, String filename);
 
     public String toSVG(Graph graph,

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -7,20 +7,16 @@
 package com.powsybl.sld;
 
 import com.google.common.io.ByteStreams;
+import com.powsybl.iidm.network.Network;
 import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.library.ResourcesComponentLibrary;
 import com.powsybl.sld.model.Graph;
 import com.powsybl.sld.model.SubstationGraph;
 import com.powsybl.sld.model.ZoneGraph;
-import com.powsybl.sld.svg.DefaultSVGWriter;
-import com.powsybl.sld.svg.DiagramLabelProvider;
-import com.powsybl.sld.svg.DiagramStyleProvider;
+import com.powsybl.sld.svg.*;
+import com.powsybl.sld.util.NominalVoltageDiagramStyleProvider;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.StringWriter;
-import java.io.UncheckedIOException;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
@@ -33,6 +29,7 @@ public abstract class AbstractTestCase {
     protected boolean writeFile = false;
 
     protected final ResourcesComponentLibrary componentLibrary = getResourcesComponentLibrary();
+    protected LayoutParameters layoutParameters;
 
     protected ResourcesComponentLibrary getResourcesComponentLibrary() {
         return new ResourcesComponentLibrary("/ConvergenceLibrary");
@@ -51,15 +48,19 @@ public abstract class AbstractTestCase {
 
     private void writeToFileInHomeDir(String filename, StringWriter content) {
         if (writeFile) {
-            try {
-                OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(System.getProperty("user.home") + filename), StandardCharsets.UTF_8);
+            File homeFolder = new File(System.getProperty("user.home"));
+            File file = new File(homeFolder, filename);
+            try (OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)){
                 fw.write(content.toString());
-                fw.close();
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
         }
     }
+
+    public abstract void toSVG(Graph g, String filename);
+    public abstract void toSVG(SubstationGraph g, String filename);
+    public abstract void toSVG(ZoneGraph g, String filename);
 
     public String toSVG(Graph graph,
                         String filename,
@@ -150,6 +151,10 @@ public abstract class AbstractTestCase {
 
             writeToFileInHomeDir(filename, writer);
 
+            if (writeFile) {
+                toSVG(graph, filename.replace(".json", ".svg"));
+            }
+
             return normalizeLineSeparator(writer.toString());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -161,6 +166,10 @@ public abstract class AbstractTestCase {
             graph.writeJson(writer);
 
             writeToFileInHomeDir(filename, writer);
+
+            if (writeFile) {
+                toSVG(graph, filename.replace(".json", ".svg"));
+            }
 
             return normalizeLineSeparator(writer.toString());
         } catch (IOException e) {
@@ -182,6 +191,9 @@ public abstract class AbstractTestCase {
         try (StringWriter writer = new StringWriter()) {
             graph.writeJson(writer);
             writeToFileInHomeDir(filename, writer);
+            if (writeFile) {
+                toSVG(graph, filename.replace(".json", ".svg"));
+            }
             return normalizeLineSeparator(writer.toString());
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
@@ -12,6 +12,13 @@ import com.powsybl.sld.GraphBuilder;
 import com.powsybl.sld.iidm.extensions.BusbarSectionPositionAdder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.iidm.extensions.ConnectablePositionAdder;
+import com.powsybl.sld.model.Graph;
+import com.powsybl.sld.model.SubstationGraph;
+import com.powsybl.sld.model.ZoneGraph;
+import com.powsybl.sld.svg.DefaultDiagramLabelProvider;
+import com.powsybl.sld.svg.DefaultDiagramStyleProvider;
+import com.powsybl.sld.svg.DiagramLabelProvider;
+import com.powsybl.sld.svg.DiagramStyleProvider;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
@@ -37,6 +44,29 @@ public abstract class AbstractTestCaseIidm extends AbstractTestCase {
 
     Substation getSubstation() {
         return substation;
+    }
+
+    @Override
+    public void toSVG(Graph g, String filename) {
+        toSVG(g, filename, layoutParameters, getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider());
+    }
+
+    @Override
+    public void toSVG(SubstationGraph g, String filename) {
+        toSVG(g, filename, layoutParameters, getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider());
+    }
+
+    @Override
+    public void toSVG(ZoneGraph g, String filename) {
+        toSVG(g, filename, layoutParameters, getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider());
+    }
+
+    private DiagramLabelProvider getDefaultDiagramLabelProvider() {
+        return new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters);
+    }
+
+    private DiagramStyleProvider getDefaultDiagramStyleProvider() {
+        return new DefaultDiagramStyleProvider();
     }
 
     protected static Substation createSubstation(Network n, String id, String name, Country country) {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
@@ -48,21 +48,21 @@ public abstract class AbstractTestCaseIidm extends AbstractTestCase {
 
     @Override
     public void toSVG(Graph g, String filename) {
-        toSVG(g, filename, layoutParameters, getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider());
+        toSVG(g, filename, getLayoutParameters(), getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider());
     }
 
     @Override
     public void toSVG(SubstationGraph g, String filename) {
-        toSVG(g, filename, layoutParameters, getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider());
+        toSVG(g, filename, getLayoutParameters(), getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider());
     }
 
     @Override
     public void toSVG(ZoneGraph g, String filename) {
-        toSVG(g, filename, layoutParameters, getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider());
+        toSVG(g, filename, getLayoutParameters(), getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider());
     }
 
     private DiagramLabelProvider getDefaultDiagramLabelProvider() {
-        return new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters);
+        return new DefaultDiagramLabelProvider(network, componentLibrary, getLayoutParameters());
     }
 
     private DiagramStyleProvider getDefaultDiagramStyleProvider() {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1.java
@@ -37,6 +37,11 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestCase1 extends AbstractTestCaseIidm {
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return createDefaultLayoutParameters();
+    }
+
     @Before
     public void setUp() {
         network = Network.create("testCase1", "test");
@@ -61,25 +66,7 @@ public class TestCase1 extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(true)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50)
-                .setArrowDistance(20);
-
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
 
         // write Json and compare to reference
         assertEquals(toString("/TestCase1.json"), toJson(g, "/TestCase1.json"));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1.java
@@ -61,7 +61,7 @@ public class TestCase1 extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase10TestBreakerToBus.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase10TestBreakerToBus.java
@@ -6,8 +6,12 @@
  */
 package com.powsybl.sld.iidm;
 
-import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.SwitchKind;
+import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
+import com.powsybl.sld.layout.LayoutParameters;
 
 /**
  * <PRE>
@@ -26,6 +30,11 @@ import com.powsybl.sld.iidm.extensions.ConnectablePosition;
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public class TestCase10TestBreakerToBus extends AbstractTestCaseIidm {
+
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return null;
+    }
 
     @Override
     public void setUp() {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11SubstationGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11SubstationGraph.java
@@ -207,7 +207,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseIidm {
 
     @Test
     public void test() {
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11SubstationGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11SubstationGraph.java
@@ -25,8 +25,17 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestCase11SubstationGraph extends AbstractTestCaseIidm {
 
+    protected LayoutParameters layoutParameters;
+
+    @Override
+    public LayoutParameters getLayoutParameters() {
+        return layoutParameters;
+    }
+
     @Before
     public void setUp() {
+        layoutParameters = createDefaultLayoutParameters();
+
         network = Network.create("testCase11", "test");
         graphBuilder = new NetworkGraphBuilder(network);
 
@@ -207,50 +216,30 @@ public class TestCase11SubstationGraph extends AbstractTestCaseIidm {
 
     @Test
     public void test() {
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(false)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50)
-                .setDrawStraightWires(false)
-                .setHorizontalSnakeLinePadding(30)
-                .setVerticalSnakeLinePadding(30);
 
         // build substation graph
-
         Graph gvl = graphBuilder.buildVoltageLevelGraph("vl1", true, true);
-        new PositionVoltageLevelLayoutFactory().create(gvl).run(layoutParameters);
+        new PositionVoltageLevelLayoutFactory().create(gvl).run(getLayoutParameters());
 
         SubstationGraph g = graphBuilder.buildSubstationGraph(substation.getId(), false);
 
         // write Json and compare to reference (with horizontal substation layout)
-        new HorizontalSubstationLayoutFactory().create(g, new PositionVoltageLevelLayoutFactory()).run(layoutParameters);
+        new HorizontalSubstationLayoutFactory().create(g, new PositionVoltageLevelLayoutFactory()).run(getLayoutParameters());
         assertEquals(toString("/TestCase11SubstationGraphH.json"), toJson(g, "/TestCase11SubstationGraphH.json"));
 
         // rebuild substation graph
         g = graphBuilder.buildSubstationGraph(substation.getId(), false);
 
         // write Json and compare to reference (with vertical substation layout)
-        new VerticalSubstationLayoutFactory().create(g, new PositionVoltageLevelLayoutFactory()).run(layoutParameters);
+        new VerticalSubstationLayoutFactory().create(g, new PositionVoltageLevelLayoutFactory()).run(getLayoutParameters());
         assertEquals(toString("/TestCase11SubstationGraphV.json"), toJson(g, "/TestCase11SubstationGraphV.json"));
 
         // compare metadata of substation diagram with reference
         // (with horizontal substation layout)
         SubstationDiagram diagram = SubstationDiagram.build(graphBuilder, substation.getId());
 
-        compareMetadata(diagram, layoutParameters, "/substDiag_metadata.json",
-                new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters),
+        compareMetadata(diagram, getLayoutParameters(), "/substDiag_metadata.json",
+                new DefaultDiagramLabelProvider(network, componentLibrary, getLayoutParameters()),
                 new DefaultDiagramStyleProvider());
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11SubstationGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11SubstationGraph.java
@@ -215,7 +215,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseIidm {
     }
 
     @Test
-    public void test() {
+    public void testHorizontal() {
 
         // build substation graph
         Graph gvl = graphBuilder.buildVoltageLevelGraph("vl1", true, true);
@@ -226,14 +226,20 @@ public class TestCase11SubstationGraph extends AbstractTestCaseIidm {
         // write Json and compare to reference (with horizontal substation layout)
         new HorizontalSubstationLayoutFactory().create(g, new PositionVoltageLevelLayoutFactory()).run(getLayoutParameters());
         assertEquals(toString("/TestCase11SubstationGraphH.json"), toJson(g, "/TestCase11SubstationGraphH.json"));
+    }
 
-        // rebuild substation graph
-        g = graphBuilder.buildSubstationGraph(substation.getId(), false);
+    @Test
+    public void testVertical() {
+        // build substation graph
+        SubstationGraph g = graphBuilder.buildSubstationGraph(substation.getId(), false);
 
         // write Json and compare to reference (with vertical substation layout)
         new VerticalSubstationLayoutFactory().create(g, new PositionVoltageLevelLayoutFactory()).run(getLayoutParameters());
         assertEquals(toString("/TestCase11SubstationGraphV.json"), toJson(g, "/TestCase11SubstationGraphV.json"));
+    }
 
+    @Test
+    public void testHorizontalMetadata() {
         // compare metadata of substation diagram with reference
         // (with horizontal substation layout)
         SubstationDiagram diagram = SubstationDiagram.build(graphBuilder, substation.getId());

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase12GraphWith3WT.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase12GraphWith3WT.java
@@ -221,7 +221,7 @@ public class TestCase12GraphWith3WT extends AbstractTestCaseIidm {
 
     @Test
     public void test() {
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)
@@ -262,8 +262,9 @@ public class TestCase12GraphWith3WT extends AbstractTestCaseIidm {
         assertEquals(toString("/TestCase12GraphVL2.json"), toJson(g2, "/TestCase12GraphVL2.json"));
         assertEquals(toString("/TestCase12GraphVL3.json"), toJson(g3, "/TestCase12GraphVL3.json"));
 
-        LayoutParameters layoutParametersOptimized = new LayoutParameters(layoutParameters);
-        layoutParametersOptimized.setAvoidSVGComponentsDuplication(true);
+        // Optimize SVG by avoiding duplication
+        layoutParameters = new LayoutParameters(layoutParameters);
+        layoutParameters.setAvoidSVGComponentsDuplication(true);
 
         // compare metadata of voltage level diagram with reference
         VoltageLevelDiagram diagram = VoltageLevelDiagram.build(graphBuilder, vl1.getId(),
@@ -283,7 +284,7 @@ public class TestCase12GraphWith3WT extends AbstractTestCaseIidm {
         generator.getTerminal().getBusView().getBus().setV(403);
         generator.getTerminal().getBusView().getBus().setAngle(-1.7);
 
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase12GraphWith3WT.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase12GraphWith3WT.java
@@ -6,21 +6,11 @@
  */
 package com.powsybl.sld.iidm;
 
-import com.powsybl.iidm.network.Country;
-import com.powsybl.iidm.network.Generator;
-import com.powsybl.iidm.network.Load;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.SwitchKind;
-import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.*;
 import com.powsybl.sld.NetworkGraphBuilder;
 import com.powsybl.sld.VoltageLevelDiagram;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
-import com.powsybl.sld.layout.BlockOrganizer;
-import com.powsybl.sld.layout.ImplicitCellDetector;
-import com.powsybl.sld.layout.LayoutParameters;
-import com.powsybl.sld.layout.PositionVoltageLevelLayout;
-import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
+import com.powsybl.sld.layout.*;
 import com.powsybl.sld.library.ComponentLibrary;
 import com.powsybl.sld.library.ResourcesComponentLibrary;
 import com.powsybl.sld.model.Graph;
@@ -41,9 +31,19 @@ public class TestCase12GraphWith3WT extends AbstractTestCaseIidm {
     private VoltageLevel vl1;
     private VoltageLevel vl2;
     private VoltageLevel vl3;
+    private LayoutParameters layoutParameters;
+
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return layoutParameters;
+    }
 
     @Before
     public void setUp() {
+        layoutParameters = createDefaultLayoutParameters()
+            .setCellWidth(80)
+            .setShowInternalNodes(false);
+
         network = Network.create("testCase11", "test");
         graphBuilder = new NetworkGraphBuilder(network);
 
@@ -221,41 +221,21 @@ public class TestCase12GraphWith3WT extends AbstractTestCaseIidm {
 
     @Test
     public void test() {
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(80)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(false)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50)
-                .setDrawStraightWires(false)
-                .setHorizontalSnakeLinePadding(30)
-                .setVerticalSnakeLinePadding(30);
-
         // build voltage level 1 graph
         Graph g1 = graphBuilder.buildVoltageLevelGraph(vl1.getId(), false, true);
         new ImplicitCellDetector().detectCells(g1);
         new BlockOrganizer().organize(g1);
-        new PositionVoltageLevelLayout(g1).run(layoutParameters);
+        new PositionVoltageLevelLayout(g1).run(getLayoutParameters());
 
         Graph g2 = graphBuilder.buildVoltageLevelGraph(vl2.getId(), false, true);
         new ImplicitCellDetector().detectCells(g2);
         new BlockOrganizer().organize(g2);
-        new PositionVoltageLevelLayout(g2).run(layoutParameters);
+        new PositionVoltageLevelLayout(g2).run(getLayoutParameters());
 
         Graph g3 = graphBuilder.buildVoltageLevelGraph(vl3.getId(), false, true);
         new ImplicitCellDetector().detectCells(g3);
         new BlockOrganizer().organize(g3);
-        new PositionVoltageLevelLayout(g3).run(layoutParameters);
+        new PositionVoltageLevelLayout(g3).run(getLayoutParameters());
 
         // write JSON and compare to reference (horizontal layout)
         assertEquals(toString("/TestCase12GraphVL1.json"), toJson(g1, "/TestCase12GraphVL1.json"));
@@ -263,14 +243,13 @@ public class TestCase12GraphWith3WT extends AbstractTestCaseIidm {
         assertEquals(toString("/TestCase12GraphVL3.json"), toJson(g3, "/TestCase12GraphVL3.json"));
 
         // Optimize SVG by avoiding duplication
-        layoutParameters = new LayoutParameters(layoutParameters);
-        layoutParameters.setAvoidSVGComponentsDuplication(true);
+        getLayoutParameters().setAvoidSVGComponentsDuplication(true);
 
         // compare metadata of voltage level diagram with reference
         VoltageLevelDiagram diagram = VoltageLevelDiagram.build(graphBuilder, vl1.getId(),
                 new PositionVoltageLevelLayoutFactory(), false);
-        compareMetadata(diagram, layoutParameters, "/vlDiag_metadata.json",
-                new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters),
+        compareMetadata(diagram, getLayoutParameters(), "/vlDiag_metadata.json",
+                new DefaultDiagramLabelProvider(network, componentLibrary, getLayoutParameters()),
                 new NominalVoltageDiagramStyleProvider(network));
     }
 
@@ -284,50 +263,32 @@ public class TestCase12GraphWith3WT extends AbstractTestCaseIidm {
         generator.getTerminal().getBusView().getBus().setV(403);
         generator.getTerminal().getBusView().getBus().setAngle(-1.7);
 
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(80)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(false)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50)
-                .setDrawStraightWires(false)
-                .setHorizontalSnakeLinePadding(30)
-                .setVerticalSnakeLinePadding(30)
-                .setAdaptCellHeightToContent(true)
-                .setAddNodesInfos(true);
+        getLayoutParameters()
+            .setAdaptCellHeightToContent(true)
+            .setAddNodesInfos(true);
 
         // build voltage level 1 graph
         Graph g1 = graphBuilder.buildVoltageLevelGraph(vl1.getId(), false, true);
         new ImplicitCellDetector().detectCells(g1);
         new BlockOrganizer().organize(g1);
-        new PositionVoltageLevelLayout(g1).run(layoutParameters);
+        new PositionVoltageLevelLayout(g1).run(getLayoutParameters());
 
         DiagramStyleProvider vNomStyleProvider = new NominalVoltageDiagramStyleProvider(network);
         DiagramStyleProvider topoStyleProvider = new TopologicalStyleProvider(network);
 
         ComponentLibrary componentLibrary = new ResourcesComponentLibrary("/ConvergenceLibrary");
-        DefaultDiagramLabelProvider initProvider = new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters);
+        DefaultDiagramLabelProvider initProvider = new DefaultDiagramLabelProvider(network, componentLibrary, getLayoutParameters());
 
         // write SVGs and compare to reference
         assertEquals(toString("/TestCase12GraphWithNodesInfosNominalVoltage.svg"),
-                toSVG(g1, "/TestCase12GraphWithNodesInfosNominalVoltage.svg", layoutParameters, initProvider, vNomStyleProvider));
+                toSVG(g1, "/TestCase12GraphWithNodesInfosNominalVoltage.svg", getLayoutParameters(), initProvider, vNomStyleProvider));
 
         g1 = graphBuilder.buildVoltageLevelGraph(vl1.getId(), false, true);
         new ImplicitCellDetector().detectCells(g1);
         new BlockOrganizer().organize(g1);
-        new PositionVoltageLevelLayout(g1).run(layoutParameters);
+        new PositionVoltageLevelLayout(g1).run(getLayoutParameters());
 
         assertEquals(toString("/TestCase12GraphWithNodesInfosTopological.svg"),
-                toSVG(g1, "/TestCase12GraphWithNodesInfosTopological.svg", layoutParameters, initProvider, topoStyleProvider));
+                toSVG(g1, "/TestCase12GraphWithNodesInfosTopological.svg", getLayoutParameters(), initProvider, topoStyleProvider));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase13ZoneGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase13ZoneGraph.java
@@ -7,6 +7,7 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.model.ZoneGraph;
 import com.powsybl.sld.model.ZoneGraphTest;
 import org.junit.Before;
@@ -24,6 +25,7 @@ public class TestCase13ZoneGraph extends AbstractTestCaseIidm {
     @Before
     public void setUp() {
         network = ZoneGraphTest.createNetwork();
+        layoutParameters = new LayoutParameters();
     }
 
     @Test

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase13ZoneGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase13ZoneGraph.java
@@ -22,10 +22,15 @@ import static org.junit.Assert.assertEquals;
  * @author Christian Biasuzzi <christian.biasuzzi@techrain.eu>
  */
 public class TestCase13ZoneGraph extends AbstractTestCaseIidm {
+
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return new LayoutParameters();
+    }
+
     @Before
     public void setUp() {
         network = ZoneGraphTest.createNetwork();
-        layoutParameters = new LayoutParameters();
     }
 
     @Test

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1BusBreaker.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1BusBreaker.java
@@ -25,6 +25,11 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestCase1BusBreaker extends AbstractTestCaseIidm {
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return createDefaultLayoutParameters();
+    }
+
     @Before
     public void setUp() {
         network = Network.create("busBreakerTestCase1", "test");
@@ -65,24 +70,8 @@ public class TestCase1BusBreaker extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(true)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
 
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
         // write Json and compare to reference
         assertEquals(toString("/TestCase1BusBreaker.json"), toJson(g, "/TestCase1BusBreaker.json"));
     }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1BusBreaker.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1BusBreaker.java
@@ -65,7 +65,7 @@ public class TestCase1BusBreaker extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1inverted.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1inverted.java
@@ -61,7 +61,7 @@ public class TestCase1inverted extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1inverted.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1inverted.java
@@ -37,6 +37,11 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestCase1inverted extends AbstractTestCaseIidm {
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return createDefaultLayoutParameters();
+    }
+
     @Before
     public void setUp() {
         network = Network.create("testCase1", "test");
@@ -61,24 +66,7 @@ public class TestCase1inverted extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(true)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50);
-
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
 
         // write Json and compare to reference
         assertEquals(toString("/TestCase1inverted.json"), toJson(g, "/TestCase1inverted.json"));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase2StackedCell.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase2StackedCell.java
@@ -38,6 +38,11 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestCase2StackedCell extends AbstractTestCaseIidm {
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return createDefaultLayoutParameters();
+    }
+
     @Before
     public void setUp() {
         network = Network.create("testCase1", "test");
@@ -64,24 +69,7 @@ public class TestCase2StackedCell extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(true)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50);
-
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
 
         // write Json and compare to reference
         assertEquals(toString("/TestCase2Stacked.json"), toJson(g, "/TestCase2Stacked.json"));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase2StackedCell.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase2StackedCell.java
@@ -64,7 +64,7 @@ public class TestCase2StackedCell extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase3Coupling.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase3Coupling.java
@@ -60,7 +60,7 @@ public class TestCase3Coupling extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase3Coupling.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase3Coupling.java
@@ -35,6 +35,11 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestCase3Coupling extends AbstractTestCaseIidm {
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return createDefaultLayoutParameters();
+    }
+
     @Before
     public void setUp() {
         network = Network.create("testCase1", "test");
@@ -60,24 +65,7 @@ public class TestCase3Coupling extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(true)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50);
-
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
 
         // write Json and compare to reference
         assertEquals(toString("/TestCase3Coupling.json"), toJson(g, "/TestCase3Coupling.json"));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase4NotParallelel.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase4NotParallelel.java
@@ -45,6 +45,11 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestCase4NotParallelel extends AbstractTestCaseIidm {
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return createDefaultLayoutParameters();
+    }
+
     @Before
     public void setUp() {
         network = Network.create("testCase1", "test");
@@ -80,24 +85,7 @@ public class TestCase4NotParallelel extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(true)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50);
-
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
 
         // write Json and compare to reference
         assertEquals(toString("/TestCase4NotParallelel.json"), toJson(g, "/TestCase4NotParallelel.json"));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase4NotParallelel.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase4NotParallelel.java
@@ -80,7 +80,7 @@ public class TestCase4NotParallelel extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntHorizontal.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntHorizontal.java
@@ -39,6 +39,11 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestCase5ShuntHorizontal extends AbstractTestCaseIidm {
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return createDefaultLayoutParameters();
+    }
+
     @Before
     public void setUp() {
         network = Network.create("testCase1", "test");
@@ -67,24 +72,7 @@ public class TestCase5ShuntHorizontal extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(true)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50);
-
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
 
         // write Json and compare to reference
         assertEquals(toString("/TestCase5H.json"), toJson(g, "/TestCase5H.json"));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntHorizontal.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntHorizontal.java
@@ -67,7 +67,7 @@ public class TestCase5ShuntHorizontal extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntVertical.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntVertical.java
@@ -39,6 +39,11 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestCase5ShuntVertical extends AbstractTestCaseIidm {
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return createDefaultLayoutParameters();
+    }
+
     @Before
     public void setUp() {
         network = Network.create("testCase1", "test");
@@ -67,24 +72,7 @@ public class TestCase5ShuntVertical extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(true)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50);
-
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
 
         // write Json and compare to reference
         assertEquals(toString("/TestCase5V.json"), toJson(g, "/TestCase5V.json"));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntVertical.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntVertical.java
@@ -67,7 +67,7 @@ public class TestCase5ShuntVertical extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase6CouplingNonFlatHorizontal.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase6CouplingNonFlatHorizontal.java
@@ -35,6 +35,11 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestCase6CouplingNonFlatHorizontal extends AbstractTestCaseIidm {
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return createDefaultLayoutParameters();
+    }
+
     @Before
     public void setUp() {
         network = Network.create("testCase1", "test");
@@ -64,24 +69,7 @@ public class TestCase6CouplingNonFlatHorizontal extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(true)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50);
-
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
 
         // write Json and compare to reference
         assertEquals(toString("/TestCase6CouplingNonFlatHorizontal.json"), toJson(g, "/TestCase6CouplingNonFlatHorizontal.json"));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase6CouplingNonFlatHorizontal.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase6CouplingNonFlatHorizontal.java
@@ -64,7 +64,7 @@ public class TestCase6CouplingNonFlatHorizontal extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(g);
 
         // calculate coordinates
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7CellDetectionIssue.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.sld.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.ImplicitCellDetector;
+import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.model.Graph;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +32,11 @@ import static org.junit.Assert.assertEquals;
 public class TestCase7CellDetectionIssue extends AbstractTestCaseIidm {
 
     private VoltageLevel vl;
+
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return null;
+    }
 
     @Before
     public void setUp() {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7DoubleDJ.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7DoubleDJ.java
@@ -7,6 +7,7 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.iidm.network.*;
+import com.powsybl.sld.layout.LayoutParameters;
 
 /**
  * <pre>
@@ -21,6 +22,11 @@ import com.powsybl.iidm.network.*;
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public class TestCase7DoubleDJ extends AbstractTestCaseIidm {
+
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return null;
+    }
 
     @Override
     public void setUp() {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase8JumpOverStacked.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase8JumpOverStacked.java
@@ -7,6 +7,7 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.iidm.network.*;
+import com.powsybl.sld.layout.LayoutParameters;
 
 /**
  * <pre>
@@ -26,6 +27,11 @@ import com.powsybl.iidm.network.*;
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public class TestCase8JumpOverStacked extends AbstractTestCaseIidm {
+
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return null;
+    }
 
     @Override
     public void setUp() {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseGraphAdaptCellHeightToContent.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseGraphAdaptCellHeightToContent.java
@@ -85,7 +85,7 @@ public class TestCaseGraphAdaptCellHeightToContent extends AbstractTestCaseIidm 
     @Test
     public void test() {
         // layout parameters with extern cell height fixed
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setExternCellHeight(200)
                 .setShowInternalNodes(true)
                 .setAdaptCellHeightToContent(false);
@@ -99,13 +99,13 @@ public class TestCaseGraphAdaptCellHeightToContent extends AbstractTestCaseIidm 
         assertEquals(toString("/TestCaseGraphExternCellHeightFixed.json"), toJson(g, "/TestCaseGraphExternCellHeightFixed.json"));
 
         // layout parameters with adapt cell height to content
-        LayoutParameters layoutParametersAdaptCellHeightToContent = new LayoutParameters(layoutParameters);
-        layoutParametersAdaptCellHeightToContent.setAdaptCellHeightToContent(true);
+        layoutParameters = new LayoutParameters(layoutParameters);
+        layoutParameters.setAdaptCellHeightToContent(true);
 
         g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
         new ImplicitCellDetector(false, true, false).detectCells(g);
         new BlockOrganizer(new PositionFromExtension(), true).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParametersAdaptCellHeightToContent);
+        new PositionVoltageLevelLayout(g).run(layoutParameters);
 
         assertEquals(toString("/TestCaseGraphAdaptCellHeightToContent.json"), toJson(g, "/TestCaseGraphAdaptCellHeightToContent.json"));
     }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseGraphAdaptCellHeightToContent.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseGraphAdaptCellHeightToContent.java
@@ -28,8 +28,18 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestCaseGraphAdaptCellHeightToContent extends AbstractTestCaseIidm {
 
+    private LayoutParameters layoutParameters;
+
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return layoutParameters;
+    }
+
     @Before
     public void setUp() {
+        layoutParameters = createDefaultLayoutParameters()
+            .setExternCellHeight(200);
+
         network = Network.create("testCaseGraphAdaptCellHeightToContent", "test");
         graphBuilder = new NetworkGraphBuilder(network);
 
@@ -83,29 +93,29 @@ public class TestCaseGraphAdaptCellHeightToContent extends AbstractTestCaseIidm 
     }
 
     @Test
-    public void test() {
+    public void testHeightFixed() {
         // layout parameters with extern cell height fixed
-        layoutParameters = new LayoutParameters()
-                .setExternCellHeight(200)
-                .setShowInternalNodes(true)
-                .setAdaptCellHeightToContent(false);
+        getLayoutParameters()
+            .setAdaptCellHeightToContent(false);
 
         Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
         new ImplicitCellDetector(false, true, false).detectCells(g);
         new BlockOrganizer(new PositionFromExtension(), false).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
-        layoutParameters.setShowGrid(true);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
 
         assertEquals(toString("/TestCaseGraphExternCellHeightFixed.json"), toJson(g, "/TestCaseGraphExternCellHeightFixed.json"));
+    }
 
+    @Test
+    public void testAdaptHeight() {
         // layout parameters with adapt cell height to content
-        layoutParameters = new LayoutParameters(layoutParameters);
-        layoutParameters.setAdaptCellHeightToContent(true);
+        getLayoutParameters()
+            .setAdaptCellHeightToContent(true);
 
-        g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
         new ImplicitCellDetector(false, true, false).detectCells(g);
         new BlockOrganizer(new PositionFromExtension(), true).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
 
         assertEquals(toString("/TestCaseGraphAdaptCellHeightToContent.json"), toJson(g, "/TestCaseGraphAdaptCellHeightToContent.json"));
     }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestNodeDecorators.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestNodeDecorators.java
@@ -31,6 +31,11 @@ public class TestNodeDecorators extends AbstractTestCaseIidm {
     private LayoutParameters layoutParameters;
 
     @Override
+    public LayoutParameters getLayoutParameters() {
+        return layoutParameters;
+    }
+
+    @Override
     protected ResourcesComponentLibrary getResourcesComponentLibrary() {
         return new ResourcesComponentLibrary("/ConvergenceLibrary", "/NodeDecoratorsLibrary");
     }
@@ -38,25 +43,8 @@ public class TestNodeDecorators extends AbstractTestCaseIidm {
     @Before
     public void setUp() {
         // Layout parameters :
-        layoutParameters = new LayoutParameters()
-            .setTranslateX(20)
-            .setTranslateY(50)
-            .setInitialXBus(0)
-            .setInitialYBus(260)
-            .setVerticalSpaceBus(25)
-            .setHorizontalBusPadding(20)
-            .setCellWidth(80)
-            .setExternCellHeight(250)
-            .setInternCellHeight(40)
-            .setStackHeight(30)
-            .setShowGrid(true)
-            .setShowInternalNodes(false)
-            .setScaleFactor(1)
-            .setHorizontalSubstationPadding(50)
-            .setVerticalSubstationPadding(50)
-            .setDrawStraightWires(false)
-            .setHorizontalSnakeLinePadding(30)
-            .setVerticalSnakeLinePadding(30);
+        layoutParameters = createDefaultLayoutParameters()
+            .setCellWidth(80);
     }
 
     @Test
@@ -65,12 +53,12 @@ public class TestNodeDecorators extends AbstractTestCaseIidm {
         Graph graph = TestSVGWriter.createVoltageLevelGraph1();
 
         TestDiagramLabelProvider nodeDecoratorLabelProvider = new TestDiagramLabelProvider();
-        assertEquals(toString("/vl1_decorated.svg"), toSVG(graph, "/vl1_decorated.svg", layoutParameters,
+        assertEquals(toString("/vl1_decorated.svg"), toSVG(graph, "/vl1_decorated.svg", getLayoutParameters(),
             nodeDecoratorLabelProvider, new DefaultDiagramStyleProvider()));
 
         // Same tests than before, with optimized svg :
-        layoutParameters.setAvoidSVGComponentsDuplication(true);
-        assertEquals(toString("/vl1_decorated_opt.svg"), toSVG(graph, "/vl1_decorated_opt.svg", layoutParameters,
+        getLayoutParameters().setAvoidSVGComponentsDuplication(true);
+        assertEquals(toString("/vl1_decorated_opt.svg"), toSVG(graph, "/vl1_decorated_opt.svg", getLayoutParameters(),
             nodeDecoratorLabelProvider, new DefaultDiagramStyleProvider()));
     }
 
@@ -79,7 +67,7 @@ public class TestNodeDecorators extends AbstractTestCaseIidm {
         private static final double DECORATOR_OFFSET = 1d;
 
         public TestDiagramLabelProvider() {
-            super(Network.create("empty", ""), componentLibrary, layoutParameters);
+            super(Network.create("empty", ""), componentLibrary, getLayoutParameters());
         }
 
         @Override

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestNodeDecorators.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestNodeDecorators.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 public class TestNodeDecorators extends AbstractTestCaseIidm {
 
     private LayoutParameters layoutParameters;
+    private Graph graph;
 
     @Override
     public LayoutParameters getLayoutParameters() {
@@ -45,18 +46,21 @@ public class TestNodeDecorators extends AbstractTestCaseIidm {
         // Layout parameters :
         layoutParameters = createDefaultLayoutParameters()
             .setCellWidth(80);
+
+        graph = TestSVGWriter.createVoltageLevelGraph1();
     }
 
     @Test
-    public void test() {
-
-        Graph graph = TestSVGWriter.createVoltageLevelGraph1();
-
+    public void testSvg() {
         TestDiagramLabelProvider nodeDecoratorLabelProvider = new TestDiagramLabelProvider();
         assertEquals(toString("/vl1_decorated.svg"), toSVG(graph, "/vl1_decorated.svg", getLayoutParameters(),
             nodeDecoratorLabelProvider, new DefaultDiagramStyleProvider()));
+    }
 
-        // Same tests than before, with optimized svg :
+    @Test
+    public void testOptimizedSvg() {
+        // Same tests than above, with optimized svg :
+        TestDiagramLabelProvider nodeDecoratorLabelProvider = new TestDiagramLabelProvider();
         getLayoutParameters().setAvoidSVGComponentsDuplication(true);
         assertEquals(toString("/vl1_decorated_opt.svg"), toSVG(graph, "/vl1_decorated_opt.svg", getLayoutParameters(),
             nodeDecoratorLabelProvider, new DefaultDiagramStyleProvider()));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
@@ -51,6 +51,11 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
     private LayoutParameters layoutParameters;
     private ZoneGraph zGraph;
 
+    @Override
+    public LayoutParameters getLayoutParameters() {
+        return layoutParameters;
+    }
+
     private void createVoltageLevelGraphs() {
         // Creation "by hand" (without any network) of 3 voltage level graphs
         // and then generation of a SVG with DefaultDiagramStyleProvider (no network necessary)
@@ -659,26 +664,8 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
         createZoneGraph();
 
         // Layout parameters :
-        //
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(80)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(false)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50)
-                .setDrawStraightWires(false)
-                .setHorizontalSnakeLinePadding(30)
-                .setVerticalSnakeLinePadding(30);
+        layoutParameters = createDefaultLayoutParameters()
+            .setCellWidth(80);
 
         // initValueProvider example for the test :
         //

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
@@ -16,8 +16,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -700,69 +698,100 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
     }
 
     @Test
-    public void test() {
+    public void testVl1() {
+        assertEquals(toString("/vl1.svg"),
+            toSVG(g1, "/vl1.svg", getLayoutParameters(), initValueProvider, new DefaultDiagramStyleProvider()));
+    }
 
-        DiagramStyleProvider styleProvider = new DefaultDiagramStyleProvider();
+    @Test
+    public void testVl2() {
+        assertEquals(toString("/vl2.svg"),
+            toSVG(g2, "/vl2.svg", getLayoutParameters(), initValueProvider, new DefaultDiagramStyleProvider()));
+    }
 
-        Map<String, Graph> mapGr = new LinkedHashMap<>();
-        mapGr.put("/vl1.svg", g1);
-        mapGr.put("/vl2.svg", g2);
-        mapGr.put("/vl3.svg", g3);
+    @Test
+    public void testVl3() {
+        assertEquals(toString("/vl3.svg"),
+            toSVG(g3, "/vl3.svg", getLayoutParameters(), initValueProvider, new DefaultDiagramStyleProvider()));
+    }
 
-        for (String filename : mapGr.keySet()) {
-            // SVG file generation first voltage level and comparison to reference :
-            assertEquals(toString(filename), toSVG(mapGr.get(filename), filename, layoutParameters, initValueProvider, styleProvider));
-        }
-
+    @Test
+    public void testSubstation() {
         // SVG file generation for substation and comparison to reference
-        assertEquals(toString("/substation.svg"), toSVG(substG, "/substation.svg", layoutParameters, initValueProvider, styleProvider));
+        assertEquals(toString("/substation.svg"),
+            toSVG(substG, "/substation.svg", getLayoutParameters(), initValueProvider, new DefaultDiagramStyleProvider()));
+    }
 
+    @Test
+    public void testSubstationArrowSymmetry() {
         // SVG file generation for substation with symmetric feeder arrow and comparison to reference
-        createSubstationGraph();
+        getLayoutParameters().setFeederArrowSymmetry(true);
         assertEquals(toString("/substation_feeder_arrow_symmetry.svg"),
-            toSVG(substG, "/substation_feeder_arrow_symmetry.svg", new LayoutParameters(layoutParameters).setFeederArrowSymmetry(true), initValueProvider, styleProvider));
+            toSVG(substG, "/substation_feeder_arrow_symmetry.svg", getLayoutParameters(), initValueProvider, new DefaultDiagramStyleProvider()));
+    }
 
+    @Test
+    public void testSubstationNoFeederValues() {
         // SVG file generation for substation and comparison to reference but with no feeder values
-        createSubstationGraph();
-        assertEquals(toString("/substation_no_feeder_values.svg"), toSVG(substG, "/substation_no_feeder_values.svg", layoutParameters, noFeederValueProvider, styleProvider));
+        assertEquals(toString("/substation_no_feeder_values.svg"),
+            toSVG(substG, "/substation_no_feeder_values.svg", getLayoutParameters(), noFeederValueProvider, new DefaultDiagramStyleProvider()));
+    }
 
-        // Same tests than before, with optimized svg :
-        //
-        layoutParameters.setAvoidSVGComponentsDuplication(true);
+    @Test
+    public void testVl1Optimized() {
+        // Same tests than before, with optimized svg
+        getLayoutParameters().setAvoidSVGComponentsDuplication(true);
+        assertEquals(toString("/vl1_optimized.svg"),
+            toSVG(g1, "/vl1_optimized.svg", getLayoutParameters(), initValueProvider, new DefaultDiagramStyleProvider()));
+    }
 
-        mapGr.clear();
-        mapGr.put("/vl1_optimized.svg", g1);
-        mapGr.put("/vl2_optimized.svg", g2);
-        mapGr.put("/vl3_optimized.svg", g3);
+    @Test
+    public void testVl2Optimized() {
+        // Same tests than before, with optimized svg
+        getLayoutParameters().setAvoidSVGComponentsDuplication(true);
+        assertEquals(toString("/vl2_optimized.svg"),
+            toSVG(g2, "/vl2_optimized.svg", getLayoutParameters(), initValueProvider, new DefaultDiagramStyleProvider()));
+    }
 
-        for (String filename : mapGr.keySet()) {
-            // SVG file generation first voltage level and comparison to reference :
-            assertEquals(toString(filename), toSVG(mapGr.get(filename), filename, layoutParameters, initValueProvider, styleProvider));
-        }
+    @Test
+    public void testVl3Optimized() {
+        // Same tests than before, with optimized svg
+        getLayoutParameters().setAvoidSVGComponentsDuplication(true);
+        assertEquals(toString("/vl3_optimized.svg"),
+            toSVG(g3, "/vl3_optimized.svg", getLayoutParameters(), initValueProvider, new DefaultDiagramStyleProvider()));
+    }
 
-        // SVG file generation for substation and comparison to reference
-        createSubstationGraph();
-        assertEquals(toString("/substation_optimized.svg"), toSVG(substG, "/substation_optimized.svg", layoutParameters, initValueProvider, styleProvider));
+    @Test
+    public void testSubstationOptimized() {
+        // Same tests than before, with optimized svg
+        getLayoutParameters().setAvoidSVGComponentsDuplication(true);
+        assertEquals(toString("/substation_optimized.svg"),
+            toSVG(substG, "/substation_optimized.svg", getLayoutParameters(), initValueProvider, new DefaultDiagramStyleProvider()));
     }
 
     @Test
     public void testWriteZone() {
-        DiagramStyleProvider styleProvider = new DefaultDiagramStyleProvider();
-        layoutParameters.setShowGrid(false);
-        assertEquals(toString("/zone.svg"), toSVG(zGraph, "/zone.svg", layoutParameters, initValueProvider, styleProvider));
+        getLayoutParameters().setShowGrid(false);
+        assertEquals(toString("/zone.svg"),
+            toSVG(zGraph, "/zone.svg", getLayoutParameters(), initValueProvider, new DefaultDiagramStyleProvider()));
     }
 
     @Test
-    public void testLayoutParameters() {
+    public void testStraightWires() {
         DiagramStyleProvider styleProvider = new DefaultDiagramStyleProvider();
-        layoutParameters.setDrawStraightWires(true);
-        layoutParameters.setTooltipEnabled(true);
-        assertEquals(toString("/vl1_lpChanged.svg"),
-            toSVG(g1, "/vl1_lpChanged.svg", layoutParameters, initValueProvider, styleProvider));
+        getLayoutParameters().setDrawStraightWires(true);
+        assertEquals(toString("/vl1_straightWires.svg"),
+            toSVG(g1, "/vl1_straightWires.svg", getLayoutParameters(), initValueProvider, styleProvider));
+    }
 
-        layoutParameters.setAvoidSVGComponentsDuplication(true);
-        assertEquals(toString("/vl1_lpChanged_opt.svg"),
-            toSVG(g1, "/vl1_lpChanged_opt.svg", layoutParameters, initValueProvider, styleProvider));
+    @Test
+    public void testTooltip() {
+        DiagramStyleProvider styleProvider = new DefaultDiagramStyleProvider();
+        getLayoutParameters()
+            .setTooltipEnabled(true)
+            .setAvoidSVGComponentsDuplication(true);
+        assertEquals(toString("/vl1_tooltip_opt.svg"),
+            toSVG(g1, "/vl1_tooltip_opt.svg", getLayoutParameters(), initValueProvider, styleProvider));
     }
 
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialBlock.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialBlock.java
@@ -27,6 +27,11 @@ import static org.junit.Assert.assertTrue;
  */
 public class TestSerialBlock extends AbstractTestCaseIidm {
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return createDefaultLayoutParameters();
+    }
+
     @Before
     public void setUp() {
         Network network = Network.create("testCase1", "test");
@@ -89,28 +94,11 @@ public class TestSerialBlock extends AbstractTestCaseIidm {
         assertEquals(2, sb.getUpperBlock().getPosition().getSpan(H));
         assertEquals(0, sb.getUpperBlock().getPosition().getSpan(V));
 
-        LayoutParameters layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(true)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50);
-
         sb.getCoord().set(X, 10);
         sb.getCoord().set(Y, 20);
         sb.getCoord().setSpan(X, 100);
         sb.getCoord().setSpan(Y, 200);
-        sb.coordHorizontalCase(layoutParameters);
+        sb.coordHorizontalCase(getLayoutParameters());
 
         assertEquals(10, sb.getLowerBlock().getCoord().get(X), 0);
         assertEquals(20, sb.getLowerBlock().getCoord().get(Y), 0);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialParallelBlock.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialParallelBlock.java
@@ -26,6 +26,11 @@ import static org.junit.Assert.*;
  */
 public class TestSerialParallelBlock extends AbstractTestCaseIidm {
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return createDefaultLayoutParameters();
+    }
+
     @Before
     public void setUp() {
         Network network = Network.create("testCase1", "test");
@@ -91,28 +96,11 @@ public class TestSerialParallelBlock extends AbstractTestCaseIidm {
         assertEquals(2, subPB.getSubBlocks().get(1).getPosition().getSpan(H));
         assertEquals(4, subPB.getSubBlocks().get(1).getPosition().getSpan(V));
 
-        LayoutParameters layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(true)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50);
-
         sb.getCoord().set(X, 10);
         sb.getCoord().set(Y, 20);
         sb.getCoord().setSpan(X, 100);
         sb.getCoord().setSpan(Y, 200);
-        sb.coordHorizontalCase(layoutParameters);
+        sb.coordHorizontalCase(getLayoutParameters());
 
         assertEquals(10, sb.getCoord().get(X), 0);
         assertEquals(20, sb.getCoord().get(Y), 0);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestTopologyCalculation.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestTopologyCalculation.java
@@ -40,6 +40,11 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestTopologyCalculation extends AbstractTestCaseIidm {
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return null;
+    }
+
     @Before
     public void setUp() {
         network = Network.create("testCase1", "test");

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnicityNodeIdWithMutipleNetwork.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnicityNodeIdWithMutipleNetwork.java
@@ -30,6 +30,11 @@ public class TestUnicityNodeIdWithMutipleNetwork extends AbstractTestCaseIidm {
     private Substation substation2;
     private VoltageLevel vl2;
 
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return new LayoutParameters();
+    }
+
     @Before
     public void setUp() {
         // Create first network with a substation and a voltageLevel
@@ -56,13 +61,11 @@ public class TestUnicityNodeIdWithMutipleNetwork extends AbstractTestCaseIidm {
 
     @Test
     public void test() {
-        layoutParameters = new LayoutParameters();
-
         // Generating json for voltage level in first network
         Graph graph1 = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
         new ImplicitCellDetector().detectCells(graph1);
         new BlockOrganizer().organize(graph1);
-        new PositionVoltageLevelLayout(graph1).run(layoutParameters);
+        new PositionVoltageLevelLayout(graph1).run(getLayoutParameters());
 
         String refJson1 = toString("/TestUnicityNodeIdNetWork1.json");
         assertEquals(refJson1, toJson(graph1, "/TestUnicityNodeIdNetWork1.json"));
@@ -71,7 +74,7 @@ public class TestUnicityNodeIdWithMutipleNetwork extends AbstractTestCaseIidm {
         Graph graph2 = graphBuilder2.buildVoltageLevelGraph(vl2.getId(), false, true);
         new ImplicitCellDetector().detectCells(graph2);
         new BlockOrganizer().organize(graph2);
-        new PositionVoltageLevelLayout(graph2).run(layoutParameters);
+        new PositionVoltageLevelLayout(graph2).run(getLayoutParameters());
 
         network = network2; // overwrite network with network2 for debug purposes (svg generated for debug in toJson if writeFile=true takes network as reference)
         String refJson2 = toString("/TestUnicityNodeIdNetWork2.json");

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnicityNodeIdWithMutipleNetwork.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnicityNodeIdWithMutipleNetwork.java
@@ -55,7 +55,7 @@ public class TestUnicityNodeIdWithMutipleNetwork extends AbstractTestCaseIidm {
 
     @Test
     public void test() {
-        LayoutParameters layoutParameters = new LayoutParameters();
+        layoutParameters = new LayoutParameters();
 
         // Generating json for voltage level in first network
         Graph graph1 = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
@@ -72,6 +72,7 @@ public class TestUnicityNodeIdWithMutipleNetwork extends AbstractTestCaseIidm {
         new BlockOrganizer().organize(graph2);
         new PositionVoltageLevelLayout(graph2).run(layoutParameters);
 
+        network = network2; // overwrite network with network2 for debug purposes (svg generated for debug in toJson if writeFile=true takes network as reference)
         String refJson2 = toString("/TestUnicityNodeIdNetWork2.json");
         assertEquals(refJson2, toJson(graph2, "/TestUnicityNodeIdNetWork2.json"));
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnicityNodeIdWithMutipleNetwork.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnicityNodeIdWithMutipleNetwork.java
@@ -45,6 +45,7 @@ public class TestUnicityNodeIdWithMutipleNetwork extends AbstractTestCaseIidm {
 
         // Create second network with a substation and a voltageLevel
         network2 = Network.create("n2", "test");
+        graphBuilder2 = new NetworkGraphBuilder(network2);
         substation2 = createSubstation(network2, "s", "s", Country.FR);
         vl2 = createVoltageLevel(substation2, "vl", "vl", TopologyKind.NODE_BREAKER, 400, 10);
         createBusBarSection(vl2, "bbs", "bbs", 0, 1, 1);
@@ -67,7 +68,7 @@ public class TestUnicityNodeIdWithMutipleNetwork extends AbstractTestCaseIidm {
         assertEquals(refJson1, toJson(graph1, "/TestUnicityNodeIdNetWork1.json"));
 
         // Generating json for voltage level in second network
-        Graph graph2 = graphBuilder.buildVoltageLevelGraph(vl2.getId(), false, true);
+        Graph graph2 = graphBuilder2.buildVoltageLevelGraph(vl2.getId(), false, true);
         new ImplicitCellDetector().detectCells(graph2);
         new BlockOrganizer().organize(graph2);
         new PositionVoltageLevelLayout(graph2).run(layoutParameters);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/model/AddNodeGraphTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/model/AddNodeGraphTest.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
 import com.powsybl.sld.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.AbstractTestCaseIidm;
+import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.library.ComponentTypeName;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,6 +24,11 @@ import static org.junit.Assert.*;
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
 public class AddNodeGraphTest extends AbstractTestCaseIidm {
+
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return null;
+    }
 
     @Before
     public void setUp() {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/AbstractTestCaseRaw.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/AbstractTestCaseRaw.java
@@ -29,46 +29,33 @@ import java.util.stream.Stream;
  */
 public abstract class AbstractTestCaseRaw extends AbstractTestCase {
     protected RawGraphBuilder rawGraphBuilder = new RawGraphBuilder();
+    private LayoutParameters layoutParameters;
 
     protected AbstractTestCaseRaw() {
-        layoutParameters = new LayoutParameters()
-            .setTranslateX(20)
-            .setTranslateY(50)
-            .setInitialXBus(0)
-            .setInitialYBus(260)
-            .setVerticalSpaceBus(25)
-            .setHorizontalBusPadding(20)
-            .setCellWidth(50)
-            .setExternCellHeight(250)
-            .setInternCellHeight(40)
-            .setStackHeight(30)
-            .setShowGrid(true)
-            .setShowInternalNodes(true)
-            .setScaleFactor(1)
-            .setHorizontalSubstationPadding(50)
-            .setVerticalSubstationPadding(50)
-            .setArrowDistance(20)
-            .setDrawStraightWires(false)
-            .setHorizontalSnakeLinePadding(30)
-            .setVerticalSnakeLinePadding(30);
+        layoutParameters = createDefaultLayoutParameters();
+    }
+
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return layoutParameters;
     }
 
     @Override
     public void toSVG(Graph graph, String filename) {
         Stream<Node> nodeStream = graph.getNodes().stream();
-        toSVG(graph, filename, layoutParameters, new RawDiagramLabelProvider(nodeStream), new DefaultDiagramStyleProvider());
+        toSVG(graph, filename, getLayoutParameters(), new RawDiagramLabelProvider(nodeStream), new DefaultDiagramStyleProvider());
     }
 
     @Override
     public void toSVG(SubstationGraph graph, String filename) {
         Stream<Node> nodeStream = graph.getNodes().stream().flatMap(g -> g.getNodes().stream());
-        toSVG(graph, filename, layoutParameters, new RawDiagramLabelProvider(nodeStream), new DefaultDiagramStyleProvider());
+        toSVG(graph, filename, getLayoutParameters(), new RawDiagramLabelProvider(nodeStream), new DefaultDiagramStyleProvider());
     }
 
     @Override
     public void toSVG(ZoneGraph graph, String filename) {
         Stream<Node> nodeStream = graph.getNodes().stream().flatMap(g -> g.getNodes().stream()).flatMap(g -> g.getNodes().stream());
-        toSVG(graph, filename, layoutParameters, new RawDiagramLabelProvider(nodeStream), new DefaultDiagramStyleProvider());
+        toSVG(graph, filename, getLayoutParameters(), new RawDiagramLabelProvider(nodeStream), new DefaultDiagramStyleProvider());
     }
 
     private static class RawDiagramLabelProvider implements DiagramLabelProvider {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/AbstractTestCaseRaw.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/AbstractTestCaseRaw.java
@@ -12,6 +12,7 @@ import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.model.Graph;
 import com.powsybl.sld.model.Node;
 import com.powsybl.sld.model.SubstationGraph;
+import com.powsybl.sld.model.ZoneGraph;
 import com.powsybl.sld.svg.DefaultDiagramStyleProvider;
 import com.powsybl.sld.svg.DiagramLabelProvider;
 import com.powsybl.sld.svg.InitialValue;
@@ -21,13 +22,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  */
 public abstract class AbstractTestCaseRaw extends AbstractTestCase {
     protected RawGraphBuilder rawGraphBuilder = new RawGraphBuilder();
-    protected LayoutParameters layoutParameters = new LayoutParameters()
+
+    protected AbstractTestCaseRaw() {
+        layoutParameters = new LayoutParameters()
             .setTranslateX(20)
             .setTranslateY(50)
             .setInitialXBus(0)
@@ -47,88 +51,52 @@ public abstract class AbstractTestCaseRaw extends AbstractTestCase {
             .setDrawStraightWires(false)
             .setHorizontalSnakeLinePadding(30)
             .setVerticalSnakeLinePadding(30);
-
-    DiagramLabelProvider getDiagramLabelProvider(Graph graph) {
-        Map<Node, List<DiagramLabelProvider.NodeLabel>> busLabels = new HashMap<>();
-        LabelPosition labelPosition = new LabelPosition("default", 0, -5, true, 0);
-        graph.getNodes().forEach(n -> {
-            List<DiagramLabelProvider.NodeLabel> labels = new ArrayList<>();
-            labels.add(new DiagramLabelProvider.NodeLabel(n.getLabel(), labelPosition));
-            busLabels.put(n, labels);
-        });
-        return new DiagramLabelProvider() {
-            @Override
-            public InitialValue getInitialValue(Node node) {
-                return new InitialValue(Direction.UP, Direction.DOWN, "tata", "tutu", "", "");
-            }
-
-            @Override
-            public List<NodeLabel> getNodeLabels(Node node) {
-                return busLabels.get(node);
-            }
-
-            @Override
-            public List<NodeDecorator> getNodeDecorators(Node node) {
-                return new ArrayList<>();
-            }
-        };
     }
 
-    DiagramLabelProvider getDiagramLabelProvider(SubstationGraph graph) {
-        Map<Node, List<DiagramLabelProvider.NodeLabel>> busLabels = new HashMap<>();
-        LabelPosition labelPosition = new LabelPosition("default", 0, -5, true, 0);
-        graph.getNodes().stream().flatMap(g -> g.getNodes().stream()).forEach(n -> {
-            List<DiagramLabelProvider.NodeLabel> labels = new ArrayList<>();
-            labels.add(new DiagramLabelProvider.NodeLabel(n.getLabel(), labelPosition));
-            busLabels.put(n, labels);
-        });
-        return new DiagramLabelProvider() {
-            @Override
-            public InitialValue getInitialValue(Node node) {
-                return new InitialValue(Direction.UP, Direction.DOWN, "tata", "tutu", "", "");
-            }
-
-            @Override
-            public List<NodeLabel> getNodeLabels(Node node) {
-                return busLabels.get(node);
-            }
-
-            @Override
-            public List<NodeDecorator> getNodeDecorators(Node node) {
-                return new ArrayList<>();
-            }
-        };
+    @Override
+    public void toSVG(Graph graph, String filename) {
+        Stream<Node> nodeStream = graph.getNodes().stream();
+        toSVG(graph, filename, layoutParameters, new RawDiagramLabelProvider(nodeStream), new DefaultDiagramStyleProvider());
     }
 
-    public void toSVG(Graph g, String filename) {
-        toSVG(g, filename, layoutParameters, getDiagramLabelProvider(g), new DefaultDiagramStyleProvider());
+    @Override
+    public void toSVG(SubstationGraph graph, String filename) {
+        Stream<Node> nodeStream = graph.getNodes().stream().flatMap(g -> g.getNodes().stream());
+        toSVG(graph, filename, layoutParameters, new RawDiagramLabelProvider(nodeStream), new DefaultDiagramStyleProvider());
     }
 
-    public void toSVG(SubstationGraph g, String filename) {
-        toSVG(g, filename, layoutParameters, getDiagramLabelProvider(g), new DefaultDiagramStyleProvider());
+    @Override
+    public void toSVG(ZoneGraph graph, String filename) {
+        Stream<Node> nodeStream = graph.getNodes().stream().flatMap(g -> g.getNodes().stream()).flatMap(g -> g.getNodes().stream());
+        toSVG(graph, filename, layoutParameters, new RawDiagramLabelProvider(nodeStream), new DefaultDiagramStyleProvider());
     }
 
-    public String toJson(Graph graph, String filename) {
-        String result = super.toJson(graph, filename);
-        if (writeFile) {
-            toSVG(graph, filename + ".svg");
+    private static class RawDiagramLabelProvider implements DiagramLabelProvider {
+        private final Map<Node, List<NodeLabel>> busLabels;
+
+        public RawDiagramLabelProvider(Stream<Node> nodeStream) {
+            this.busLabels = new HashMap<>();
+            LabelPosition labelPosition = new LabelPosition("default", 0, -5, true, 0);
+            nodeStream.forEach(n -> {
+                List<DiagramLabelProvider.NodeLabel> labels = new ArrayList<>();
+                labels.add(new DiagramLabelProvider.NodeLabel(n.getLabel(), labelPosition));
+                busLabels.put(n, labels);
+            });
         }
-        return result;
-    }
 
-    public String toJson(SubstationGraph graph, String filename) {
-        String result = super.toJson(graph, filename);
-        if (writeFile) {
-            toSVG(graph, filename + ".svg");
+        @Override
+        public InitialValue getInitialValue(Node node) {
+            return new InitialValue(Direction.UP, Direction.DOWN, "tata", "tutu", "", "");
         }
-        return result;
-    }
 
-    public String toJson(SubstationGraph graph, String filename, boolean genCoords) {
-        String result = super.toJson(graph, filename, genCoords);
-        if (writeFile) {
-            toSVG(graph, filename + ".svg");
+        @Override
+        public List<NodeLabel> getNodeLabels(Node node) {
+            return busLabels.get(node);
         }
-        return result;
+
+        @Override
+        public List<NodeDecorator> getNodeDecorators(Node node) {
+            return new ArrayList<>();
+        }
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase1.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase1.java
@@ -47,7 +47,7 @@ public class TestCase1 extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestCase1.json"), toJson(g, "/TestCase1.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase11SubstationGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase11SubstationGraph.java
@@ -292,14 +292,14 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
     @Test
     public void testH() {
         SubstationGraph g = rawGraphBuilder.buildSubstationGraph("subst", false);
-        new HorizontalSubstationLayoutFactory().create(g, new PositionVoltageLevelLayoutFactory()).run(layoutParameters);
+        new HorizontalSubstationLayoutFactory().create(g, new PositionVoltageLevelLayoutFactory()).run(getLayoutParameters());
         assertEquals(toString("/TestCase11SubstationGraphH.json"), toJson(g, "/TestCase11SubstationGraphH.json"));
     }
 
     @Test
     public void testV() {
         SubstationGraph g = rawGraphBuilder.buildSubstationGraph("subst", false);
-        new VerticalSubstationLayoutFactory().create(g, new PositionVoltageLevelLayoutFactory()).run(layoutParameters);
+        new VerticalSubstationLayoutFactory().create(g, new PositionVoltageLevelLayoutFactory()).run(getLayoutParameters());
         assertEquals(toString("/TestCase11SubstationGraphV.json"), toJson(g, "/TestCase11SubstationGraphV.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase2.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase2.java
@@ -60,7 +60,7 @@ public class TestCase2 extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestCase2Stacked.json"), toJson(g, "/TestCase2Stacked.json"));
     }
 
@@ -69,7 +69,7 @@ public class TestCase2 extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vlUnstack", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer(new PositionFromExtension(), false).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestCase2UnStackedCell.json"), toJson(g, "/TestCase2UnStackedCell.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase3.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase3.java
@@ -49,7 +49,7 @@ public class TestCase3 extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestCase3Coupling.json"), toJson(g, "/TestCase3Coupling.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase4.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase4.java
@@ -86,7 +86,7 @@ public class TestCase4 extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestCase4NotParallelel.json"), toJson(g, "/TestCase4NotParallelel.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5H.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5H.java
@@ -61,7 +61,7 @@ public class TestCase5H extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestCase5H.json"), toJson(g, "/TestCase5H.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5V.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5V.java
@@ -63,7 +63,7 @@ public class TestCase5V extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestCase5V.json"), toJson(g, "/TestCase5V.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase6.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase6.java
@@ -61,7 +61,7 @@ public class TestCase6 extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestCase6CouplingNonFlatHorizontal.json"), toJson(g, "/TestCase6CouplingNonFlatHorizontal.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseComplexCoupling.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseComplexCoupling.java
@@ -55,7 +55,7 @@ public class TestCaseComplexCoupling extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestCaseComplexCoupling.json"), toJson(g, "/TestCaseComplexCoupling.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseShuntArrangement.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseShuntArrangement.java
@@ -169,7 +169,7 @@ public class TestCaseShuntArrangement extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer(new PositionFromExtension(), true, true, false).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestCaseShuntArrangementNo.json"), toJson(g, "/TestCaseShuntArrangementNo.json"));
     }
 
@@ -178,7 +178,7 @@ public class TestCaseShuntArrangement extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer(new PositionFromExtension(), true, true, true).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestCaseShuntArrangementYes.json"), toJson(g, "/TestCaseShuntArrangementYes.json"));
     }
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellShapes.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellShapes.java
@@ -78,7 +78,7 @@ public class TestInternCellShapes extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestInternCellShapes.json"), toJson(g, "/TestInternCellShapes.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestLanesWithUnileg.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestLanesWithUnileg.java
@@ -61,7 +61,7 @@ public class TestLanesWithUnileg extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/testLanesWithUnileg.json"), toJson(g, "/testLanesWithUnileg.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestOrderConsistency.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestOrderConsistency.java
@@ -90,7 +90,7 @@ public class TestOrderConsistency extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl1", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer(new PositionByClustering()).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/orderConsistencyClust1.json"), toJson(g, "/orderConsistencyClust1.json"));
     }
 
@@ -99,7 +99,7 @@ public class TestOrderConsistency extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl2", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer(new PositionByClustering()).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/orderConsistencyClust2.json"), toJson(g, "/orderConsistencyClust2.json"));
     }
 
@@ -108,7 +108,7 @@ public class TestOrderConsistency extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl1", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer(new PositionFromExtension()).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/orderConsistencyExt1.json"), toJson(g, "/orderConsistencyExt1.json"));
     }
 
@@ -117,7 +117,7 @@ public class TestOrderConsistency extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl2", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer(new PositionFromExtension()).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/orderConsistencyExt2.json"), toJson(g, "/orderConsistencyExt2.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOrders.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOrders.java
@@ -43,7 +43,7 @@ public class TestParallelFeedersOrders extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/testParallelFeedersOrders.json"), toJson(g, "/testParallelFeedersOrders.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestSerialBlocksInternCells.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestSerialBlocksInternCells.java
@@ -61,7 +61,7 @@ public class TestSerialBlocksInternCells extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector(false, true, false).detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/testSerialBlocksInternCells.json"), toJson(g, "/testSerialBlocksInternCells.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUndefinedBlockExternCell.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUndefinedBlockExternCell.java
@@ -57,7 +57,7 @@ public class TestUndefinedBlockExternCell extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(toString("/TestUndefinedBlockExternCell.json"), toJson(g, "/TestUndefinedBlockExternCell.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUnhandledPatternInternCell.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUnhandledPatternInternCell.java
@@ -49,7 +49,7 @@ public class TestUnhandledPatternInternCell extends AbstractTestCaseRaw {
         Graph g = rawGraphBuilder.buildVoltageLevelGraph("vl", false, true);
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
         assertEquals(InternCell.Shape.UNHANDLEDPATTERN, ((InternCell) g.getCells().iterator().next()).getShape());
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/util/NominalVoltageStyleTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/util/NominalVoltageStyleTest.java
@@ -14,7 +14,9 @@ import com.powsybl.sld.iidm.AbstractTestCaseIidm;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.library.ComponentSize;
-import com.powsybl.sld.model.*;
+import com.powsybl.sld.model.Edge;
+import com.powsybl.sld.model.Graph;
+import com.powsybl.sld.model.Node;
 import com.powsybl.sld.svg.DefaultDiagramLabelProvider;
 import com.powsybl.sld.svg.DiagramLabelProvider;
 import com.powsybl.sld.svg.InitialValue;
@@ -35,9 +37,20 @@ public class NominalVoltageStyleTest extends AbstractTestCaseIidm {
     VoltageLevel vl1;
     VoltageLevel vl2;
     VoltageLevel vl3;
+    private LayoutParameters layoutParameters;
+
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return layoutParameters;
+    }
 
     @Before
     public void setUp() {
+
+        layoutParameters = createDefaultLayoutParameters()
+            .setCellWidth(80)
+            .setShowInternalNodes(false);
+
         network = Network.create("testCase1", "test");
         graphBuilder = new NetworkGraphBuilder(network);
         substation = createSubstation(network, "s", "s", Country.FR);
@@ -138,31 +151,8 @@ public class NominalVoltageStyleTest extends AbstractTestCaseIidm {
         assertTrue(attributesArrow.containsKey("fill-opacity"));
         assertEquals("1", attributesArrow.get("fill-opacity"));
 
-        // Layout parameters :
-        //
-        LayoutParameters layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(80)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(false)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50)
-                .setDrawStraightWires(false)
-                .setHorizontalSnakeLinePadding(30)
-                .setVerticalSnakeLinePadding(30)
-                .setHighlightLineState(true);
-
         DiagramLabelProvider noFeederValueProvider = new DefaultDiagramLabelProvider(
-                Network.create("empty", ""), componentLibrary, layoutParameters) {
+                Network.create("empty", ""), componentLibrary, getLayoutParameters()) {
             @Override
             public InitialValue getInitialValue(Node node) {
                 InitialValue initialValue;
@@ -175,8 +165,8 @@ public class NominalVoltageStyleTest extends AbstractTestCaseIidm {
             }
         };
 
-        assertEquals(toString("/vl1_nominal_voltage_style.svg"), toSVG(graph1, "/vl1_nominal_voltage_style.svg", layoutParameters, noFeederValueProvider, styleProvider));
-        assertEquals(toString("/vl2_nominal_voltage_style.svg"), toSVG(graph2, "/vl2_nominal_voltage_style.svg", layoutParameters, noFeederValueProvider, styleProvider));
-        assertEquals(toString("/vl3_nominal_voltage_style.svg"), toSVG(graph3, "/vl3_nominal_voltage_style.svg", layoutParameters, noFeederValueProvider, styleProvider));
+        assertEquals(toString("/vl1_nominal_voltage_style.svg"), toSVG(graph1, "/vl1_nominal_voltage_style.svg", getLayoutParameters(), noFeederValueProvider, styleProvider));
+        assertEquals(toString("/vl2_nominal_voltage_style.svg"), toSVG(graph2, "/vl2_nominal_voltage_style.svg", getLayoutParameters(), noFeederValueProvider, styleProvider));
+        assertEquals(toString("/vl3_nominal_voltage_style.svg"), toSVG(graph3, "/vl3_nominal_voltage_style.svg", getLayoutParameters(), noFeederValueProvider, styleProvider));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
@@ -14,6 +14,7 @@ import com.powsybl.sld.NetworkGraphBuilder;
 import com.powsybl.sld.color.BaseVoltageColor;
 import com.powsybl.sld.iidm.AbstractTestCaseIidm;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
+import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.library.ComponentSize;
 import com.powsybl.sld.model.Edge;
 import com.powsybl.sld.model.Graph;
@@ -41,6 +42,11 @@ public class TopologicalStyleTest extends AbstractTestCaseIidm {
     VoltageLevel vl3;
     private FileSystem fileSystem;
     private Path tmpDir;
+
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return null;
+    }
 
     @Before
     public void setUp() throws IOException {

--- a/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
@@ -271,7 +271,6 @@
             <polyline points="420.0,370.0,410.0,370.0"/>
         </g>
         <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
-            <title>vl1_d1</title>
             <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
                 <line x1="0" x2="8" y1="0" y2="8"/>
                 <line x1="8" x2="0" y1="0" y2="8"/>
@@ -281,7 +280,6 @@
             </g>
         </g>
         <g class="BREAKER idvl1_95_b1" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-            <title>vl1_b1</title>
             <g class="closed" id="idvl1_95_b1_BREAKER-closed">
                 <rect height="18" width="18" x="1" y="1"/>
                 <line x1="10" x2="10" y1="5" y2="15"/>
@@ -292,7 +290,6 @@
             </g>
         </g>
         <g class="DISCONNECTOR idvl1_95_d2" id="idvl1_95_d2" transform="translate(286.0,366.0)">
-            <title>vl1_d2</title>
             <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
                 <line x1="0" x2="8" y1="0" y2="8"/>
                 <line x1="8" x2="0" y1="0" y2="8"/>
@@ -302,14 +299,12 @@
             </g>
         </g>
         <g class="LOAD idvl1_95_load1" id="idvl1_95_load1" transform="translate(52.0,145.5)">
-            <title>vl1_load1</title>
             <rect height="9" width="16"/>
             <line x1="0" x2="16" y1="0" y2="9"/>
             <line x1="16" x2="0" y1="0" y2="9"/>
             <text class="component-label" font-family="Verdana" font-size="8" id="vl1_load1__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_load1</text>
         </g>
         <g class="BREAKER idvl1_95_bload1" id="idvl1_95_bload1" transform="translate(50.0,240.0)">
-            <title>vl1_bload1</title>
             <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
                 <rect height="18" width="18" x="1" y="1"/>
                 <line x1="10" x2="10" y1="5" y2="15"/>
@@ -320,7 +315,6 @@
             </g>
         </g>
         <g class="DISCONNECTOR idvl1_95_dload1" id="idvl1_95_dload1" transform="translate(56.0,366.0)">
-            <title>vl1_dload1</title>
             <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
                 <line x1="0" x2="8" y1="0" y2="8"/>
                 <line x1="8" x2="0" y1="0" y2="8"/>
@@ -330,13 +324,11 @@
             </g>
         </g>
         <g class="TWO_WINDINGS_TRANSFORMER idvl1_95_trf1" id="idvl1_95_trf1" transform="translate(95.0,562.5)">
-            <title>vl1_trf1</title>
             <circle cx="5" cy="10" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" r="5"/>
             <circle cx="5" cy="5" id="idvl1_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" r="5"/>
             <text class="component-label" font-family="Verdana" font-size="8" id="vl1_trf1__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_trf1</text>
         </g>
         <g class="BREAKER idvl1_95_btrf1" id="idvl1_95_btrf1" transform="translate(90.0,460.0)">
-            <title>vl1_btrf1</title>
             <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
                 <rect height="18" width="18" x="1" y="1"/>
                 <line x1="10" x2="10" y1="5" y2="15"/>
@@ -347,7 +339,6 @@
             </g>
         </g>
         <g class="DISCONNECTOR idvl1_95_dtrf1" id="idvl1_95_dtrf1" transform="translate(96.0,366.0)">
-            <title>vl1_dtrf1</title>
             <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
                 <line x1="0" x2="8" y1="0" y2="8"/>
                 <line x1="8" x2="0" y1="0" y2="8"/>
@@ -363,13 +354,11 @@
             <text class="component-label" font-family="Verdana" font-size="8" id="vl1_trf2_two__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_trf2</text>
         </g>
         <g class="THREE_WINDINGS_TRANSFORMER idFICT_95_vl1_95_vl1_95_trf2" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,203.0)">
-            <title>vl1_trf2</title>
             <circle cx="5" cy="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING1" r="5"/>
             <circle cx="11" cy="5" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING2" r="5"/>
             <circle cx="8" cy="9" id="idFICT_95_vl1_95_vl1_95_trf2_THREE_WINDINGS_TRANSFORMER-WINDING3" r="5"/>
         </g>
         <g class="BREAKER idvl1_95_btrf2" id="idvl1_95_btrf2" transform="translate(410.0,240.0)">
-            <title>vl1_btrf2</title>
             <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
                 <rect height="18" width="18" x="1" y="1"/>
                 <line x1="10" x2="10" y1="5" y2="15"/>
@@ -380,7 +369,6 @@
             </g>
         </g>
         <g class="DISCONNECTOR idvl1_95_dtrf2" id="idvl1_95_dtrf2" transform="translate(416.0,366.0)">
-            <title>vl1_dtrf2</title>
             <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
                 <line x1="0" x2="8" y1="0" y2="8"/>
                 <line x1="8" x2="0" y1="0" y2="8"/>

--- a/single-line-diagram-core/src/test/resources/vl1_tooltip_opt.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_tooltip_opt.svg
@@ -230,24 +230,24 @@
             <polyline points="100.0,370.0,90.0,370.0"/>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2">
-            <polyline points="380.0,150.0,413.0,205.0"/>
+            <polyline points="380.0,150.0,380.0,205.0,413.0,205.0"/>
         </g>
-        <g class="ARROW1_vl1_95_trf2_95_one_UP" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(0.8575,-0.5145,0.5145,0.8575,383.43,165.4349)">
+        <g class="ARROW1_vl1_95_trf2_95_one_UP" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,162.5)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text class="component-label" font-family="Verdana" font-size="8" textLength="25" transform="rotate(0,0,0)" x="15.0" xml:space="preserve" y="9.0">10   </text>
         </g>
-        <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(0.8575,-0.5145,0.5145,0.8575,393.7199,182.5847)">
+        <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,182.5)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text class="component-label" font-family="Verdana" font-size="8" textLength="25" transform="rotate(0,0,0)" x="15.0" xml:space="preserve" y="9.0">20   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2">
-            <polyline points="460.0,150.0,427.0,205.0"/>
+            <polyline points="460.0,150.0,460.0,205.0,427.0,205.0"/>
         </g>
-        <g class="ARROW1_vl1_95_trf2_95_two_UP" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(0.8575,0.5145,-0.5145,0.8575,447.9951,160.2899)">
+        <g class="ARROW1_vl1_95_trf2_95_two_UP" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,162.5)">
             <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" stroke="black"/>
             <text class="component-label" font-family="Verdana" font-size="8" textLength="25" transform="rotate(0,0,0)" x="15.0" xml:space="preserve" y="9.0">10   </text>
         </g>
-        <g class="ARROW2_vl1_95_trf2_95_two_DOWN" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(0.8575,0.5145,-0.5145,0.8575,437.7052,177.4398)">
+        <g class="ARROW2_vl1_95_trf2_95_two_DOWN" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,182.5)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" stroke="blue"/>
             <text class="component-label" font-family="Verdana" font-size="8" textLength="25" transform="rotate(0,0,0)" x="15.0" xml:space="preserve" y="9.0">20   </text>
         </g>

--- a/single-line-diagram-force-layout/src/test/java/com/powsybl/sld/force/layout/TestCaseSmartSubstationGraph.java
+++ b/single-line-diagram-force-layout/src/test/java/com/powsybl/sld/force/layout/TestCaseSmartSubstationGraph.java
@@ -7,7 +7,6 @@
 package com.powsybl.sld.force.layout;
 
 import com.powsybl.sld.iidm.TestCase11SubstationGraph;
-import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
 import com.powsybl.sld.model.SubstationGraph;
 import org.junit.Before;
@@ -23,33 +22,15 @@ public class TestCaseSmartSubstationGraph extends TestCase11SubstationGraph {
     @Before
     public void setUp() {
         super.setUp();
+        layoutParameters.setShowInternalNodes(false);
     }
 
     @Test
     public void test() {
-        layoutParameters = new LayoutParameters()
-                .setTranslateX(20)
-                .setTranslateY(50)
-                .setInitialXBus(0)
-                .setInitialYBus(260)
-                .setVerticalSpaceBus(25)
-                .setHorizontalBusPadding(20)
-                .setCellWidth(50)
-                .setExternCellHeight(250)
-                .setInternCellHeight(40)
-                .setStackHeight(30)
-                .setShowGrid(true)
-                .setShowInternalNodes(false)
-                .setScaleFactor(1)
-                .setHorizontalSubstationPadding(50)
-                .setVerticalSubstationPadding(50)
-                .setDrawStraightWires(false)
-                .setHorizontalSnakeLinePadding(30)
-                .setVerticalSnakeLinePadding(30);
 
         // write Json and compare to reference (with smart substation layout)
         SubstationGraph g = graphBuilder.buildSubstationGraph(substation.getId(), false);
-        new ForceSubstationLayoutFactory(ForceSubstationLayoutFactory.CompactionType.NONE).create(g, new PositionVoltageLevelLayoutFactory()).run(layoutParameters);
+        new ForceSubstationLayoutFactory(ForceSubstationLayoutFactory.CompactionType.NONE).create(g, new PositionVoltageLevelLayoutFactory()).run(getLayoutParameters());
         assertEquals(toString("/TestCase11SubstationGraphSmart.json"), toJson(g, "/TestCase11SubstationGraphSmart.json", false));
         assertEquals(substation.getId(), g.getSubstationId());
         assertEquals(substation.getVoltageLevelStream().count(), g.getNodes().size());
@@ -58,7 +39,7 @@ public class TestCaseSmartSubstationGraph extends TestCase11SubstationGraph {
 
         // write Json and compare to reference (with smart substation layout and horizontal compaction)
         g = graphBuilder.buildSubstationGraph(substation.getId(), false);
-        new ForceSubstationLayoutFactory(ForceSubstationLayoutFactory.CompactionType.HORIZONTAL).create(g, new PositionVoltageLevelLayoutFactory()).run(layoutParameters);
+        new ForceSubstationLayoutFactory(ForceSubstationLayoutFactory.CompactionType.HORIZONTAL).create(g, new PositionVoltageLevelLayoutFactory()).run(getLayoutParameters());
         assertEquals(toString("/TestCase11SubstationGraphSmartHorizontal.json"), toJson(g, "/TestCase11SubstationGraphSmartHorizontal.json", false));
         assertEquals(substation.getId(), g.getSubstationId());
         assertEquals(substation.getVoltageLevelStream().count(), g.getNodes().size());
@@ -67,7 +48,7 @@ public class TestCaseSmartSubstationGraph extends TestCase11SubstationGraph {
 
         // write Json and compare to reference (with smart substation layout and vertical compaction)
         g = graphBuilder.buildSubstationGraph(substation.getId(), false);
-        new ForceSubstationLayoutFactory(ForceSubstationLayoutFactory.CompactionType.VERTICAL).create(g, new PositionVoltageLevelLayoutFactory()).run(layoutParameters);
+        new ForceSubstationLayoutFactory(ForceSubstationLayoutFactory.CompactionType.VERTICAL).create(g, new PositionVoltageLevelLayoutFactory()).run(getLayoutParameters());
         assertEquals(toString("/TestCase11SubstationGraphSmartVertical.json"), toJson(g, "/TestCase11SubstationGraphSmartVertical.json", false));
         assertEquals(substation.getId(), g.getSubstationId());
         assertEquals(substation.getVoltageLevelStream().count(), g.getNodes().size());

--- a/single-line-diagram-force-layout/src/test/java/com/powsybl/sld/force/layout/TestCaseSmartSubstationGraph.java
+++ b/single-line-diagram-force-layout/src/test/java/com/powsybl/sld/force/layout/TestCaseSmartSubstationGraph.java
@@ -27,7 +27,7 @@ public class TestCaseSmartSubstationGraph extends TestCase11SubstationGraph {
 
     @Test
     public void test() {
-        LayoutParameters layoutParameters = new LayoutParameters()
+        layoutParameters = new LayoutParameters()
                 .setTranslateX(20)
                 .setTranslateY(50)
                 .setInitialXBus(0)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No.


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
One cannot easily generate all svg files related to json reference test files (which sometimes correspond to not-so-good diagrams) to see whether the reference is ok, and when changing the reference file whether that change is not unexpectedly changing the diagram rendering.


**What is the new behavior (if this is a feature change)?**
If writeFile parameter is true in AbstractTestCase, all json tests inheriting from `AbstractTestCase` will generate the corresponding svg file.


**Does this PR introduce a breaking change or deprecate an API?**
No

**Other information**:
Note that this had already been done by @BenoitJeanson for tests extending `AbstractTestCaseRaw`, this PR simply extends this behaviour to all tests extending `AbstractTestCase`
