### PR TITLE
Remove setting the access external for XML parsing factories

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/DomUtil.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/DomUtil.java
@@ -10,7 +10,6 @@ import com.powsybl.commons.exceptions.UncheckedParserConfigurationException;
 import com.powsybl.commons.exceptions.UncheckedTransformerException;
 import org.w3c.dom.Document;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -33,8 +32,6 @@ public final class DomUtil {
     public static DocumentBuilder getDocumentBuilder() {
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             return dbf.newDocumentBuilder();
         } catch (ParserConfigurationException e) {
             throw new UncheckedParserConfigurationException(e);
@@ -46,8 +43,6 @@ public final class DomUtil {
             DOMSource source = new DOMSource(document);
             StreamResult result = new StreamResult(writer);
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
-            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
If a user of single-line-diagram is using Xalan 2.7.2 (latest version), or embeds another TransformerFactory or DocumentBuilderFactory which does not support ACCESS_EXTERNAL_DTD or ACCESS_EXTERNAL_STYLESHEET, creating the svg file will throw an exception


**What is the new behavior (if this is a feature change)?**
While waiting for a better solution to be found, the ACCESS_EXTERNAL_DTD and ACCESS_EXTERNAL_STYLESHEET attributes are not set to DocumentBuilderFactory / TransformerFactory used.


**Does this PR introduce a breaking change or deprecate an API?** 
No


**Other information**:
A related issue is about to be created. 
