### PR TITLE
Correct breaker fill color missing

### DIFF
--- a/single-line-diagram-core/src/main/resources/baseVoltageConstantColors.css
+++ b/single-line-diagram-core/src/main/resources/baseVoltageConstantColors.css
@@ -1,6 +1,6 @@
 .sld-constant-color {fill: none}
 .sld-node.sld-constant-color {stroke: none; fill: black}
 .sld-busbreaker-connection.sld-constant-color {stroke: black}
-.sld-breaker.sld-constant-color {stroke: blue;}
+.sld-breaker.sld-constant-color {stroke: blue; fill: white}
 .sld-disconnector.sld-constant-color {stroke: black}
 .sld-label {fill: black; stroke: none;}

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -25,7 +25,7 @@ polyline {fill: none}
 .sld-constant-color {fill: none}
 .sld-node.sld-constant-color {stroke: none; fill: black}
 .sld-busbreaker-connection.sld-constant-color {stroke: black}
-.sld-breaker.sld-constant-color {stroke: blue;}
+.sld-breaker.sld-constant-color {stroke: blue; fill: white}
 .sld-disconnector.sld-constant-color {stroke: black}
 .sld-label {fill: black; stroke: none;}
 .sld-busbar-section {stroke-width: 3}

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -99,7 +99,7 @@ polyline {fill: none}
 .sld-constant-color {fill: none}
 .sld-node.sld-constant-color {stroke: none; fill: black}
 .sld-busbreaker-connection.sld-constant-color {stroke: black}
-.sld-breaker.sld-constant-color {stroke: blue;}
+.sld-breaker.sld-constant-color {stroke: blue; fill: white}
 .sld-disconnector.sld-constant-color {stroke: black}
 .sld-label {fill: black; stroke: none;}
 .sld-busbar-section {stroke-width: 3}

--- a/single-line-diagram-core/src/test/resources/vl1_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_nominal_voltage_style.svg
@@ -25,7 +25,7 @@ polyline {fill: none}
 .sld-constant-color {fill: none}
 .sld-node.sld-constant-color {stroke: none; fill: black}
 .sld-busbreaker-connection.sld-constant-color {stroke: black}
-.sld-breaker.sld-constant-color {stroke: blue;}
+.sld-breaker.sld-constant-color {stroke: blue; fill: white}
 .sld-disconnector.sld-constant-color {stroke: black}
 .sld-label {fill: black; stroke: none;}
 .sld-busbar-section {stroke-width: 3}

--- a/single-line-diagram-core/src/test/resources/vl2_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_nominal_voltage_style.svg
@@ -25,7 +25,7 @@ polyline {fill: none}
 .sld-constant-color {fill: none}
 .sld-node.sld-constant-color {stroke: none; fill: black}
 .sld-busbreaker-connection.sld-constant-color {stroke: black}
-.sld-breaker.sld-constant-color {stroke: blue;}
+.sld-breaker.sld-constant-color {stroke: blue; fill: white}
 .sld-disconnector.sld-constant-color {stroke: black}
 .sld-label {fill: black; stroke: none;}
 .sld-busbar-section {stroke-width: 3}

--- a/single-line-diagram-core/src/test/resources/vl3_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_nominal_voltage_style.svg
@@ -25,7 +25,7 @@ polyline {fill: none}
 .sld-constant-color {fill: none}
 .sld-node.sld-constant-color {stroke: none; fill: black}
 .sld-busbreaker-connection.sld-constant-color {stroke: black}
-.sld-breaker.sld-constant-color {stroke: blue;}
+.sld-breaker.sld-constant-color {stroke: blue; fill: white}
 .sld-disconnector.sld-constant-color {stroke: black}
 .sld-label {fill: black; stroke: none;}
 .sld-busbar-section {stroke-width: 3}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Breaker fill color is missing for TopologicalStyleProvider and NominalVoltageDiagramStyleProvider


**What is the new behavior (if this is a feature change)?**
Breaker fill color set to white for those DiagramStyleProviders


**Does this PR introduce a breaking change or deprecate an API?** 
No