### PR TITLE
Clean Gephi dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,13 @@
                 <groupId>org.gephi</groupId>
                 <artifactId>layout-plugin</artifactId>
                 <version>${gephi.version}</version>
+                <exclusions>
+                    <!-- there is a license issue with itextpdf and we don't need it -->
+                    <exclusion>
+                        <groupId>com.itextpdf</groupId>
+                        <artifactId>itextpdf</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.netbeans.api</groupId>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Dependency cleanup


**What is the current behavior?** *(You can also link to an open issue here)*
We depend on itextpdf through gephi which has an incompatible license.


**What is the new behavior (if this is a feature change)?**
itextpdf is not used and has been excluded.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
