### PR TITLE
Remove guava direct dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
         <joda-time.version>2.9.7</joda-time.version>
         <junit.version>4.13.1</junit.version>
         <logback.version>1.2.3</logback.version>
-        <guava.version>27.0.1-jre</guava.version>
         <mockito.version>1.10.19</mockito.version>
         <slf4j.version>1.7.22</slf4j.version>
         <xmlunit.version>2.3.0</xmlunit.version>
@@ -154,11 +153,6 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?**
Dependency fix


**What is the current behavior?**
Guava is listed as a direct dependency of single-line-diagram, but is only inherited from powsybl-commons and powsybl-iidm-impl (plus jimfs for tests).


**What is the new behavior (if this is a feature change)?**
Guava removed from dependencies in pom.xml



**Does this PR introduce a breaking change or deprecate an API?**
No


**Other information**:
As a consequence PR #227 will be closed.