### PR TITLE
Put active power values above reactive power values

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -71,6 +71,8 @@ public class LayoutParameters {
 
     private boolean addNodesInfos = false;
 
+    private boolean feederArrowSymmetry = false;
+
     @JsonIgnore
     private Map<String, ComponentSize> componentsSize;
 
@@ -110,7 +112,8 @@ public class LayoutParameters {
                             @JsonProperty("labelDiagonal") boolean labelDiagonal,
                             @JsonProperty("angleLabelShift") double angleLabelShift,
                             @JsonProperty("highlightLineState") boolean highlightLineState,
-                            @JsonProperty("addNodesInfos") boolean addNodesInfos) {
+                            @JsonProperty("addNodesInfos") boolean addNodesInfos,
+                            @JsonProperty("feederArrowSymmetry") boolean feederArrowSymmetry) {
         this.translateX = translateX;
         this.translateY = translateY;
         this.initialXBus = initialXBus;
@@ -143,6 +146,7 @@ public class LayoutParameters {
         this.angleLabelShift = angleLabelShift;
         this.highlightLineState = highlightLineState;
         this.addNodesInfos = addNodesInfos;
+        this.feederArrowSymmetry = feederArrowSymmetry;
     }
 
     public LayoutParameters(LayoutParameters other) {
@@ -180,6 +184,7 @@ public class LayoutParameters {
         labelCentered = other.labelCentered;
         highlightLineState = other.highlightLineState;
         addNodesInfos = other.addNodesInfos;
+        feederArrowSymmetry = other.feederArrowSymmetry;
     }
 
     public double getTranslateX() {
@@ -475,6 +480,15 @@ public class LayoutParameters {
 
     public LayoutParameters setMinSpaceForFeederArrows(double minSpaceForFeederArrows) {
         this.minSpaceForFeederArrows = minSpaceForFeederArrows;
+        return this;
+    }
+
+    public boolean isFeederArrowSymmetry() {
+        return feederArrowSymmetry;
+    }
+
+    public LayoutParameters setFeederArrowSymmetry(boolean feederArrowSymmetry) {
+        this.feederArrowSymmetry = feederArrowSymmetry;
         return this;
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -1022,34 +1022,32 @@ public class DefaultSVGWriter implements SVGWriter {
                                          String wireId,
                                          List<Double> points,
                                          Element root,
-                                         Node n,
+                                         FeederNode feederNode,
                                          GraphMetadata metadata,
                                          DiagramLabelProvider initProvider,
-                                         DiagramStyleProvider styleProvider) {
-        if (!(n instanceof FeederNode)) {
-            throw new AssertionError("Node n must be a feeder node");
-        }
+                                         DiagramStyleProvider styleProvider,
+                                         boolean feederArrowSymmetry) {
+        InitialValue init = initProvider.getInitialValue(feederNode);
 
-        FeederNode feederNode = (FeederNode) n;
-        InitialValue init = initProvider.getInitialValue(n);
+        boolean arrowSymmetry = feederNode.getDirection() == BusCell.Direction.TOP || feederArrowSymmetry;
 
-        Optional<String> label1 = feederNode.getDirection() == BusCell.Direction.TOP ? init.getLabel1() : init.getLabel2();
-        Optional<Direction> direction1 = feederNode.getDirection() == BusCell.Direction.TOP ? init.getArrowDirection1() : init.getArrowDirection2();
+        Optional<String> label1 = arrowSymmetry ? init.getLabel1() : init.getLabel2();
+        Optional<Direction> direction1 = arrowSymmetry ? init.getArrowDirection1() : init.getArrowDirection2();
 
-        Optional<String> label2 = feederNode.getDirection() == BusCell.Direction.TOP ? init.getLabel2() : init.getLabel1();
-        Optional<Direction> direction2 = feederNode.getDirection() == BusCell.Direction.TOP ? init.getArrowDirection2() : init.getArrowDirection1();
+        Optional<String> label2 = arrowSymmetry ? init.getLabel2() : init.getLabel1();
+        Optional<Direction> direction2 = arrowSymmetry ? init.getArrowDirection2() : init.getArrowDirection1();
 
-        int iArrow1 = feederNode.getDirection() == BusCell.Direction.TOP ? 1 : 2;
-        int iArrow2 = feederNode.getDirection() == BusCell.Direction.TOP ? 2 : 1;
+        int iArrow1 = arrowSymmetry ? 1 : 2;
+        int iArrow2 = arrowSymmetry ? 2 : 1;
 
         // we draw the arrow only if value 1 is present
         label1.ifPresent(lb ->
-                        drawArrowAndLabel(prefixId, wireId, points, root, n, lb, init.getLabel3(), direction1, 0, iArrow1, metadata, styleProvider));
+                        drawArrowAndLabel(prefixId, wireId, points, root, feederNode, lb, init.getLabel3(), direction1, 0, iArrow1, metadata, styleProvider));
 
         // we draw the arrow only if value 2 is present
         label2.ifPresent(lb -> {
             double shiftArrow2 = 2 * metadata.getComponentMetadata(ARROW).getSize().getHeight();
-            drawArrowAndLabel(prefixId, wireId, points, root, n, lb, init.getLabel4(),
+            drawArrowAndLabel(prefixId, wireId, points, root, feederNode, lb, init.getLabel4(),
                     direction2, shiftArrow2, iArrow2, metadata, styleProvider);
         });
     }
@@ -1140,7 +1138,8 @@ public class DefaultSVGWriter implements SVGWriter {
 
             if (edge.getNode1() instanceof FeederNode) {
                 if (!(edge.getNode2() instanceof FeederNode)) {
-                    insertArrowsAndLabels(prefixId, wireId, pol, root, edge.getNode1(), metadata, initProvider, styleProvider);
+                    insertArrowsAndLabels(prefixId, wireId, pol, root, (FeederNode) edge.getNode1(), metadata, initProvider, styleProvider,
+                            layoutParameters.isFeederArrowSymmetry());
                 }
             } else if (edge.getNode2() instanceof FeederNode) {
                 List<Double> reversePoints = new ArrayList<>();
@@ -1152,7 +1151,8 @@ public class DefaultSVGWriter implements SVGWriter {
                     }
                 }
 
-                insertArrowsAndLabels(prefixId, wireId, reversePoints, root, edge.getNode2(), metadata, initProvider, styleProvider);
+                insertArrowsAndLabels(prefixId, wireId, reversePoints, root, (FeederNode) edge.getNode2(), metadata, initProvider, styleProvider,
+                        layoutParameters.isFeederArrowSymmetry());
             }
         }
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -1026,20 +1026,32 @@ public class DefaultSVGWriter implements SVGWriter {
                                          GraphMetadata metadata,
                                          DiagramLabelProvider initProvider,
                                          DiagramStyleProvider styleProvider) {
+        if (!(n instanceof FeederNode)) {
+            throw new AssertionError("Node n must be a feeder node");
+        }
+
+        FeederNode feederNode = (FeederNode) n;
         InitialValue init = initProvider.getInitialValue(n);
 
+        Optional<String> label1 = feederNode.getDirection() == BusCell.Direction.TOP ? init.getLabel1() : init.getLabel2();
+        Optional<Direction> direction1 = feederNode.getDirection() == BusCell.Direction.TOP ? init.getArrowDirection1() : init.getArrowDirection2();
+
+        Optional<String> label2 = feederNode.getDirection() == BusCell.Direction.TOP ? init.getLabel2() : init.getLabel1();
+        Optional<Direction> direction2 = feederNode.getDirection() == BusCell.Direction.TOP ? init.getArrowDirection2() : init.getArrowDirection1();
+
+        int iArrow1 = feederNode.getDirection() == BusCell.Direction.TOP ? 1 : 2;
+        int iArrow2 = feederNode.getDirection() == BusCell.Direction.TOP ? 2 : 1;
+
         // we draw the arrow only if value 1 is present
-        init.getLabel1()
-                .ifPresent(lb ->
-                        drawArrowAndLabel(prefixId, wireId, points, root, n, lb, init.getLabel3(), init.getArrowDirection1(), 0, 1, metadata, styleProvider));
+        label1.ifPresent(lb ->
+                        drawArrowAndLabel(prefixId, wireId, points, root, n, lb, init.getLabel3(), direction1, 0, iArrow1, metadata, styleProvider));
 
         // we draw the arrow only if value 2 is present
-        init.getLabel2()
-                .ifPresent(lb -> {
-                    double shiftArrow2 = 2 * metadata.getComponentMetadata(ARROW).getSize().getHeight();
-                    drawArrowAndLabel(prefixId, wireId, points, root, n, lb, init.getLabel4(),
-                            init.getArrowDirection2(), shiftArrow2, 2, metadata, styleProvider);
-                });
+        label2.ifPresent(lb -> {
+            double shiftArrow2 = 2 * metadata.getComponentMetadata(ARROW).getSize().getHeight();
+            drawArrowAndLabel(prefixId, wireId, points, root, n, lb, init.getLabel4(),
+                    direction2, shiftArrow2, iArrow2, metadata, styleProvider);
+        });
     }
 
     private void drawArrowAndLabel(String prefixId, String wireId, List<Double> points, Element root, Node n,

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
@@ -730,6 +730,10 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
         // SVG file generation for substation and comparison to reference
         assertEquals(toString("/substation.svg"), toSVG(substG, "/substation.svg", layoutParameters, initValueProvider, styleProvider));
 
+        // SVG file generation for substation with symmetric feeder arrow and comparison to reference
+        assertEquals(toSVG(substG, "/substation_feeder_arrow_symmetry.svg",
+                new LayoutParameters(layoutParameters).setFeederArrowSymmetry(true), initValueProvider, styleProvider), toString("/substation_feeder_arrow_symmetry.svg"));
+
         // SVG file generation for substation and comparison to reference but with no feeder values
         createSubstationGraph();
         assertEquals(toString("/substation_no_feeder_values.svg"), toSVG(substG, "/substation_no_feeder_values.svg", layoutParameters, noFeederValueProvider, styleProvider));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
@@ -731,8 +731,9 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
         assertEquals(toString("/substation.svg"), toSVG(substG, "/substation.svg", layoutParameters, initValueProvider, styleProvider));
 
         // SVG file generation for substation with symmetric feeder arrow and comparison to reference
-        assertEquals(toSVG(substG, "/substation_feeder_arrow_symmetry.svg",
-                new LayoutParameters(layoutParameters).setFeederArrowSymmetry(true), initValueProvider, styleProvider), toString("/substation_feeder_arrow_symmetry.svg"));
+        createSubstationGraph();
+        assertEquals(toString("/substation_feeder_arrow_symmetry.svg"),
+            toSVG(substG, "/substation_feeder_arrow_symmetry.svg", new LayoutParameters(layoutParameters).setFeederArrowSymmetry(true), initValueProvider, styleProvider));
 
         // SVG file generation for substation and comparison to reference but with no feeder values
         createSubstationGraph();

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
@@ -51,7 +51,8 @@ public class LayoutParametersTest {
                 .setHighlightLineState(false)
                 .setTooltipEnabled(true)
                 .setAddNodesInfos(true)
-                .setMinSpaceForFeederArrows(70);
+                .setMinSpaceForFeederArrows(70)
+                .setFeederArrowSymmetry(true);
         LayoutParameters layoutParameters2 = new LayoutParameters(layoutParameters);
 
         assertEquals(layoutParameters.getTranslateX(), layoutParameters2.getTranslateX(), 0);
@@ -86,5 +87,6 @@ public class LayoutParametersTest {
         assertEquals(layoutParameters.isTooltipEnabled(), layoutParameters2.isTooltipEnabled());
         assertEquals(layoutParameters.isAddNodesInfos(), layoutParameters2.isAddNodesInfos());
         assertEquals(layoutParameters.getMinSpaceForFeederArrows(), layoutParameters2.getMinSpaceForFeederArrows(), 0);
+        assertEquals(layoutParameters.isFeederArrowSymmetry(), layoutParameters2.isFeederArrowSymmetry());
     }
 }

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -161,6 +161,15 @@
 .idbtrf17 .open { visibility: hidden;}.idbtrf17 .closed { visibility: visible;}
 .iddtrf18 .open { visibility: hidden;}.iddtrf18 .closed { visibility: visible;}
 .idbtrf18 .open { visibility: hidden;}.idbtrf18 .closed { visibility: visible;}
+.idFICT_95_vl1_95_load1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_gen1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_load2Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_gen2Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_trf1_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_trf2_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_trf3_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_trf4_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_trf5_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
 .idFICT_95_vl1_95_dsect11Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
 .idFICT_95_vl1_95_dload1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
 .idFICT_95_vl1_95_dtrf11Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
@@ -330,7 +339,10 @@
             <g class="NODE idFICT_95_vl1_95_dload1Fictif" id="idFICT_95_vl1_95_dload1Fictif" transform="translate(56.0,276.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="LOAD idload1" id="idload1" transform="translate(52.0,135.5)">
+            <g class="NODE idFICT_95_vl1_95_load1Fictif" id="idFICT_95_vl1_95_load1Fictif" transform="translate(56.0,196.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="LOAD idload1" id="idload1" transform="translate(52.0,133.5)">
                 <rect fill="#ff0000" width="16" height="9" stroke="#ff0000"/>
                 <line y2="9" fill="#ff0000" x1="0" x2="16" stroke="#ff0000" y1="0"/>
                 <line y2="9" fill="#ff0000" x1="16" x2="0" stroke="#ff0000" y1="0"/>
@@ -343,25 +355,28 @@
                 <polyline points="60.0,310.0,60.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_bload1_95_FICT_95_vl1_95_dload1Fictif">
-                <polyline points="60.0,230.0,60.0,280.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="60.0,250.0,60.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_load1_95_bload1">
-                <polyline points="60.0,144.5,60.0,210.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_bload1_95_FICT_95_vl1_95_load1Fictif">
+                <polyline points="60.0,230.0,60.0,200.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="ARROW1_load1_DOWN" id="_95_vl1_95_load1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,159.5)">
-                <g class="arrow-up" id="_95_vl1_95_load1_95_bload1_ARROW1_ARROW-arrow-up">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1">
+                <polyline points="60.0,200.0,60.0,142.5" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_load1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,156.25)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_load1_95_bload1_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_load1_DOWN" id="_95_vl1_95_load1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,179.5)">
-                <g class="arrow-up" id="_95_vl1_95_load1_95_bload1_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_load1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,176.25)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_load1_95_bload1_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -375,7 +390,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbload1" id="idbload1" transform="translate(50.0,210.0)">
+            <g class="BREAKER idbload1" id="idbload1" transform="translate(50.0,230.0)">
                 <g class="closed" id="idbload1_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -390,7 +405,10 @@
             <g class="NODE idFICT_95_vl1_95_dtrf11Fictif" id="idFICT_95_vl1_95_dtrf11Fictif" transform="translate(136.0,276.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf1_95_ONE" id="idtrf1_95_ONE" transform="translate(135.0,132.5)">
+            <g class="NODE idFICT_95_vl1_95_trf1_95_ONEFictif" id="idFICT_95_vl1_95_trf1_95_ONEFictif" transform="translate(136.0,196.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf1_95_ONE" id="idtrf1_95_ONE" transform="translate(135.0,130.5)">
                 <circle fill="#ff0000" r="5" id="idtrf1_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#ff0000"/>
                 <circle fill="#228b22" r="5" id="idtrf1_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#228b22"/>
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf1_ONE_N_LABEL">trf1</text>
@@ -402,25 +420,28 @@
                 <polyline points="140.0,310.0,140.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf11_95_FICT_95_vl1_95_dtrf11Fictif">
-                <polyline points="140.0,230.0,140.0,280.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="140.0,250.0,140.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf11_95_trf1_95_ONE">
-                <polyline points="140.0,210.0,140.0,148.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_btrf11_95_FICT_95_vl1_95_trf1_95_ONEFictif">
+                <polyline points="140.0,230.0,140.0,200.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="ARROW1_trf1_95_ONE_DOWN" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,135.0,163.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1_ARROW-arrow-up">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE">
+                <polyline points="140.0,200.0,140.0,146.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_trf1_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,135.0,158.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf1_95_ONE_DOWN" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,135.0,183.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_trf1_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,135.0,178.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -434,7 +455,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf11" id="idbtrf11" transform="translate(130.0,210.0)">
+            <g class="BREAKER idbtrf11" id="idbtrf11" transform="translate(130.0,230.0)">
                 <g class="closed" id="idbtrf11_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -449,7 +470,10 @@
             <g class="NODE idFICT_95_vl1_95_dtrf15Fictif" id="idFICT_95_vl1_95_dtrf15Fictif" transform="translate(376.0,276.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf5_95_ONE" id="idtrf5_95_ONE" transform="translate(375.0,132.5)">
+            <g class="NODE idFICT_95_vl1_95_trf5_95_ONEFictif" id="idFICT_95_vl1_95_trf5_95_ONEFictif" transform="translate(376.0,196.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf5_95_ONE" id="idtrf5_95_ONE" transform="translate(375.0,130.5)">
                 <circle fill="#ff0000" r="5" id="idtrf5_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#ff0000"/>
                 <circle fill="#a020f0" r="5" id="idtrf5_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#a020f0"/>
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_ONE_N_LABEL">trf5</text>
@@ -461,25 +485,28 @@
                 <polyline points="380.0,310.0,380.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf15_95_FICT_95_vl1_95_dtrf15Fictif">
-                <polyline points="380.0,230.0,380.0,280.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="380.0,250.0,380.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf15_95_trf5_95_ONE">
-                <polyline points="380.0,210.0,380.0,148.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_btrf15_95_FICT_95_vl1_95_trf5_95_ONEFictif">
+                <polyline points="380.0,230.0,380.0,200.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="ARROW1_trf5_95_ONE_DOWN" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,163.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1_ARROW-arrow-up">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE">
+                <polyline points="380.0,200.0,380.0,146.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_trf5_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,158.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf5_95_ONE_DOWN" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,183.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_trf5_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,178.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -493,7 +520,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf15" id="idbtrf15" transform="translate(370.0,210.0)">
+            <g class="BREAKER idbtrf15" id="idbtrf15" transform="translate(370.0,230.0)">
                 <g class="closed" id="idbtrf15_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -513,10 +540,10 @@
                 <circle fill="#a020f0" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#a020f0"/>
                 <circle fill="#ff0000" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#ff0000"/>
             </g>
-            <g class="LINE idtrf6_95_TWO" id="idtrf6_95_TWO" transform="translate(460.0,140.0)">
+            <g class="LINE idtrf6_95_TWO" id="idtrf6_95_TWO" transform="translate(460.0,138.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf6_TWO_N_LABEL">trf61</text>
             </g>
-            <g class="LINE idtrf6_95_THREE" id="idtrf6_95_THREE" transform="translate(540.0,140.0)">
+            <g class="LINE idtrf6_95_THREE" id="idtrf6_95_THREE" transform="translate(540.0,138.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf6_THREE_N_LABEL">trf61</text>
             </g>
             <g class="wire" id="_95_vl1_95_bbs1_95_dtrf16">
@@ -532,9 +559,9 @@
                 <polyline points="500.0,230.0,500.0,207.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO">
-                <polyline points="493.0,195.0,460.0,195.0,460.0,140.0" stroke-width="1" stroke="#228b22"/>
+                <polyline points="493.0,195.0,460.0,195.0,460.0,138.0" stroke-width="1" stroke="#228b22"/>
             </g>
-            <g class="ARROW1_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,155.0)">
+            <g class="ARROW1_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,151.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -543,7 +570,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,175.0)">
+            <g class="ARROW2_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,171.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -553,9 +580,9 @@
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE">
-                <polyline points="507.0,195.0,540.0,195.0,540.0,140.0" stroke-width="1" stroke="#a020f0"/>
+                <polyline points="507.0,195.0,540.0,195.0,540.0,138.0" stroke-width="1" stroke="#a020f0"/>
             </g>
-            <g class="ARROW1_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,155.0)">
+            <g class="ARROW1_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,151.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -564,7 +591,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,175.0)">
+            <g class="ARROW2_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,171.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -597,7 +624,10 @@
             <g class="NODE idFICT_95_vl1_95_dload2Fictif" id="idFICT_95_vl1_95_dload2Fictif" transform="translate(856.0,276.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="LOAD idload2" id="idload2" transform="translate(852.0,135.5)">
+            <g class="NODE idFICT_95_vl1_95_load2Fictif" id="idFICT_95_vl1_95_load2Fictif" transform="translate(856.0,196.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="LOAD idload2" id="idload2" transform="translate(852.0,133.5)">
                 <rect fill="#ff0000" width="16" height="9" stroke="#ff0000"/>
                 <line y2="9" fill="#ff0000" x1="0" x2="16" stroke="#ff0000" y1="0"/>
                 <line y2="9" fill="#ff0000" x1="16" x2="0" stroke="#ff0000" y1="0"/>
@@ -610,25 +640,28 @@
                 <polyline points="860.0,310.0,860.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_bload2_95_FICT_95_vl1_95_dload2Fictif">
-                <polyline points="860.0,230.0,860.0,280.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="860.0,250.0,860.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_load2_95_bload2">
-                <polyline points="860.0,144.5,860.0,210.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_bload2_95_FICT_95_vl1_95_load2Fictif">
+                <polyline points="860.0,230.0,860.0,200.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="ARROW1_load2_DOWN" id="_95_vl1_95_load2_95_bload2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,159.5)">
-                <g class="arrow-up" id="_95_vl1_95_load2_95_bload2_ARROW1_ARROW-arrow-up">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2">
+                <polyline points="860.0,200.0,860.0,142.5" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_load2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,156.25)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_load2_95_bload2_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_load2_DOWN" id="_95_vl1_95_load2_95_bload2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,179.5)">
-                <g class="arrow-up" id="_95_vl1_95_load2_95_bload2_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_load2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,176.25)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_load2_95_bload2_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -642,7 +675,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbload2" id="idbload2" transform="translate(850.0,210.0)">
+            <g class="BREAKER idbload2" id="idbload2" transform="translate(850.0,230.0)">
                 <g class="closed" id="idbload2_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -657,7 +690,10 @@
             <g class="NODE idFICT_95_vl1_95_dtrf12Fictif" id="idFICT_95_vl1_95_dtrf12Fictif" transform="translate(1176.0,276.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf2_95_ONE" id="idtrf2_95_ONE" transform="translate(1175.0,132.5)">
