### PR TITLE
Default resources component library

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagramTool.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagramTool.java
@@ -97,7 +97,7 @@ public class SingleLineDiagramTool implements Tool {
 
     static class SvgGenerationConfig {
 
-        ComponentLibrary componentLibrary = new ResourcesComponentLibrary("/ConvergenceLibrary");
+        ComponentLibrary componentLibrary = new ResourcesComponentLibrary();
 
         LayoutParameters parameters = new LayoutParameters();
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ResourcesComponentLibrary.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ResourcesComponentLibrary.java
@@ -37,12 +37,24 @@ import java.util.*;
 public class ResourcesComponentLibrary implements ComponentLibrary {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourcesComponentLibrary.class);
+    public static final String DEFAULT_LIBRARY_DIR = "/ConvergenceLibrary";
 
     private final Map<String, Map<String, Document>> svgDocuments = new HashMap<>();
 
     private final Map<String, Component> components = new HashMap<>();
 
     private final String styleSheet;
+
+    private static String getDefaultLibraryDirectory() {
+        return DEFAULT_LIBRARY_DIR;
+    }
+
+    /**
+     * Constructs a new library containing the default components
+     */
+    public ResourcesComponentLibrary() {
+        this(getDefaultLibraryDirectory());
+    }
 
     /**
      * Constructs a new library containing the components in the given directories

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -35,7 +35,7 @@ public abstract class AbstractTestCase {
     protected final ResourcesComponentLibrary componentLibrary = getResourcesComponentLibrary();
 
     protected ResourcesComponentLibrary getResourcesComponentLibrary() {
-        return new ResourcesComponentLibrary("/ConvergenceLibrary");
+        return new ResourcesComponentLibrary();
     }
 
     protected static String normalizeLineSeparator(String str) {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase12GraphWith3WT.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase12GraphWith3WT.java
@@ -6,23 +6,11 @@
  */
 package com.powsybl.sld.iidm;
 
-import com.powsybl.iidm.network.Country;
-import com.powsybl.iidm.network.Generator;
-import com.powsybl.iidm.network.Load;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.SwitchKind;
-import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.*;
 import com.powsybl.sld.NetworkGraphBuilder;
 import com.powsybl.sld.VoltageLevelDiagram;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
-import com.powsybl.sld.layout.BlockOrganizer;
-import com.powsybl.sld.layout.ImplicitCellDetector;
-import com.powsybl.sld.layout.LayoutParameters;
-import com.powsybl.sld.layout.PositionVoltageLevelLayout;
-import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
-import com.powsybl.sld.library.ComponentLibrary;
-import com.powsybl.sld.library.ResourcesComponentLibrary;
+import com.powsybl.sld.layout.*;
 import com.powsybl.sld.model.Graph;
 import com.powsybl.sld.svg.DefaultDiagramLabelProvider;
 import com.powsybl.sld.svg.DiagramStyleProvider;
@@ -314,8 +302,7 @@ public class TestCase12GraphWith3WT extends AbstractTestCaseIidm {
         DiagramStyleProvider vNomStyleProvider = new NominalVoltageDiagramStyleProvider(network);
         DiagramStyleProvider topoStyleProvider = new TopologicalStyleProvider(network);
 
-        ComponentLibrary componentLibrary = new ResourcesComponentLibrary("/ConvergenceLibrary");
-        DefaultDiagramLabelProvider initProvider = new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters);
+        DefaultDiagramLabelProvider initProvider = new DefaultDiagramLabelProvider(network, getResourcesComponentLibrary(), layoutParameters);
 
         // write SVGs and compare to reference
         assertEquals(toString("/TestCase12GraphWithNodesInfosNominalVoltage.svg"),

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/InitialValueProviderTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/InitialValueProviderTest.java
@@ -89,7 +89,7 @@ public class InitialValueProviderTest {
     @Test
     public void test() {
         Network network2 = Network.create("testCase2", "test2");
-        ComponentLibrary componentLibrary = new ResourcesComponentLibrary("/ConvergenceLibrary");
+        ComponentLibrary componentLibrary = new ResourcesComponentLibrary();
         LayoutParameters layoutParameters = new LayoutParameters();
         DefaultDiagramLabelProvider initProvider = new DefaultDiagramLabelProvider(network2, componentLibrary, layoutParameters);
         Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, false);

--- a/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
+++ b/single-line-diagram-view-app/src/main/java/com/powsybl/sld/view/app/AbstractSingleLineDiagramViewer.java
@@ -93,7 +93,7 @@ public abstract class AbstractSingleLineDiagramViewer extends Application implem
 
     private Map<String, SubstationLayoutFactory> substationsLayouts = new LinkedHashMap<>();
 
-    private final ComponentLibrary convergenceComponentLibrary = new ResourcesComponentLibrary("/ConvergenceLibrary");
+    private final ComponentLibrary convergenceComponentLibrary = new ResourcesComponentLibrary();
 
     private final Map<String, ComponentLibrary> svgLibraries
             = ImmutableMap.of("CVG Design", convergenceComponentLibrary);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Creating a new ResourcesComponentLibrary requires to know in which directory the default components are.


**What is the new behavior (if this is a feature change)?**
Creating a new ResourcesComponentLibrary can be done without specifying the directory to get the default library.


**Does this PR introduce a breaking change or deprecate an API?**
No