### PR TITLE
Change LayoutParameters cssInternal parameter

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -115,7 +115,8 @@ public class LayoutParameters {
                             @JsonProperty("angleLabelShift") double angleLabelShift,
                             @JsonProperty("highlightLineState") boolean highlightLineState,
                             @JsonProperty("addNodesInfos") boolean addNodesInfos,
-                            @JsonProperty("feederArrowSymmetry") boolean feederArrowSymmetry) {
+                            @JsonProperty("feederArrowSymmetry") boolean feederArrowSymmetry,
+                            @JsonProperty("cssInternal") boolean cssInternal) {
         this.translateX = translateX;
         this.translateY = translateY;
         this.initialXBus = initialXBus;
@@ -149,6 +150,7 @@ public class LayoutParameters {
         this.highlightLineState = highlightLineState;
         this.addNodesInfos = addNodesInfos;
         this.feederArrowSymmetry = feederArrowSymmetry;
+        this.cssInternal = cssInternal;
     }
 
     public LayoutParameters(LayoutParameters other) {
@@ -187,6 +189,7 @@ public class LayoutParameters {
         highlightLineState = other.highlightLineState;
         addNodesInfos = other.addNodesInfos;
         feederArrowSymmetry = other.feederArrowSymmetry;
+        cssInternal = other.cssInternal;
     }
 
     public double getTranslateX() {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -73,7 +73,7 @@ public class LayoutParameters {
 
     private boolean feederArrowSymmetry = false;
 
-    private boolean cssInternal = false;
+    private CssLocation cssLocation = CssLocation.EXTERNAL_IMPORTED;
 
     @JsonIgnore
     private Map<String, ComponentSize> componentsSize;
@@ -116,7 +116,7 @@ public class LayoutParameters {
                             @JsonProperty("highlightLineState") boolean highlightLineState,
                             @JsonProperty("addNodesInfos") boolean addNodesInfos,
                             @JsonProperty("feederArrowSymmetry") boolean feederArrowSymmetry,
-                            @JsonProperty("cssInternal") boolean cssInternal) {
+                            @JsonProperty("cssLocation") CssLocation cssLocation) {
         this.translateX = translateX;
         this.translateY = translateY;
         this.initialXBus = initialXBus;
@@ -150,7 +150,7 @@ public class LayoutParameters {
         this.highlightLineState = highlightLineState;
         this.addNodesInfos = addNodesInfos;
         this.feederArrowSymmetry = feederArrowSymmetry;
-        this.cssInternal = cssInternal;
+        this.cssLocation = cssLocation;
     }
 
     public LayoutParameters(LayoutParameters other) {
@@ -189,7 +189,7 @@ public class LayoutParameters {
         highlightLineState = other.highlightLineState;
         addNodesInfos = other.addNodesInfos;
         feederArrowSymmetry = other.feederArrowSymmetry;
-        cssInternal = other.cssInternal;
+        cssLocation = other.cssLocation;
     }
 
     public double getTranslateX() {
@@ -497,12 +497,16 @@ public class LayoutParameters {
         return this;
     }
 
-    public boolean isCssInternal() {
-        return cssInternal;
+    public CssLocation getCssLocation() {
+        return cssLocation;
     }
 
-    public LayoutParameters setCssInternal(boolean cssInternal) {
-        this.cssInternal = cssInternal;
+    public LayoutParameters setCssLocation(CssLocation cssLocation) {
+        this.cssLocation = cssLocation;
         return this;
+    }
+
+    public enum CssLocation {
+        INSERTED_IN_SVG, EXTERNAL_IMPORTED, EXTERNAL_NO_IMPORT;
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -54,7 +54,7 @@ public abstract class AbstractTestCase {
             .setDrawStraightWires(false)
             .setHorizontalSnakeLinePadding(30)
             .setVerticalSnakeLinePadding(30)
-            .setCssInternal(true);
+            .setCssLocation(LayoutParameters.CssLocation.INSERTED_IN_SVG);
     }
 
     protected ResourcesComponentLibrary getResourcesComponentLibrary() {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase13ZoneGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase13ZoneGraph.java
@@ -25,7 +25,7 @@ public class TestCase13ZoneGraph extends AbstractTestCaseIidm {
 
     @Override
     protected LayoutParameters getLayoutParameters() {
-        return new LayoutParameters().setCssInternal(true);
+        return new LayoutParameters().setCssLocation(LayoutParameters.CssLocation.INSERTED_IN_SVG);
     }
 
     @Before

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
@@ -721,6 +721,12 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
     }
 
     @Test
+    public void testVl1CssExternalNoImport() {
+        assertEquals(toString("/vl1_external_css_no_import.svg"),
+            toSVG(g1, "/vl1_external_css.svg", getLayoutParameters().setCssLocation(LayoutParameters.CssLocation.EXTERNAL_NO_IMPORT), initValueProvider, new DefaultDiagramStyleProvider()));
+    }
+
+    @Test
     public void testVl2() {
         assertEquals(toString("/vl2.svg"),
             toSVG(g2, "/vl2.svg", getLayoutParameters(), initValueProvider, new DefaultDiagramStyleProvider()));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
@@ -715,9 +715,9 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
     }
 
     @Test
-    public void testVl1CssExternal() {
+    public void testVl1CssExternalImported() {
         assertEquals(toString("/vl1_external_css.svg"),
-            toSVG(g1, "/vl1_external_css.svg", getLayoutParameters().setCssInternal(false), initValueProvider, new DefaultDiagramStyleProvider()));
+            toSVG(g1, "/vl1_external_css.svg", getLayoutParameters().setCssLocation(LayoutParameters.CssLocation.EXTERNAL_IMPORTED), initValueProvider, new DefaultDiagramStyleProvider()));
     }
 
     @Test

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnicityNodeIdWithMutipleNetwork.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnicityNodeIdWithMutipleNetwork.java
@@ -32,7 +32,7 @@ public class TestUnicityNodeIdWithMutipleNetwork extends AbstractTestCaseIidm {
 
     @Override
     protected LayoutParameters getLayoutParameters() {
-        return new LayoutParameters().setCssInternal(true);
+        return new LayoutParameters().setCssLocation(LayoutParameters.CssLocation.INSERTED_IN_SVG);
     }
 
     @Before

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
@@ -52,7 +52,8 @@ public class LayoutParametersTest {
                 .setTooltipEnabled(true)
                 .setAddNodesInfos(true)
                 .setMinSpaceForFeederArrows(70)
-                .setFeederArrowSymmetry(true);
+                .setFeederArrowSymmetry(true)
+                .setCssInternal(true);
         LayoutParameters layoutParameters2 = new LayoutParameters(layoutParameters);
 
         assertEquals(layoutParameters.getTranslateX(), layoutParameters2.getTranslateX(), 0);
@@ -88,5 +89,6 @@ public class LayoutParametersTest {
         assertEquals(layoutParameters.isAddNodesInfos(), layoutParameters2.isAddNodesInfos());
         assertEquals(layoutParameters.getMinSpaceForFeederArrows(), layoutParameters2.getMinSpaceForFeederArrows(), 0);
         assertEquals(layoutParameters.isFeederArrowSymmetry(), layoutParameters2.isFeederArrowSymmetry());
+        assertEquals(layoutParameters.isCssInternal(), layoutParameters2.isCssInternal());
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
@@ -53,7 +53,7 @@ public class LayoutParametersTest {
                 .setAddNodesInfos(true)
                 .setMinSpaceForFeederArrows(70)
                 .setFeederArrowSymmetry(true)
-                .setCssInternal(true);
+                .setCssLocation(LayoutParameters.CssLocation.EXTERNAL_NO_IMPORT);
         LayoutParameters layoutParameters2 = new LayoutParameters(layoutParameters);
 
         assertEquals(layoutParameters.getTranslateX(), layoutParameters2.getTranslateX(), 0);
@@ -89,6 +89,6 @@ public class LayoutParametersTest {
         assertEquals(layoutParameters.isAddNodesInfos(), layoutParameters2.isAddNodesInfos());
         assertEquals(layoutParameters.getMinSpaceForFeederArrows(), layoutParameters2.getMinSpaceForFeederArrows(), 0);
         assertEquals(layoutParameters.isFeederArrowSymmetry(), layoutParameters2.isFeederArrowSymmetry());
-        assertEquals(layoutParameters.isCssInternal(), layoutParameters2.isCssInternal());
+        assertEquals(layoutParameters.getCssLocation(), layoutParameters2.getCssLocation());
     }
 }

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -3256,6 +3256,6 @@
     "highlightLineState" : true,
     "addNodesInfos" : false,
     "feederArrowSymmetry" : false,
-    "cssInternal" : false
+    "cssLocation" : "EXTERNAL_IMPORTED"
   }
 }

--- a/single-line-diagram-core/src/test/resources/vl1_external_css_no_import.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_external_css_no_import.svg
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <g>
+        <g class="sld-grid" id="GRID_vl1" transform="translate(20.0,50.0)">
+            <line x1="0.0" x2="0.0" y1="0.0" y2="560.0"/>
+            <line x1="80.0" x2="80.0" y1="0.0" y2="560.0"/>
+            <line x1="160.0" x2="160.0" y1="0.0" y2="560.0"/>
+            <line x1="240.0" x2="240.0" y1="0.0" y2="560.0"/>
+            <line x1="320.0" x2="320.0" y1="0.0" y2="560.0"/>
+            <line x1="400.0" x2="400.0" y1="0.0" y2="560.0"/>
+            <line x1="480.0" x2="480.0" y1="0.0" y2="560.0"/>
+            <line x1="0.0" x2="480.0" y1="250.0" y2="250.0"/>
+            <line x1="0.0" x2="480.0" y1="310.0" y2="310.0"/>
+            <line x1="0.0" x2="480.0" y1="240.0" y2="240.0"/>
+            <line x1="0.0" x2="480.0" y1="320.0" y2="320.0"/>
+        </g>
+        <g class="sld-busbar-section sld-constant-color" id="idvl1_95_bbs1" transform="translate(20.0,370.0)">
+            <line x1="0" x2="200.0" y1="0" y2="0"/>
+            <text class="sld-label" id="vl1_bbs1_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_bbs1</text>
+        </g>
+        <g class="sld-busbar-section sld-constant-color" id="idvl1_95_bbs2" transform="translate(300.0,370.0)">
+            <line x1="0" x2="200.0" y1="0" y2="0"/>
+            <text class="sld-label" id="vl1_bbs2_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_bbs2</text>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_bbs1_95_vl1_95_d1">
+            <polyline points="220.0,370.0,240.0,370.0"/>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_d1_95_vl1_95_b1">
+            <polyline points="240.0,370.0,255.0,370.0"/>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_b1_95_vl1_95_d2">
+            <polyline points="275.0,370.0,290.0,370.0"/>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_d2_95_vl1_95_bbs2">
+            <polyline points="290.0,370.0,300.0,370.0"/>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
+            <polyline points="60.0,154.5,60.0,240.0"/>
+        </g>
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,55.0,169.5)">
+            <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
+            <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
+            <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
+        </g>
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,55.0,189.5)">
+            <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
+            <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
+            <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_bload1_95_vl1_95_dload1">
+            <polyline points="60.0,260.0,60.0,370.0"/>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_dload1_95_vl1_95_bbs1">
+            <polyline points="60.0,370.0,50.0,370.0"/>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
+            <polyline points="100.0,562.0,100.0,480.0"/>
+        </g>
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,95.0,537.0)">
+            <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+            <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+            <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
+        </g>
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,95.0,517.0)">
+            <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+            <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+            <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_btrf1_95_vl1_95_dtrf1">
+            <polyline points="100.0,460.0,100.0,370.0"/>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1">
+            <polyline points="100.0,370.0,90.0,370.0"/>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2">
+            <polyline points="380.0,150.0,380.0,205.0,413.0,205.0"/>
+        </g>
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,162.5)">
+            <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
+            <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
+            <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
+        </g>
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,182.5)">
+            <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
+            <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
+            <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2">
+            <polyline points="460.0,150.0,460.0,205.0,427.0,205.0"/>
+        </g>
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,162.5)">
+            <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
+            <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
+            <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
+        </g>
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,182.5)">
+            <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
+            <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
+            <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
+            <polyline points="420.0,217.0,420.0,240.0"/>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2">
+            <polyline points="420.0,260.0,420.0,370.0"/>
+        </g>
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_dtrf2_95_vl1_95_bbs2">
+            <polyline points="420.0,370.0,410.0,370.0"/>
+        </g>
+        <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_d1" transform="translate(236.0,366.0)">
+            <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
+            <path class="sld-sw-open" d="M8,0 0,8"/>
+        </g>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
+            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+        </g>
+        <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_d2" transform="translate(286.0,366.0)">
+            <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
+            <path class="sld-sw-open" d="M8,0 0,8"/>
+        </g>
+        <g class="sld-load sld-constant-color" id="idvl1_95_load1" transform="translate(52.0,145.5)">
+            <rect height="9" width="16"/>
+            <line x1="0" x2="16" y1="0" y2="9"/>
+            <line x1="16" x2="0" y1="0" y2="9"/>
+            <text class="sld-label" id="vl1_load1__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_load1</text>
+        </g>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_bload1" transform="translate(50.0,240.0)">
+            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+        </g>
+        <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_dload1" transform="translate(56.0,366.0)">
+            <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
+            <path class="sld-sw-open" d="M8,0 0,8"/>
+        </g>
+        <g class="sld-two-wt sld-constant-color" id="idvl1_95_trf1" transform="translate(95.0,562.5)">
+            <circle cx="5" cy="10" r="5"/>
+            <circle cx="5" cy="5" r="5"/>
+            <text class="sld-label" id="vl1_trf1__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_trf1</text>
+        </g>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_btrf1" transform="translate(90.0,460.0)">
+            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+        </g>
+        <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_dtrf1" transform="translate(96.0,366.0)">
+            <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
+            <path class="sld-sw-open" d="M8,0 0,8"/>
+        </g>
+        <g class="sld-constant-color" id="idvl1_95_trf2_95_one" transform="translate(380.0,150.0)">
+            <text class="sld-label" id="vl1_trf2_one__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_trf2</text>
+        </g>
+        <g class="sld-constant-color" id="idvl1_95_trf2_95_two" transform="translate(460.0,150.0)">
+            <text class="sld-label" id="vl1_trf2_two__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_trf2</text>
+        </g>
+        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,203.0)">
+            <circle cx="5" cy="5" r="5"/>
+            <circle cx="11" cy="5" r="5"/>
+            <circle cx="8" cy="9" r="5"/>
+        </g>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_btrf2" transform="translate(410.0,240.0)">
+            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+        </g>
+        <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_dtrf2" transform="translate(416.0,366.0)">
+            <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
+            <path class="sld-sw-open" d="M8,0 0,8"/>
+        </g>
+    </g>
+</svg>

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -1626,6 +1626,6 @@
     "highlightLineState" : true,
     "addNodesInfos" : false,
     "feederArrowSymmetry" : false,
-    "cssInternal" : false
+    "cssLocation" : "EXTERNAL_IMPORTED"
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** 
Bug fix + feature



**What is the current behavior?**
`cssInternal` parameter is missing in constructor and in copy constructor, and there is no way not to import css if external css is dealt by html




**What is the new behavior (if this is a feature change)?**
`cssInternal` boolean parameter is changed into `cssLocation` enum parameter (either `INSERTED_IN_SVG`, `EXTERNAL_IMPORTED` or `EXTERNAL_NO_IMPORT`). It is initialized in constructor and copied in copy constructor. `EXTERNAL_NO_IMPORT` allows not to import the external css.



**Does this PR introduce a breaking change or deprecate an API?** 
No