+            <g class="NODE idFICT_95_vl1_95_trf2_95_ONEFictif" id="idFICT_95_vl1_95_trf2_95_ONEFictif" transform="translate(1176.0,196.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf2_95_ONE" id="idtrf2_95_ONE" transform="translate(1175.0,130.5)">
                 <circle fill="#ff0000" r="5" id="idtrf2_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#ff0000"/>
                 <circle fill="#228b22" r="5" id="idtrf2_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#228b22"/>
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf2_ONE_N_LABEL">trf2</text>
@@ -669,25 +705,28 @@
                 <polyline points="1180.0,310.0,1180.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf12_95_FICT_95_vl1_95_dtrf12Fictif">
-                <polyline points="1180.0,230.0,1180.0,280.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="1180.0,250.0,1180.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf12_95_trf2_95_ONE">
-                <polyline points="1180.0,210.0,1180.0,148.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_btrf12_95_FICT_95_vl1_95_trf2_95_ONEFictif">
+                <polyline points="1180.0,230.0,1180.0,200.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="ARROW1_trf2_95_ONE_DOWN" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,163.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1_ARROW-arrow-up">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE">
+                <polyline points="1180.0,200.0,1180.0,146.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW1_trf2_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,158.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf2_95_ONE_DOWN" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,183.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_trf2_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,178.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -701,7 +740,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf12" id="idbtrf12" transform="translate(1170.0,210.0)">
+            <g class="BREAKER idbtrf12" id="idbtrf12" transform="translate(1170.0,230.0)">
                 <g class="closed" id="idbtrf12_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -721,10 +760,10 @@
                 <circle fill="#a020f0" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#a020f0"/>
                 <circle fill="#ff0000" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#ff0000"/>
             </g>
-            <g class="LINE idtrf8_95_TWO" id="idtrf8_95_TWO" transform="translate(940.0,140.0)">
+            <g class="LINE idtrf8_95_TWO" id="idtrf8_95_TWO" transform="translate(940.0,138.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf8_TWO_N_LABEL">trf81</text>
             </g>
-            <g class="LINE idtrf8_95_THREE" id="idtrf8_95_THREE" transform="translate(1020.0,140.0)">
+            <g class="LINE idtrf8_95_THREE" id="idtrf8_95_THREE" transform="translate(1020.0,138.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf8_THREE_N_LABEL">trf81</text>
             </g>
             <g class="wire" id="_95_vl1_95_bbs2_95_dtrf18">
@@ -740,9 +779,9 @@
                 <polyline points="980.0,230.0,980.0,207.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO">
-                <polyline points="973.0,195.0,940.0,195.0,940.0,140.0" stroke-width="1" stroke="#228b22"/>
+                <polyline points="973.0,195.0,940.0,195.0,940.0,138.0" stroke-width="1" stroke="#228b22"/>
             </g>
-            <g class="ARROW1_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,155.0)">
+            <g class="ARROW1_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,151.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -751,7 +790,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,175.0)">
+            <g class="ARROW2_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,171.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -761,9 +800,9 @@
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE">
-                <polyline points="987.0,195.0,1020.0,195.0,1020.0,140.0" stroke-width="1" stroke="#a020f0"/>
+                <polyline points="987.0,195.0,1020.0,195.0,1020.0,138.0" stroke-width="1" stroke="#a020f0"/>
             </g>
-            <g class="ARROW1_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,155.0)">
+            <g class="ARROW1_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,151.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -772,7 +811,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,175.0)">
+            <g class="ARROW2_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,171.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -805,7 +844,10 @@
             <g class="NODE idFICT_95_vl1_95_dgen1Fictif" id="idFICT_95_vl1_95_dgen1Fictif" transform="translate(216.0,361.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="GENERATOR idgen1" id="idgen1" transform="translate(214.0,499.0)">
+            <g class="NODE idFICT_95_vl1_95_gen1Fictif" id="idFICT_95_vl1_95_gen1Fictif" transform="translate(216.0,441.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="GENERATOR idgen1" id="idgen1" transform="translate(214.0,501.0)">
                 <circle fill="#ff0000" r="6" cx="6" cy="6" stroke="#ff0000"/>
                 <path fill="#ff0000" d="M6,6 A 6 40 0 0 0 2,6" stroke="#ff0000"/>
                 <path fill="#ff0000" d="M6,6 A 6 40 0 0 0 10,6" stroke="#ff0000"/>
@@ -818,25 +860,28 @@
                 <polyline points="220.0,335.0,220.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_bgen1_95_FICT_95_vl1_95_dgen1Fictif">
-                <polyline points="220.0,415.0,220.0,365.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="220.0,395.0,220.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_gen1_95_bgen1">
-                <polyline points="220.0,499.0,220.0,435.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_bgen1_95_FICT_95_vl1_95_gen1Fictif">
+                <polyline points="220.0,415.0,220.0,445.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="ARROW1_gen1_DOWN" id="_95_vl1_95_gen1_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,474.0)">
-                <g class="arrow-up" id="_95_vl1_95_gen1_95_bgen1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1">
+                <polyline points="220.0,445.0,220.0,501.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW2_gen1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,478.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_gen1_95_bgen1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_gen1_DOWN" id="_95_vl1_95_gen1_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,454.0)">
-                <g class="arrow-up" id="_95_vl1_95_gen1_95_bgen1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_gen1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,458.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_gen1_95_bgen1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -850,7 +895,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbgen1" id="idbgen1" transform="translate(210.0,415.0)">
+            <g class="BREAKER idbgen1" id="idbgen1" transform="translate(210.0,395.0)">
                 <g class="closed" id="idbgen1_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -865,7 +910,10 @@
             <g class="NODE idFICT_95_vl1_95_dtrf13Fictif" id="idFICT_95_vl1_95_dtrf13Fictif" transform="translate(296.0,361.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="translate(295.0,497.5)">
+            <g class="NODE idFICT_95_vl1_95_trf3_95_ONEFictif" id="idFICT_95_vl1_95_trf3_95_ONEFictif" transform="translate(296.0,441.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="translate(295.0,499.5)">
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#ff0000" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#ff0000"/>
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#228b22" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#228b22"/>
                 <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf3_ONE_S_LABEL">trf3</text>
@@ -877,25 +925,28 @@
                 <polyline points="300.0,335.0,300.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf13_95_FICT_95_vl1_95_dtrf13Fictif">
-                <polyline points="300.0,415.0,300.0,365.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="300.0,395.0,300.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf13_95_trf3_95_ONE">
-                <polyline points="300.0,435.0,300.0,497.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_btrf13_95_FICT_95_vl1_95_trf3_95_ONEFictif">
+                <polyline points="300.0,415.0,300.0,445.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="ARROW1_trf3_95_ONE_DOWN" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,295.0,472.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE">
+                <polyline points="300.0,445.0,300.0,499.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW2_trf3_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,295.0,477.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf3_95_ONE_DOWN" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,295.0,452.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_trf3_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,295.0,457.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -909,7 +960,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf13" id="idbtrf13" transform="translate(290.0,415.0)">
+            <g class="BREAKER idbtrf13" id="idbtrf13" transform="translate(290.0,395.0)">
                 <g class="closed" id="idbtrf13_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -929,10 +980,10 @@
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#228b22" r="5" cx="11" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#228b22"/>
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#ff0000" r="5" cx="8" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cy="9" stroke="#ff0000"/>
             </g>
-            <g class="LINE idtrf7_95_TWO" id="idtrf7_95_TWO" transform="translate(620.0,505.0)">
+            <g class="LINE idtrf7_95_TWO" id="idtrf7_95_TWO" transform="translate(620.0,507.0)">
                 <text x="-5.0" font-size="8" y="13.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf7_TWO_S_LABEL">trf71</text>
             </g>
-            <g class="LINE idtrf7_95_THREE" id="idtrf7_95_THREE" transform="translate(700.0,505.0)">
+            <g class="LINE idtrf7_95_THREE" id="idtrf7_95_THREE" transform="translate(700.0,507.0)">
                 <text x="-5.0" font-size="8" y="13.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf7_THREE_S_LABEL">trf71</text>
             </g>
             <g class="wire" id="_95_vl1_95_bbs3_95_dtrf17">
@@ -948,18 +999,9 @@
                 <polyline points="660.0,415.0,660.0,438.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO">
-                <polyline points="653.0,450.0,620.0,450.0,620.0,505.0" stroke-width="1" stroke="#228b22"/>
+                <polyline points="653.0,450.0,620.0,450.0,620.0,507.0" stroke-width="1" stroke="#228b22"/>
             </g>
-            <g class="ARROW1_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,480.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-                    <polygon points="5,0 10,10 0,10"/>
-                </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-                    <polygon points="0,0 10,0 5,10"/>
-                </g>
-                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
-            </g>
-            <g class="ARROW2_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,460.0)">
+            <g class="ARROW2_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,483.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -968,23 +1010,32 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE">
-                <polyline points="667.0,450.0,700.0,450.0,700.0,505.0" stroke-width="1" stroke="#a020f0"/>
-            </g>
-            <g class="ARROW1_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,480.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,463.5)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,460.0)">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE">
+                <polyline points="667.0,450.0,700.0,450.0,700.0,507.0" stroke-width="1" stroke="#a020f0"/>
+            </g>
+            <g class="ARROW2_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,483.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
                 <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW1_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,463.5)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -1013,7 +1064,10 @@
             <g class="NODE idFICT_95_vl1_95_dgen2Fictif" id="idFICT_95_vl1_95_dgen2Fictif" transform="translate(1256.0,361.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="GENERATOR idgen2" id="idgen2" transform="translate(1254.0,499.0)">
+            <g class="NODE idFICT_95_vl1_95_gen2Fictif" id="idFICT_95_vl1_95_gen2Fictif" transform="translate(1256.0,441.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="GENERATOR idgen2" id="idgen2" transform="translate(1254.0,501.0)">
                 <circle fill="#ff0000" r="6" cx="6" cy="6" stroke="#ff0000"/>
                 <path fill="#ff0000" d="M6,6 A 6 40 0 0 0 2,6" stroke="#ff0000"/>
                 <path fill="#ff0000" d="M6,6 A 6 40 0 0 0 10,6" stroke="#ff0000"/>
@@ -1026,25 +1080,28 @@
                 <polyline points="1260.0,335.0,1260.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_bgen2_95_FICT_95_vl1_95_dgen2Fictif">
-                <polyline points="1260.0,415.0,1260.0,365.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="1260.0,395.0,1260.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_gen2_95_bgen2">
-                <polyline points="1260.0,499.0,1260.0,435.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_bgen2_95_FICT_95_vl1_95_gen2Fictif">
+                <polyline points="1260.0,415.0,1260.0,445.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="ARROW1_gen2_DOWN" id="_95_vl1_95_gen2_95_bgen2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,474.0)">
-                <g class="arrow-up" id="_95_vl1_95_gen2_95_bgen2_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2">
+                <polyline points="1260.0,445.0,1260.0,501.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW2_gen2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,478.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_gen2_95_bgen2_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_gen2_DOWN" id="_95_vl1_95_gen2_95_bgen2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,454.0)">
-                <g class="arrow-up" id="_95_vl1_95_gen2_95_bgen2_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_gen2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,458.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_gen2_95_bgen2_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -1058,7 +1115,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbgen2" id="idbgen2" transform="translate(1250.0,415.0)">
+            <g class="BREAKER idbgen2" id="idbgen2" transform="translate(1250.0,395.0)">
                 <g class="closed" id="idbgen2_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -1073,7 +1130,10 @@
             <g class="NODE idFICT_95_vl1_95_dtrf14Fictif" id="idFICT_95_vl1_95_dtrf14Fictif" transform="translate(1096.0,361.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="translate(1095.0,497.5)">
+            <g class="NODE idFICT_95_vl1_95_trf4_95_ONEFictif" id="idFICT_95_vl1_95_trf4_95_ONEFictif" transform="translate(1096.0,441.0)">
+                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="translate(1095.0,499.5)">
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#ff0000" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#ff0000"/>
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#228b22" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#228b22"/>
                 <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_ONE_S_LABEL">trf4</text>
@@ -1085,25 +1145,28 @@
                 <polyline points="1100.0,335.0,1100.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf14_95_FICT_95_vl1_95_dtrf14Fictif">
-                <polyline points="1100.0,415.0,1100.0,365.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="1100.0,395.0,1100.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf14_95_trf4_95_ONE">
-                <polyline points="1100.0,435.0,1100.0,497.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_btrf14_95_FICT_95_vl1_95_trf4_95_ONEFictif">
+                <polyline points="1100.0,415.0,1100.0,445.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="ARROW1_trf4_95_ONE_DOWN" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,472.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE">
+                <polyline points="1100.0,445.0,1100.0,499.0" stroke-width="1" stroke="#ff0000"/>
+            </g>
+            <g class="ARROW2_trf4_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,477.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf4_95_ONE_DOWN" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,452.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_trf4_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,457.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -1117,7 +1180,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf14" id="idbtrf14" transform="translate(1090.0,415.0)">
+            <g class="BREAKER idbtrf14" id="idbtrf14" transform="translate(1090.0,395.0)">
                 <g class="closed" id="idbtrf14_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -1129,14 +1192,14 @@
             </g>
         </g>
         <g id="NODE_0_vl1">
-            <circle fill="#ff0000" r="10.0" id="NODE_0_vl1_circle" cx="40.0" cy="595.0"/>
-            <text x="30.0" font-size="8" id="NODE_0_vl1_v" y="620.0" class="component-label" font-family="Verdana">392.0 kV</text>
-            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-2.3 °</text>
+            <circle fill="#ff0000" r="10.0" id="NODE_0_vl1_circle" cx="40.0" cy="597.0"/>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_v" y="622.0" class="component-label" font-family="Verdana">392.0 kV</text>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="637.0" class="component-label" font-family="Verdana">-2.3 °</text>
         </g>
         <g id="NODE_1_vl1">
-            <circle fill="#ff0000" r="10.0" id="NODE_1_vl1_circle" cx="110.0" cy="595.0"/>
-            <text x="100.0" font-size="8" id="NODE_1_vl1_v" y="620.0" class="component-label" font-family="Verdana">403.0 kV</text>
-            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-1.7 °</text>
+            <circle fill="#ff0000" r="10.0" id="NODE_1_vl1_circle" cx="110.0" cy="597.0"/>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_v" y="622.0" class="component-label" font-family="Verdana">403.0 kV</text>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="637.0" class="component-label" font-family="Verdana">-1.7 °</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -161,15 +161,6 @@
 .idbtrf17 .open { visibility: hidden;}.idbtrf17 .closed { visibility: visible;}
 .iddtrf18 .open { visibility: hidden;}.iddtrf18 .closed { visibility: visible;}
 .idbtrf18 .open { visibility: hidden;}.idbtrf18 .closed { visibility: visible;}
-.idFICT_95_vl1_95_load1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_gen1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_load2Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_gen2Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_trf1_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_trf2_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_trf3_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_trf4_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_trf5_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
 .idFICT_95_vl1_95_dsect11Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
 .idFICT_95_vl1_95_dload1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
 .idFICT_95_vl1_95_dtrf11Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
@@ -339,10 +330,7 @@
             <g class="NODE idFICT_95_vl1_95_dload1Fictif" id="idFICT_95_vl1_95_dload1Fictif" transform="translate(56.0,276.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_load1Fictif" id="idFICT_95_vl1_95_load1Fictif" transform="translate(56.0,196.0)">
-                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
-            </g>
-            <g class="LOAD idload1" id="idload1" transform="translate(52.0,133.5)">
+            <g class="LOAD idload1" id="idload1" transform="translate(52.0,135.5)">
                 <rect fill="#ff0000" width="16" height="9" stroke="#ff0000"/>
                 <line y2="9" fill="#ff0000" x1="0" x2="16" stroke="#ff0000" y1="0"/>
                 <line y2="9" fill="#ff0000" x1="16" x2="0" stroke="#ff0000" y1="0"/>
@@ -355,28 +343,25 @@
                 <polyline points="60.0,310.0,60.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_bload1_95_FICT_95_vl1_95_dload1Fictif">
-                <polyline points="60.0,250.0,60.0,280.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="60.0,230.0,60.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_bload1_95_FICT_95_vl1_95_load1Fictif">
-                <polyline points="60.0,230.0,60.0,200.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_load1_95_bload1">
+                <polyline points="60.0,144.5,60.0,210.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1">
-                <polyline points="60.0,200.0,60.0,142.5" stroke-width="1" stroke="#ff0000"/>
-            </g>
-            <g class="ARROW1_load1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,156.25)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW1_ARROW-arrow-up">
+            <g class="ARROW1_load1_DOWN" id="_95_vl1_95_load1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,159.5)">
+                <g class="arrow-up" id="_95_vl1_95_load1_95_bload1_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_load1_95_bload1_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_load1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,176.25)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_load1_DOWN" id="_95_vl1_95_load1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,179.5)">
+                <g class="arrow-up" id="_95_vl1_95_load1_95_bload1_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_load1_95_bload1_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -390,7 +375,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbload1" id="idbload1" transform="translate(50.0,230.0)">
+            <g class="BREAKER idbload1" id="idbload1" transform="translate(50.0,210.0)">
                 <g class="closed" id="idbload1_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -405,10 +390,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf11Fictif" id="idFICT_95_vl1_95_dtrf11Fictif" transform="translate(136.0,276.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_trf1_95_ONEFictif" id="idFICT_95_vl1_95_trf1_95_ONEFictif" transform="translate(136.0,196.0)">
