### PR TITLE
Correct vertical intern cells instability

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Subsection.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Subsection.java
@@ -126,7 +126,7 @@ public class Subsection {
     }
 
     private static void identifyVerticalInternCells(Graph graph, List<Subsection> subsections) {
-        Map<InternCell, Subsection> verticalCells = new HashMap<>();
+        Map<InternCell, Subsection> verticalCells = new LinkedHashMap<>();
 
         graph.getCells().stream()
                 .filter(c -> c.getType() == Cell.CellType.INTERN

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase3TripleCoupling.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase3TripleCoupling.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.iidm;
+
+import com.powsybl.iidm.network.SwitchKind;
+import com.powsybl.sld.layout.BlockOrganizer;
+import com.powsybl.sld.layout.ImplicitCellDetector;
+import com.powsybl.sld.layout.PositionVoltageLevelLayout;
+import com.powsybl.sld.model.Graph;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * <pre>
+ *     b        b2       b3
+ *    / \      / \      / \
+ *   |   |    |   |    |   |
+ * -d1---|---d3---|---d6---|---- bbs1
+ *       |    |   |        |
+ * -----d2---d4--d5-------d7---- bbs2
+ *
+ * </pre>
+ *
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class TestCase3TripleCoupling extends TestCase3Coupling {
+
+    @Before
+    public void setUp() {
+        // we add two other coupling to TestCase3Coupling setUp
+        super.setUp();
+
+        // second coupling
+        createSwitch(vl, "d3", "d3", SwitchKind.DISCONNECTOR, false, false, false, 0, 4);
+        createSwitch(vl, "d4", "d4", SwitchKind.DISCONNECTOR, false, false, false, 3, 4);
+        createSwitch(vl, "b2", "b2", SwitchKind.BREAKER, false, false, false, 4, 5);
+        createSwitch(vl, "d5", "d5", SwitchKind.DISCONNECTOR, false, false, false, 5, 3);
+
+        // third coupling
+        createSwitch(vl, "d6", "d6", SwitchKind.DISCONNECTOR, false, false, false, 0, 6);
+        createSwitch(vl, "b3", "b3", SwitchKind.BREAKER, false, false, false, 6, 7);
+        createSwitch(vl, "d7", "d7", SwitchKind.DISCONNECTOR, false, false, false, 7, 3);
+    }
+
+    @Test
+    public void test() {
+        // build graph
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
+
+        // detect cells
+        new ImplicitCellDetector().detectCells(g);
+
+        // build blocks
+        new BlockOrganizer().organize(g);
+
+        // calculate coordinates
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
+
+        // write Json and compare to reference
+        assertEquals(toString("/TestCase3TripleCoupling.json"), toJson(g, "/TestCase3TripleCoupling.json"));
+    }
+
+    @Test
+    public void testDisconnectorOpen() {
+        // the displayed result should remain the same in terms of intern cells order after opening a switch
+        network.getSwitch("d3").setOpen(true);
+
+        // build graph
+        Graph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), false, true);
+
+        // detect cells
+        new ImplicitCellDetector().detectCells(g);
+
+        // build blocks
+        new BlockOrganizer().organize(g);
+
+        // calculate coordinates
+        new PositionVoltageLevelLayout(g).run(getLayoutParameters());
+
+        // write Json and compare to reference
+        String reference = toString("/TestCase3TripleCoupling.json");
+        int d3Index = reference.indexOf("d3");
+        int d3StateIndex = d3Index + reference.substring(d3Index).indexOf("\"open\" : false");
+        reference = reference.substring(0, d3StateIndex) + reference.substring(d3StateIndex).replaceFirst("\"open\" : false", "\"open\" : true");
+        assertEquals(reference, toJson(g, "/TestCase3TripleCoupling_disconnectorOpen.json"));
+    }
+}

