### PR TITLE
Use JDK internal Xalan version (http://javax.xml.XMLConstants/propert…

### DIFF
--- a/single-line-diagram-view-app/pom.xml
+++ b/single-line-diagram-view-app/pom.xml
@@ -32,6 +32,14 @@
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-single-line-diagram-view</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <!-- The Xalan version from FranzXaver does not support http://javax.xml.XMLConstants/property/accessExternalDTD
+                 but JDK internal does -->
+                <exclusion>
+                    <groupId>xalan</groupId>
+                    <artifactId>xalan</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
FranzXaver library has a dependency on xalan:xalan:2.7.2 and http://javax.xml.XMLConstants/property/accessExternalDTD option which is not supported.


**What is the new behavior (if this is a feature change)?**
We exclude this dependency to fallback to JDK internal default one.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