-                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
-            </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf1_95_ONE" id="idtrf1_95_ONE" transform="translate(135.0,130.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf1_95_ONE" id="idtrf1_95_ONE" transform="translate(135.0,132.5)">
                 <circle fill="#ff0000" r="5" id="idtrf1_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#ff0000"/>
                 <circle fill="#228b22" r="5" id="idtrf1_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#228b22"/>
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf1_ONE_N_LABEL">trf1</text>
@@ -420,28 +402,25 @@
                 <polyline points="140.0,310.0,140.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf11_95_FICT_95_vl1_95_dtrf11Fictif">
-                <polyline points="140.0,250.0,140.0,280.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="140.0,230.0,140.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf11_95_FICT_95_vl1_95_trf1_95_ONEFictif">
-                <polyline points="140.0,230.0,140.0,200.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_btrf11_95_trf1_95_ONE">
+                <polyline points="140.0,210.0,140.0,148.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE">
-                <polyline points="140.0,200.0,140.0,146.0" stroke-width="1" stroke="#ff0000"/>
-            </g>
-            <g class="ARROW1_trf1_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,135.0,158.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW1_ARROW-arrow-up">
+            <g class="ARROW1_trf1_95_ONE_DOWN" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,135.0,163.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf1_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,135.0,178.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_trf1_95_ONE_DOWN" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,135.0,183.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -455,7 +434,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf11" id="idbtrf11" transform="translate(130.0,230.0)">
+            <g class="BREAKER idbtrf11" id="idbtrf11" transform="translate(130.0,210.0)">
                 <g class="closed" id="idbtrf11_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -470,10 +449,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf15Fictif" id="idFICT_95_vl1_95_dtrf15Fictif" transform="translate(376.0,276.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_trf5_95_ONEFictif" id="idFICT_95_vl1_95_trf5_95_ONEFictif" transform="translate(376.0,196.0)">
-                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
-            </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf5_95_ONE" id="idtrf5_95_ONE" transform="translate(375.0,130.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf5_95_ONE" id="idtrf5_95_ONE" transform="translate(375.0,132.5)">
                 <circle fill="#ff0000" r="5" id="idtrf5_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#ff0000"/>
                 <circle fill="#a020f0" r="5" id="idtrf5_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#a020f0"/>
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_ONE_N_LABEL">trf5</text>
@@ -485,28 +461,25 @@
                 <polyline points="380.0,310.0,380.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf15_95_FICT_95_vl1_95_dtrf15Fictif">
-                <polyline points="380.0,250.0,380.0,280.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="380.0,230.0,380.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf15_95_FICT_95_vl1_95_trf5_95_ONEFictif">
-                <polyline points="380.0,230.0,380.0,200.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_btrf15_95_trf5_95_ONE">
+                <polyline points="380.0,210.0,380.0,148.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE">
-                <polyline points="380.0,200.0,380.0,146.0" stroke-width="1" stroke="#ff0000"/>
-            </g>
-            <g class="ARROW1_trf5_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,158.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1_ARROW-arrow-up">
+            <g class="ARROW1_trf5_95_ONE_DOWN" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,163.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf5_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,178.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_trf5_95_ONE_DOWN" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,183.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -520,7 +493,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf15" id="idbtrf15" transform="translate(370.0,230.0)">
+            <g class="BREAKER idbtrf15" id="idbtrf15" transform="translate(370.0,210.0)">
                 <g class="closed" id="idbtrf15_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -540,10 +513,10 @@
                 <circle fill="#a020f0" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#a020f0"/>
                 <circle fill="#ff0000" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#ff0000"/>
             </g>
-            <g class="LINE idtrf6_95_TWO" id="idtrf6_95_TWO" transform="translate(460.0,138.0)">
+            <g class="LINE idtrf6_95_TWO" id="idtrf6_95_TWO" transform="translate(460.0,140.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf6_TWO_N_LABEL">trf61</text>
             </g>
-            <g class="LINE idtrf6_95_THREE" id="idtrf6_95_THREE" transform="translate(540.0,138.0)">
+            <g class="LINE idtrf6_95_THREE" id="idtrf6_95_THREE" transform="translate(540.0,140.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf6_THREE_N_LABEL">trf61</text>
             </g>
             <g class="wire" id="_95_vl1_95_bbs1_95_dtrf16">
@@ -559,9 +532,9 @@
                 <polyline points="500.0,230.0,500.0,207.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO">
-                <polyline points="493.0,195.0,460.0,195.0,460.0,138.0" stroke-width="1" stroke="#228b22"/>
+                <polyline points="493.0,195.0,460.0,195.0,460.0,140.0" stroke-width="1" stroke="#228b22"/>
             </g>
-            <g class="ARROW1_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,151.5)">
+            <g class="ARROW1_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,155.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -570,7 +543,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,171.5)">
+            <g class="ARROW2_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,175.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -580,9 +553,9 @@
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE">
-                <polyline points="507.0,195.0,540.0,195.0,540.0,138.0" stroke-width="1" stroke="#a020f0"/>
+                <polyline points="507.0,195.0,540.0,195.0,540.0,140.0" stroke-width="1" stroke="#a020f0"/>
             </g>
-            <g class="ARROW1_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,151.5)">
+            <g class="ARROW1_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,155.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -591,7 +564,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,171.5)">
+            <g class="ARROW2_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,175.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -624,10 +597,7 @@
             <g class="NODE idFICT_95_vl1_95_dload2Fictif" id="idFICT_95_vl1_95_dload2Fictif" transform="translate(856.0,276.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_load2Fictif" id="idFICT_95_vl1_95_load2Fictif" transform="translate(856.0,196.0)">
-                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
-            </g>
-            <g class="LOAD idload2" id="idload2" transform="translate(852.0,133.5)">
+            <g class="LOAD idload2" id="idload2" transform="translate(852.0,135.5)">
                 <rect fill="#ff0000" width="16" height="9" stroke="#ff0000"/>
                 <line y2="9" fill="#ff0000" x1="0" x2="16" stroke="#ff0000" y1="0"/>
                 <line y2="9" fill="#ff0000" x1="16" x2="0" stroke="#ff0000" y1="0"/>
@@ -640,28 +610,25 @@
                 <polyline points="860.0,310.0,860.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_bload2_95_FICT_95_vl1_95_dload2Fictif">
-                <polyline points="860.0,250.0,860.0,280.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="860.0,230.0,860.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_bload2_95_FICT_95_vl1_95_load2Fictif">
-                <polyline points="860.0,230.0,860.0,200.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_load2_95_bload2">
+                <polyline points="860.0,144.5,860.0,210.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2">
-                <polyline points="860.0,200.0,860.0,142.5" stroke-width="1" stroke="#ff0000"/>
-            </g>
-            <g class="ARROW1_load2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,156.25)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1_ARROW-arrow-up">
+            <g class="ARROW1_load2_DOWN" id="_95_vl1_95_load2_95_bload2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,159.5)">
+                <g class="arrow-up" id="_95_vl1_95_load2_95_bload2_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_load2_95_bload2_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_load2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,176.25)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_load2_DOWN" id="_95_vl1_95_load2_95_bload2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,179.5)">
+                <g class="arrow-up" id="_95_vl1_95_load2_95_bload2_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_load2_95_bload2_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -675,7 +642,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbload2" id="idbload2" transform="translate(850.0,230.0)">
+            <g class="BREAKER idbload2" id="idbload2" transform="translate(850.0,210.0)">
                 <g class="closed" id="idbload2_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -690,10 +657,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf12Fictif" id="idFICT_95_vl1_95_dtrf12Fictif" transform="translate(1176.0,276.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_trf2_95_ONEFictif" id="idFICT_95_vl1_95_trf2_95_ONEFictif" transform="translate(1176.0,196.0)">
-                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
-            </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf2_95_ONE" id="idtrf2_95_ONE" transform="translate(1175.0,130.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf2_95_ONE" id="idtrf2_95_ONE" transform="translate(1175.0,132.5)">
                 <circle fill="#ff0000" r="5" id="idtrf2_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#ff0000"/>
                 <circle fill="#228b22" r="5" id="idtrf2_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#228b22"/>
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf2_ONE_N_LABEL">trf2</text>
@@ -705,28 +669,25 @@
                 <polyline points="1180.0,310.0,1180.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf12_95_FICT_95_vl1_95_dtrf12Fictif">
-                <polyline points="1180.0,250.0,1180.0,280.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="1180.0,230.0,1180.0,280.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf12_95_FICT_95_vl1_95_trf2_95_ONEFictif">
-                <polyline points="1180.0,230.0,1180.0,200.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_btrf12_95_trf2_95_ONE">
+                <polyline points="1180.0,210.0,1180.0,148.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE">
-                <polyline points="1180.0,200.0,1180.0,146.0" stroke-width="1" stroke="#ff0000"/>
-            </g>
-            <g class="ARROW1_trf2_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,158.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1_ARROW-arrow-up">
+            <g class="ARROW1_trf2_95_ONE_DOWN" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,163.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf2_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,178.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_trf2_95_ONE_DOWN" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,183.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -740,7 +701,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf12" id="idbtrf12" transform="translate(1170.0,230.0)">
+            <g class="BREAKER idbtrf12" id="idbtrf12" transform="translate(1170.0,210.0)">
                 <g class="closed" id="idbtrf12_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -760,10 +721,10 @@
                 <circle fill="#a020f0" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#a020f0"/>
                 <circle fill="#ff0000" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#ff0000"/>
             </g>
-            <g class="LINE idtrf8_95_TWO" id="idtrf8_95_TWO" transform="translate(940.0,138.0)">
+            <g class="LINE idtrf8_95_TWO" id="idtrf8_95_TWO" transform="translate(940.0,140.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf8_TWO_N_LABEL">trf81</text>
             </g>
-            <g class="LINE idtrf8_95_THREE" id="idtrf8_95_THREE" transform="translate(1020.0,138.0)">
+            <g class="LINE idtrf8_95_THREE" id="idtrf8_95_THREE" transform="translate(1020.0,140.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf8_THREE_N_LABEL">trf81</text>
             </g>
             <g class="wire" id="_95_vl1_95_bbs2_95_dtrf18">
@@ -779,9 +740,9 @@
                 <polyline points="980.0,230.0,980.0,207.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO">
-                <polyline points="973.0,195.0,940.0,195.0,940.0,138.0" stroke-width="1" stroke="#228b22"/>
+                <polyline points="973.0,195.0,940.0,195.0,940.0,140.0" stroke-width="1" stroke="#228b22"/>
             </g>
-            <g class="ARROW1_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,151.5)">
+            <g class="ARROW1_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,155.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -790,7 +751,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,171.5)">
+            <g class="ARROW2_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,175.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -800,9 +761,9 @@
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE">
-                <polyline points="987.0,195.0,1020.0,195.0,1020.0,138.0" stroke-width="1" stroke="#a020f0"/>
+                <polyline points="987.0,195.0,1020.0,195.0,1020.0,140.0" stroke-width="1" stroke="#a020f0"/>
             </g>
-            <g class="ARROW1_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,151.5)">
+            <g class="ARROW1_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,155.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -811,7 +772,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,171.5)">
+            <g class="ARROW2_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,175.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -844,10 +805,7 @@
             <g class="NODE idFICT_95_vl1_95_dgen1Fictif" id="idFICT_95_vl1_95_dgen1Fictif" transform="translate(216.0,361.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_gen1Fictif" id="idFICT_95_vl1_95_gen1Fictif" transform="translate(216.0,441.0)">
-                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
-            </g>
-            <g class="GENERATOR idgen1" id="idgen1" transform="translate(214.0,501.0)">
+            <g class="GENERATOR idgen1" id="idgen1" transform="translate(214.0,499.0)">
                 <circle fill="#ff0000" r="6" cx="6" cy="6" stroke="#ff0000"/>
                 <path fill="#ff0000" d="M6,6 A 6 40 0 0 0 2,6" stroke="#ff0000"/>
                 <path fill="#ff0000" d="M6,6 A 6 40 0 0 0 10,6" stroke="#ff0000"/>
@@ -860,28 +818,25 @@
                 <polyline points="220.0,335.0,220.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_bgen1_95_FICT_95_vl1_95_dgen1Fictif">
-                <polyline points="220.0,395.0,220.0,365.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="220.0,415.0,220.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_bgen1_95_FICT_95_vl1_95_gen1Fictif">
-                <polyline points="220.0,415.0,220.0,445.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_gen1_95_bgen1">
+                <polyline points="220.0,499.0,220.0,435.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1">
-                <polyline points="220.0,445.0,220.0,501.0" stroke-width="1" stroke="#ff0000"/>
-            </g>
-            <g class="ARROW1_gen1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,478.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_gen1_DOWN" id="_95_vl1_95_gen1_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,474.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen1_95_bgen1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_gen1_95_bgen1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_gen1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,458.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW2_gen1_DOWN" id="_95_vl1_95_gen1_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,454.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen1_95_bgen1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_gen1_95_bgen1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -895,7 +850,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbgen1" id="idbgen1" transform="translate(210.0,395.0)">
+            <g class="BREAKER idbgen1" id="idbgen1" transform="translate(210.0,415.0)">
                 <g class="closed" id="idbgen1_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -910,10 +865,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf13Fictif" id="idFICT_95_vl1_95_dtrf13Fictif" transform="translate(296.0,361.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_trf3_95_ONEFictif" id="idFICT_95_vl1_95_trf3_95_ONEFictif" transform="translate(296.0,441.0)">
-                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
-            </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="translate(295.0,499.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="translate(295.0,497.5)">
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#ff0000" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#ff0000"/>
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#228b22" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#228b22"/>
                 <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf3_ONE_S_LABEL">trf3</text>
@@ -925,28 +877,25 @@
                 <polyline points="300.0,335.0,300.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf13_95_FICT_95_vl1_95_dtrf13Fictif">
-                <polyline points="300.0,395.0,300.0,365.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="300.0,415.0,300.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf13_95_FICT_95_vl1_95_trf3_95_ONEFictif">
-                <polyline points="300.0,415.0,300.0,445.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_btrf13_95_trf3_95_ONE">
+                <polyline points="300.0,435.0,300.0,497.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE">
-                <polyline points="300.0,445.0,300.0,499.0" stroke-width="1" stroke="#ff0000"/>
-            </g>
-            <g class="ARROW1_trf3_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,295.0,477.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_trf3_95_ONE_DOWN" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,295.0,472.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf3_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,295.0,457.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW2_trf3_95_ONE_DOWN" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,295.0,452.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -960,7 +909,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf13" id="idbtrf13" transform="translate(290.0,395.0)">
+            <g class="BREAKER idbtrf13" id="idbtrf13" transform="translate(290.0,415.0)">
                 <g class="closed" id="idbtrf13_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -980,10 +929,10 @@
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#228b22" r="5" cx="11" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#228b22"/>
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#ff0000" r="5" cx="8" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cy="9" stroke="#ff0000"/>
             </g>
-            <g class="LINE idtrf7_95_TWO" id="idtrf7_95_TWO" transform="translate(620.0,507.0)">
+            <g class="LINE idtrf7_95_TWO" id="idtrf7_95_TWO" transform="translate(620.0,505.0)">
                 <text x="-5.0" font-size="8" y="13.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf7_TWO_S_LABEL">trf71</text>
             </g>
-            <g class="LINE idtrf7_95_THREE" id="idtrf7_95_THREE" transform="translate(700.0,507.0)">
+            <g class="LINE idtrf7_95_THREE" id="idtrf7_95_THREE" transform="translate(700.0,505.0)">
                 <text x="-5.0" font-size="8" y="13.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf7_THREE_S_LABEL">trf71</text>
             </g>
             <g class="wire" id="_95_vl1_95_bbs3_95_dtrf17">
@@ -999,9 +948,9 @@
                 <polyline points="660.0,415.0,660.0,438.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO">
-                <polyline points="653.0,450.0,620.0,450.0,620.0,507.0" stroke-width="1" stroke="#228b22"/>
+                <polyline points="653.0,450.0,620.0,450.0,620.0,505.0" stroke-width="1" stroke="#228b22"/>
             </g>
-            <g class="ARROW1_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,483.5)">
+            <g class="ARROW1_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,480.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -1010,7 +959,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,463.5)">
+            <g class="ARROW2_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,460.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -1020,9 +969,9 @@
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE">
-                <polyline points="667.0,450.0,700.0,450.0,700.0,507.0" stroke-width="1" stroke="#a020f0"/>
+                <polyline points="667.0,450.0,700.0,450.0,700.0,505.0" stroke-width="1" stroke="#a020f0"/>
             </g>
-            <g class="ARROW1_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,483.5)">
+            <g class="ARROW1_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,480.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -1031,7 +980,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,463.5)">
+            <g class="ARROW2_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,460.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -1064,10 +1013,7 @@
             <g class="NODE idFICT_95_vl1_95_dgen2Fictif" id="idFICT_95_vl1_95_dgen2Fictif" transform="translate(1256.0,361.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_gen2Fictif" id="idFICT_95_vl1_95_gen2Fictif" transform="translate(1256.0,441.0)">
-                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
-            </g>
-            <g class="GENERATOR idgen2" id="idgen2" transform="translate(1254.0,501.0)">
+            <g class="GENERATOR idgen2" id="idgen2" transform="translate(1254.0,499.0)">
                 <circle fill="#ff0000" r="6" cx="6" cy="6" stroke="#ff0000"/>
                 <path fill="#ff0000" d="M6,6 A 6 40 0 0 0 2,6" stroke="#ff0000"/>
                 <path fill="#ff0000" d="M6,6 A 6 40 0 0 0 10,6" stroke="#ff0000"/>
@@ -1080,28 +1026,25 @@
                 <polyline points="1260.0,335.0,1260.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_bgen2_95_FICT_95_vl1_95_dgen2Fictif">
-                <polyline points="1260.0,395.0,1260.0,365.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="1260.0,415.0,1260.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_bgen2_95_FICT_95_vl1_95_gen2Fictif">
-                <polyline points="1260.0,415.0,1260.0,445.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_gen2_95_bgen2">
+                <polyline points="1260.0,499.0,1260.0,435.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2">
-                <polyline points="1260.0,445.0,1260.0,501.0" stroke-width="1" stroke="#ff0000"/>
-            </g>
-            <g class="ARROW1_gen2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,478.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_gen2_DOWN" id="_95_vl1_95_gen2_95_bgen2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,474.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen2_95_bgen2_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_gen2_95_bgen2_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_gen2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,458.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW2_gen2_DOWN" id="_95_vl1_95_gen2_95_bgen2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,454.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen2_95_bgen2_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_gen2_95_bgen2_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -1115,7 +1058,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbgen2" id="idbgen2" transform="translate(1250.0,395.0)">
+            <g class="BREAKER idbgen2" id="idbgen2" transform="translate(1250.0,415.0)">
                 <g class="closed" id="idbgen2_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -1130,10 +1073,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf14Fictif" id="idFICT_95_vl1_95_dtrf14Fictif" transform="translate(1096.0,361.0)">
                 <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_trf4_95_ONEFictif" id="idFICT_95_vl1_95_trf4_95_ONEFictif" transform="translate(1096.0,441.0)">
-                <circle fill-opacity="0" fill="#ff0000" r="4" cx="4" cy="4" stroke="#ff0000" stroke-opacity="0"/>
-            </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="translate(1095.0,499.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="translate(1095.0,497.5)">
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#ff0000" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#ff0000"/>
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#228b22" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#228b22"/>
                 <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_ONE_S_LABEL">trf4</text>
@@ -1145,28 +1085,25 @@
                 <polyline points="1100.0,335.0,1100.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf14_95_FICT_95_vl1_95_dtrf14Fictif">
-                <polyline points="1100.0,395.0,1100.0,365.0" stroke-width="1" stroke="#ff0000"/>
+                <polyline points="1100.0,415.0,1100.0,365.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf14_95_FICT_95_vl1_95_trf4_95_ONEFictif">
-                <polyline points="1100.0,415.0,1100.0,445.0" stroke-width="1" stroke="#ff0000"/>
+            <g class="wire" id="_95_vl1_95_btrf14_95_trf4_95_ONE">
+                <polyline points="1100.0,435.0,1100.0,497.0" stroke-width="1" stroke="#ff0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE">
-                <polyline points="1100.0,445.0,1100.0,499.0" stroke-width="1" stroke="#ff0000"/>
-            </g>
-            <g class="ARROW1_trf4_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,477.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_trf4_95_ONE_DOWN" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,472.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf4_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,457.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW2_trf4_95_ONE_DOWN" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,452.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -1180,7 +1117,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf14" id="idbtrf14" transform="translate(1090.0,395.0)">
+            <g class="BREAKER idbtrf14" id="idbtrf14" transform="translate(1090.0,415.0)">
                 <g class="closed" id="idbtrf14_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -1192,14 +1129,14 @@
             </g>
         </g>
         <g id="NODE_0_vl1">
-            <circle fill="#ff0000" r="10.0" id="NODE_0_vl1_circle" cx="40.0" cy="597.0"/>
-            <text x="30.0" font-size="8" id="NODE_0_vl1_v" y="622.0" class="component-label" font-family="Verdana">392.0 kV</text>
-            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="637.0" class="component-label" font-family="Verdana">-2.3 °</text>
+            <circle fill="#ff0000" r="10.0" id="NODE_0_vl1_circle" cx="40.0" cy="595.0"/>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_v" y="620.0" class="component-label" font-family="Verdana">392.0 kV</text>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-2.3 °</text>
         </g>
         <g id="NODE_1_vl1">
-            <circle fill="#ff0000" r="10.0" id="NODE_1_vl1_circle" cx="110.0" cy="597.0"/>
-            <text x="100.0" font-size="8" id="NODE_1_vl1_v" y="622.0" class="component-label" font-family="Verdana">403.0 kV</text>
-            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="637.0" class="component-label" font-family="Verdana">-1.7 °</text>
+            <circle fill="#ff0000" r="10.0" id="NODE_1_vl1_circle" cx="110.0" cy="595.0"/>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_v" y="620.0" class="component-label" font-family="Verdana">403.0 kV</text>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-1.7 °</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -161,15 +161,6 @@
 .idbtrf17 .open { visibility: hidden;}.idbtrf17 .closed { visibility: visible;}
 .iddtrf18 .open { visibility: hidden;}.iddtrf18 .closed { visibility: visible;}
 .idbtrf18 .open { visibility: hidden;}.idbtrf18 .closed { visibility: visible;}
-.idFICT_95_vl1_95_load1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_gen1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_load2Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_gen2Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_trf1_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_trf2_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_trf3_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_trf4_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
-.idFICT_95_vl1_95_trf5_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
 .idFICT_95_vl1_95_dsect11Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
 .idFICT_95_vl1_95_dload1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
 .idFICT_95_vl1_95_dtrf11Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
@@ -339,10 +330,7 @@
             <g class="NODE idFICT_95_vl1_95_dload1Fictif" id="idFICT_95_vl1_95_dload1Fictif" transform="translate(56.0,276.0)">
                 <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_load1Fictif" id="idFICT_95_vl1_95_load1Fictif" transform="translate(56.0,196.0)">
-                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
-            </g>
-            <g class="LOAD idload1" id="idload1" transform="translate(52.0,133.5)">
+            <g class="LOAD idload1" id="idload1" transform="translate(52.0,135.5)">
                 <rect fill="#7F6C00" width="16" height="9" stroke="#7F6C00"/>
                 <line y2="9" fill="#7F6C00" x1="0" x2="16" stroke="#7F6C00" y1="0"/>
                 <line y2="9" fill="#7F6C00" x1="16" x2="0" stroke="#7F6C00" y1="0"/>
@@ -355,28 +343,25 @@
                 <polyline points="60.0,310.0,60.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_bload1_95_FICT_95_vl1_95_dload1Fictif">
-                <polyline points="60.0,250.0,60.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+                <polyline points="60.0,230.0,60.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_bload1_95_FICT_95_vl1_95_load1Fictif">
-                <polyline points="60.0,230.0,60.0,200.0" stroke-width="1" stroke="#7F6C00"/>
+            <g class="wire" id="_95_vl1_95_load1_95_bload1">
+                <polyline points="60.0,144.5,60.0,210.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1">
-                <polyline points="60.0,200.0,60.0,142.5" stroke-width="1" stroke="#7F6C00"/>
-            </g>
-            <g class="ARROW1_load1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,156.25)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW1_ARROW-arrow-up">
+            <g class="ARROW1_load1_DOWN" id="_95_vl1_95_load1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,159.5)">
+                <g class="arrow-up" id="_95_vl1_95_load1_95_bload1_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_load1_95_bload1_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_load1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,176.25)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_load1_DOWN" id="_95_vl1_95_load1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,179.5)">
+                <g class="arrow-up" id="_95_vl1_95_load1_95_bload1_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_load1_95_bload1_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -390,7 +375,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbload1" id="idbload1" transform="translate(50.0,230.0)">
+            <g class="BREAKER idbload1" id="idbload1" transform="translate(50.0,210.0)">
                 <g class="closed" id="idbload1_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -405,10 +390,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf11Fictif" id="idFICT_95_vl1_95_dtrf11Fictif" transform="translate(136.0,276.0)">
                 <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_trf1_95_ONEFictif" id="idFICT_95_vl1_95_trf1_95_ONEFictif" transform="translate(136.0,196.0)">
-                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
-            </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf1_95_ONE" id="idtrf1_95_ONE" transform="translate(135.0,130.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf1_95_ONE" id="idtrf1_95_ONE" transform="translate(135.0,132.5)">
                 <circle fill="#7F6C00" r="5" id="idtrf1_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#7F6C00"/>
                 <circle fill="#218B21" r="5" id="idtrf1_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#218B21"/>
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf1_ONE_N_LABEL">trf1</text>
@@ -420,28 +402,25 @@
                 <polyline points="140.0,310.0,140.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf11_95_FICT_95_vl1_95_dtrf11Fictif">
-                <polyline points="140.0,250.0,140.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+                <polyline points="140.0,230.0,140.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf11_95_FICT_95_vl1_95_trf1_95_ONEFictif">
-                <polyline points="140.0,230.0,140.0,200.0" stroke-width="1" stroke="#7F6C00"/>
+            <g class="wire" id="_95_vl1_95_btrf11_95_trf1_95_ONE">
+                <polyline points="140.0,210.0,140.0,148.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE">
-                <polyline points="140.0,200.0,140.0,146.0" stroke-width="1" stroke="#7F6C00"/>
-            </g>
-            <g class="ARROW1_trf1_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,135.0,158.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW1_ARROW-arrow-up">
+            <g class="ARROW1_trf1_95_ONE_DOWN" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,135.0,163.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf1_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,135.0,178.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_trf1_95_ONE_DOWN" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,135.0,183.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -455,7 +434,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf11" id="idbtrf11" transform="translate(130.0,230.0)">
+            <g class="BREAKER idbtrf11" id="idbtrf11" transform="translate(130.0,210.0)">
                 <g class="closed" id="idbtrf11_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -470,10 +449,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf15Fictif" id="idFICT_95_vl1_95_dtrf15Fictif" transform="translate(376.0,276.0)">
                 <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_trf5_95_ONEFictif" id="idFICT_95_vl1_95_trf5_95_ONEFictif" transform="translate(376.0,196.0)">
-                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
-            </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf5_95_ONE" id="idtrf5_95_ONE" transform="translate(375.0,130.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf5_95_ONE" id="idtrf5_95_ONE" transform="translate(375.0,132.5)">
                 <circle fill="#7F6C00" r="5" id="idtrf5_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#7F6C00"/>
                 <circle fill="#7F0848" r="5" id="idtrf5_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#7F0848"/>
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_ONE_N_LABEL">trf5</text>
@@ -485,28 +461,25 @@
                 <polyline points="380.0,310.0,380.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf15_95_FICT_95_vl1_95_dtrf15Fictif">
-                <polyline points="380.0,250.0,380.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+                <polyline points="380.0,230.0,380.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf15_95_FICT_95_vl1_95_trf5_95_ONEFictif">
-                <polyline points="380.0,230.0,380.0,200.0" stroke-width="1" stroke="#7F6C00"/>
+            <g class="wire" id="_95_vl1_95_btrf15_95_trf5_95_ONE">
+                <polyline points="380.0,210.0,380.0,148.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE">
-                <polyline points="380.0,200.0,380.0,146.0" stroke-width="1" stroke="#7F6C00"/>
-            </g>
-            <g class="ARROW1_trf5_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,158.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1_ARROW-arrow-up">
+            <g class="ARROW1_trf5_95_ONE_DOWN" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,163.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf5_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,178.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_trf5_95_ONE_DOWN" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,183.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -520,7 +493,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf15" id="idbtrf15" transform="translate(370.0,230.0)">
+            <g class="BREAKER idbtrf15" id="idbtrf15" transform="translate(370.0,210.0)">
                 <g class="closed" id="idbtrf15_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -540,10 +513,10 @@
                 <circle fill="#7F0848" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#7F0848"/>
                 <circle fill="#7F6C00" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#7F6C00"/>
             </g>
-            <g class="LINE idtrf6_95_TWO" id="idtrf6_95_TWO" transform="translate(460.0,138.0)">
+            <g class="LINE idtrf6_95_TWO" id="idtrf6_95_TWO" transform="translate(460.0,140.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf6_TWO_N_LABEL">trf61</text>
             </g>
-            <g class="LINE idtrf6_95_THREE" id="idtrf6_95_THREE" transform="translate(540.0,138.0)">
+            <g class="LINE idtrf6_95_THREE" id="idtrf6_95_THREE" transform="translate(540.0,140.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf6_THREE_N_LABEL">trf61</text>
             </g>
             <g class="wire" id="_95_vl1_95_bbs1_95_dtrf16">
@@ -559,9 +532,9 @@
                 <polyline points="500.0,230.0,500.0,207.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO">
-                <polyline points="493.0,195.0,460.0,195.0,460.0,138.0" stroke-width="1" stroke="#218B21"/>
+                <polyline points="493.0,195.0,460.0,195.0,460.0,140.0" stroke-width="1" stroke="#218B21"/>
             </g>
-            <g class="ARROW1_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,151.5)">
+            <g class="ARROW1_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,155.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -570,7 +543,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,171.5)">
+            <g class="ARROW2_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,175.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -580,9 +553,9 @@
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE">
-                <polyline points="507.0,195.0,540.0,195.0,540.0,138.0" stroke-width="1" stroke="#7F0848"/>
+                <polyline points="507.0,195.0,540.0,195.0,540.0,140.0" stroke-width="1" stroke="#7F0848"/>
             </g>
-            <g class="ARROW1_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,151.5)">
+            <g class="ARROW1_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,155.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -591,7 +564,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,171.5)">
+            <g class="ARROW2_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,175.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -624,10 +597,7 @@
             <g class="NODE idFICT_95_vl1_95_dload2Fictif" id="idFICT_95_vl1_95_dload2Fictif" transform="translate(856.0,276.0)">
                 <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_load2Fictif" id="idFICT_95_vl1_95_load2Fictif" transform="translate(856.0,196.0)">
-                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
-            </g>
-            <g class="LOAD idload2" id="idload2" transform="translate(852.0,133.5)">
+            <g class="LOAD idload2" id="idload2" transform="translate(852.0,135.5)">
                 <rect fill="#7F6C00" width="16" height="9" stroke="#7F6C00"/>
                 <line y2="9" fill="#7F6C00" x1="0" x2="16" stroke="#7F6C00" y1="0"/>
                 <line y2="9" fill="#7F6C00" x1="16" x2="0" stroke="#7F6C00" y1="0"/>
@@ -640,28 +610,25 @@
                 <polyline points="860.0,310.0,860.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_bload2_95_FICT_95_vl1_95_dload2Fictif">
-                <polyline points="860.0,250.0,860.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+                <polyline points="860.0,230.0,860.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_bload2_95_FICT_95_vl1_95_load2Fictif">
-                <polyline points="860.0,230.0,860.0,200.0" stroke-width="1" stroke="#7F6C00"/>
+            <g class="wire" id="_95_vl1_95_load2_95_bload2">
+                <polyline points="860.0,144.5,860.0,210.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2">
-                <polyline points="860.0,200.0,860.0,142.5" stroke-width="1" stroke="#7F6C00"/>
-            </g>
-            <g class="ARROW1_load2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,156.25)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1_ARROW-arrow-up">
+            <g class="ARROW1_load2_DOWN" id="_95_vl1_95_load2_95_bload2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,159.5)">
+                <g class="arrow-up" id="_95_vl1_95_load2_95_bload2_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_load2_95_bload2_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_load2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,176.25)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_load2_DOWN" id="_95_vl1_95_load2_95_bload2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,179.5)">
+                <g class="arrow-up" id="_95_vl1_95_load2_95_bload2_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_load2_95_bload2_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -675,7 +642,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbload2" id="idbload2" transform="translate(850.0,230.0)">
+            <g class="BREAKER idbload2" id="idbload2" transform="translate(850.0,210.0)">
                 <g class="closed" id="idbload2_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -690,10 +657,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf12Fictif" id="idFICT_95_vl1_95_dtrf12Fictif" transform="translate(1176.0,276.0)">
                 <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_trf2_95_ONEFictif" id="idFICT_95_vl1_95_trf2_95_ONEFictif" transform="translate(1176.0,196.0)">
-                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
-            </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf2_95_ONE" id="idtrf2_95_ONE" transform="translate(1175.0,130.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf2_95_ONE" id="idtrf2_95_ONE" transform="translate(1175.0,132.5)">
                 <circle fill="#7F6C00" r="5" id="idtrf2_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#7F6C00"/>
                 <circle fill="#218B21" r="5" id="idtrf2_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#218B21"/>
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf2_ONE_N_LABEL">trf2</text>
@@ -705,28 +669,25 @@
                 <polyline points="1180.0,310.0,1180.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf12_95_FICT_95_vl1_95_dtrf12Fictif">
-                <polyline points="1180.0,250.0,1180.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+                <polyline points="1180.0,230.0,1180.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf12_95_FICT_95_vl1_95_trf2_95_ONEFictif">
-                <polyline points="1180.0,230.0,1180.0,200.0" stroke-width="1" stroke="#7F6C00"/>
+            <g class="wire" id="_95_vl1_95_btrf12_95_trf2_95_ONE">
+                <polyline points="1180.0,210.0,1180.0,148.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE">
-                <polyline points="1180.0,200.0,1180.0,146.0" stroke-width="1" stroke="#7F6C00"/>
-            </g>
-            <g class="ARROW1_trf2_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,158.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1_ARROW-arrow-up">
+            <g class="ARROW1_trf2_95_ONE_DOWN" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,163.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf2_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,178.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_trf2_95_ONE_DOWN" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,183.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -740,7 +701,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf12" id="idbtrf12" transform="translate(1170.0,230.0)">
+            <g class="BREAKER idbtrf12" id="idbtrf12" transform="translate(1170.0,210.0)">
                 <g class="closed" id="idbtrf12_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -760,10 +721,10 @@
                 <circle fill="#7F0848" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#7F0848"/>
                 <circle fill="#7F6C00" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#7F6C00"/>
             </g>
-            <g class="LINE idtrf8_95_TWO" id="idtrf8_95_TWO" transform="translate(940.0,138.0)">
+            <g class="LINE idtrf8_95_TWO" id="idtrf8_95_TWO" transform="translate(940.0,140.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf8_TWO_N_LABEL">trf81</text>
             </g>
-            <g class="LINE idtrf8_95_THREE" id="idtrf8_95_THREE" transform="translate(1020.0,138.0)">
+            <g class="LINE idtrf8_95_THREE" id="idtrf8_95_THREE" transform="translate(1020.0,140.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf8_THREE_N_LABEL">trf81</text>
             </g>
             <g class="wire" id="_95_vl1_95_bbs2_95_dtrf18">
@@ -779,9 +740,9 @@
                 <polyline points="980.0,230.0,980.0,207.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO">
-                <polyline points="973.0,195.0,940.0,195.0,940.0,138.0" stroke-width="1" stroke="#218B21"/>
+                <polyline points="973.0,195.0,940.0,195.0,940.0,140.0" stroke-width="1" stroke="#218B21"/>
             </g>
-            <g class="ARROW1_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,151.5)">
+            <g class="ARROW1_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,155.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -790,7 +751,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,171.5)">
+            <g class="ARROW2_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,175.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -800,9 +761,9 @@
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE">
-                <polyline points="987.0,195.0,1020.0,195.0,1020.0,138.0" stroke-width="1" stroke="#7F0848"/>
+                <polyline points="987.0,195.0,1020.0,195.0,1020.0,140.0" stroke-width="1" stroke="#7F0848"/>
             </g>
-            <g class="ARROW1_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,151.5)">
+            <g class="ARROW1_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,155.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -811,7 +772,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,171.5)">
+            <g class="ARROW2_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,175.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -844,10 +805,7 @@
             <g class="NODE idFICT_95_vl1_95_dgen1Fictif" id="idFICT_95_vl1_95_dgen1Fictif" transform="translate(216.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_gen1Fictif" id="idFICT_95_vl1_95_gen1Fictif" transform="translate(216.0,441.0)">
-                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
-            </g>
-            <g class="GENERATOR idgen1" id="idgen1" transform="translate(214.0,501.0)">
+            <g class="GENERATOR idgen1" id="idgen1" transform="translate(214.0,499.0)">
                 <circle fill="#FF0000" r="6" cx="6" cy="6" stroke="#FF0000"/>
                 <path fill="#FF0000" d="M6,6 A 6 40 0 0 0 2,6" stroke="#FF0000"/>
                 <path fill="#FF0000" d="M6,6 A 6 40 0 0 0 10,6" stroke="#FF0000"/>
@@ -860,28 +818,25 @@
                 <polyline points="220.0,335.0,220.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_bgen1_95_FICT_95_vl1_95_dgen1Fictif">
-                <polyline points="220.0,395.0,220.0,365.0" stroke-width="1" stroke="#FF0000"/>
+                <polyline points="220.0,415.0,220.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_bgen1_95_FICT_95_vl1_95_gen1Fictif">
-                <polyline points="220.0,415.0,220.0,445.0" stroke-width="1" stroke="#FF0000"/>
+            <g class="wire" id="_95_vl1_95_gen1_95_bgen1">
+                <polyline points="220.0,499.0,220.0,435.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1">
-                <polyline points="220.0,445.0,220.0,501.0" stroke-width="1" stroke="#FF0000"/>
-            </g>
-            <g class="ARROW1_gen1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,478.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_gen1_DOWN" id="_95_vl1_95_gen1_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,474.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen1_95_bgen1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_gen1_95_bgen1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_gen1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,458.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW2_gen1_DOWN" id="_95_vl1_95_gen1_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,454.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen1_95_bgen1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_gen1_95_bgen1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -895,7 +850,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbgen1" id="idbgen1" transform="translate(210.0,395.0)">
+            <g class="BREAKER idbgen1" id="idbgen1" transform="translate(210.0,415.0)">
                 <g class="closed" id="idbgen1_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -910,10 +865,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf13Fictif" id="idFICT_95_vl1_95_dtrf13Fictif" transform="translate(296.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_trf3_95_ONEFictif" id="idFICT_95_vl1_95_trf3_95_ONEFictif" transform="translate(296.0,441.0)">
-                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
-            </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="translate(295.0,499.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="translate(295.0,497.5)">
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#FF0000" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#FF0000"/>
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#218B21" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
                 <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf3_ONE_S_LABEL">trf3</text>
@@ -925,28 +877,25 @@
                 <polyline points="300.0,335.0,300.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf13_95_FICT_95_vl1_95_dtrf13Fictif">
-                <polyline points="300.0,395.0,300.0,365.0" stroke-width="1" stroke="#FF0000"/>
+                <polyline points="300.0,415.0,300.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf13_95_FICT_95_vl1_95_trf3_95_ONEFictif">
-                <polyline points="300.0,415.0,300.0,445.0" stroke-width="1" stroke="#FF0000"/>
+            <g class="wire" id="_95_vl1_95_btrf13_95_trf3_95_ONE">
+                <polyline points="300.0,435.0,300.0,497.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE">
-                <polyline points="300.0,445.0,300.0,499.0" stroke-width="1" stroke="#FF0000"/>
-            </g>
-            <g class="ARROW1_trf3_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,295.0,477.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_trf3_95_ONE_DOWN" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,295.0,472.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf3_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,295.0,457.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW2_trf3_95_ONE_DOWN" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,295.0,452.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -960,7 +909,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf13" id="idbtrf13" transform="translate(290.0,395.0)">
+            <g class="BREAKER idbtrf13" id="idbtrf13" transform="translate(290.0,415.0)">
                 <g class="closed" id="idbtrf13_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -980,10 +929,10 @@
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#218B21" r="5" cx="11" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#FF0000" r="5" cx="8" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cy="9" stroke="#FF0000"/>
             </g>
-            <g class="LINE idtrf7_95_TWO" id="idtrf7_95_TWO" transform="translate(620.0,507.0)">
+            <g class="LINE idtrf7_95_TWO" id="idtrf7_95_TWO" transform="translate(620.0,505.0)">
                 <text x="-5.0" font-size="8" y="13.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf7_TWO_S_LABEL">trf71</text>
             </g>
-            <g class="LINE idtrf7_95_THREE" id="idtrf7_95_THREE" transform="translate(700.0,507.0)">
+            <g class="LINE idtrf7_95_THREE" id="idtrf7_95_THREE" transform="translate(700.0,505.0)">
                 <text x="-5.0" font-size="8" y="13.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf7_THREE_S_LABEL">trf71</text>
             </g>
             <g class="wire" id="_95_vl1_95_bbs3_95_dtrf17">
@@ -999,9 +948,9 @@
                 <polyline points="660.0,415.0,660.0,438.0" stroke-width="1" stroke="#FF0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO">
-                <polyline points="653.0,450.0,620.0,450.0,620.0,507.0" stroke-width="1" stroke="#218B21"/>
+                <polyline points="653.0,450.0,620.0,450.0,620.0,505.0" stroke-width="1" stroke="#218B21"/>
             </g>
-            <g class="ARROW1_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,483.5)">
+            <g class="ARROW1_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,480.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -1010,7 +959,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,463.5)">
+            <g class="ARROW2_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,460.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -1020,9 +969,9 @@
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE">
-                <polyline points="667.0,450.0,700.0,450.0,700.0,507.0" stroke-width="1" stroke="#7F0848"/>
+                <polyline points="667.0,450.0,700.0,450.0,700.0,505.0" stroke-width="1" stroke="#7F0848"/>
             </g>
-            <g class="ARROW1_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,483.5)">
+            <g class="ARROW1_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,480.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -1031,7 +980,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,463.5)">
+            <g class="ARROW2_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,460.0)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -1064,10 +1013,7 @@
             <g class="NODE idFICT_95_vl1_95_dgen2Fictif" id="idFICT_95_vl1_95_dgen2Fictif" transform="translate(1256.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_gen2Fictif" id="idFICT_95_vl1_95_gen2Fictif" transform="translate(1256.0,441.0)">
-                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
-            </g>
-            <g class="GENERATOR idgen2" id="idgen2" transform="translate(1254.0,501.0)">
+            <g class="GENERATOR idgen2" id="idgen2" transform="translate(1254.0,499.0)">
                 <circle fill="#FF0000" r="6" cx="6" cy="6" stroke="#FF0000"/>
                 <path fill="#FF0000" d="M6,6 A 6 40 0 0 0 2,6" stroke="#FF0000"/>
                 <path fill="#FF0000" d="M6,6 A 6 40 0 0 0 10,6" stroke="#FF0000"/>
@@ -1080,28 +1026,25 @@
                 <polyline points="1260.0,335.0,1260.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_bgen2_95_FICT_95_vl1_95_dgen2Fictif">
-                <polyline points="1260.0,395.0,1260.0,365.0" stroke-width="1" stroke="#FF0000"/>
+                <polyline points="1260.0,415.0,1260.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_bgen2_95_FICT_95_vl1_95_gen2Fictif">
-                <polyline points="1260.0,415.0,1260.0,445.0" stroke-width="1" stroke="#FF0000"/>
+            <g class="wire" id="_95_vl1_95_gen2_95_bgen2">
+                <polyline points="1260.0,499.0,1260.0,435.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2">
-                <polyline points="1260.0,445.0,1260.0,501.0" stroke-width="1" stroke="#FF0000"/>
-            </g>
-            <g class="ARROW1_gen2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,478.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_gen2_DOWN" id="_95_vl1_95_gen2_95_bgen2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,474.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen2_95_bgen2_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_gen2_95_bgen2_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_gen2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,458.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW2_gen2_DOWN" id="_95_vl1_95_gen2_95_bgen2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,454.0)">
+                <g class="arrow-up" id="_95_vl1_95_gen2_95_bgen2_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_gen2_95_bgen2_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -1115,7 +1058,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbgen2" id="idbgen2" transform="translate(1250.0,395.0)">
+            <g class="BREAKER idbgen2" id="idbgen2" transform="translate(1250.0,415.0)">
                 <g class="closed" id="idbgen2_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -1130,10 +1073,7 @@
             <g class="NODE idFICT_95_vl1_95_dtrf14Fictif" id="idFICT_95_vl1_95_dtrf14Fictif" transform="translate(1096.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="NODE idFICT_95_vl1_95_trf4_95_ONEFictif" id="idFICT_95_vl1_95_trf4_95_ONEFictif" transform="translate(1096.0,441.0)">
-                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
-            </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="translate(1095.0,499.5)">
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="translate(1095.0,497.5)">
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#FF0000" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#FF0000"/>
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#218B21" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
                 <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_ONE_S_LABEL">trf4</text>
@@ -1145,28 +1085,25 @@
                 <polyline points="1100.0,335.0,1100.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf14_95_FICT_95_vl1_95_dtrf14Fictif">
-                <polyline points="1100.0,395.0,1100.0,365.0" stroke-width="1" stroke="#FF0000"/>
+                <polyline points="1100.0,415.0,1100.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf14_95_FICT_95_vl1_95_trf4_95_ONEFictif">
-                <polyline points="1100.0,415.0,1100.0,445.0" stroke-width="1" stroke="#FF0000"/>
+            <g class="wire" id="_95_vl1_95_btrf14_95_trf4_95_ONE">
+                <polyline points="1100.0,435.0,1100.0,497.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE">
-                <polyline points="1100.0,445.0,1100.0,499.0" stroke-width="1" stroke="#FF0000"/>
-            </g>
-            <g class="ARROW1_trf4_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,477.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_trf4_95_ONE_DOWN" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,472.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf4_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,457.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW2_trf4_95_ONE_DOWN" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,452.0)">
+                <g class="arrow-up" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -1180,7 +1117,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf14" id="idbtrf14" transform="translate(1090.0,395.0)">
+            <g class="BREAKER idbtrf14" id="idbtrf14" transform="translate(1090.0,415.0)">
                 <g class="closed" id="idbtrf14_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -1192,14 +1129,14 @@
             </g>
         </g>
         <g id="NODE_0_vl1">
-            <circle fill="#7F6C00" r="10.0" id="NODE_0_vl1_circle" cx="40.0" cy="597.0"/>
-            <text x="30.0" font-size="8" id="NODE_0_vl1_v" y="622.0" class="component-label" font-family="Verdana">392.0 kV</text>
-            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="637.0" class="component-label" font-family="Verdana">-2.3 °</text>
+            <circle fill="#7F6C00" r="10.0" id="NODE_0_vl1_circle" cx="40.0" cy="595.0"/>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_v" y="620.0" class="component-label" font-family="Verdana">392.0 kV</text>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-2.3 °</text>
         </g>
         <g id="NODE_1_vl1">
-            <circle fill="#FF0000" r="10.0" id="NODE_1_vl1_circle" cx="110.0" cy="597.0"/>
-            <text x="100.0" font-size="8" id="NODE_1_vl1_v" y="622.0" class="component-label" font-family="Verdana">403.0 kV</text>
-            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="637.0" class="component-label" font-family="Verdana">-1.7 °</text>
+            <circle fill="#FF0000" r="10.0" id="NODE_1_vl1_circle" cx="110.0" cy="595.0"/>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_v" y="620.0" class="component-label" font-family="Verdana">403.0 kV</text>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-1.7 °</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -161,6 +161,15 @@
 .idbtrf17 .open { visibility: hidden;}.idbtrf17 .closed { visibility: visible;}
 .iddtrf18 .open { visibility: hidden;}.iddtrf18 .closed { visibility: visible;}
 .idbtrf18 .open { visibility: hidden;}.idbtrf18 .closed { visibility: visible;}
+.idFICT_95_vl1_95_load1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_gen1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_load2Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_gen2Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_trf1_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_trf2_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_trf3_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_trf4_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idFICT_95_vl1_95_trf5_95_ONEFictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
 .idFICT_95_vl1_95_dsect11Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
 .idFICT_95_vl1_95_dload1Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
 .idFICT_95_vl1_95_dtrf11Fictif {stroke-opacity:0; fill-opacity:0; visibility: hidden;}
@@ -330,7 +339,10 @@
             <g class="NODE idFICT_95_vl1_95_dload1Fictif" id="idFICT_95_vl1_95_dload1Fictif" transform="translate(56.0,276.0)">
                 <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
             </g>
-            <g class="LOAD idload1" id="idload1" transform="translate(52.0,135.5)">
+            <g class="NODE idFICT_95_vl1_95_load1Fictif" id="idFICT_95_vl1_95_load1Fictif" transform="translate(56.0,196.0)">
+                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="LOAD idload1" id="idload1" transform="translate(52.0,133.5)">
                 <rect fill="#7F6C00" width="16" height="9" stroke="#7F6C00"/>
                 <line y2="9" fill="#7F6C00" x1="0" x2="16" stroke="#7F6C00" y1="0"/>
                 <line y2="9" fill="#7F6C00" x1="16" x2="0" stroke="#7F6C00" y1="0"/>
@@ -343,25 +355,28 @@
                 <polyline points="60.0,310.0,60.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_bload1_95_FICT_95_vl1_95_dload1Fictif">
-                <polyline points="60.0,230.0,60.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+                <polyline points="60.0,250.0,60.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_load1_95_bload1">
-                <polyline points="60.0,144.5,60.0,210.0" stroke-width="1" stroke="#7F6C00"/>
+            <g class="wire" id="_95_vl1_95_bload1_95_FICT_95_vl1_95_load1Fictif">
+                <polyline points="60.0,230.0,60.0,200.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="ARROW1_load1_DOWN" id="_95_vl1_95_load1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,159.5)">
-                <g class="arrow-up" id="_95_vl1_95_load1_95_bload1_ARROW1_ARROW-arrow-up">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1">
+                <polyline points="60.0,200.0,60.0,142.5" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="ARROW1_load1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,156.25)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_load1_95_bload1_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_load1_DOWN" id="_95_vl1_95_load1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,179.5)">
-                <g class="arrow-up" id="_95_vl1_95_load1_95_bload1_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_load1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,176.25)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_load1_95_bload1_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -375,7 +390,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbload1" id="idbload1" transform="translate(50.0,210.0)">
+            <g class="BREAKER idbload1" id="idbload1" transform="translate(50.0,230.0)">
                 <g class="closed" id="idbload1_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -390,7 +405,10 @@
             <g class="NODE idFICT_95_vl1_95_dtrf11Fictif" id="idFICT_95_vl1_95_dtrf11Fictif" transform="translate(136.0,276.0)">
                 <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf1_95_ONE" id="idtrf1_95_ONE" transform="translate(135.0,132.5)">
+            <g class="NODE idFICT_95_vl1_95_trf1_95_ONEFictif" id="idFICT_95_vl1_95_trf1_95_ONEFictif" transform="translate(136.0,196.0)">
+                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf1_95_ONE" id="idtrf1_95_ONE" transform="translate(135.0,130.5)">
                 <circle fill="#7F6C00" r="5" id="idtrf1_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#7F6C00"/>
                 <circle fill="#218B21" r="5" id="idtrf1_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#218B21"/>
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf1_ONE_N_LABEL">trf1</text>
@@ -402,25 +420,28 @@
                 <polyline points="140.0,310.0,140.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf11_95_FICT_95_vl1_95_dtrf11Fictif">
-                <polyline points="140.0,230.0,140.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+                <polyline points="140.0,250.0,140.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf11_95_trf1_95_ONE">
-                <polyline points="140.0,210.0,140.0,148.0" stroke-width="1" stroke="#7F6C00"/>
+            <g class="wire" id="_95_vl1_95_btrf11_95_FICT_95_vl1_95_trf1_95_ONEFictif">
+                <polyline points="140.0,230.0,140.0,200.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="ARROW1_trf1_95_ONE_DOWN" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,135.0,163.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1_ARROW-arrow-up">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE">
+                <polyline points="140.0,200.0,140.0,146.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="ARROW1_trf1_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,135.0,158.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf1_95_ONE_DOWN" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,135.0,183.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_trf1_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,135.0,178.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf11_95_trf1_95_ONE_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -434,7 +455,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf11" id="idbtrf11" transform="translate(130.0,210.0)">
+            <g class="BREAKER idbtrf11" id="idbtrf11" transform="translate(130.0,230.0)">
                 <g class="closed" id="idbtrf11_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -449,7 +470,10 @@
             <g class="NODE idFICT_95_vl1_95_dtrf15Fictif" id="idFICT_95_vl1_95_dtrf15Fictif" transform="translate(376.0,276.0)">
                 <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf5_95_ONE" id="idtrf5_95_ONE" transform="translate(375.0,132.5)">
+            <g class="NODE idFICT_95_vl1_95_trf5_95_ONEFictif" id="idFICT_95_vl1_95_trf5_95_ONEFictif" transform="translate(376.0,196.0)">
+                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf5_95_ONE" id="idtrf5_95_ONE" transform="translate(375.0,130.5)">
                 <circle fill="#7F6C00" r="5" id="idtrf5_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#7F6C00"/>
                 <circle fill="#7F0848" r="5" id="idtrf5_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#7F0848"/>
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf5_ONE_N_LABEL">trf5</text>
@@ -461,25 +485,28 @@
                 <polyline points="380.0,310.0,380.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf15_95_FICT_95_vl1_95_dtrf15Fictif">
-                <polyline points="380.0,230.0,380.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+                <polyline points="380.0,250.0,380.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf15_95_trf5_95_ONE">
-                <polyline points="380.0,210.0,380.0,148.0" stroke-width="1" stroke="#7F6C00"/>
+            <g class="wire" id="_95_vl1_95_btrf15_95_FICT_95_vl1_95_trf5_95_ONEFictif">
+                <polyline points="380.0,230.0,380.0,200.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="ARROW1_trf5_95_ONE_DOWN" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,163.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1_ARROW-arrow-up">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE">
+                <polyline points="380.0,200.0,380.0,146.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="ARROW1_trf5_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,158.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf5_95_ONE_DOWN" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,183.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_trf5_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,178.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf15_95_trf5_95_ONE_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -493,7 +520,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf15" id="idbtrf15" transform="translate(370.0,210.0)">
+            <g class="BREAKER idbtrf15" id="idbtrf15" transform="translate(370.0,230.0)">
                 <g class="closed" id="idbtrf15_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -513,10 +540,10 @@
                 <circle fill="#7F0848" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#7F0848"/>
                 <circle fill="#7F6C00" r="5" id="idFICT_95_vl1_95_trf6_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#7F6C00"/>
             </g>
-            <g class="LINE idtrf6_95_TWO" id="idtrf6_95_TWO" transform="translate(460.0,140.0)">
+            <g class="LINE idtrf6_95_TWO" id="idtrf6_95_TWO" transform="translate(460.0,138.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf6_TWO_N_LABEL">trf61</text>
             </g>
-            <g class="LINE idtrf6_95_THREE" id="idtrf6_95_THREE" transform="translate(540.0,140.0)">
+            <g class="LINE idtrf6_95_THREE" id="idtrf6_95_THREE" transform="translate(540.0,138.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf6_THREE_N_LABEL">trf61</text>
             </g>
             <g class="wire" id="_95_vl1_95_bbs1_95_dtrf16">
@@ -532,9 +559,9 @@
                 <polyline points="500.0,230.0,500.0,207.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO">
-                <polyline points="493.0,195.0,460.0,195.0,460.0,140.0" stroke-width="1" stroke="#218B21"/>
+                <polyline points="493.0,195.0,460.0,195.0,460.0,138.0" stroke-width="1" stroke="#218B21"/>
             </g>
-            <g class="ARROW1_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,155.0)">
+            <g class="ARROW1_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,151.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -543,7 +570,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,175.0)">
+            <g class="ARROW2_trf6_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,171.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -553,9 +580,9 @@
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE">
-                <polyline points="507.0,195.0,540.0,195.0,540.0,140.0" stroke-width="1" stroke="#7F0848"/>
+                <polyline points="507.0,195.0,540.0,195.0,540.0,138.0" stroke-width="1" stroke="#7F0848"/>
             </g>
-            <g class="ARROW1_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,155.0)">
+            <g class="ARROW1_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,151.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -564,7 +591,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,175.0)">
+            <g class="ARROW2_trf6_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,171.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -597,7 +624,10 @@
             <g class="NODE idFICT_95_vl1_95_dload2Fictif" id="idFICT_95_vl1_95_dload2Fictif" transform="translate(856.0,276.0)">
                 <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
             </g>
-            <g class="LOAD idload2" id="idload2" transform="translate(852.0,135.5)">
+            <g class="NODE idFICT_95_vl1_95_load2Fictif" id="idFICT_95_vl1_95_load2Fictif" transform="translate(856.0,196.0)">
+                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="LOAD idload2" id="idload2" transform="translate(852.0,133.5)">
                 <rect fill="#7F6C00" width="16" height="9" stroke="#7F6C00"/>
                 <line y2="9" fill="#7F6C00" x1="0" x2="16" stroke="#7F6C00" y1="0"/>
                 <line y2="9" fill="#7F6C00" x1="16" x2="0" stroke="#7F6C00" y1="0"/>
@@ -610,25 +640,28 @@
                 <polyline points="860.0,310.0,860.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_bload2_95_FICT_95_vl1_95_dload2Fictif">
-                <polyline points="860.0,230.0,860.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+                <polyline points="860.0,250.0,860.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_load2_95_bload2">
-                <polyline points="860.0,144.5,860.0,210.0" stroke-width="1" stroke="#7F6C00"/>
+            <g class="wire" id="_95_vl1_95_bload2_95_FICT_95_vl1_95_load2Fictif">
+                <polyline points="860.0,230.0,860.0,200.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="ARROW1_load2_DOWN" id="_95_vl1_95_load2_95_bload2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,159.5)">
-                <g class="arrow-up" id="_95_vl1_95_load2_95_bload2_ARROW1_ARROW-arrow-up">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2">
+                <polyline points="860.0,200.0,860.0,142.5" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="ARROW1_load2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,855.0,156.25)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_load2_95_bload2_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_load2_DOWN" id="_95_vl1_95_load2_95_bload2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,179.5)">
-                <g class="arrow-up" id="_95_vl1_95_load2_95_bload2_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_load2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,855.0,176.25)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_load2_95_bload2_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -642,7 +675,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbload2" id="idbload2" transform="translate(850.0,210.0)">
+            <g class="BREAKER idbload2" id="idbload2" transform="translate(850.0,230.0)">
                 <g class="closed" id="idbload2_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -657,7 +690,10 @@
             <g class="NODE idFICT_95_vl1_95_dtrf12Fictif" id="idFICT_95_vl1_95_dtrf12Fictif" transform="translate(1176.0,276.0)">
                 <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf2_95_ONE" id="idtrf2_95_ONE" transform="translate(1175.0,132.5)">
+            <g class="NODE idFICT_95_vl1_95_trf2_95_ONEFictif" id="idFICT_95_vl1_95_trf2_95_ONEFictif" transform="translate(1176.0,196.0)">
+                <circle fill-opacity="0" fill="#7F6C00" r="4" cx="4" cy="4" stroke="#7F6C00" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf2_95_ONE" id="idtrf2_95_ONE" transform="translate(1175.0,130.5)">
                 <circle fill="#7F6C00" r="5" id="idtrf2_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="10" stroke="#7F6C00"/>
                 <circle fill="#218B21" r="5" id="idtrf2_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" cy="5" stroke="#218B21"/>
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf2_ONE_N_LABEL">trf2</text>
@@ -669,25 +705,28 @@
                 <polyline points="1180.0,310.0,1180.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf12_95_FICT_95_vl1_95_dtrf12Fictif">
-                <polyline points="1180.0,230.0,1180.0,280.0" stroke-width="1" stroke="#7F6C00"/>
+                <polyline points="1180.0,250.0,1180.0,280.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf12_95_trf2_95_ONE">
-                <polyline points="1180.0,210.0,1180.0,148.0" stroke-width="1" stroke="#7F6C00"/>
+            <g class="wire" id="_95_vl1_95_btrf12_95_FICT_95_vl1_95_trf2_95_ONEFictif">
+                <polyline points="1180.0,230.0,1180.0,200.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
-            <g class="ARROW1_trf2_95_ONE_DOWN" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,163.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1_ARROW-arrow-up">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE">
+                <polyline points="1180.0,200.0,1180.0,146.0" stroke-width="1" stroke="#7F6C00"/>
+            </g>
+            <g class="ARROW1_trf2_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,158.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW1_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf2_95_ONE_DOWN" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,183.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2_ARROW-arrow-up">
+            <g class="ARROW2_trf2_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1175.0,178.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf12_95_trf2_95_ONE_ARROW2_ARROW-arrow-down">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW2_ARROW-arrow-down">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -701,7 +740,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf12" id="idbtrf12" transform="translate(1170.0,210.0)">
+            <g class="BREAKER idbtrf12" id="idbtrf12" transform="translate(1170.0,230.0)">
                 <g class="closed" id="idbtrf12_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -721,10 +760,10 @@
                 <circle fill="#7F0848" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5" stroke="#7F0848"/>
                 <circle fill="#7F6C00" r="5" id="idFICT_95_vl1_95_trf8_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9" stroke="#7F6C00"/>
             </g>
-            <g class="LINE idtrf8_95_TWO" id="idtrf8_95_TWO" transform="translate(940.0,140.0)">
+            <g class="LINE idtrf8_95_TWO" id="idtrf8_95_TWO" transform="translate(940.0,138.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf8_TWO_N_LABEL">trf81</text>
             </g>
-            <g class="LINE idtrf8_95_THREE" id="idtrf8_95_THREE" transform="translate(1020.0,140.0)">
+            <g class="LINE idtrf8_95_THREE" id="idtrf8_95_THREE" transform="translate(1020.0,138.0)">
                 <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf8_THREE_N_LABEL">trf81</text>
             </g>
             <g class="wire" id="_95_vl1_95_bbs2_95_dtrf18">
@@ -740,9 +779,9 @@
                 <polyline points="980.0,230.0,980.0,207.0" stroke-width="1" stroke="#7F6C00"/>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO">
-                <polyline points="973.0,195.0,940.0,195.0,940.0,140.0" stroke-width="1" stroke="#218B21"/>
+                <polyline points="973.0,195.0,940.0,195.0,940.0,138.0" stroke-width="1" stroke="#218B21"/>
             </g>
-            <g class="ARROW1_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,155.0)">
+            <g class="ARROW1_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,151.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -751,7 +790,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,175.0)">
+            <g class="ARROW2_trf8_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,171.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -761,9 +800,9 @@
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE">
-                <polyline points="987.0,195.0,1020.0,195.0,1020.0,140.0" stroke-width="1" stroke="#7F0848"/>
+                <polyline points="987.0,195.0,1020.0,195.0,1020.0,138.0" stroke-width="1" stroke="#7F0848"/>
             </g>
-            <g class="ARROW1_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,155.0)">
+            <g class="ARROW1_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,151.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -772,7 +811,7 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,175.0)">
+            <g class="ARROW2_trf8_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,171.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2_ARROW-arrow-up">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -805,7 +844,10 @@
             <g class="NODE idFICT_95_vl1_95_dgen1Fictif" id="idFICT_95_vl1_95_dgen1Fictif" transform="translate(216.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="GENERATOR idgen1" id="idgen1" transform="translate(214.0,499.0)">
+            <g class="NODE idFICT_95_vl1_95_gen1Fictif" id="idFICT_95_vl1_95_gen1Fictif" transform="translate(216.0,441.0)">
+                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
+            </g>
+            <g class="GENERATOR idgen1" id="idgen1" transform="translate(214.0,501.0)">
                 <circle fill="#FF0000" r="6" cx="6" cy="6" stroke="#FF0000"/>
                 <path fill="#FF0000" d="M6,6 A 6 40 0 0 0 2,6" stroke="#FF0000"/>
                 <path fill="#FF0000" d="M6,6 A 6 40 0 0 0 10,6" stroke="#FF0000"/>
@@ -818,25 +860,28 @@
                 <polyline points="220.0,335.0,220.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_bgen1_95_FICT_95_vl1_95_dgen1Fictif">
-                <polyline points="220.0,415.0,220.0,365.0" stroke-width="1" stroke="#FF0000"/>
+                <polyline points="220.0,395.0,220.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_gen1_95_bgen1">
-                <polyline points="220.0,499.0,220.0,435.0" stroke-width="1" stroke="#FF0000"/>
+            <g class="wire" id="_95_vl1_95_bgen1_95_FICT_95_vl1_95_gen1Fictif">
+                <polyline points="220.0,415.0,220.0,445.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="ARROW1_gen1_DOWN" id="_95_vl1_95_gen1_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,474.0)">
-                <g class="arrow-up" id="_95_vl1_95_gen1_95_bgen1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1">
+                <polyline points="220.0,445.0,220.0,501.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="ARROW2_gen1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,478.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_gen1_95_bgen1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_gen1_DOWN" id="_95_vl1_95_gen1_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,215.0,454.0)">
-                <g class="arrow-up" id="_95_vl1_95_gen1_95_bgen1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_gen1_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,215.0,458.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_gen1_95_bgen1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -850,7 +895,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbgen1" id="idbgen1" transform="translate(210.0,415.0)">
+            <g class="BREAKER idbgen1" id="idbgen1" transform="translate(210.0,395.0)">
                 <g class="closed" id="idbgen1_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -865,7 +910,10 @@
             <g class="NODE idFICT_95_vl1_95_dtrf13Fictif" id="idFICT_95_vl1_95_dtrf13Fictif" transform="translate(296.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="translate(295.0,497.5)">
+            <g class="NODE idFICT_95_vl1_95_trf3_95_ONEFictif" id="idFICT_95_vl1_95_trf3_95_ONEFictif" transform="translate(296.0,441.0)">
+                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf3_95_ONE" id="idtrf3_95_ONE" transform="translate(295.0,499.5)">
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#FF0000" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#FF0000"/>
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#218B21" r="5" cx="5" id="idtrf3_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
                 <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf3_ONE_S_LABEL">trf3</text>
@@ -877,25 +925,28 @@
                 <polyline points="300.0,335.0,300.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf13_95_FICT_95_vl1_95_dtrf13Fictif">
-                <polyline points="300.0,415.0,300.0,365.0" stroke-width="1" stroke="#FF0000"/>
+                <polyline points="300.0,395.0,300.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf13_95_trf3_95_ONE">
-                <polyline points="300.0,435.0,300.0,497.0" stroke-width="1" stroke="#FF0000"/>
+            <g class="wire" id="_95_vl1_95_btrf13_95_FICT_95_vl1_95_trf3_95_ONEFictif">
+                <polyline points="300.0,415.0,300.0,445.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="ARROW1_trf3_95_ONE_DOWN" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,295.0,472.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE">
+                <polyline points="300.0,445.0,300.0,499.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="ARROW2_trf3_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,295.0,477.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf3_95_ONE_DOWN" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,295.0,452.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_trf3_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,295.0,457.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf13_95_trf3_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -909,7 +960,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf13" id="idbtrf13" transform="translate(290.0,415.0)">
+            <g class="BREAKER idbtrf13" id="idbtrf13" transform="translate(290.0,395.0)">
                 <g class="closed" id="idbtrf13_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -929,10 +980,10 @@
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#218B21" r="5" cx="11" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
                 <circle transform="rotate(180.0,8.0,7.0)" fill="#FF0000" r="5" cx="8" id="idFICT_95_vl1_95_trf7_95_fictif_THREE_WINDINGS_TRANSFORMER-WINDING3" cy="9" stroke="#FF0000"/>
             </g>
-            <g class="LINE idtrf7_95_TWO" id="idtrf7_95_TWO" transform="translate(620.0,505.0)">
+            <g class="LINE idtrf7_95_TWO" id="idtrf7_95_TWO" transform="translate(620.0,507.0)">
                 <text x="-5.0" font-size="8" y="13.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf7_TWO_S_LABEL">trf71</text>
             </g>
-            <g class="LINE idtrf7_95_THREE" id="idtrf7_95_THREE" transform="translate(700.0,505.0)">
+            <g class="LINE idtrf7_95_THREE" id="idtrf7_95_THREE" transform="translate(700.0,507.0)">
                 <text x="-5.0" font-size="8" y="13.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf7_THREE_S_LABEL">trf71</text>
             </g>
             <g class="wire" id="_95_vl1_95_bbs3_95_dtrf17">
@@ -948,18 +999,9 @@
                 <polyline points="660.0,415.0,660.0,438.0" stroke-width="1" stroke="#FF0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO">
-                <polyline points="653.0,450.0,620.0,450.0,620.0,505.0" stroke-width="1" stroke="#218B21"/>
+                <polyline points="653.0,450.0,620.0,450.0,620.0,507.0" stroke-width="1" stroke="#218B21"/>
             </g>
-            <g class="ARROW1_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,480.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-                    <polygon points="5,0 10,10 0,10"/>
-                </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-                    <polygon points="0,0 10,0 5,10"/>
-                </g>
-                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
-            </g>
-            <g class="ARROW2_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,460.0)">
+            <g class="ARROW2_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,483.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
@@ -968,23 +1010,32 @@
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE">
-                <polyline points="667.0,450.0,700.0,450.0,700.0,505.0" stroke-width="1" stroke="#7F0848"/>
-            </g>
-            <g class="ARROW1_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,480.0)">
-                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_trf7_95_TWO_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,463.5)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,460.0)">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE">
+                <polyline points="667.0,450.0,700.0,450.0,700.0,507.0" stroke-width="1" stroke="#7F0848"/>
+            </g>
+            <g class="ARROW2_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,483.5)">
                 <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
                 <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="0,0 10,0 5,10"/>