--- a/single-line-diagram-core/src/test/resources/TestCase3TripleCoupling.json
+++ b/single-line-diagram-core/src/test/resources/TestCase3TripleCoupling.json
@@ -1,0 +1,595 @@
+{
+  "voltageLevelInfos" : {
+    "id" : "vl",
+    "name" : "vl",
+    "nominalVoltage" : 380.0
+  },
+  "x" : 0.0,
+  "y" : 0.0,
+  "nodes" : [ {
+    "type" : "FICTITIOUS",
+    "id" : "FICT_vl_4",
+    "name" : "4",
+    "equipmentId" : "4",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 125.0,
+    "y" : 220.0,
+    "rotationAngle" : 90.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "FICT_vl_d1Fictif",
+    "name" : "d1Fictif",
+    "equipmentId" : "d1Fictif",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 75.0,
+    "y" : 220.0,
+    "rotationAngle" : 90.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "FICT_vl_d2Fictif",
+    "name" : "d2Fictif",
+    "equipmentId" : "d2Fictif",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 25.0,
+    "y" : 220.0,
+    "rotationAngle" : 90.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "FICT_vl_d5Fictif",
+    "name" : "d5Fictif",
+    "equipmentId" : "d5Fictif",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 175.0,
+    "y" : 220.0,
+    "rotationAngle" : 90.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "FICT_vl_d6Fictif",
+    "name" : "d6Fictif",
+    "equipmentId" : "d6Fictif",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 275.0,
+    "y" : 220.0,
+    "rotationAngle" : 90.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "FICT_vl_d7Fictif",
+    "name" : "d7Fictif",
+    "equipmentId" : "d7Fictif",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 225.0,
+    "y" : 220.0,
+    "rotationAngle" : 90.0,
+    "open" : false
+  }, {
+    "type" : "SWITCH",
+    "id" : "b",
+    "name" : "b",
+    "equipmentId" : "b",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 50.0,
+    "y" : 220.0,
+    "rotationAngle" : 90.0,
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "SWITCH",
+    "id" : "b2",
+    "name" : "b2",
+    "equipmentId" : "b2",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 150.0,
+    "y" : 220.0,
+    "rotationAngle" : 90.0,
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "SWITCH",
+    "id" : "b3",
+    "name" : "b3",
+    "equipmentId" : "b3",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 250.0,
+    "y" : 220.0,
+    "rotationAngle" : 90.0,
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "BUS",
+    "id" : "bbs1",
+    "name" : "bbs1",
+    "equipmentId" : "bbs1",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 10.0,
+    "y" : 260.0,
+    "open" : false,
+    "pxWidth" : 280.0,
+    "busbarIndex" : 1,
+    "sectionIndex" : 1,
+    "position" : {
+      "h" : 0,
+      "v" : 1,
+      "hSpan" : 12,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "BUS",
+    "id" : "bbs2",
+    "name" : "bbs2",
+    "equipmentId" : "bbs2",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 10.0,
+    "y" : 285.0,
+    "open" : false,
+    "pxWidth" : 280.0,
+    "busbarIndex" : 2,
+    "sectionIndex" : 1,
+    "position" : {
+      "h" : 0,
+      "v" : 2,
+      "hSpan" : 12,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "SWITCH",
+    "id" : "d1",
+    "name" : "d1",
+    "equipmentId" : "d1",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 75.0,
+    "y" : 260.0,
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d2",
+    "name" : "d2",
+    "equipmentId" : "d2",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 25.0,
+    "y" : 285.0,
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d3",
+    "name" : "d3",
+    "equipmentId" : "d3",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 125.0,
+    "y" : 260.0,
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d4",
+    "name" : "d4",
+    "equipmentId" : "d4",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 125.0,
+    "y" : 285.0,
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d5",
+    "name" : "d5",
+    "equipmentId" : "d5",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 175.0,
+    "y" : 285.0,
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d6",
+    "name" : "d6",
+    "equipmentId" : "d6",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 275.0,
+    "y" : 260.0,
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d7",
+    "name" : "d7",
+    "equipmentId" : "d7",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 225.0,
+    "y" : 285.0,
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  } ],
+  "cells" : [ {
+    "type" : "INTERN",
+    "number" : 0,
+    "direction" : "TOP",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : -1,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 260.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs2", "d2", "FICT_vl_d2Fictif" ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 2,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 220.0,
+          "xSpan" : 50.0,
+          "ySpan" : 40.0
+        },
+        "nodes" : [ "FICT_vl_d2Fictif", "b", "FICT_vl_d1Fictif" ]
+      }, {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 2,
+          "v" : -1,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 260.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs1", "d1", "FICT_vl_d1Fictif" ]
+      } ]
+    }
+  }, {
+    "type" : "INTERN",
+    "number" : 1,
+    "direction" : "TOP",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 2
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "LEGPARALLEL",
+        "cardinalities" : [ {
+          "START" : 2
+        }, {
+          "END" : 2
+        } ],
+        "position" : {
+          "h" : 4,
+          "v" : -1,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 260.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "subBlocks" : [ {
+          "type" : "LEGPRIMARY",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 0,
+            "hSpan" : 2,
+            "vSpan" : 0,
+            "orientation" : "UP"
+          },
+          "coord" : {
+            "x" : 125.0,
+            "y" : 260.0,
+            "xSpan" : 50.0,
+            "ySpan" : 0.0
+          },
+          "nodes" : [ "bbs2", "d4", "FICT_vl_4" ]
+        }, {
+          "type" : "LEGPRIMARY",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 0,
+            "hSpan" : 2,
+            "vSpan" : 0,
+            "orientation" : "UP"
+          },
+          "coord" : {
+            "x" : 125.0,
+            "y" : 260.0,
+            "xSpan" : 50.0,
+            "ySpan" : 0.0
+          },
+          "nodes" : [ "bbs1", "d3", "FICT_vl_4" ]
+        } ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 4,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 2,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 220.0,
+          "xSpan" : 50.0,
+          "ySpan" : 40.0
+        },
+        "nodes" : [ "FICT_vl_4", "b2", "FICT_vl_d5Fictif" ]
+      }, {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 6,
+          "v" : -1,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 175.0,
+          "y" : 260.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs2", "d5", "FICT_vl_d5Fictif" ]
+      } ]
+    }
+  }, {
+    "type" : "INTERN",
+    "number" : 2,
+    "direction" : "TOP",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 8,
+          "v" : -1,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 225.0,
+          "y" : 260.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs2", "d7", "FICT_vl_d7Fictif" ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 8,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 2,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 225.0,
+          "y" : 220.0,
+          "xSpan" : 50.0,
+          "ySpan" : 40.0
+        },
+        "nodes" : [ "FICT_vl_d7Fictif", "b3", "FICT_vl_d6Fictif" ]
+      }, {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 10,
+          "v" : -1,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 275.0,
+          "y" : 260.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs1", "d6", "FICT_vl_d6Fictif" ]
+      } ]
+    }
+  } ],
+  "edges" : [ {
+    "node1" : "bbs1",
+    "node2" : "d1"
+  }, {
+    "node1" : "d2",
+    "node2" : "bbs2"
+  }, {
+    "node1" : "bbs1",
+    "node2" : "d3"
+  }, {
+    "node1" : "d3",
+    "node2" : "FICT_vl_4"
+  }, {
+    "node1" : "bbs2",
+    "node2" : "d4"
+  }, {
+    "node1" : "d4",
+    "node2" : "FICT_vl_4"
+  }, {
+    "node1" : "FICT_vl_4",
+    "node2" : "b2"
+  }, {
+    "node1" : "d5",
+    "node2" : "bbs2"
+  }, {
+    "node1" : "bbs1",
+    "node2" : "d6"
+  }, {
+    "node1" : "d7",
+    "node2" : "bbs2"
+  }, {
+    "node1" : "b",
+    "node2" : "FICT_vl_d1Fictif"
+  }, {
+    "node1" : "d1",
+    "node2" : "FICT_vl_d1Fictif"
+  }, {
+    "node1" : "b3",
+    "node2" : "FICT_vl_d6Fictif"
+  }, {
+    "node1" : "d6",
+    "node2" : "FICT_vl_d6Fictif"
+  }, {
+    "node1" : "b",
+    "node2" : "FICT_vl_d2Fictif"
+  }, {
+    "node1" : "d2",
+    "node2" : "FICT_vl_d2Fictif"
+  }, {
+    "node1" : "b2",
+    "node2" : "FICT_vl_d5Fictif"
+  }, {
+    "node1" : "d5",
+    "node2" : "FICT_vl_d5Fictif"
+  }, {
+    "node1" : "b3",
+    "node2" : "FICT_vl_d7Fictif"
+  }, {
+    "node1" : "d7",
+    "node2" : "FICT_vl_d7Fictif"
+  } ]
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When there are several vertical intern cells in a voltage level, their order is not stable (in particular it can be seen when changing disconnector state)


**What is the new behavior (if this is a feature change)?**
Stable ordering


**Does this PR introduce a breaking change or deprecate an API?** 
No