### PR TITLE
Update actions to latest versions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2.3.4
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,8 +15,9 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Set up JDK 11
-        uses: actions/setup-java@master
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: 11
 
       - name: Build with Maven


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Bug fix / library update


**What is the current behavior?** *(You can also link to an open issue here)*
actions checkout uses version 1.0.0
actions setup-java uses master version
CI stops when setting up JDK 11 with error message `Error: Input required and not supplied: distribution`


**What is the new behavior (if this is a feature change)?**
actions checkout uses [latest version 2.3.4](https://github.com/actions/checkout/releases/tag/v2.3.4)
actions setup-java uses [latest version 2.0.0](https://github.com/actions/setup-java/releases/tag/v2.0.0)
CI succeeds when setting up JDK 11


**Does this PR introduce a breaking change or deprecate an API?** 
No