+                </g>
+                <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
+            </g>
+            <g class="ARROW1_trf7_95_THREE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,463.5)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                    <polygon points="5,0 10,10 0,10"/>
+                </g>
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -1013,7 +1064,10 @@
             <g class="NODE idFICT_95_vl1_95_dgen2Fictif" id="idFICT_95_vl1_95_dgen2Fictif" transform="translate(1256.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="GENERATOR idgen2" id="idgen2" transform="translate(1254.0,499.0)">
+            <g class="NODE idFICT_95_vl1_95_gen2Fictif" id="idFICT_95_vl1_95_gen2Fictif" transform="translate(1256.0,441.0)">
+                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
+            </g>
+            <g class="GENERATOR idgen2" id="idgen2" transform="translate(1254.0,501.0)">
                 <circle fill="#FF0000" r="6" cx="6" cy="6" stroke="#FF0000"/>
                 <path fill="#FF0000" d="M6,6 A 6 40 0 0 0 2,6" stroke="#FF0000"/>
                 <path fill="#FF0000" d="M6,6 A 6 40 0 0 0 10,6" stroke="#FF0000"/>
@@ -1026,25 +1080,28 @@
                 <polyline points="1260.0,335.0,1260.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_bgen2_95_FICT_95_vl1_95_dgen2Fictif">
