### PR TITLE
Fix for BusBreakerConnection creation with a switch connected on a empty bus

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Graph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Graph.java
@@ -488,7 +488,7 @@ public final class Graph {
     public void substituteFictitiousNodesMirroringBusNodes() {
         getNodeBuses().forEach(busNode -> {
             List<Node> adjs = busNode.getAdjacentNodes();
-            if (adjs.size() == 1 && adjs.get(0).getType() == Node.NodeType.FICTITIOUS) {
+            if (adjs.size() == 1 && adjs.get(0).getType() == Node.NodeType.FICTITIOUS && !(adjs.get(0) instanceof BusBreakerConnection)) {
                 Node adj = adjs.get(0);
                 removeEdge(adj, busNode);
                 substituteNode(adj, busNode);

--- a/single-line-diagram-core/src/test/resources/TestCase1BusBreaker.json
+++ b/single-line-diagram-core/src/test/resources/TestCase1BusBreaker.json
@@ -18,6 +18,17 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
+    "id" : "FICT_vl_b1_sw",
+    "name" : "b1_sw",
+    "equipmentId" : "b1_sw",
+    "componentType" : "BUSBREAKER_CONNECTION",
+    "fictitious" : true,
+    "x" : 25.0,
+    "y" : 285.0,
+    "rotationAngle" : 90.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
     "id" : "FICT_vl_b2_sw",
     "name" : "b2_sw",
     "equipmentId" : "b2_sw",
@@ -36,17 +47,6 @@
     "fictitious" : true,
     "x" : 125.0,
     "y" : 42.0,
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "FICT_vl_swfNode",
-    "name" : "swfNode",
-    "equipmentId" : "swfNode",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 25.0,
-    "y" : 220.0,
-    "rotationAngle" : 90.0,
     "open" : false
   }, {
     "type" : "BUS",
@@ -111,17 +111,6 @@
     "rotationAngle" : 90.0,
     "open" : false,
     "kind" : "BREAKER"
-  }, {
-    "type" : "SWITCH",
-    "id" : "swfSwitch",
-    "name" : "swfSwitch",
-    "equipmentId" : "swfSwitch",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 25.0,
-    "y" : 285.0,
-    "open" : false,
-    "kind" : "DISCONNECTOR"
   } ],
   "cells" : [ {
     "type" : "INTERN",
@@ -166,7 +155,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "b2", "swfSwitch", "FICT_vl_swfNode" ]
+        "nodes" : [ "b2", "FICT_vl_b1_sw" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -187,7 +176,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "FICT_vl_swfNode", "sw", "FICT_vl_b2_sw" ]
+        "nodes" : [ "FICT_vl_b1_sw", "sw", "FICT_vl_b2_sw" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -306,25 +295,22 @@
     "node1" : "b1",
     "node2" : "FICT_vl_b1_l"
   }, {
+    "node1" : "FICT_vl_b1_sw",
+    "node2" : "sw"
+  }, {
     "node1" : "FICT_vl_b2_sw",
     "node2" : "sw"
   }, {
     "node1" : "b1",
     "node2" : "FICT_vl_b2_sw"
   }, {
+    "node1" : "FICT_vl_b1_sw",
+    "node2" : "b2"
+  }, {
     "node1" : "FICT_vl_b1_l",
     "node2" : "FICT_vl_lFictif"
   }, {
     "node1" : "FICT_vl_lFictif",
     "node2" : "l"
-  }, {
-    "node1" : "b2",
-    "node2" : "swfSwitch"
-  }, {
-    "node1" : "swfSwitch",
-    "node2" : "FICT_vl_swfNode"
-  }, {
-    "node1" : "FICT_vl_swfNode",
-    "node2" : "sw"
   } ]
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
BusBreakerConnection not created with a switch connected on a empty bus


**What is the new behavior (if this is a feature change)?**
BusBreakerConnection  created with a switch connected on a empty bus


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No
