### PR TITLE
use ServiceLoader.load with the current classloader instead of the context classloader

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VoltageLevelLayoutFactorySmartSelector.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VoltageLevelLayoutFactorySmartSelector.java
@@ -30,7 +30,7 @@ public interface VoltageLevelLayoutFactorySmartSelector {
      */
     static Optional<VoltageLevelLayoutFactorySmartSelector> findBest(VoltageLevel vl) {
         Objects.requireNonNull(vl);
-        return StreamSupport.stream(ServiceLoader.load(VoltageLevelLayoutFactorySmartSelector.class).spliterator(), false)
+        return StreamSupport.stream(ServiceLoader.load(VoltageLevelLayoutFactorySmartSelector.class, VoltageLevelLayoutFactorySmartSelector.class.getClassLoader()).spliterator(), false)
                 .filter(selector -> selector.isSelectable(vl))
                 .max(Comparator.comparingInt(selector -> selector.getPriority(vl)));
     }


### PR DESCRIPTION
The context classloader can be the wrong one (and ServiceLoader.load returns an empty list)
when you are calling ServiceLoader.load in the ForkJoinPool.commonPool() (or any other thread pool)
and you have your classes in another classloader than the AppClassLoader (=system classloader).
This is the case when using a springboot fat jar, or when deploying the code in a war in an application
server, or when using mvn exec:java

Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
https://github.com/powsybl/powsybl-core/pull/1727