-                <polyline points="1260.0,415.0,1260.0,365.0" stroke-width="1" stroke="#FF0000"/>
+                <polyline points="1260.0,395.0,1260.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_gen2_95_bgen2">
-                <polyline points="1260.0,499.0,1260.0,435.0" stroke-width="1" stroke="#FF0000"/>
+            <g class="wire" id="_95_vl1_95_bgen2_95_FICT_95_vl1_95_gen2Fictif">
+                <polyline points="1260.0,415.0,1260.0,445.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="ARROW1_gen2_DOWN" id="_95_vl1_95_gen2_95_bgen2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,474.0)">
-                <g class="arrow-up" id="_95_vl1_95_gen2_95_bgen2_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2">
+                <polyline points="1260.0,445.0,1260.0,501.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="ARROW2_gen2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,478.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_gen2_95_bgen2_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_gen2_DOWN" id="_95_vl1_95_gen2_95_bgen2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,454.0)">
-                <g class="arrow-up" id="_95_vl1_95_gen2_95_bgen2_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_gen2_DOWN" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1255.0,458.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_gen2_95_bgen2_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -1058,7 +1115,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbgen2" id="idbgen2" transform="translate(1250.0,415.0)">
+            <g class="BREAKER idbgen2" id="idbgen2" transform="translate(1250.0,395.0)">
                 <g class="closed" id="idbgen2_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -1073,7 +1130,10 @@
             <g class="NODE idFICT_95_vl1_95_dtrf14Fictif" id="idFICT_95_vl1_95_dtrf14Fictif" transform="translate(1096.0,361.0)">
                 <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
             </g>
