### PR TITLE
Creation of a BranchStatus extension

### DIFF
--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatus.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatus.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.iidm.extensions;
+
+import com.powsybl.commons.extensions.Extension;
+import com.powsybl.iidm.network.Connectable;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+public interface BranchStatus<C extends Connectable<C>> extends Extension<C> {
+
+    static final String NAME = "branchStatus";
+
+    public enum Status {
+        IN_OPERATION,
+        PLANNED_OUTAGE,
+        FORCED_OUTAGE
+    }
+
+    @Override
+    default String getName() {
+        return NAME;
+    }
+
+    Status getStatus();
+
+    BranchStatus setStatus(Status status);
+}

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusAdder.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusAdder.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.iidm.extensions;
+
+import com.powsybl.commons.extensions.ExtensionAdder;
+import com.powsybl.iidm.network.Connectable;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+public interface BranchStatusAdder<C extends Connectable<C>> extends ExtensionAdder<C, BranchStatus<C>> {
+
+    default Class<BranchStatus> getExtensionClass() {
+        return BranchStatus.class;
+    }
+
+    BranchStatusAdder withStatus(BranchStatus.Status branchStatus);
+
+}

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusAdderImpl.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusAdderImpl.java
@@ -1,8 +1,17 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.sld.iidm.extensions;
 
 import com.powsybl.commons.extensions.AbstractExtensionAdder;
 import com.powsybl.iidm.network.Connectable;
 
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
 public class BranchStatusAdderImpl<C extends Connectable<C>> extends AbstractExtensionAdder<C, BranchStatus<C>>
         implements BranchStatusAdder<C> {
 

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusAdderImpl.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusAdderImpl.java
@@ -9,6 +9,8 @@ package com.powsybl.sld.iidm.extensions;
 import com.powsybl.commons.extensions.AbstractExtensionAdder;
 import com.powsybl.iidm.network.Connectable;
 
+import java.util.Objects;
+
 /**
  * @author Nicolas Noir <nicolas.noir at rte-france.com>
  */
@@ -28,6 +30,7 @@ public class BranchStatusAdderImpl<C extends Connectable<C>> extends AbstractExt
 
     @Override
     public BranchStatusAdder withStatus(BranchStatus.Status branchStatus) {
+        Objects.requireNonNull(branchStatus);
         this.status = branchStatus;
         return this;
     }

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusAdderImpl.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusAdderImpl.java
@@ -1,0 +1,25 @@
+package com.powsybl.sld.iidm.extensions;
+
+import com.powsybl.commons.extensions.AbstractExtensionAdder;
+import com.powsybl.iidm.network.Connectable;
+
+public class BranchStatusAdderImpl<C extends Connectable<C>> extends AbstractExtensionAdder<C, BranchStatus<C>>
+        implements BranchStatusAdder<C> {
+
+    private BranchStatus.Status status = BranchStatus.Status.IN_OPERATION;
+
+    BranchStatusAdderImpl(C branch) {
+        super(branch);
+    }
+
+    @Override
+    protected BranchStatus createExtension(Connectable branch) {
+        return new BranchStatusImpl(branch, status);
+    }
+
+    @Override
+    public BranchStatusAdder withStatus(BranchStatus.Status branchStatus) {
+        this.status = branchStatus;
+        return this;
+    }
+}

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusAdderImplProvider.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusAdderImplProvider.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.iidm.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.ExtensionAdderProvider;
+import com.powsybl.iidm.network.Connectable;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+@AutoService(ExtensionAdderProvider.class)
+public class BranchStatusAdderImplProvider<C extends Connectable<C>> implements
+        ExtensionAdderProvider<C, BranchStatus<C>, BranchStatusAdderImpl<C>> {
+
+    @Override
+    public String getImplementationName() {
+        return "Default";
+    }
+
+    @Override
+    public Class<BranchStatusAdderImpl> getAdderClass() {
+        return BranchStatusAdderImpl.class;
+    }
+
+    @Override
+    public BranchStatusAdderImpl<C> newAdder(C connectable) {
+        return new BranchStatusAdderImpl<>(connectable);
+    }
+
+}

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusImpl.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusImpl.java
@@ -1,8 +1,17 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.sld.iidm.extensions;
 
 import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.iidm.network.Connectable;
 
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
 public class BranchStatusImpl<C extends Connectable<C>> extends AbstractExtension<C> implements BranchStatus<C> {
 
     private Status status;

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusImpl.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusImpl.java
@@ -1,0 +1,24 @@
+package com.powsybl.sld.iidm.extensions;
+
+import com.powsybl.commons.extensions.AbstractExtension;
+import com.powsybl.iidm.network.Connectable;
+
+public class BranchStatusImpl<C extends Connectable<C>> extends AbstractExtension<C> implements BranchStatus<C> {
+
+    private Status status;
+
+    public BranchStatusImpl(C branch, Status branchStatus) {
+        super(branch);
+        this.status = branchStatus;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public BranchStatus setStatus(Status branchStatus) {
+        this.status = branchStatus;
+        return this;
+    }
+
+}

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusImpl.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusImpl.java
@@ -9,6 +9,8 @@ package com.powsybl.sld.iidm.extensions;
 import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.iidm.network.Connectable;
 
+import java.util.Objects;
+
 /**
  * @author Nicolas Noir <nicolas.noir at rte-france.com>
  */
@@ -26,6 +28,7 @@ public class BranchStatusImpl<C extends Connectable<C>> extends AbstractExtensio
     }
 
     public BranchStatus setStatus(Status branchStatus) {
+        Objects.requireNonNull(branchStatus);
         this.status = branchStatus;
         return this;
     }

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusXmlSerializer.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusXmlSerializer.java
@@ -38,7 +38,7 @@ public class BranchStatusXmlSerializer<C extends Connectable<C>> implements Exte
 
     @Override
     public boolean hasSubElements() {
-        return true;
+        return false;
     }
 
     @Override

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusXmlSerializer.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusXmlSerializer.java
@@ -9,6 +9,7 @@ package com.powsybl.sld.iidm.extensions;
 import com.google.auto.service.AutoService;
 import com.powsybl.commons.extensions.ExtensionXmlSerializer;
 import com.powsybl.commons.xml.XmlReaderContext;
+import com.powsybl.commons.xml.XmlUtil;
 import com.powsybl.commons.xml.XmlWriterContext;
 import com.powsybl.iidm.network.Connectable;
 
@@ -38,7 +39,7 @@ public class BranchStatusXmlSerializer<C extends Connectable<C>> implements Exte
 
     @Override
     public boolean hasSubElements() {
-        return false;
+        return true;
     }
 
     @Override
@@ -58,12 +59,12 @@ public class BranchStatusXmlSerializer<C extends Connectable<C>> implements Exte
 
     @Override
     public void write(BranchStatus branchStatus, XmlWriterContext context) throws XMLStreamException {
-        context.getExtensionsWriter().writeAttribute("status", branchStatus.getStatus().name());
+        context.getExtensionsWriter().writeCharacters(branchStatus.getStatus().name());
     }
 
     @Override
-    public BranchStatus read(Connectable connectable, XmlReaderContext context) {
-        BranchStatus.Status status = BranchStatus.Status.valueOf(context.getReader().getAttributeValue(null, "status"));
+    public BranchStatus read(Connectable connectable, XmlReaderContext context) throws XMLStreamException {
+        BranchStatus.Status status = BranchStatus.Status.valueOf(XmlUtil.readText("branchStatus", context.getReader()));
         ((Connectable<?>) connectable).newExtension(BranchStatusAdder.class)
                 .withStatus(status)
                 .add();

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusXmlSerializer.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/BranchStatusXmlSerializer.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.iidm.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.ExtensionXmlSerializer;
+import com.powsybl.commons.xml.XmlReaderContext;
+import com.powsybl.commons.xml.XmlWriterContext;
+import com.powsybl.iidm.network.Connectable;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.InputStream;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+@AutoService(ExtensionXmlSerializer.class)
+public class BranchStatusXmlSerializer<C extends Connectable<C>> implements ExtensionXmlSerializer<C, BranchStatus<C>> {
+
+    @Override
+    public String getExtensionName() {
+        return  BranchStatus.NAME;
+    }
+
+    @Override
+    public String getCategoryName() {
+        return "network";
+    }
+
+    @Override
+    public Class<? super BranchStatus> getExtensionClass() {
+        return BranchStatus.class;
+    }
+
+    @Override
+    public boolean hasSubElements() {
+        return true;
+    }
+
+    @Override
+    public InputStream getXsdAsStream() {
+        return getClass().getResourceAsStream("/xsd/branchStatus.xsd");
+    }
+
+    @Override
+    public String getNamespaceUri() {
+        return "http://www.powsybl.org/schema/iidm/ext/branch_status/1_0";
+    }
+
+    @Override
+    public String getNamespacePrefix() {
+        return "bs";
+    }
+
+    @Override
+    public void write(BranchStatus branchStatus, XmlWriterContext context) throws XMLStreamException {
+        context.getExtensionsWriter().writeAttribute("status", branchStatus.getStatus().name());
+    }
+
+    @Override
+    public BranchStatus read(Connectable connectable, XmlReaderContext context) {
+        BranchStatus.Status status = BranchStatus.Status.valueOf(context.getReader().getAttributeValue(null, "status"));
+        ((Connectable<?>) connectable).newExtension(BranchStatusAdder.class)
+                .withStatus(status)
+                .add();
+        return ((Connectable<?>) connectable).getExtension(BranchStatus.class);
+    }
+}

--- a/single-line-diagram-iidm-extensions/src/main/resources/xsd/branchStatus.xsd
+++ b/single-line-diagram-iidm-extensions/src/main/resources/xsd/branchStatus.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<xs:schema version="1.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:cp="http://www.powsybl.org/schema/iidm/ext/branch_status/1_0"
+           targetNamespace="http://www.powsybl.org/schema/iidm/ext/branch_status/1_0"
+           elementFormDefault="qualified">
+    <xs:simpleType name="BranchStatus">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="IN_OPERATION"/>
+            <xs:enumeration value="PLANNED_OUTAGE"/>
+            <xs:enumeration value="FORCED_OUTAGE"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="branchStatus">
+        <xs:complexType>
+            <xs:attribute name="status" use="required" type="cp:BranchStatus"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/single-line-diagram-iidm-extensions/src/main/resources/xsd/branchStatus.xsd
+++ b/single-line-diagram-iidm-extensions/src/main/resources/xsd/branchStatus.xsd
@@ -9,7 +9,7 @@
 -->
 <xs:schema version="1.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:cp="http://www.powsybl.org/schema/iidm/ext/branch_status/1_0"
+           xmlns:bs="http://www.powsybl.org/schema/iidm/ext/branch_status/1_0"
            targetNamespace="http://www.powsybl.org/schema/iidm/ext/branch_status/1_0"
            elementFormDefault="qualified">
     <xs:simpleType name="BranchStatus">
@@ -19,9 +19,5 @@
             <xs:enumeration value="FORCED_OUTAGE"/>
         </xs:restriction>
     </xs:simpleType>
-    <xs:element name="branchStatus">
-        <xs:complexType>
-            <xs:attribute name="status" use="required" type="cp:BranchStatus"/>
-        </xs:complexType>
-    </xs:element>
+    <xs:element name="branchStatus" type="bs:BranchStatus"/>
 </xs:schema>

--- a/single-line-diagram-iidm-extensions/src/test/java/com/powsybl/sld/iidm/extensions/BranchStatusXmlTest.java
+++ b/single-line-diagram-iidm-extensions/src/test/java/com/powsybl/sld/iidm/extensions/BranchStatusXmlTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.iidm.extensions;
+
+import com.powsybl.commons.AbstractConverterTest;
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.xml.NetworkXml;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+public class BranchStatusXmlTest  extends AbstractConverterTest {
+
+    private static Network createTestNetwork() {
+        Network network = Network.create("test", "test");
+        network.setCaseDate(DateTime.parse("2016-06-27T12:27:58.535+02:00"));
+        Substation s = network.newSubstation()
+                .setId("S")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl = s.newVoltageLevel()
+                .setId("VL")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        Substation s2 = network.newSubstation()
+                .setId("S2")
+                .setCountry(Country.FR)
+                .add();
+        VoltageLevel vl2 = s2.newVoltageLevel()
+                .setId("VL2")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+        network.newLine()
+                .setId("L")
+                .setVoltageLevel1("VL")
+                .setNode1(2)
+                .setVoltageLevel2("VL2")
+                .setNode2(0)
+                .setR(1)
+                .setX(1)
+                .setG1(0)
+                .setG2(0)
+                .setB1(0)
+                .setB2(0)
+                .add();
+        return network;
+    }
+
+    @Test
+    public void test() throws IOException {
+        Network network = createTestNetwork();
+
+        // extend line
+        Line line = network.getLine("L");
+        assertNotNull(line);
+        BranchStatus<Line> lineBranchStatus = new BranchStatusImpl<>(line,
+                BranchStatus.Status.PLANNED_OUTAGE);
+        line.addExtension(BranchStatus.class, lineBranchStatus);
+
+        Network network2 = roundTripXmlTest(network,
+                NetworkXml::writeAndValidate,
+                NetworkXml::read,
+                "/branchStatusRef.xml");
+
+        Line line2 = network2.getLine("L");
+        assertNotNull(line2);
+        BranchStatus lineBranchStatus2 = line2.getExtension(BranchStatus.class);
+        assertNotNull(lineBranchStatus2);
+        assertEquals(lineBranchStatus.getStatus(), lineBranchStatus2.getStatus());
+    }
+}

--- a/single-line-diagram-iidm-extensions/src/test/resources/branchStatusRef.xml
+++ b/single-line-diagram-iidm-extensions/src/test/resources/branchStatusRef.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_5" xmlns:bs="http://www.powsybl.org/schema/iidm/ext/branch_status/1_0" id="test" caseDate="2016-06-27T12:27:58.535+02:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="S" country="FR">
+        <iidm:voltageLevel id="VL" nominalV="400.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology></iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S2" country="FR">
+        <iidm:voltageLevel id="VL2" nominalV="400.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology></iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="L" r="1.0" x="1.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL" node2="0" voltageLevelId2="VL2"/>
+    <iidm:extension id="L">
+        <bs:branchStatus status="PLANNED_OUTAGE"/>
+    </iidm:extension>
+</iidm:network>

--- a/single-line-diagram-iidm-extensions/src/test/resources/branchStatusRef.xml
+++ b/single-line-diagram-iidm-extensions/src/test/resources/branchStatusRef.xml
@@ -12,6 +12,6 @@
     </iidm:substation>
     <iidm:line id="L" r="1.0" x="1.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="2" voltageLevelId1="VL" node2="0" voltageLevelId2="VL2"/>
     <iidm:extension id="L">
-        <bs:branchStatus status="PLANNED_OUTAGE"/>
+        <bs:branchStatus>PLANNED_OUTAGE</bs:branchStatus>
     </iidm:extension>
 </iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR introduces a new kind of extension, the BranchStatus. This extension allows to add a new status on a branch (or a three windings transformer). The possible values for this status are: "In operation", "Planned outage" and "Forced outage"
This will allow to clearly represent these three possible states of a branch on the single line diagram.

**What is the current behavior?** *(You can also link to an open issue here)*
Currently, the planned outage or forced outage statuses of a branch are not modeled (nor displayed) on the single line diagram.


**What is the new behavior (if this is a feature change)?**
The new branch statuses will now be modeled (and displayed) on the single line diagram.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
