### PR TITLE
Correct static var compensator svg height

### DIFF
--- a/single-line-diagram-core/src/main/resources/ConvergenceLibrary/svc.svg
+++ b/single-line-diagram-core/src/main/resources/ConvergenceLibrary/svc.svg
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" id="svg53" height="12" width="12" version="1.0">
-  <line id="line45" y2="3" x2="6" y1="0" x1="6" />
-  <line id="line47" y2="3" x2="12" y1="3" x1="0" />
-  <line id="line49" y2="6" x2="12" y1="6" x1="0" />
-  <line id="line51" y2="9" x2="6" y1="6" x1="6" />
-  <path id="path5227" d="M 0.23047375,8.9270166 11.723431,0.30729834" style="fill:none;stroke:#0000ff;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:1.39999998;stroke-dasharray:none" />
-  <path id="path5229" d="M 11.723431,0.30729834 9.4207823,0.57177914" style="fill:none;stroke:#0000ff;stroke-width:0.384;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <path id="path5231" d="M 11.723431,0.30729834 11.370038,1.9820743" style="fill:none;stroke:#0000ff;stroke-width:0.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <line x1="6" y1="0" x2="6" y2="4.5"/>
+  <line x1="0" y1="4.5" x2="12" y2="4.5"/>
+  <line x1="0" y1="7.5" x2="12" y2="7.5"/>
+  <line x1="6" y1="7.5" x2="6" y2="12"/>
+  <path d="M 0.2555944,10.611633 11.670701,1.4475367 M 9.3291114,2.0449964 11.670701,1.4475367 10.581166,3.6045982" style="fill:none;stroke:#0000ff;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:1.4;stroke-dasharray:none"/>
 </svg>

--- a/single-line-diagram-core/src/main/resources/ConvergenceLibrary/svc.svg
+++ b/single-line-diagram-core/src/main/resources/ConvergenceLibrary/svc.svg
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" id="svg53" height="12" width="12" version="1.0">
-  <line x1="6" y1="0" x2="6" y2="4.5"/>
-  <line x1="0" y1="4.5" x2="12" y2="4.5"/>
-  <line x1="0" y1="7.5" x2="12" y2="7.5"/>
-  <line x1="6" y1="7.5" x2="6" y2="12"/>
-  <path d="M 0.2555944,10.611633 11.670701,1.4475367 M 9.3291114,2.0449964 11.670701,1.4475367 10.581166,3.6045982" style="fill:none;stroke:#0000ff;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:1.4;stroke-dasharray:none"/>
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" height="12" width="12">
+  <path d="M 6,0 V 4.5 M 0,4.5 H 12 M 0,7.5 H 12 M 6,7.5 V 12"/>
+  <path d="M 0.2556,10.611 11.671,1.448 M 9.329,2.045 11.671,1.448 10.581,3.6046" style="fill:none;stroke:#0000ff;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:1.4;stroke-dasharray:none"/>
 </svg>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Wrong height (12px) for svc component in components.xml and in svc.svg instead of 9px (and ugly arrow)
![svc_before](https://user-images.githubusercontent.com/66690739/100612029-93617e00-3312-11eb-8389-4e604ea6c4b5.png)

**What is the new behavior (if this is a feature change)?**
svg corrected to have height of 12px
![svc_after](https://user-images.githubusercontent.com/66690739/100612072-a1af9a00-3312-11eb-91ff-28cead63ebf8.png)


**Does this PR introduce a breaking change or deprecate an API?** No