-            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="translate(1095.0,497.5)">
+            <g class="NODE idFICT_95_vl1_95_trf4_95_ONEFictif" id="idFICT_95_vl1_95_trf4_95_ONEFictif" transform="translate(1096.0,441.0)">
+                <circle fill-opacity="0" fill="#FF0000" r="4" cx="4" cy="4" stroke="#FF0000" stroke-opacity="0"/>
+            </g>
+            <g class="TWO_WINDINGS_TRANSFORMER idtrf4_95_ONE" id="idtrf4_95_ONE" transform="translate(1095.0,499.5)">
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#FF0000" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING1" cy="10" stroke="#FF0000"/>
                 <circle transform="rotate(180.0,5.0,7.5)" fill="#218B21" r="5" cx="5" id="idtrf4_95_ONE_TWO_WINDINGS_TRANSFORMER-WINDING2" cy="5" stroke="#218B21"/>
                 <text x="-5.0" font-size="8" y="28.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="trf4_ONE_S_LABEL">trf4</text>
@@ -1085,25 +1145,28 @@
                 <polyline points="1100.0,335.0,1100.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
             <g class="wire" id="_95_vl1_95_btrf14_95_FICT_95_vl1_95_dtrf14Fictif">
-                <polyline points="1100.0,415.0,1100.0,365.0" stroke-width="1" stroke="#FF0000"/>
+                <polyline points="1100.0,395.0,1100.0,365.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="wire" id="_95_vl1_95_btrf14_95_trf4_95_ONE">
-                <polyline points="1100.0,435.0,1100.0,497.0" stroke-width="1" stroke="#FF0000"/>
+            <g class="wire" id="_95_vl1_95_btrf14_95_FICT_95_vl1_95_trf4_95_ONEFictif">
+                <polyline points="1100.0,415.0,1100.0,445.0" stroke-width="1" stroke="#FF0000"/>
             </g>
-            <g class="ARROW1_trf4_95_ONE_DOWN" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,472.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="wire" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE">
+                <polyline points="1100.0,445.0,1100.0,499.0" stroke-width="1" stroke="#FF0000"/>
+            </g>
+            <g class="ARROW2_trf4_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,477.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
             </g>
-            <g class="ARROW2_trf4_95_ONE_DOWN" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,452.0)">
-                <g class="arrow-up" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+            <g class="ARROW1_trf4_95_ONE_DOWN" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1095.0,457.0)">
+                <g class="arrow-up" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="5,0 10,10 0,10"/>
                 </g>
-                <g class="arrow-down" id="_95_vl1_95_btrf14_95_trf4_95_ONE_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <g class="arrow-down" id="_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                     <polygon points="0,0 10,0 5,10"/>
                 </g>
                 <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">0    </text>
@@ -1117,7 +1180,7 @@
                     <line y2="8" x1="8" x2="0" y1="0"/>
                 </g>
             </g>
-            <g class="BREAKER idbtrf14" id="idbtrf14" transform="translate(1090.0,415.0)">
+            <g class="BREAKER idbtrf14" id="idbtrf14" transform="translate(1090.0,395.0)">
                 <g class="closed" id="idbtrf14_BREAKER-closed">
                     <rect x="1" width="18" y="1" height="18"/>
                     <line y2="15" x1="10" x2="10" y1="5"/>
@@ -1129,14 +1192,14 @@
             </g>
         </g>
         <g id="NODE_0_vl1">
-            <circle fill="#7F6C00" r="10.0" id="NODE_0_vl1_circle" cx="40.0" cy="595.0"/>
-            <text x="30.0" font-size="8" id="NODE_0_vl1_v" y="620.0" class="component-label" font-family="Verdana">392.0 kV</text>
-            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-2.3 °</text>
+            <circle fill="#7F6C00" r="10.0" id="NODE_0_vl1_circle" cx="40.0" cy="597.0"/>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_v" y="622.0" class="component-label" font-family="Verdana">392.0 kV</text>
+            <text x="30.0" font-size="8" id="NODE_0_vl1_angle" y="637.0" class="component-label" font-family="Verdana">-2.3 °</text>
         </g>
         <g id="NODE_1_vl1">
-            <circle fill="#FF0000" r="10.0" id="NODE_1_vl1_circle" cx="110.0" cy="595.0"/>
-            <text x="100.0" font-size="8" id="NODE_1_vl1_v" y="620.0" class="component-label" font-family="Verdana">403.0 kV</text>
-            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="635.0" class="component-label" font-family="Verdana">-1.7 °</text>
+            <circle fill="#FF0000" r="10.0" id="NODE_1_vl1_circle" cx="110.0" cy="597.0"/>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_v" y="622.0" class="component-label" font-family="Verdana">403.0 kV</text>
+            <text x="100.0" font-size="8" id="NODE_1_vl1_angle" y="637.0" class="component-label" font-family="Verdana">-1.7 °</text>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -3214,6 +3214,7 @@
     "labelDiagonal" : false,
     "angleLabelShift" : 15.0,
     "highlightLineState" : true,
-    "addNodesInfos" : false
+    "addNodesInfos" : false,
+    "feederArrowSymmetry" : false
   }
 }

--- a/single-line-diagram-core/src/test/resources/substation.svg
+++ b/single-line-diagram-core/src/test/resources/substation.svg
@@ -228,16 +228,7 @@
         <g class="wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="100.0,570.0,100.0,480.0"/>
         </g>
