### PR TITLE
Check access external feature available before setting

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/DomUtil.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/DomUtil.java
@@ -46,8 +46,12 @@ public final class DomUtil {
             DOMSource source = new DOMSource(document);
             StreamResult result = new StreamResult(writer);
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
-            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            if (transformerFactory.getFeature(XMLConstants.ACCESS_EXTERNAL_DTD)) {
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            }
+            if (transformerFactory.getFeature(XMLConstants.ACCESS_EXTERNAL_STYLESHEET)) {
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            }
             Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
If a user of single-line-diagram has a Xalan version which does not support ACCESS_EXTERNAL_DTD or ACCESS_EXTERNAL_STYLESHEET creating the svg file will throw an exception


**What is the new behavior (if this is a feature change)?**
Check before setting those properties if the corresponding feature is available


**Does this PR introduce a breaking change or deprecate an API?** 
No