-        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,545.0)">
-            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="5,0 10,10 0,10"/>
-            </g>
-            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="0,0 10,0 5,10"/>
-            </g>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,525.0)">
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,545.0)">
             <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -245,6 +236,15 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,525.0)">
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
             <polyline points="100.0,460.0,100.0,370.0"/>
@@ -410,16 +410,7 @@
         <g class="wire" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1">
             <polyline points="670.0,570.0,670.0,480.0"/>
         </g>
-        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,665.0,545.0)">
-            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="5,0 10,10 0,10"/>
-            </g>
-            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="0,0 10,0 5,10"/>
-            </g>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,665.0,525.0)">
+        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,665.0,545.0)">
             <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -427,6 +418,15 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,665.0,525.0)">
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="wire" id="_95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1">
             <polyline points="670.0,460.0,670.0,370.0"/>

--- a/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
+++ b/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
@@ -1,0 +1,673 @@
+<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.BUSBAR_SECTION {
+    stroke: rgb(0,0,0);
+    stroke-width: 3;
+}
+
+.BREAKER {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 2;
+    fill: rgb(255, 255, 255);
+}
+
+.DISCONNECTOR {
+    stroke: rgb(0, 0, 0);
+    stroke-width: 3
+}
+
+.GENERATOR {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.LOAD {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.LOAD_BREAK_SWITCH {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill: rgb(255, 255, 255);
+}
+
+.NODE {
+    stroke: rgb(0, 0, 0);
+    fill: rgb(0, 0, 0);
+    fill-opacity: 1;
+}
+
+.CAPACITOR {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.INDUCTOR {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.STATIC_VAR_COMPENSATOR {
+    stroke: rgb(0, 0, 255);
+}
+
+.TWO_WINDINGS_TRANSFORMER {
+    stroke: rgb(0, 0, 255);
+    fill-opacity: 0;
+}
+
+.THREE_WINDINGS_TRANSFORMER {
+    stroke: rgb(0, 0, 255);
+    fill-opacity: 0;
+}
+
+.VSC_CONVERTER_STATION {
+    stroke: rgb(0, 0, 255);
+    font-size: 7.4314661px;
+    line-height: 1.25;
+    font-family: sans-serif;
+    font-variant-ligatures: normal;
+    font-variant-caps: normal;
+    font-variant-numeric: normal;
+    font-feature-settings: normal;
+    text-align: start;
+    letter-spacing: 0px;
+    word-spacing: 0px;
+    writing-mode: lr-tb;
+    text-anchor: start;
+    stroke-miterlimit: 4;
+}
+
+.PHASE_SHIFT_TRANSFORMER {
+    stroke: rgb(0, 0, 255);
+    stroke-linecap: butt;
+    stroke-linejoin: miter;
+    stroke-miterlimit: 4;
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.wire {
+    stroke: rgb(200,0,0);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+
+.grid {
+    stroke: rgb(0,55,0);
+    stroke-width: 1;
+    stroke-dasharray: 1,10;
+}
+
+.component-label {
+    fill: black;
+    color: black;
+    stroke: none;
+    fill-opacity: 1;
+}
+
+.LINE {
+    stroke: rgb(0, 0, 255);
+    stroke-width: 1;
+    fill-opacity: 0;
+}
+.idvl1_95_d1 .open { visibility: hidden;}.idvl1_95_d1 .closed { visibility: visible;}
+.idvl1_95_b1 .open { visibility: hidden;}.idvl1_95_b1 .closed { visibility: visible;}
+.idvl1_95_d2 .open { visibility: hidden;}.idvl1_95_d2 .closed { visibility: visible;}
+.ARROW1_vl1_95_load1_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_vl1_95_load1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_vl1_95_load1_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_vl1_95_load1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl1_95_load1_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_vl1_95_load1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl1_95_load1_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_vl1_95_load1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idvl1_95_bload1 .open { visibility: hidden;}.idvl1_95_bload1 .closed { visibility: visible;}
+.idvl1_95_dload1 .open { visibility: hidden;}.idvl1_95_dload1 .closed { visibility: visible;}
+.ARROW1_vl1_95_trf1_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_vl1_95_trf1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_vl1_95_trf1_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_vl1_95_trf1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl1_95_trf1_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_vl1_95_trf1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl1_95_trf1_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_vl1_95_trf1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idvl1_95_btrf1 .open { visibility: hidden;}.idvl1_95_btrf1 .closed { visibility: visible;}
+.idvl1_95_dtrf1 .open { visibility: hidden;}.idvl1_95_dtrf1 .closed { visibility: visible;}
+.ARROW1_vl1_95_trf2_95_one_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_vl1_95_trf2_95_one_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_vl1_95_trf2_95_one_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_vl1_95_trf2_95_one_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl1_95_trf2_95_one_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_vl1_95_trf2_95_one_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl1_95_trf2_95_one_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_vl1_95_trf2_95_one_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idvl1_95_btrf2 .open { visibility: hidden;}.idvl1_95_btrf2 .closed { visibility: visible;}
+.idvl1_95_dtrf2 .open { visibility: hidden;}.idvl1_95_dtrf2 .closed { visibility: visible;}
+.ARROW1_vl2_95_gen1_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_vl2_95_gen1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_vl2_95_gen1_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_vl2_95_gen1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl2_95_gen1_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_vl2_95_gen1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl2_95_gen1_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_vl2_95_gen1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idvl2_95_bgen1 .open { visibility: hidden;}.idvl2_95_bgen1 .closed { visibility: visible;}
+.idvl2_95_dgen1 .open { visibility: hidden;}.idvl2_95_dgen1 .closed { visibility: visible;}
+.ARROW1_vl2_95_trf1_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_vl2_95_trf1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_vl2_95_trf1_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_vl2_95_trf1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl2_95_trf1_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_vl2_95_trf1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl2_95_trf1_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_vl2_95_trf1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idvl2_95_btrf1 .open { visibility: hidden;}.idvl2_95_btrf1 .closed { visibility: visible;}
+.idvl2_95_dtrf1 .open { visibility: hidden;}.idvl2_95_dtrf1 .closed { visibility: visible;}
+.ARROW1_vl2_95_trf2_95_one_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_vl2_95_trf2_95_one_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_vl2_95_trf2_95_one_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_vl2_95_trf2_95_one_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl2_95_trf2_95_one_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_vl2_95_trf2_95_one_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl2_95_trf2_95_one_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_vl2_95_trf2_95_one_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idvl2_95_btrf2 .open { visibility: hidden;}.idvl2_95_btrf2 .closed { visibility: visible;}
+.idvl2_95_dtrf2 .open { visibility: hidden;}.idvl2_95_dtrf2 .closed { visibility: visible;}
+.ARROW1_vl3_95_capa1_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_vl3_95_capa1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_vl3_95_capa1_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_vl3_95_capa1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl3_95_capa1_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_vl3_95_capa1_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl3_95_capa1_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_vl3_95_capa1_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idvl3_95_bcapa1 .open { visibility: hidden;}.idvl3_95_bcapa1 .closed { visibility: visible;}
+.idvl3_95_dcapa1 .open { visibility: hidden;}.idvl3_95_dcapa1 .closed { visibility: visible;}
+.ARROW1_vl3_95_trf2_95_one_UP .arrow-up {stroke: black; fill: black; fill-opacity:1; visibility: visible;}.ARROW1_vl3_95_trf2_95_one_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW1_vl3_95_trf2_95_one_DOWN .arrow-down {stroke: black; fill: black; fill-opacity:1;  visibility: visible;}.ARROW1_vl3_95_trf2_95_one_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl3_95_trf2_95_one_UP .arrow-up {stroke: blue; fill: blue; fill-opacity:1; visibility: visible;}.ARROW2_vl3_95_trf2_95_one_UP .arrow-down { stroke-opacity:0; fill-opacity:0; visibility: hidden;}.ARROW2_vl3_95_trf2_95_one_DOWN .arrow-down {stroke: blue; fill: blue; fill-opacity:1;  visibility: visible;}.ARROW2_vl3_95_trf2_95_one_DOWN .arrow-up { stroke-opacity:0; fill-opacity:0; visibility: hidden;}
+.idvl3_95_btrf2 .open { visibility: hidden;}.idvl3_95_btrf2 .closed { visibility: visible;}
+.idvl3_95_dtrf2 .open { visibility: hidden;}.idvl3_95_dtrf2 .closed { visibility: visible;}
+]]></style>
+    <g>
+        <g class="grid" id="GRID_vl1" transform="translate(20.0,50.0)">
+            <line y2="560.0" x1="0.0" x2="0.0" y1="0.0"/>
+            <line y2="560.0" x1="80.0" x2="80.0" y1="0.0"/>
+            <line y2="560.0" x1="160.0" x2="160.0" y1="0.0"/>
+            <line y2="560.0" x1="240.0" x2="240.0" y1="0.0"/>
+            <line y2="560.0" x1="320.0" x2="320.0" y1="0.0"/>
+            <line y2="560.0" x1="400.0" x2="400.0" y1="0.0"/>
+            <line y2="560.0" x1="480.0" x2="480.0" y1="0.0"/>
+            <line y2="250.0" x1="0.0" x2="480.0" y1="250.0"/>
+            <line y2="310.0" x1="0.0" x2="480.0" y1="310.0"/>
+            <line y2="240.0" x1="0.0" x2="480.0" y1="240.0"/>
+            <line y2="320.0" x1="0.0" x2="480.0" y1="320.0"/>
+        </g>
+        <g class="grid" id="GRID_vl2" transform="translate(20.0,50.0)">
+            <line y2="560.0" x1="550.0" x2="550.0" y1="0.0"/>
+            <line y2="560.0" x1="630.0" x2="630.0" y1="0.0"/>
+            <line y2="560.0" x1="710.0" x2="710.0" y1="0.0"/>
+            <line y2="560.0" x1="790.0" x2="790.0" y1="0.0"/>
+            <line y2="250.0" x1="550.0" x2="790.0" y1="250.0"/>
+            <line y2="310.0" x1="550.0" x2="790.0" y1="310.0"/>
+            <line y2="240.0" x1="550.0" x2="790.0" y1="240.0"/>
+            <line y2="320.0" x1="550.0" x2="790.0" y1="320.0"/>
+        </g>
+        <g class="grid" id="GRID_vl3" transform="translate(20.0,50.0)">
+            <line y2="560.0" x1="850.0" x2="850.0" y1="0.0"/>
+            <line y2="560.0" x1="930.0" x2="930.0" y1="0.0"/>
+            <line y2="560.0" x1="1010.0" x2="1010.0" y1="0.0"/>
+            <line y2="560.0" x1="1090.0" x2="1090.0" y1="0.0"/>
+            <line y2="250.0" x1="850.0" x2="1090.0" y1="250.0"/>
+            <line y2="310.0" x1="850.0" x2="1090.0" y1="310.0"/>
+            <line y2="240.0" x1="850.0" x2="1090.0" y1="240.0"/>
+            <line y2="320.0" x1="850.0" x2="1090.0" y1="320.0"/>
+        </g>
+        <g class="BUSBAR_SECTION idvl1_95_bbs1" id="idvl1_95_bbs1" transform="translate(20.0,370.0)">
+            <line y2="0" x1="0" x2="200.0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_bbs1_NW_LABEL">vl1_bbs1</text>
+        </g>
+        <g class="BUSBAR_SECTION idvl1_95_bbs2" id="idvl1_95_bbs2" transform="translate(300.0,370.0)">
+            <line y2="0" x1="0" x2="200.0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_bbs2_NW_LABEL">vl1_bbs2</text>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_bbs1_95_vl1_95_d1">
+            <polyline points="220.0,370.0,240.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_d1_95_vl1_95_b1">
+            <polyline points="240.0,370.0,255.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_b1_95_vl1_95_d2">
+            <polyline points="275.0,370.0,290.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_d2_95_vl1_95_bbs2">
+            <polyline points="290.0,370.0,300.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
+            <polyline points="60.0,154.5,60.0,240.0"/>
+        </g>
+        <g class="ARROW1_vl1_95_load1_UP" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.5)">
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+        </g>
+        <g class="ARROW2_vl1_95_load1_DOWN" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.5)">
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_bload1_95_vl1_95_dload1">
+            <polyline points="60.0,260.0,60.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1">
+            <polyline points="60.0,370.0,50.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
+            <polyline points="100.0,570.0,100.0,480.0"/>
+        </g>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,545.0)">
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+        </g>
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,525.0)">
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
+            <polyline points="100.0,460.0,100.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1">
+            <polyline points="100.0,370.0,90.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2">
+            <polyline points="420.0,150.0,420.0,240.0"/>
+        </g>
+        <g class="ARROW1_vl1_95_trf2_95_one_UP" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,415.0,165.0)">
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+        </g>
+        <g class="ARROW2_vl1_95_trf2_95_one_DOWN" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,415.0,185.0)">
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2">
+            <polyline points="420.0,260.0,420.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2">
+            <polyline points="420.0,370.0,410.0,370.0"/>
+        </g>
+        <g class="DISCONNECTOR idvl1_95_d1" id="idvl1_95_d1" transform="translate(236.0,366.0)">
+            <g class="closed" id="idvl1_95_d1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_d1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
+        <g class="BREAKER idvl1_95_b1" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
+            <g class="closed" id="idvl1_95_b1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_b1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
+        <g class="DISCONNECTOR idvl1_95_d2" id="idvl1_95_d2" transform="translate(286.0,366.0)">
+            <g class="closed" id="idvl1_95_d2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_d2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
+        <g class="LOAD idvl1_95_load1" id="idvl1_95_load1" transform="translate(52.0,145.5)">
+            <rect height="9" width="16"/>
+            <line y2="9" x1="0" x2="16" y1="0"/>
+            <line y2="9" x1="16" x2="0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_load1__LABEL">vl1_load1</text>
+        </g>
+        <g class="BREAKER idvl1_95_bload1" id="idvl1_95_bload1" transform="translate(50.0,240.0)">
+            <g class="closed" id="idvl1_95_bload1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_bload1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
+        <g class="DISCONNECTOR idvl1_95_dload1" id="idvl1_95_dload1" transform="translate(56.0,366.0)">
+            <g class="closed" id="idvl1_95_dload1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dload1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
+        <g class="LINE idvl1_95_trf1" id="idvl1_95_trf1" transform="translate(100.0,570.0)">
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf1__LABEL">vl1_trf1</text>
+        </g>
+        <g class="BREAKER idvl1_95_btrf1" id="idvl1_95_btrf1" transform="translate(90.0,460.0)">
+            <g class="closed" id="idvl1_95_btrf1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_btrf1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
+        <g class="DISCONNECTOR idvl1_95_dtrf1" id="idvl1_95_dtrf1" transform="translate(96.0,366.0)">
+            <g class="closed" id="idvl1_95_dtrf1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dtrf1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
+        <g class="LINE idvl1_95_trf2_95_one" id="idvl1_95_trf2_95_one" transform="translate(420.0,150.0)">
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl1_trf2_one__LABEL">vl1_trf2</text>
+        </g>
+        <g class="BREAKER idvl1_95_btrf2" id="idvl1_95_btrf2" transform="translate(410.0,240.0)">
+            <g class="closed" id="idvl1_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl1_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
+        <g class="DISCONNECTOR idvl1_95_dtrf2" id="idvl1_95_dtrf2" transform="translate(416.0,366.0)">
+            <g class="closed" id="idvl1_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl1_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
+        <g class="BUSBAR_SECTION idvl2_95_bbs1" id="idvl2_95_bbs1" transform="translate(570.0,370.0)">
+            <line y2="0" x1="0" x2="200.0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_bbs1_NW_LABEL">vl2_bbs1</text>
+        </g>
+        <g class="wire" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1">
+            <polyline points="620.0,156.0,620.0,240.0"/>
+        </g>
+        <g class="ARROW1_vl2_95_gen1_UP" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,171.0)">
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+        </g>
+        <g class="ARROW2_vl2_95_gen1_DOWN" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,191.0)">
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="wire" id="_95_vl2_95_vl2_95_bgen1_95_vl2_95_dgen1">
+            <polyline points="620.0,260.0,620.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl2_95_vl2_95_dgen1_95_vl2_95_bbs1">
+            <polyline points="620.0,370.0,600.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1">
+            <polyline points="670.0,570.0,670.0,480.0"/>
+        </g>
+        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,665.0,545.0)">
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+        </g>
+        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,665.0,525.0)">
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="wire" id="_95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1">
+            <polyline points="670.0,460.0,670.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1">
+            <polyline points="670.0,370.0,680.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2">
+            <polyline points="730.0,150.0,730.0,240.0"/>
+        </g>
+        <g class="ARROW1_vl2_95_trf2_95_one_UP" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,725.0,165.0)">
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+        </g>
+        <g class="ARROW2_vl2_95_trf2_95_one_DOWN" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,725.0,185.0)">
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="wire" id="_95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2">
+            <polyline points="730.0,260.0,730.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl2_95_vl2_95_dtrf2_95_vl2_95_bbs1">
+            <polyline points="730.0,370.0,720.0,370.0"/>
+        </g>
+        <g class="GENERATOR idvl2_95_gen1" id="idvl2_95_gen1" transform="translate(614.0,144.0)">
+            <circle r="6" cx="6" cy="6"/>
+            <path d="M6,6 A 6 40 0 0 0 2,6"/>
+            <path d="M6,6 A 6 40 0 0 0 10,6"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_gen1__LABEL">vl2_gen1</text>
+        </g>
+        <g class="BREAKER idvl2_95_bgen1" id="idvl2_95_bgen1" transform="translate(610.0,240.0)">
+            <g class="closed" id="idvl2_95_bgen1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl2_95_bgen1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
+        <g class="DISCONNECTOR idvl2_95_dgen1" id="idvl2_95_dgen1" transform="translate(616.0,366.0)">
+            <g class="closed" id="idvl2_95_dgen1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl2_95_dgen1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
+        <g class="LINE idvl2_95_trf1" id="idvl2_95_trf1" transform="translate(670.0,570.0)">
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_trf1__LABEL">vl2_trf1</text>
+        </g>
+        <g class="BREAKER idvl2_95_btrf1" id="idvl2_95_btrf1" transform="translate(660.0,460.0)">
+            <g class="closed" id="idvl2_95_btrf1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl2_95_btrf1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
+        <g class="DISCONNECTOR idvl2_95_dtrf1" id="idvl2_95_dtrf1" transform="translate(666.0,366.0)">
+            <g class="closed" id="idvl2_95_dtrf1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl2_95_dtrf1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
+        <g class="LINE idvl2_95_trf2_95_one" id="idvl2_95_trf2_95_one" transform="translate(730.0,150.0)">
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl2_trf2_one__LABEL">vl2_trf2</text>
+        </g>
+        <g class="BREAKER idvl2_95_btrf2" id="idvl2_95_btrf2" transform="translate(720.0,240.0)">
+            <g class="closed" id="idvl2_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl2_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
+        <g class="DISCONNECTOR idvl2_95_dtrf2" id="idvl2_95_dtrf2" transform="translate(726.0,366.0)">
+            <g class="closed" id="idvl2_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl2_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
+        <g class="BUSBAR_SECTION idvl3_95_bbs1" id="idvl3_95_bbs1" transform="translate(870.0,370.0)">
+            <line y2="0" x1="0" x2="200.0" y1="0"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_bbs1_NW_LABEL">vl3_bbs1</text>
+        </g>
+        <g class="wire" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1">
+            <polyline points="910.0,156.0,910.0,240.0"/>
+        </g>
+        <g class="ARROW1_vl3_95_capa1_UP" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,905.0,171.0)">
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+        </g>
+        <g class="ARROW2_vl3_95_capa1_DOWN" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,905.0,191.0)">
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="wire" id="_95_vl3_95_vl3_95_bcapa1_95_vl3_95_dcapa1">
+            <polyline points="910.0,260.0,910.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1">
+            <polyline points="910.0,370.0,900.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2">
+            <polyline points="1020.0,150.0,1020.0,240.0"/>
+        </g>
+        <g class="ARROW1_vl3_95_trf2_95_one_UP" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,165.0)">
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
+        </g>
+        <g class="ARROW2_vl3_95_trf2_95_one_DOWN" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,185.0)">
+            <g class="arrow-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW2_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2_ARROW2_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="wire" id="_95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2">
+            <polyline points="1020.0,260.0,1020.0,370.0"/>
+        </g>
+        <g class="wire" id="_95_vl3_95_vl3_95_dtrf2_95_vl3_95_bbs1">
+            <polyline points="1020.0,370.0,1020.0,370.0"/>
+        </g>
+        <g class="CAPACITOR idvl3_95_capa1" id="idvl3_95_capa1" transform="translate(904.0,144.0)">
+            <line y2="4.5" x1="6" x2="6" y1="0"/>
+            <line y2="4.5" x1="0" x2="12" y1="4.5"/>
+            <line y2="7.5" x1="0" x2="12" y1="7.5"/>
+            <line y2="12" x1="6" x2="6" y1="7.5"/>
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_capa1__LABEL">vl3_capa1</text>
+        </g>
+        <g class="BREAKER idvl3_95_bcapa1" id="idvl3_95_bcapa1" transform="translate(900.0,240.0)">
+            <g class="closed" id="idvl3_95_bcapa1_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl3_95_bcapa1_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
+        <g class="DISCONNECTOR idvl3_95_dcapa1" id="idvl3_95_dcapa1" transform="translate(906.0,366.0)">
+            <g class="closed" id="idvl3_95_dcapa1_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl3_95_dcapa1_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
+        <g class="LINE idvl3_95_trf2_95_one" id="idvl3_95_trf2_95_one" transform="translate(1020.0,150.0)">
+            <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="vl3_trf2_one__LABEL">vl3_trf2</text>
+        </g>
+        <g class="BREAKER idvl3_95_btrf2" id="idvl3_95_btrf2" transform="translate(1010.0,240.0)">
+            <g class="closed" id="idvl3_95_btrf2_BREAKER-closed">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="15" x1="10" x2="10" y1="5"/>
+            </g>
+            <g class="open" id="idvl3_95_btrf2_BREAKER-open">
+                <rect x="1" width="18" y="1" height="18"/>
+                <line y2="10" x1="5" x2="15" y1="10"/>
+            </g>
+        </g>
+        <g class="DISCONNECTOR idvl3_95_dtrf2" id="idvl3_95_dtrf2" transform="translate(1016.0,366.0)">
+            <g class="closed" id="idvl3_95_dtrf2_DISCONNECTOR-closed">
+                <line y2="8" x1="0" x2="8" y1="0"/>
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+            <g class="open" id="idvl3_95_dtrf2_DISCONNECTOR-open">
+                <line y2="8" x1="8" x2="0" y1="0"/>
+            </g>
+        </g>
+        <g class="TWO_WINDINGS_TRANSFORMER idvl1_95_trf1_95_vl2_95_trf1" id="idvl1_95_trf1_95_vl2_95_trf1" transform="matrix(0.0,1.0,-1.0,0.0,392.5,595.0)">
+            <circle r="5" id="idvl1_95_trf1_95_vl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" transform="rotate(90.0,5.0,7.5)" cy="10"/>
+            <circle r="5" id="idvl1_95_trf1_95_vl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" transform="rotate(90.0,5.0,7.5)" cy="5"/>
+        </g>
+        <g class="THREE_WINDINGS_TRANSFORMER idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" transform="translate(722.0,93.0)">
+            <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING1" cx="5" cy="5"/>
+            <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING2" cx="11" cy="5"/>
+            <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
+        </g>
+        <g class="wire" id="_95_subst_95_vl1_95_trf1_95_vl1_95_trf1_95_vl2_95_trf1">
+            <polyline points="100.0,550.0,100.0,600.0,369.0,600.0"/>
+        </g>
+        <g class="wire" id="_95_subst_95_vl1_95_trf1_95_vl2_95_trf1_95_vl2_95_trf1">
+            <polyline points="401.0,600.0,670.0,600.0,670.0,550.0"/>
+        </g>
+        <g class="wire" id="_95_subst_95_vl1_95_trf2_95_one_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one">
+            <polyline points="420.0,130.0,420.0,90.0,716.0,90.0"/>
+        </g>
+        <g class="wire" id="_95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl2_95_trf2_95_one">
+            <polyline points="730.0,114.0,730.0,130.0"/>
+        </g>
+        <g class="wire" id="_95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl3_95_trf2_95_one">
+            <polyline points="744.0,90.0,1020.0,90.0,1020.0,130.0"/>
+        </g>
+        <g id="LABEL_VL_vl1">
+            <text x="0.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>
+        </g>
+        <g id="LABEL_VL_vl2">
+            <text x="550.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl2</text>
+        </g>
+        <g id="LABEL_VL_vl3">
+            <text x="850.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl3</text>
+        </g>
+    </g>
+</svg>

--- a/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
+++ b/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
@@ -636,7 +636,7 @@
                 <line y2="8" x1="8" x2="0" y1="0"/>
             </g>
         </g>
-        <g class="TWO_WINDINGS_TRANSFORMER idvl1_95_trf1_95_vl2_95_trf1" id="idvl1_95_trf1_95_vl2_95_trf1" transform="matrix(0.0,1.0,-1.0,0.0,392.5,595.0)">
+        <g class="TWO_WINDINGS_TRANSFORMER idvl1_95_trf1_95_vl2_95_trf1" id="idvl1_95_trf1_95_vl2_95_trf1" transform="translate(380.0,592.5)">
             <circle r="5" id="idvl1_95_trf1_95_vl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING1" cx="5" transform="rotate(90.0,5.0,7.5)" cy="10"/>
             <circle r="5" id="idvl1_95_trf1_95_vl2_95_trf1_TWO_WINDINGS_TRANSFORMER-WINDING2" cx="5" transform="rotate(90.0,5.0,7.5)" cy="5"/>
         </g>
@@ -646,19 +646,19 @@
             <circle r="5" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_THREE_WINDINGS_TRANSFORMER-WINDING3" cx="8" cy="9"/>
         </g>
         <g class="wire" id="_95_subst_95_vl1_95_trf1_95_vl1_95_trf1_95_vl2_95_trf1">
-            <polyline points="100.0,550.0,100.0,600.0,369.0,600.0"/>
+            <polyline points="100.0,550.0,100.0,600.0,377.0,600.0"/>
         </g>
         <g class="wire" id="_95_subst_95_vl1_95_trf1_95_vl2_95_trf1_95_vl2_95_trf1">
-            <polyline points="401.0,600.0,670.0,600.0,670.0,550.0"/>
+            <polyline points="393.0,600.0,670.0,600.0,670.0,550.0"/>
         </g>
         <g class="wire" id="_95_subst_95_vl1_95_trf2_95_one_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one">
-            <polyline points="420.0,130.0,420.0,90.0,716.0,90.0"/>
+            <polyline points="420.0,130.0,420.0,95.0,723.0,95.0"/>
         </g>
         <g class="wire" id="_95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl2_95_trf2_95_one">
-            <polyline points="730.0,114.0,730.0,130.0"/>
+            <polyline points="730.0,107.0,730.0,130.0"/>
         </g>
         <g class="wire" id="_95_subst_95_vl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one_95_vl3_95_trf2_95_one">
-            <polyline points="744.0,90.0,1020.0,90.0,1020.0,130.0"/>
+            <polyline points="737.0,95.0,1020.0,95.0,1020.0,130.0"/>
         </g>
         <g id="LABEL_VL_vl1">
             <text x="0.0" font-size="12" y="10.0" class="component-label" font-family="Verdana" transform="rotate(0,0,0)">vl1</text>

--- a/single-line-diagram-core/src/test/resources/substation_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/substation_optimized.svg
@@ -245,13 +245,13 @@
         <g class="wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="100.0,570.0,100.0,480.0"/>
         </g>
-        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,545.0)">
-            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,525.0)">
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,545.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,525.0)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
             <polyline points="100.0,460.0,100.0,370.0"/>
@@ -337,13 +337,13 @@
         <g class="wire" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1">
             <polyline points="670.0,570.0,670.0,480.0"/>
         </g>
-        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,665.0,545.0)">
-            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,665.0,525.0)">
+        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,665.0,545.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,665.0,525.0)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="wire" id="_95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1">
             <polyline points="670.0,460.0,670.0,370.0"/>

--- a/single-line-diagram-core/src/test/resources/vl1.svg
+++ b/single-line-diagram-core/src/test/resources/vl1.svg
@@ -194,16 +194,7 @@
         <g class="wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="100.0,562.0,100.0,480.0"/>
         </g>
-        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
-            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="5,0 10,10 0,10"/>
-            </g>
-            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="0,0 10,0 5,10"/>
-            </g>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
             <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -211,6 +202,15 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
             <polyline points="100.0,460.0,100.0,370.0"/>

--- a/single-line-diagram-core/src/test/resources/vl1_decorated.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_decorated.svg
@@ -206,16 +206,7 @@
         <g class="wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="100.0,562.0,100.0,480.0"/>
         </g>
-        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
-            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="5,0 10,10 0,10"/>
-            </g>
-            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="0,0 10,0 5,10"/>
-            </g>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
             <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -223,6 +214,15 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
             <polyline points="100.0,460.0,100.0,370.0"/>

--- a/single-line-diagram-core/src/test/resources/vl1_decorated_opt.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_decorated_opt.svg
@@ -232,13 +232,13 @@
         <g class="wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="100.0,562.0,100.0,480.0"/>
         </g>
-        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
-            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
             <polyline points="100.0,460.0,100.0,370.0"/>

--- a/single-line-diagram-core/src/test/resources/vl1_lpChanged.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_lpChanged.svg
@@ -194,16 +194,7 @@
         <g class="wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="100.0,562.0,100.0,480.0"/>
         </g>
-        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
-            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="5,0 10,10 0,10"/>
-            </g>
-            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="0,0 10,0 5,10"/>
-            </g>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
             <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -211,6 +202,15 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+            <g class="arrow-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
             <polyline points="100.0,460.0,100.0,370.0"/>

--- a/single-line-diagram-core/src/test/resources/vl1_lpChanged_opt.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_lpChanged_opt.svg
@@ -214,13 +214,13 @@
         <g class="wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="100.0,562.0,100.0,480.0"/>
         </g>
-        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
-            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
             <polyline points="100.0,460.0,100.0,370.0"/>

--- a/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -214,13 +214,13 @@
         <g class="wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="100.0,562.0,100.0,480.0"/>
         </g>
-        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
-            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+        <g class="ARROW2_vl1_95_trf1_DOWN" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_vl1_95_trf1_UP" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="wire" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
             <polyline points="100.0,460.0,100.0,370.0"/>

--- a/single-line-diagram-core/src/test/resources/vl2.svg
+++ b/single-line-diagram-core/src/test/resources/vl2.svg
@@ -172,16 +172,7 @@
         <g class="wire" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1">
             <polyline points="670.0,562.0,670.0,480.0"/>
         </g>
-        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,665.0,537.0)">
-            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="5,0 10,10 0,10"/>
-            </g>
-            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="0,0 10,0 5,10"/>
-            </g>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,665.0,517.0)">
+        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,665.0,537.0)">
             <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -189,6 +180,15 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,665.0,517.0)">
+            <g class="arrow-up" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="wire" id="_95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1">
             <polyline points="670.0,460.0,670.0,370.0"/>

--- a/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -195,13 +195,13 @@
         <g class="wire" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1">
             <polyline points="670.0,562.0,670.0,480.0"/>
         </g>
-        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,665.0,537.0)">
-            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,665.0,517.0)">
+        <g class="ARROW2_vl2_95_trf1_DOWN" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,665.0,537.0)">
             <use fill="blue" fill-opacity="1" href="#ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)" stroke="blue"/>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_vl2_95_trf1_UP" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,665.0,517.0)">
+            <use fill="black" fill-opacity="1" href="#ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)" stroke="black"/>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="wire" id="_95_vl2_95_vl2_95_btrf1_95_vl2_95_dtrf1">
             <polyline points="670.0,460.0,670.0,370.0"/>

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -1614,6 +1614,7 @@
     "labelDiagonal" : false,
     "angleLabelShift" : 15.0,
     "highlightLineState" : true,
-    "addNodesInfos" : false
+    "addNodesInfos" : false,
+    "feederArrowSymmetry" : false
   }
 }

--- a/single-line-diagram-core/src/test/resources/zone.svg
+++ b/single-line-diagram-core/src/test/resources/zone.svg
@@ -131,16 +131,7 @@
         <g class="wire" id="_95_VoltageLevel11_95_Bus11_95_Load">
             <polyline points="50.0,250.0,70.0,250.0,70.0,104.5"/>
         </g>
-        <g class="ARROW1_Load_UP" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,119.5)">
-            <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1_ARROW-arrow-up">
-                <polygon points="5,0 10,10 0,10"/>
-            </g>
-            <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1_ARROW-arrow-down">
-                <polygon points="0,0 10,0 5,10"/>
-            </g>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_Load_DOWN" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,139.5)">
+        <g class="ARROW2_Load_DOWN" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,119.5)">
             <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW2_ARROW-arrow-up">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -149,19 +140,19 @@
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
-        <g class="wire" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE">
-            <polyline points="50.0,250.0,70.0,250.0,70.0,350.0"/>
-        </g>
-        <g class="ARROW1_Transformer_95_ONE_UP" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,325.0)">
-            <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <g class="ARROW1_Load_UP" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,139.5)">
+            <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1_ARROW-arrow-up">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+            <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Load_ARROW1_ARROW-arrow-down">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
-        <g class="ARROW2_Transformer_95_ONE_DOWN" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,305.0)">
+        <g class="wire" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE">
+            <polyline points="50.0,250.0,70.0,250.0,70.0,350.0"/>
+        </g>
+        <g class="ARROW2_Transformer_95_ONE_DOWN" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,325.0)">
             <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -169,6 +160,15 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_Transformer_95_ONE_UP" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,305.0)">
+            <g class="arrow-up" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="LOAD idLoad" id="idLoad" transform="translate(62.0,95.5)">
             <rect height="9" width="16"/>
@@ -186,16 +186,7 @@
         <g class="wire" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO">
             <polyline points="50.0,550.0,70.0,550.0,70.0,450.0"/>
         </g>
-        <g class="ARROW1_Transformer_95_TWO_UP" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,465.0)">
-            <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1_ARROW-arrow-up">
-                <polygon points="5,0 10,10 0,10"/>
-            </g>
-            <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1_ARROW-arrow-down">
-                <polygon points="0,0 10,0 5,10"/>
-            </g>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_Transformer_95_TWO_DOWN" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,485.0)">
+        <g class="ARROW2_Transformer_95_TWO_DOWN" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,465.0)">
             <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW2_ARROW-arrow-up">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -204,19 +195,19 @@
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
-        <g class="wire" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE">
-            <polyline points="50.0,550.0,70.0,550.0,70.0,700.0"/>
-        </g>
-        <g class="ARROW1_Line_95_ONE_UP" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,675.0)">
-            <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+        <g class="ARROW1_Transformer_95_TWO_UP" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,485.0)">
+            <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1_ARROW-arrow-up">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+            <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO_ARROW1_ARROW-arrow-down">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
-        <g class="ARROW2_Line_95_ONE_DOWN" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,655.0)">
+        <g class="wire" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE">
+            <polyline points="50.0,550.0,70.0,550.0,70.0,700.0"/>
+        </g>
+        <g class="ARROW2_Line_95_ONE_DOWN" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,65.0,675.0)">
             <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -224,6 +215,15 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_Line_95_ONE_UP" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,65.0,655.0)">
+            <g class="arrow-up" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="LINE idTransformer_95_TWO" id="idTransformer_95_TWO" transform="translate(70.0,450.0)">
             <text x="-5.0" font-size="8" y="-5.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" id="Transformer_TWO__LABEL">Transformer</text>
@@ -248,16 +248,7 @@
         <g class="wire" id="_95_VoltageLevel21_95_Bus21_95_Generator">
             <polyline points="150.0,1150.0,170.0,1150.0,170.0,1294.0"/>
         </g>
-        <g class="ARROW1_Generator_UP" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1269.0)">
-            <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="5,0 10,10 0,10"/>
-            </g>
-            <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
-                <polygon points="0,0 10,0 5,10"/>
-            </g>
-            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
-        </g>
-        <g class="ARROW2_Generator_DOWN" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1249.0)">
+        <g class="ARROW2_Generator_DOWN" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1269.0)">
             <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW2_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -266,19 +257,19 @@
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
         </g>
-        <g class="wire" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO">
-            <polyline points="150.0,1150.0,170.0,1150.0,170.0,1000.0"/>
-        </g>
-        <g class="ARROW1_Line_95_TWO_UP" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1015.0)">
-            <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1_ARROW-arrow-up">
+        <g class="ARROW1_Generator_UP" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1249.0)">
+            <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1_ARROW-arrow-up" transform="rotate(180.0,5.0,5.0)">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
-            <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1_ARROW-arrow-down">
+            <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Generator_ARROW1_ARROW-arrow-down" transform="rotate(180.0,5.0,5.0)">
                 <polygon points="0,0 10,0 5,10"/>
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
-        <g class="ARROW2_Line_95_TWO_DOWN" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1035.0)">
+        <g class="wire" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO">
+            <polyline points="150.0,1150.0,170.0,1150.0,170.0,1000.0"/>
+        </g>
+        <g class="ARROW2_Line_95_TWO_DOWN" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1015.0)">
             <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW2_ARROW-arrow-up">
                 <polygon points="5,0 10,10 0,10"/>
             </g>
@@ -286,6 +277,15 @@
                 <polygon points="0,0 10,0 5,10"/>
             </g>
             <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">20   </text>
+        </g>
+        <g class="ARROW1_Line_95_TWO_UP" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,165.0,1035.0)">
+            <g class="arrow-up" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1_ARROW-arrow-up">
+                <polygon points="5,0 10,10 0,10"/>
+            </g>
+            <g class="arrow-down" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO_ARROW1_ARROW-arrow-down">
+                <polygon points="0,0 10,0 5,10"/>
+            </g>
+            <text x="15.0" font-size="8" y="9.0" transform="rotate(0,0,0)" font-family="Verdana" class="component-label" xml:space="preserve" textLength="25">10   </text>
         </g>
         <g class="GENERATOR idGenerator" id="idGenerator" transform="translate(164.0,1294.0)">
             <circle r="6" cx="6" cy="6"/>

--- a/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
+++ b/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
@@ -742,6 +742,8 @@ public abstract class AbstractSingleLineDiagramViewer extends Application implem
         addCheckBox("HighLight line state", rowIndex, LayoutParameters::isHighlightLineState, LayoutParameters::setHighlightLineState);
         rowIndex += 2;
         addCheckBox("Add nodes infos", rowIndex, LayoutParameters::isAddNodesInfos, LayoutParameters::setAddNodesInfos);
+        rowIndex += 2;
+        addCheckBox("Feeder arrow symmetry", rowIndex, LayoutParameters::isFeederArrowSymmetry, LayoutParameters::setFeederArrowSymmetry);
     }
 
     private void setDiagramsNamesContent(Network network, boolean setValues) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Active power values are above reactive power values, if feeder cell direction is top
Active power values are below reactive power values, if feeder cell direction is bottom

**What is the new behavior (if this is a feature change)?**
Active power values are always above reactive power values, whatever the feeder cell direction is (top or bottom)

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
