### PR TITLE
SVG draw refactor

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Edge.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Edge.java
@@ -48,4 +48,10 @@ public class Edge {
         }
         generator.writeEndObject();
     }
+
+    public boolean isZeroLength() {
+        Point node1 = getNode1().getCoordinates();
+        Point node2 = getNode2().getCoordinates();
+        return node1.getX() == node2.getX() && node1.getY() == node2.getY();
+    }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/VoltageLevelGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/VoltageLevelGraph.java
@@ -547,6 +547,14 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
         return new ArrayList<>(edges);
     }
 
+    public Set<Node> getNodeSet() {
+        return new LinkedHashSet<>(nodes);
+    }
+
+    public Set<Edge> getEdgeSet() {
+        return new LinkedHashSet<>(edges);
+    }
+
     public Set<Cell> getCells() {
         return new TreeSet<>(cells);
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/VoltageLevelGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/VoltageLevelGraph.java
@@ -19,6 +19,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.powsybl.sld.library.ComponentTypeName.*;
 import static com.powsybl.sld.model.Position.Dimension.H;
 import static com.powsybl.sld.model.Position.Dimension.V;
 
@@ -660,5 +661,21 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
 
     public void setMaxVerticalBusPosition(int maxVerticalBusPosition) {
         this.maxVerticalBusPosition = maxVerticalBusPosition;
+    }
+
+    @Override
+    public void handleMultiTermsNodeRotation() {
+        super.handleMultiTermsNodeRotation();
+        for (Node node : nodes) {
+            if ((node.getComponentType().equals(TWO_WINDINGS_TRANSFORMER)
+                || node.getComponentType().equals(PHASE_SHIFT_TRANSFORMER)
+                || node.getComponentType().equals(THREE_WINDINGS_TRANSFORMER))
+                && node.getCell() != null
+                && ((ExternCell) node.getCell()).getDirection() == BusCell.Direction.BOTTOM) {
+                // permutation if cell direction is BOTTOM,
+                // because in the svg component library, circle for winding1 is below circle for winding2
+                node.setRotationAngle(180.);
+            }
+        }
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -220,6 +220,9 @@ public class DefaultSVGWriter implements SVGWriter {
             return componentLibrary.getAnchorPoints(type);
         };
 
+        // Handle multi-term nodes rotation
+        graph.handleMultiTermsNodeRotation();
+
         Set<Node> remainingNodesToDraw = graph.getNodeSet();
         Set<Edge> remainingEdgesToDraw = graph.getEdgeSet();
 
@@ -389,6 +392,9 @@ public class DefaultSVGWriter implements SVGWriter {
 
         // Drawing the nodes outside the voltageLevel graphs (multi-terminal nodes)
         drawMultiTerminalNodes(prefixId, root, graph, metadata, styleProvider);
+
+        // Handle multi-terminal nodes rotation
+        graph.handleMultiTermsNodeRotation();
 
         // Drawing the snake lines
         drawSnakeLines(prefixId, root, graph, metadata, styleProvider, (type, id) -> componentLibrary.getAnchorPoints(type));
@@ -676,82 +682,10 @@ public class DefaultSVGWriter implements SVGWriter {
         }
     }
 
-    private void handleNodeRotation(Node node) {
-        if (node.getGraph() != null) { // node in voltage level graph
-            if ((node.getComponentType().equals(TWO_WINDINGS_TRANSFORMER)
-                    || node.getComponentType().equals(PHASE_SHIFT_TRANSFORMER)
-                    || node.getComponentType().equals(THREE_WINDINGS_TRANSFORMER))
-                    && node.getCell() != null
-                    && ((ExternCell) node.getCell()).getDirection() == BusCell.Direction.BOTTOM) {
-                // permutation if cell direction is BOTTOM,
-                // because in the svg component library, circle for winding1 is below circle for winding2
-                node.setRotationAngle(180.);
-            }
-        } else {  // node outside any graph
-            List<Node> adjacentNodes = node.getAdjacentNodes();
-            adjacentNodes.sort(Comparator.comparingDouble(Node::getX));
-            if (adjacentNodes.size() == 2) {  // 2 windings transformer
-                FeederWithSideNode node1 = (FeederWithSideNode) adjacentNodes.get(0);
-                FeederWithSideNode node2 = (FeederWithSideNode) adjacentNodes.get(1);
-                List<Edge> edges = node.getAdjacentEdges();
-                List<Point> pol1 = ((BranchEdge) edges.get(0)).getSnakeLine();
-                List<Point> pol2 = ((BranchEdge) edges.get(1)).getSnakeLine();
-                if (!(pol1.isEmpty() || pol2.isEmpty())) {
-                    // get points for the line supporting the svg component
-                    double x1 = pol1.get(pol1.size() - 2).getX(); // absciss of the first polyline second last point
-                    double x2 = pol2.get(1).getX();  // absciss of the second polyline third point
-
-                    if (x1 == x2) {
-                        // vertical line supporting the svg component
-                        FeederWithSideNode nodeWinding1 = node1.getSide() == FeederWithSideNode.Side.ONE ? node1 : node2;
-                        FeederWithSideNode nodeWinding2 = node1.getSide() == FeederWithSideNode.Side.TWO ? node1 : node2;
-                        if (nodeWinding2.getY() > nodeWinding1.getY()) {
-                            // permutation here, because in the svg component library, circle for winding1 is below circle for winding2
-                            node.setRotationAngle(180.);
-                        }
-                    } else {
-                        // horizontal line supporting the svg component,
-                        // so we rotate the component by 90 or 270 (the component is vertical in the library)
-                        if (node1.getSide() == FeederWithSideNode.Side.ONE) {
-                            // rotation by 90 to get circle for winding1 at the left side
-                            node.setRotationAngle(90.);
-                        } else {
-                            // rotation by 90 to get circle for winding1 at the right side
-                            node.setRotationAngle(270.);
-                        }
-                    }
-                }
-            } else {  // 3 windings transformer
-                List<Edge> edges = node.getAdjacentEdges();
-                List<Point> pol1 = ((BranchEdge) edges.get(0)).getSnakeLine();
-                List<Point> pol2 = ((BranchEdge) edges.get(1)).getSnakeLine();
-                List<Point> pol3 = ((BranchEdge) edges.get(2)).getSnakeLine();
-                if (!(pol1.isEmpty() || pol2.isEmpty() || pol3.isEmpty())) {
-                    // get points for the line supporting the svg component
-                    Point coord1 = pol1.get(pol1.size() - 2); // abscissa of the first polyline second last point
-                    Point coord2 = pol2.get(1);  // abscissa of the second polyline second point
-                    Point coord3 = pol3.get(1);  // abscissa of the third polyline second point
-                    if (coord1.getY() == coord3.getY()) {
-                        if (coord2.getY() < coord1.getY()) {
-                            node.setRotationAngle(180.);  // rotation if middle node cell orientation is BOTTOM
-                        }
-                    } else {
-                        if (coord2.getX() == coord1.getX()) {
-                            node.setRotationAngle(coord3.getX() > coord1.getX() ? 270. : 90.);
-                        } else if (coord2.getX() == coord3.getX()) {
-                            node.setRotationAngle(coord1.getX() > coord3.getX() ? 270. : 90.);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     protected void insertComponentSVGIntoDocumentSVG(String prefixId,
                                                      String componentType,
                                                      Element g, Node node,
                                                      DiagramStyleProvider styleProvider) {
-        handleNodeRotation(node);
         BiConsumer<Element, String> elementAttributesSetter
                 = (elt, subComponent) -> setComponentAttributes(prefixId, g, node, styleProvider, elt, componentType, subComponent);
         insertSVGIntoDocumentSVG(node.getName(), componentType, g, elementAttributesSetter);
@@ -832,7 +766,7 @@ public class DefaultSVGWriter implements SVGWriter {
                                         Element elt, String componentType, String subComponent) {
         replaceId(g, elt, prefixId);
         ComponentSize size = componentLibrary.getSize(componentType);
-        if (node.getType() != Node.NodeType.SWITCH && node.isRotated()) {
+        if (node.isRotated()) {
             elt.setAttribute(TRANSFORM, ROTATE + "(" + node.getRotationAngle() + "," + size.getWidth() / 2 + "," + size.getHeight() / 2 + ")");
         }
         List<String> subComponentStyles = styleProvider.getSvgNodeSubcomponentStyles(node, subComponent);
@@ -873,42 +807,25 @@ public class DefaultSVGWriter implements SVGWriter {
     }
 
     private String getTransformStringDecorator(Node node, LabelPosition decoratorPosition, ComponentSize decoratorSize) {
-        String transform;
-        if (node.isRotated() && node.getType() == Node.NodeType.SWITCH) {
-            double[] matrix = getDecoratorTransformMatrix(node, decoratorPosition, decoratorSize);
-            transform = transformMatrixToString(matrix, 4);
-        } else {
-            ComponentSize componentSize = componentLibrary.getSize(node.getComponentType());
-            double dX = componentSize.getWidth() / 2 + decoratorPosition.getdX();
-            double dY = componentSize.getHeight() / 2 + decoratorPosition.getdY();
-            if (decoratorPosition.isCentered()) {
-                dX -= decoratorSize.getWidth() / 2;
-                dY -= decoratorSize.getHeight() / 2;
-            }
-            transform = TRANSLATE + "(" + dX + "," + dY + ")";
+        ComponentSize componentSize = componentLibrary.getSize(node.getComponentType());
+        double dX = componentSize.getWidth() / 2 + decoratorPosition.getdX();
+        double dY = componentSize.getHeight() / 2 + decoratorPosition.getdY();
+        if (decoratorPosition.isCentered()) {
+            dX -= decoratorSize.getWidth() / 2;
+            dY -= decoratorSize.getHeight() / 2;
         }
-        return transform;
+        return TRANSLATE + "(" + dX + "," + dY + ")";
     }
 
     protected void transformComponent(Node node, Element g) {
-        ComponentSize componentSize = componentLibrary.getSize(node.getComponentType());
-
         // For a node marked for rotation during the graph building, but with an svg component not allowed
         // to rotate (ex : disconnector in SVG component library), we cancel the rotation
         if (node.isRotated() && !componentLibrary.isAllowRotation(node.getComponentType())) {
             node.setRotationAngle(null);
         }
 
-        String trans;
-        if (!node.isRotated()) {
-            double[] translate = getNodeTranslate(node);
-            trans = TRANSLATE + "(" + translate[0] + "," + translate[1] + ")";
-        } else {
-            // afester javafx library does not handle more than one transformation, yet, so
-            // combine the couple of transformations, translation+rotation, in a single matrix transformation
-            trans = getTransformMatrixString(node.getX(), node.getY(), Math.toRadians(node.getRotationAngle()), componentSize);
-        }
-        g.setAttribute(TRANSFORM, trans);
+        double[] translate = getNodeTranslate(node);
+        g.setAttribute(TRANSFORM, TRANSLATE + "(" + translate[0] + "," + translate[1] + ")");
     }
 
     private double[] getNodeTranslate(Node node) {
@@ -918,24 +835,7 @@ public class DefaultSVGWriter implements SVGWriter {
         return new double[]{translateX, translateY};
     }
 
-    private double[] getDecoratorTransformMatrix(Node node, LabelPosition decoratorPosition, ComponentSize decoratorSize) {
-        ComponentSize componentSize = componentLibrary.getSize(node.getComponentType());
-        double[] translateNode = getNodeTranslate(node);
-        double[] matrixNode = getTransformMatrix(componentSize.getWidth(), componentSize.getHeight(), node.getRotationAngle() * Math.PI / 180,
-                layoutParameters.getTranslateX() + node.getX(), layoutParameters.getTranslateY() + node.getY());
-        double translateDecoratorX = translateNode[0] + componentSize.getWidth() / 2 + decoratorPosition.getdX();
-        double translateDecoratorY = translateNode[1] + componentSize.getHeight() / 2 + decoratorPosition.getdY();
-        if (decoratorPosition.isCentered()) {
-            translateDecoratorX -= decoratorSize.getWidth() / 2;
-            translateDecoratorY -= decoratorSize.getHeight() / 2;
-        }
-        double t1 = +matrixNode[3] * (translateDecoratorX - matrixNode[4]) - matrixNode[2] * (translateDecoratorY - matrixNode[5]);
-        double t2 = -matrixNode[1] * (translateDecoratorX - matrixNode[4]) + matrixNode[0] * (translateDecoratorY - matrixNode[5]);
-        return new double[]{matrixNode[3], -matrixNode[1], -matrixNode[2], matrixNode[0], t1, t2};
-    }
-
     protected void transformArrow(List<Point> points, ComponentSize componentSize, double shift, Element g) {
-
         Point pointA = points.get(0);
         Point pointB = points.get(1);
         double distancePoints = pointA.distance(pointB);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -220,17 +220,17 @@ public class DefaultSVGWriter implements SVGWriter {
             return componentLibrary.getAnchorPoints(type);
         };
 
-        List<Node> nodesToDraw = graph.getNodes();
-        List<Edge> edgesToDraw = graph.getEdges();
+        Set<Node> remainingNodesToDraw = graph.getNodeSet();
+        Set<Edge> remainingEdgesToDraw = graph.getEdgeSet();
 
-        drawBuses(prefixId, root, graph, metadata, anchorPointProvider, initProvider, styleProvider, nodesToDraw);
+        drawBuses(prefixId, root, graph, metadata, anchorPointProvider, initProvider, styleProvider, remainingNodesToDraw);
         for (Cell cell : graph.getCells()) {
             drawCell(prefixId, root, graph, cell, metadata, anchorPointProvider, initProvider, styleProvider,
-                edgesToDraw, nodesToDraw);
+                remainingEdgesToDraw, remainingNodesToDraw);
         }
 
-        drawEdges(prefixId, root, graph, metadata, anchorPointProvider, initProvider, styleProvider, edgesToDraw);
-        drawNodes(prefixId, root, graph, metadata, initProvider, styleProvider, nodesToDraw);
+        drawEdges(prefixId, root, graph, metadata, anchorPointProvider, initProvider, styleProvider, remainingEdgesToDraw);
+        drawNodes(prefixId, root, graph, metadata, initProvider, styleProvider, remainingNodesToDraw);
 
         // Drawing the nodes outside the voltageLevel graphs (multi-terminal nodes)
         drawMultiTerminalNodes(prefixId, root, graph, metadata, styleProvider);
@@ -245,7 +245,7 @@ public class DefaultSVGWriter implements SVGWriter {
 
     private void drawCell(String prefixId, Element root, VoltageLevelGraph graph, Cell cell,
                           GraphMetadata metadata, AnchorPointProvider anchorPointProvider, DiagramLabelProvider initProvider,
-                          DiagramStyleProvider styleProvider, List<Edge> remainingEdgesToDraw, List<Node> remainingNodesToDraw) {
+                          DiagramStyleProvider styleProvider, Set<Edge> remainingEdgesToDraw, Set<Node> remainingNodesToDraw) {
 
         // To avoid overlapping lines over the switches, first, we draw all nodes except the switch nodes and bus connections,
         // then we draw all the edges, and finally we draw the switch nodes and bus connections
@@ -277,8 +277,8 @@ public class DefaultSVGWriter implements SVGWriter {
         drawNodes(prefixId, g, graph, metadata, initProvider, styleProvider, nodesToDrawAfter);
 
         remainingEdgesToDraw.removeAll(edgesToDraw);
-        remainingNodesToDraw.removeAll(nodesToDrawBefore);
-        remainingNodesToDraw.removeAll(nodesToDrawAfter);
+        nodesToDrawBefore.forEach(remainingNodesToDraw::remove);
+        nodesToDrawAfter.forEach(remainingNodesToDraw::remove);
 
         root.appendChild(g);
     }
@@ -479,7 +479,7 @@ public class DefaultSVGWriter implements SVGWriter {
                              AnchorPointProvider anchorPointProvider,
                              DiagramLabelProvider initProvider,
                              DiagramStyleProvider styleProvider,
-                             List<Node> remainingNodesToDraw) {
+                             Set<Node> remainingNodesToDraw) {
 
         for (BusNode busNode : graph.getNodeBuses()) {
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -235,11 +235,11 @@ public class DefaultSVGWriter implements SVGWriter {
         drawEdges(prefixId, root, graph, metadata, anchorPointProvider, initProvider, styleProvider, remainingEdgesToDraw);
         drawNodes(prefixId, root, graph, metadata, initProvider, styleProvider, remainingNodesToDraw);
 
+        // Drawing the snake lines before multi-terminal nodes to hide the 3WT connections
+        drawSnakeLines(prefixId, root, graph, metadata, styleProvider, anchorPointProvider);
+
         // Drawing the nodes outside the voltageLevel graphs (multi-terminal nodes)
         drawMultiTerminalNodes(prefixId, root, graph, metadata, styleProvider);
-
-        // Drawing the snake lines
-        drawSnakeLines(prefixId, root, graph, metadata, styleProvider, anchorPointProvider);
 
         if (useNodesInfosParam && layoutParameters.isAddNodesInfos()) {
             drawNodesInfos(prefixId, root, graph, styleProvider);
@@ -266,7 +266,7 @@ public class DefaultSVGWriter implements SVGWriter {
                 // Buses have already been drawn in drawBusNodes
                 continue;
             }
-            if (n instanceof SwitchNode || n instanceof BusConnection) {
+            if (n instanceof SwitchNode || n instanceof BusConnection || n instanceof Middle3WTNode) {
                 nodesToDrawAfter.add(n);
             } else {
                 nodesToDrawBefore.add(n);
@@ -390,14 +390,14 @@ public class DefaultSVGWriter implements SVGWriter {
             drawVoltageLevel(prefixId, vlGraph, root, metadata, initProvider, styleProvider, false);
         }
 
-        // Drawing the nodes outside the voltageLevel graphs (multi-terminal nodes)
-        drawMultiTerminalNodes(prefixId, root, graph, metadata, styleProvider);
-
         // Handle multi-terminal nodes rotation
         graph.handleMultiTermsNodeRotation();
 
-        // Drawing the snake lines
+        // Drawing the snake lines before multi-terminal nodes to hide the 3WT connections
         drawSnakeLines(prefixId, root, graph, metadata, styleProvider, (type, id) -> componentLibrary.getAnchorPoints(type));
+
+        // Drawing the nodes outside the voltageLevel graphs (multi-terminal nodes)
+        drawMultiTerminalNodes(prefixId, root, graph, metadata, styleProvider);
     }
 
     /*

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
@@ -65,10 +65,10 @@ polyline {fill: none}
             <text class="sld-label" id="B12_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">B12</text>
         </g>
         <g class="cell idINTERN_32_0" id="idINTERN_32_0">
-            <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_BR1_95_fNode" transform="matrix(0.0,1.0,-1.0,0.0,99.0,266.0)">
+            <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_BR1_95_fNode" transform="translate(91.0,266.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
-            <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_BR1_95_fNode" transform="matrix(0.0,1.0,-1.0,0.0,49.0,266.0)">
+            <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_BR1_95_fNode" transform="translate(41.0,266.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
             <g class="sld-wire sld-constant-color" id="_95_VL1_95_B11_95_FICT_95_VL1_95_BR1_95_fBc">
@@ -92,9 +92,9 @@ polyline {fill: none}
             <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_BR1_95_fBc" transform="translate(91.0,306.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
-            <g class="sld-breaker sld-constant-color sld-closed" id="idBR1" transform="matrix(0.0,1.0,-1.0,0.0,80.0,260.0)">
-                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            <g class="sld-breaker sld-constant-color sld-closed" id="idBR1" transform="translate(60.0,260.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
             <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_BR1_95_fBc" transform="translate(41.0,331.0)">
                 <circle cx="4" cy="4" r="2"/>
@@ -251,11 +251,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fNode" transform="translate(366.0,361.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(362.0,541.0)">
-                <circle cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <circle cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <circle cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
-            </g>
             <g class="sld-bottom-feeder sld-constant-color" id="idT3_95_12_95_TWO" transform="translate(345.0,615.0)">
                 <text class="sld-label" id="T3_12_TWO_S_LABEL" transform="rotate(0,0,0)" x="-5.0" y="5.0">T3_12</text>
             </g>
@@ -299,6 +294,11 @@ polyline {fill: none}
             </g>
             <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fBc" transform="translate(366.0,306.0)">
                 <circle cx="4" cy="4" r="2"/>
+            </g>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(362.0,541.0)">
+                <circle cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <circle cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <circle cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_6" id="idEXTERN_32_6">
@@ -454,11 +454,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fNode" transform="translate(666.0,361.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(662.0,541.0)">
-                <circle cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <circle cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <circle cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
-            </g>
             <g class="sld-bottom-feeder sld-constant-color" id="idT3_95_12_95_ONE" transform="translate(645.0,615.0)">
                 <text class="sld-label" id="T3_12_ONE_S_LABEL" transform="rotate(0,0,0)" x="-5.0" y="5.0">T3_12</text>
             </g>
@@ -503,10 +498,11 @@ polyline {fill: none}
             <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fBc" transform="translate(666.0,331.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
-        </g>
-        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(390.0,-7.5)">
-            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
-            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(662.0,541.0)">
+                <circle cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <circle cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <circle cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
+            </g>
         </g>
         <g class="sld-wire sld-constant-color" id="idL11">
             <polyline points="195.0,615.0,195.0,645.0,495.0,645.0,495.0,615.0"/>
@@ -516,6 +512,10 @@ polyline {fill: none}
         </g>
         <g class="sld-wire sld-constant-color" id="idT11_95_TWO_95_edge">
             <polyline points="403.0,0.0,545.0,0.0,545.0,30.0"/>
+        </g>
+        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(390.0,-7.5)">
+            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
@@ -65,10 +65,10 @@ polyline {fill: none}
             <text class="sld-label" id="BBS12_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">BBS12</text>
         </g>
         <g class="cell idINTERN_32_0" id="idINTERN_32_0">
-            <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_D10Fictif" transform="matrix(0.0,1.0,-1.0,0.0,99.0,266.0)">
+            <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_D10Fictif" transform="translate(91.0,266.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
-            <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_D20Fictif" transform="matrix(0.0,1.0,-1.0,0.0,49.0,266.0)">
+            <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_D20Fictif" transform="translate(41.0,266.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
             <g class="sld-wire sld-constant-color" id="_95_VL1_95_BBS11_95_D10">
@@ -93,9 +93,9 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-constant-color sld-closed" id="idBR1" transform="matrix(0.0,1.0,-1.0,0.0,80.0,260.0)">
-                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            <g class="sld-breaker sld-constant-color sld-closed" id="idBR1" transform="translate(60.0,260.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
             <g class="sld-disconnector sld-constant-color sld-closed" id="idD20" transform="translate(41.0,331.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
@@ -285,11 +285,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_D19Fictif" transform="translate(566.0,276.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(562.0,80.0)">
-                <circle cx="5" cy="15" r="5"/>
-                <circle cx="11" cy="15" r="5"/>
-                <circle cx="8" cy="19" r="5"/>
-            </g>
             <g class="sld-top-feeder sld-constant-color" id="idT3_95_12_95_TWO" transform="translate(545.0,30.0)">
                 <text class="sld-label" id="T3_12_TWO_N_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">T3_12</text>
             </g>
@@ -341,6 +336,11 @@ polyline {fill: none}
             <g class="sld-breaker sld-constant-color sld-closed" id="idBR20" transform="translate(560.0,176.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(562.0,80.0)">
+                <circle cx="5" cy="15" r="5"/>
+                <circle cx="11" cy="15" r="5"/>
+                <circle cx="8" cy="19" r="5"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_6" id="idEXTERN_32_6">
@@ -528,11 +528,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_D29Fictif" transform="translate(666.0,276.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(662.0,80.0)">
-                <circle cx="5" cy="15" r="5"/>
-                <circle cx="11" cy="15" r="5"/>
-                <circle cx="8" cy="19" r="5"/>
-            </g>
             <g class="sld-top-feeder sld-constant-color" id="idT3_95_12_95_ONE" transform="translate(645.0,30.0)">
                 <text class="sld-label" id="T3_12_ONE_N_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">T3_12</text>
             </g>
@@ -585,10 +580,11 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-        </g>
-        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(365.0,-7.5)">
-            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
-            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(662.0,80.0)">
+                <circle cx="5" cy="15" r="5"/>
+                <circle cx="11" cy="15" r="5"/>
+                <circle cx="8" cy="19" r="5"/>
+            </g>
         </g>
         <g class="sld-wire sld-constant-color" id="idL11">
             <polyline points="195.0,30.0,195.0,-30.0,395.0,-30.0,395.0,30.0"/>
@@ -598,6 +594,10 @@ polyline {fill: none}
         </g>
         <g class="sld-wire sld-constant-color" id="idT11_95_TWO_95_edge">
             <polyline points="378.0,0.0,445.0,0.0,445.0,30.0"/>
+        </g>
+        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(365.0,-7.5)">
+            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
@@ -65,10 +65,10 @@ polyline {fill: none}
             <text class="sld-label" id="B12_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">B12</text>
         </g>
         <g class="cell idINTERN_32_0" id="idINTERN_32_0">
-            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_BR1_95_fNode" transform="matrix(0.0,1.0,-1.0,0.0,99.0,266.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_BR1_95_fNode" transform="translate(91.0,266.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
-            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_BR1_95_fNode" transform="matrix(0.0,1.0,-1.0,0.0,49.0,266.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_BR1_95_fNode" transform="translate(41.0,266.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
             <g class="sld-wire sld-constant-color" id="_95_VL1_95_B11_95_FICT_95_VL1_95_BR1_95_fBc">
@@ -92,9 +92,9 @@ polyline {fill: none}
             <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_BR1_95_fBc" transform="translate(91.0,306.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
-            <g class="sld-breaker sld-constant-color sld-closed" id="idBR1" transform="matrix(0.0,1.0,-1.0,0.0,80.0,260.0)">
-                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            <g class="sld-breaker sld-constant-color sld-closed" id="idBR1" transform="translate(60.0,260.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
             <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_BR1_95_fBc" transform="translate(41.0,331.0)">
                 <circle cx="4" cy="4" r="2"/>
@@ -260,14 +260,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fNode" transform="translate(366.0,361.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(362.0,541.0)">
-                <circle cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <circle cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <circle cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <g class="sld-flash">
-                    <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(3.0,18.5)"/>
-                </g>
-            </g>
             <g class="sld-bottom-feeder sld-constant-color" id="idT3_95_12_95_TWO" transform="translate(345.0,615.0)">
                 <text class="sld-label" id="T3_12_TWO_S_LABEL" transform="rotate(0,0,0)" x="-5.0" y="5.0">T3_12</text>
             </g>
@@ -311,6 +303,14 @@ polyline {fill: none}
             </g>
             <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fBc" transform="translate(366.0,306.0)">
                 <circle cx="4" cy="4" r="2"/>
+            </g>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(362.0,541.0)">
+                <circle cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <circle cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <circle cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <g class="sld-flash">
+                    <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(3.0,18.5)"/>
+                </g>
             </g>
         </g>
         <g class="cell idEXTERN_32_6" id="idEXTERN_32_6">
@@ -475,14 +475,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fNode" transform="translate(666.0,361.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(662.0,541.0)">
-                <circle cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <circle cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <circle cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <g class="sld-flash">
-                    <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(3.0,18.5)"/>
-                </g>
-            </g>
             <g class="sld-bottom-feeder sld-constant-color" id="idT3_95_12_95_ONE" transform="translate(645.0,615.0)">
                 <text class="sld-label" id="T3_12_ONE_S_LABEL" transform="rotate(0,0,0)" x="-5.0" y="5.0">T3_12</text>
             </g>
@@ -527,10 +519,14 @@ polyline {fill: none}
             <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fBc" transform="translate(666.0,331.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
-        </g>
-        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(390.0,-7.5)">
-            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
-            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(662.0,541.0)">
+                <circle cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <circle cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <circle cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <g class="sld-flash">
+                    <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(3.0,18.5)"/>
+                </g>
+            </g>
         </g>
         <g class="sld-wire sld-constant-color" id="idL11">
             <polyline points="195.0,615.0,195.0,645.0,495.0,645.0,495.0,615.0"/>
@@ -540,6 +536,10 @@ polyline {fill: none}
         </g>
         <g class="sld-wire sld-constant-color" id="idT11_95_TWO_95_edge">
             <polyline points="403.0,0.0,545.0,0.0,545.0,30.0"/>
+        </g>
+        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(390.0,-7.5)">
+            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
@@ -74,10 +74,10 @@ polyline {fill: none}
             <text class="sld-label" id="BBS12_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">BBS12</text>
         </g>
         <g class="cell idINTERN_32_0" id="idINTERN_32_0">
-            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_D10Fictif" transform="matrix(0.0,1.0,-1.0,0.0,149.0,316.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_D10Fictif" transform="translate(141.0,316.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
-            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_D20Fictif" transform="matrix(0.0,1.0,-1.0,0.0,99.0,316.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_D20Fictif" transform="translate(91.0,316.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
             <g class="sld-wire sld-constant-color" id="_95_VL1_95_BBS11_95_D10">
@@ -102,9 +102,9 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-constant-color sld-closed" id="idBR1" transform="matrix(0.0,1.0,-1.0,0.0,130.0,310.0)">
-                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            <g class="sld-breaker sld-constant-color sld-closed" id="idBR1" transform="translate(110.0,310.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
             <g class="sld-disconnector sld-constant-color sld-closed" id="idD20" transform="translate(91.0,381.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
@@ -581,10 +581,6 @@ polyline {fill: none}
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(440.0,42.5)">
-            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
-            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
-        </g>
         <g class="sld-wire sld-constant-color" id="idL11">
             <polyline points="245.0,80.0,245.0,20.0,495.0,20.0,495.0,80.0"/>
         </g>
@@ -593,6 +589,10 @@ polyline {fill: none}
         </g>
         <g class="sld-wire sld-constant-color" id="idT11_95_TWO_95_edge">
             <polyline points="453.0,50.0,545.0,50.0,545.0,80.0"/>
+        </g>
+        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(440.0,42.5)">
+            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
         </g>
         <g class="sld-busbar-section sld-constant-color" id="idBBS2" transform="translate(830.0,360.0)">
             <line x1="0" x2="180.0" y1="0" y2="0"/>
@@ -786,15 +786,6 @@ polyline {fill: none}
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idT12_95_ONE_95_T12_95_TWO" transform="translate(765.0,-17.5)">
-            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
-            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
-        </g>
-        <g class="sld-three-wt sld-constant-color" id="idT3_95_12_95_ONE_95_T3_95_12_95_TWO_95_T3_95_12_95_THREE" transform="translate(637.0,-52.0)">
-            <circle cx="5" cy="15" r="5"/>
-            <circle cx="11" cy="15" r="5"/>
-            <circle cx="8" cy="19" r="5"/>
-        </g>
         <g class="sld-wire sld-constant-color" id="idL12">
             <polyline points="295.0,80.0,295.0,-70.0,895.0,-70.0,895.0,80.0"/>
         </g>
@@ -812,6 +803,15 @@ polyline {fill: none}
         </g>
         <g class="sld-wire sld-constant-color" id="idT3_95_12_95_THREE_95_EDGE">
             <polyline points="652.0,-40.0,995.0,-40.0,995.0,80.0"/>
+        </g>
+        <g class="sld-two-wt sld-constant-color" id="idT12_95_ONE_95_T12_95_TWO" transform="translate(765.0,-17.5)">
+            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
+        </g>
+        <g class="sld-three-wt sld-constant-color" id="idT3_95_12_95_ONE_95_T3_95_12_95_TWO_95_T3_95_12_95_THREE" transform="translate(637.0,-52.0)">
+            <circle cx="5" cy="15" r="5"/>
+            <circle cx="11" cy="15" r="5"/>
+            <circle cx="8" cy="19" r="5"/>
         </g>
         <g id="LABEL_VL_VL1">
             <text class="sld-graph-label" transform="rotate(0,0,0)" x="50.0" y="40.0">VL1</text>

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
@@ -65,10 +65,10 @@ polyline {fill: none}
             <text class="sld-label" id="BBS12_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">BBS12</text>
         </g>
         <g class="cell idINTERN_32_0" id="idINTERN_32_0">
-            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_D10Fictif" transform="matrix(0.0,1.0,-1.0,0.0,99.0,266.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_D10Fictif" transform="translate(91.0,266.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
-            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_D20Fictif" transform="matrix(0.0,1.0,-1.0,0.0,49.0,266.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_D20Fictif" transform="translate(41.0,266.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
             <g class="sld-wire sld-constant-color" id="_95_VL1_95_BBS11_95_D10">
@@ -96,11 +96,11 @@ polyline {fill: none}
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(9.0,0.0)"/>
                 </g>
             </g>
-            <g class="sld-breaker sld-constant-color sld-closed" id="idBR1" transform="matrix(0.0,1.0,-1.0,0.0,80.0,260.0)">
-                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            <g class="sld-breaker sld-constant-color sld-closed" id="idBR1" transform="translate(60.0,260.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
                 <g class="sld-lock">
-                    <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="matrix(0.0,-1.0,1.0,0.0,0.0,-1.0)"/>
+                    <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(21.0,0.0)"/>
                 </g>
             </g>
             <g class="sld-disconnector sld-constant-color sld-closed" id="idD20" transform="translate(41.0,331.0)">
@@ -318,11 +318,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_D19Fictif" transform="translate(566.0,276.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(562.0,80.0)">
-                <circle cx="5" cy="15" r="5"/>
-                <circle cx="11" cy="15" r="5"/>
-                <circle cx="8" cy="19" r="5"/>
-            </g>
             <g class="sld-top-feeder sld-constant-color" id="idT3_95_12_95_TWO" transform="translate(545.0,30.0)">
                 <text class="sld-label" id="T3_12_TWO_N_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">T3_12</text>
             </g>
@@ -380,6 +375,11 @@ polyline {fill: none}
                 <g class="sld-lock">
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(21.0,0.0)"/>
                 </g>
+            </g>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(562.0,80.0)">
+                <circle cx="5" cy="15" r="5"/>
+                <circle cx="11" cy="15" r="5"/>
+                <circle cx="8" cy="19" r="5"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_6" id="idEXTERN_32_6">
@@ -591,11 +591,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_D29Fictif" transform="translate(666.0,276.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(662.0,80.0)">
-                <circle cx="5" cy="15" r="5"/>
-                <circle cx="11" cy="15" r="5"/>
-                <circle cx="8" cy="19" r="5"/>
-            </g>
             <g class="sld-top-feeder sld-constant-color" id="idT3_95_12_95_ONE" transform="translate(645.0,30.0)">
                 <text class="sld-label" id="T3_12_ONE_N_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">T3_12</text>
             </g>
@@ -654,10 +649,11 @@ polyline {fill: none}
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(21.0,0.0)"/>
                 </g>
             </g>
-        </g>
-        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(365.0,-7.5)">
-            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
-            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(662.0,80.0)">
+                <circle cx="5" cy="15" r="5"/>
+                <circle cx="11" cy="15" r="5"/>
+                <circle cx="8" cy="19" r="5"/>
+            </g>
         </g>
         <g class="sld-wire sld-constant-color" id="idL11">
             <polyline points="195.0,30.0,195.0,-30.0,395.0,-30.0,395.0,30.0"/>
@@ -667,6 +663,10 @@ polyline {fill: none}
         </g>
         <g class="sld-wire sld-constant-color" id="idT11_95_TWO_95_edge">
             <polyline points="378.0,0.0,445.0,0.0,445.0,30.0"/>
+        </g>
+        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(365.0,-7.5)">
+            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -92,17 +92,11 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_bbs1_95_dsect11">
                 <polyline points="730.0,310.0,740.0,310.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_dsect11_95_FICT_95_vl1_95_dsect11Fictif">
-                <polyline points="740.0,310.0,740.0,310.0"/>
-            </g>
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_dtrct11_95_FICT_95_vl1_95_dsect11Fictif">
                 <polyline points="770.0,310.0,740.0,310.0"/>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_dtrct11_95_FICT_95_vl1_95_dsect12Fictif">
                 <polyline points="790.0,310.0,820.0,310.0"/>
-            </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_dsect12_95_FICT_95_vl1_95_dsect12Fictif">
-                <polyline points="820.0,310.0,820.0,310.0"/>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_dsect12_95_bbs2">
                 <polyline points="820.0,310.0,830.0,310.0"/>
@@ -130,17 +124,11 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_bbs3_95_dsect21">
                 <polyline points="730.0,335.0,740.0,335.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_dsect21_95_FICT_95_vl1_95_dsect21Fictif">
-                <polyline points="740.0,335.0,740.0,335.0"/>
-            </g>
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect21Fictif">
                 <polyline points="770.0,335.0,740.0,335.0"/>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect22Fictif">
                 <polyline points="790.0,335.0,820.0,335.0"/>
-            </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_dsect22_95_FICT_95_vl1_95_dsect22Fictif">
-                <polyline points="820.0,335.0,820.0,335.0"/>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_dsect22_95_bbs4">
                 <polyline points="820.0,335.0,830.0,335.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -83,10 +83,10 @@ polyline {fill: none}
             <text class="sld-label" id="bbs4_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">bbs4</text>
         </g>
         <g class="cell idINTERN_32_0" id="idINTERN_32_0">
-            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500" id="idFICT_95_vl1_95_dsect11Fictif" transform="matrix(0.0,1.0,-1.0,0.0,744.0,306.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500" id="idFICT_95_vl1_95_dsect11Fictif" transform="translate(736.0,306.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
-            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500" id="idFICT_95_vl1_95_dsect12Fictif" transform="matrix(0.0,1.0,-1.0,0.0,824.0,306.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500" id="idFICT_95_vl1_95_dsect12Fictif" transform="translate(816.0,306.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_bbs1_95_dsect11">
@@ -105,9 +105,9 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500" id="iddtrct11" transform="matrix(0.0,1.0,-1.0,0.0,790.0,300.0)">
-                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500" id="iddtrct11" transform="translate(770.0,300.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
             <g class="sld-disconnector sld-constant-color sld-closed sld-vl300to500" id="iddsect12" transform="translate(816.0,306.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
@@ -115,10 +115,10 @@ polyline {fill: none}
             </g>
         </g>
         <g class="cell idINTERN_32_1" id="idINTERN_32_1">
-            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500" id="idFICT_95_vl1_95_dsect21Fictif" transform="matrix(0.0,1.0,-1.0,0.0,744.0,331.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500" id="idFICT_95_vl1_95_dsect21Fictif" transform="translate(736.0,331.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
-            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500" id="idFICT_95_vl1_95_dsect22Fictif" transform="matrix(0.0,1.0,-1.0,0.0,824.0,331.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500" id="idFICT_95_vl1_95_dsect22Fictif" transform="translate(816.0,331.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_bbs3_95_dsect21">
@@ -137,9 +137,9 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500" id="iddtrct21" transform="matrix(0.0,1.0,-1.0,0.0,790.0,325.0)">
-                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500" id="iddtrct21" transform="translate(770.0,325.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
             <g class="sld-disconnector sld-constant-color sld-closed sld-vl300to500" id="iddsect22" transform="translate(816.0,331.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
@@ -289,11 +289,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500" id="idFICT_95_vl1_95_dtrf16Fictif" transform="translate(496.0,276.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf6_95_fictif" transform="translate(492.0,188.0)">
-                <circle class="sld-vl180to300" cx="5" cy="15" r="5"/>
-                <circle class="sld-vl50to70" cx="11" cy="15" r="5"/>
-                <circle class="sld-vl300to500" cx="8" cy="19" r="5"/>
-            </g>
             <g class="sld-top-feeder sld-constant-color sld-vl300to500" id="idtrf6_95_TWO" transform="translate(460.0,138.0)">
                 <text class="sld-label" id="trf6_TWO_N_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">trf61</text>
             </g>
@@ -345,6 +340,11 @@ polyline {fill: none}
             <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500" id="idbtrf16" transform="translate(490.0,230.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf6_95_fictif" transform="translate(492.0,188.0)">
+                <circle class="sld-vl180to300" cx="5" cy="15" r="5"/>
+                <circle class="sld-vl50to70" cx="11" cy="15" r="5"/>
+                <circle class="sld-vl300to500" cx="8" cy="19" r="5"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_6" id="idEXTERN_32_6">
@@ -444,11 +444,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500" id="idFICT_95_vl1_95_dtrf18Fictif" transform="translate(976.0,276.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf8_95_fictif" transform="translate(972.0,188.0)">
-                <circle class="sld-vl180to300" cx="5" cy="15" r="5"/>
-                <circle class="sld-vl50to70" cx="11" cy="15" r="5"/>
-                <circle class="sld-vl300to500" cx="8" cy="19" r="5"/>
-            </g>
             <g class="sld-top-feeder sld-constant-color sld-vl300to500" id="idtrf8_95_TWO" transform="translate(940.0,138.0)">
                 <text class="sld-label" id="trf8_TWO_N_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">trf81</text>
             </g>
@@ -500,6 +495,11 @@ polyline {fill: none}
             <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500" id="idbtrf18" transform="translate(970.0,230.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf8_95_fictif" transform="translate(972.0,188.0)">
+                <circle class="sld-vl180to300" cx="5" cy="15" r="5"/>
+                <circle class="sld-vl50to70" cx="11" cy="15" r="5"/>
+                <circle class="sld-vl300to500" cx="8" cy="19" r="5"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_9" id="idEXTERN_32_9">
@@ -599,11 +599,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500" id="idFICT_95_vl1_95_dtrf17Fictif" transform="translate(656.0,361.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf7_95_fictif" transform="translate(652.0,433.0)">
-                <circle class="sld-vl50to70" cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <circle class="sld-vl180to300" cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <circle class="sld-vl300to500" cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
-            </g>
             <g class="sld-bottom-feeder sld-constant-color sld-vl300to500" id="idtrf7_95_TWO" transform="translate(620.0,507.0)">
                 <text class="sld-label" id="trf7_TWO_S_LABEL" transform="rotate(0,0,0)" x="-5.0" y="5.0">trf71</text>
             </g>
@@ -655,6 +650,11 @@ polyline {fill: none}
             <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500" id="idbtrf17" transform="translate(650.0,395.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf7_95_fictif" transform="translate(652.0,433.0)">
+                <circle class="sld-vl50to70" cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <circle class="sld-vl180to300" cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <circle class="sld-vl300to500" cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_12" id="idEXTERN_32_12">

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -148,10 +148,10 @@ polyline {fill: none}
             <text class="sld-label" id="bbs4_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">bbs4</text>
         </g>
         <g class="cell idINTERN_32_0" id="idINTERN_32_0">
-            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500-0" id="idFICT_95_vl1_95_dsect11Fictif" transform="matrix(0.0,1.0,-1.0,0.0,744.0,306.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500-0" id="idFICT_95_vl1_95_dsect11Fictif" transform="translate(736.0,306.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
-            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500-0" id="idFICT_95_vl1_95_dsect12Fictif" transform="matrix(0.0,1.0,-1.0,0.0,824.0,306.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500-0" id="idFICT_95_vl1_95_dsect12Fictif" transform="translate(816.0,306.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_bbs1_95_dsect11">
@@ -170,9 +170,9 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500-0" id="iddtrct11" transform="matrix(0.0,1.0,-1.0,0.0,790.0,300.0)">
-                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500-0" id="iddtrct11" transform="translate(770.0,300.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
             <g class="sld-disconnector sld-constant-color sld-closed sld-vl300to500-0" id="iddsect12" transform="translate(816.0,306.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
@@ -180,10 +180,10 @@ polyline {fill: none}
             </g>
         </g>
         <g class="cell idINTERN_32_1" id="idINTERN_32_1">
-            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500-1" id="idFICT_95_vl1_95_dsect21Fictif" transform="matrix(0.0,1.0,-1.0,0.0,744.0,331.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500-1" id="idFICT_95_vl1_95_dsect21Fictif" transform="translate(736.0,331.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
-            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500-1" id="idFICT_95_vl1_95_dsect22Fictif" transform="matrix(0.0,1.0,-1.0,0.0,824.0,331.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500-1" id="idFICT_95_vl1_95_dsect22Fictif" transform="translate(816.0,331.0)">
                 <circle cx="4" cy="4" r="4" transform="rotate(90.0,4.0,4.0)"/>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-1" id="_95_vl1_95_bbs3_95_dsect21">
@@ -202,9 +202,9 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500-1" id="iddtrct21" transform="matrix(0.0,1.0,-1.0,0.0,790.0,325.0)">
-                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500-1" id="iddtrct21" transform="translate(770.0,325.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
             <g class="sld-disconnector sld-constant-color sld-closed sld-vl300to500-1" id="iddsect22" transform="translate(816.0,331.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
@@ -354,11 +354,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500-0" id="idFICT_95_vl1_95_dtrf16Fictif" transform="translate(496.0,276.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf6_95_fictif" transform="translate(492.0,188.0)">
-                <circle class="sld-vl180to300-0" cx="5" cy="15" r="5"/>
-                <circle class="sld-vl50to70-0" cx="11" cy="15" r="5"/>
-                <circle class="sld-vl300to500-0" cx="8" cy="19" r="5"/>
-            </g>
             <g class="sld-top-feeder sld-constant-color sld-vl300to500-0" id="idtrf6_95_TWO" transform="translate(460.0,138.0)">
                 <text class="sld-label" id="trf6_TWO_N_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">trf61</text>
             </g>
@@ -410,6 +405,11 @@ polyline {fill: none}
             <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500-0" id="idbtrf16" transform="translate(490.0,230.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf6_95_fictif" transform="translate(492.0,188.0)">
+                <circle class="sld-vl180to300-0" cx="5" cy="15" r="5"/>
+                <circle class="sld-vl50to70-0" cx="11" cy="15" r="5"/>
+                <circle class="sld-vl300to500-0" cx="8" cy="19" r="5"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_6" id="idEXTERN_32_6">
@@ -509,11 +509,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500-0" id="idFICT_95_vl1_95_dtrf18Fictif" transform="translate(976.0,276.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf8_95_fictif" transform="translate(972.0,188.0)">
-                <circle class="sld-vl180to300-0" cx="5" cy="15" r="5"/>
-                <circle class="sld-vl50to70-0" cx="11" cy="15" r="5"/>
-                <circle class="sld-vl300to500-0" cx="8" cy="19" r="5"/>
-            </g>
             <g class="sld-top-feeder sld-constant-color sld-vl300to500-0" id="idtrf8_95_TWO" transform="translate(940.0,138.0)">
                 <text class="sld-label" id="trf8_TWO_N_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">trf81</text>
             </g>
@@ -565,6 +560,11 @@ polyline {fill: none}
             <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500-0" id="idbtrf18" transform="translate(970.0,230.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf8_95_fictif" transform="translate(972.0,188.0)">
+                <circle class="sld-vl180to300-0" cx="5" cy="15" r="5"/>
+                <circle class="sld-vl50to70-0" cx="11" cy="15" r="5"/>
+                <circle class="sld-vl300to500-0" cx="8" cy="19" r="5"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_9" id="idEXTERN_32_9">
@@ -664,11 +664,6 @@ polyline {fill: none}
             <g class="sld-node sld-constant-color sld-hidden-node sld-vl300to500-1" id="idFICT_95_vl1_95_dtrf17Fictif" transform="translate(656.0,361.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf7_95_fictif" transform="translate(652.0,433.0)">
-                <circle class="sld-vl50to70-0" cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <circle class="sld-vl180to300-0" cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
-                <circle class="sld-vl300to500-1" cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
-            </g>
             <g class="sld-bottom-feeder sld-constant-color sld-vl300to500-1" id="idtrf7_95_TWO" transform="translate(620.0,507.0)">
                 <text class="sld-label" id="trf7_TWO_S_LABEL" transform="rotate(0,0,0)" x="-5.0" y="5.0">trf71</text>
             </g>
@@ -720,6 +715,11 @@ polyline {fill: none}
             <g class="sld-breaker sld-constant-color sld-closed sld-vl300to500-1" id="idbtrf17" transform="translate(650.0,395.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf7_95_fictif" transform="translate(652.0,433.0)">
+                <circle class="sld-vl50to70-0" cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <circle class="sld-vl180to300-0" cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
+                <circle class="sld-vl300to500-1" cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_12" id="idEXTERN_32_12">

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -157,17 +157,11 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_bbs1_95_dsect11">
                 <polyline points="730.0,310.0,740.0,310.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_dsect11_95_FICT_95_vl1_95_dsect11Fictif">
-                <polyline points="740.0,310.0,740.0,310.0"/>
-            </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_dtrct11_95_FICT_95_vl1_95_dsect11Fictif">
                 <polyline points="770.0,310.0,740.0,310.0"/>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_dtrct11_95_FICT_95_vl1_95_dsect12Fictif">
                 <polyline points="790.0,310.0,820.0,310.0"/>
-            </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_dsect12_95_FICT_95_vl1_95_dsect12Fictif">
-                <polyline points="820.0,310.0,820.0,310.0"/>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_dsect12_95_bbs2">
                 <polyline points="820.0,310.0,830.0,310.0"/>
@@ -195,17 +189,11 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color sld-vl300to500-1" id="_95_vl1_95_bbs3_95_dsect21">
                 <polyline points="730.0,335.0,740.0,335.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500-1" id="_95_vl1_95_dsect21_95_FICT_95_vl1_95_dsect21Fictif">
-                <polyline points="740.0,335.0,740.0,335.0"/>
-            </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-1" id="_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect21Fictif">
                 <polyline points="770.0,335.0,740.0,335.0"/>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-1" id="_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect22Fictif">
                 <polyline points="790.0,335.0,820.0,335.0"/>
-            </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500-1" id="_95_vl1_95_dsect22_95_FICT_95_vl1_95_dsect22Fictif">
-                <polyline points="820.0,335.0,820.0,335.0"/>
             </g>
             <g class="sld-wire sld-constant-color sld-vl300to500-1" id="_95_vl1_95_dsect22_95_bbs4">
                 <polyline points="820.0,335.0,830.0,335.0"/>

--- a/single-line-diagram-core/src/test/resources/substation.svg
+++ b/single-line-diagram-core/src/test/resources/substation.svg
@@ -149,9 +149,9 @@ polyline {fill: none}
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
             <path class="sld-sw-open" d="M8,0 0,8"/>
         </g>
-        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="translate(255.0,360.0)">
+            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
         </g>
         <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_d2" transform="translate(286.0,366.0)">
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
@@ -358,15 +358,6 @@ polyline {fill: none}
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
             <path class="sld-sw-open" d="M8,0 0,8"/>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idvl1_95_trf1_95_vl2_95_trf1" transform="translate(380.0,592.5)">
-            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
-            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
-        </g>
-        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" transform="translate(722.0,88.0)">
-            <circle cx="5" cy="15" r="5"/>
-            <circle cx="11" cy="15" r="5"/>
-            <circle cx="8" cy="19" r="5"/>
-        </g>
         <g class="sld-wire sld-constant-color" id="idedge_95_vl1_95_trf1">
             <polyline points="100.0,550.0,100.0,600.0,377.0,600.0"/>
         </g>
@@ -381,6 +372,15 @@ polyline {fill: none}
         </g>
         <g class="sld-wire sld-constant-color" id="idedge_95_vl3_95_trf2_95_one">
             <polyline points="737.0,100.0,1020.0,100.0,1020.0,130.0"/>
+        </g>
+        <g class="sld-two-wt sld-constant-color" id="idvl1_95_trf1_95_vl2_95_trf1" transform="translate(380.0,592.5)">
+            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
+        </g>
+        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" transform="translate(722.0,88.0)">
+            <circle cx="5" cy="15" r="5"/>
+            <circle cx="11" cy="15" r="5"/>
+            <circle cx="8" cy="19" r="5"/>
         </g>
         <g id="LABEL_VL_vl1">
             <text class="sld-graph-label" transform="rotate(0,0,0)" x="0.0" y="10.0">vl1</text>

--- a/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
+++ b/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
@@ -149,9 +149,9 @@ polyline {fill: none}
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
             <path class="sld-sw-open" d="M8,0 0,8"/>
         </g>
-        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="translate(255.0,360.0)">
+            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
         </g>
         <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_d2" transform="translate(286.0,366.0)">
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
@@ -358,15 +358,6 @@ polyline {fill: none}
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
             <path class="sld-sw-open" d="M8,0 0,8"/>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idvl1_95_trf1_95_vl2_95_trf1" transform="translate(380.0,592.5)">
-            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
-            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
-        </g>
-        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" transform="translate(722.0,88.0)">
-            <circle cx="5" cy="15" r="5"/>
-            <circle cx="11" cy="15" r="5"/>
-            <circle cx="8" cy="19" r="5"/>
-        </g>
         <g class="sld-wire sld-constant-color" id="idedge_95_vl1_95_trf1">
             <polyline points="100.0,550.0,100.0,600.0,377.0,600.0"/>
         </g>
@@ -381,6 +372,15 @@ polyline {fill: none}
         </g>
         <g class="sld-wire sld-constant-color" id="idedge_95_vl3_95_trf2_95_one">
             <polyline points="737.0,100.0,1020.0,100.0,1020.0,130.0"/>
+        </g>
+        <g class="sld-two-wt sld-constant-color" id="idvl1_95_trf1_95_vl2_95_trf1" transform="translate(380.0,592.5)">
+            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
+        </g>
+        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" transform="translate(722.0,88.0)">
+            <circle cx="5" cy="15" r="5"/>
+            <circle cx="11" cy="15" r="5"/>
+            <circle cx="8" cy="19" r="5"/>
         </g>
         <g id="LABEL_VL_vl1">
             <text class="sld-graph-label" transform="rotate(0,0,0)" x="0.0" y="10.0">vl1</text>

--- a/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
+++ b/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
@@ -119,9 +119,9 @@ polyline {fill: none}
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
             <path class="sld-sw-open" d="M8,0 0,8"/>
         </g>
-        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="translate(255.0,360.0)">
+            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
         </g>
         <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_d2" transform="translate(286.0,366.0)">
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
@@ -278,15 +278,6 @@ polyline {fill: none}
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
             <path class="sld-sw-open" d="M8,0 0,8"/>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idvl1_95_trf1_95_vl2_95_trf1" transform="translate(380.0,592.5)">
-            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
-            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
-        </g>
-        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" transform="translate(722.0,88.0)">
-            <circle cx="5" cy="15" r="5"/>
-            <circle cx="11" cy="15" r="5"/>
-            <circle cx="8" cy="19" r="5"/>
-        </g>
         <g class="sld-wire sld-constant-color" id="idedge_95_vl1_95_trf1">
             <polyline points="100.0,550.0,100.0,600.0,377.0,600.0"/>
         </g>
@@ -301,6 +292,15 @@ polyline {fill: none}
         </g>
         <g class="sld-wire sld-constant-color" id="idedge_95_vl3_95_trf2_95_one">
             <polyline points="737.0,100.0,1020.0,100.0,1020.0,130.0"/>
+        </g>
+        <g class="sld-two-wt sld-constant-color" id="idvl1_95_trf1_95_vl2_95_trf1" transform="translate(380.0,592.5)">
+            <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
+            <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
+        </g>
+        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" transform="translate(722.0,88.0)">
+            <circle cx="5" cy="15" r="5"/>
+            <circle cx="11" cy="15" r="5"/>
+            <circle cx="8" cy="19" r="5"/>
         </g>
         <g id="LABEL_VL_vl1">
             <text class="sld-graph-label" transform="rotate(0,0,0)" x="0.0" y="10.0">vl1</text>

--- a/single-line-diagram-core/src/test/resources/substation_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/substation_optimized.svg
@@ -210,9 +210,9 @@ polyline {fill: none}
             <use class="sld-sw-closed" href="#DISCONNECTOR-CLOSED"/>
             <use class="sld-sw-open" href="#DISCONNECTOR-OPEN"/>
         </g>
-        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-            <use class="sld-sw-closed" href="#BREAKER-CLOSED"/>
-            <use class="sld-sw-open" href="#BREAKER-OPEN"/>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="translate(255.0,360.0)">
+            <use class="sld-sw-closed" href="#BREAKER-CLOSED" transform="rotate(90.0,10.0,10.0)"/>
+            <use class="sld-sw-open" href="#BREAKER-OPEN" transform="rotate(90.0,10.0,10.0)"/>
         </g>
         <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_d2" transform="translate(286.0,366.0)">
             <use class="sld-sw-closed" href="#DISCONNECTOR-CLOSED"/>
@@ -412,15 +412,6 @@ polyline {fill: none}
             <use class="sld-sw-closed" href="#DISCONNECTOR-CLOSED"/>
             <use class="sld-sw-open" href="#DISCONNECTOR-OPEN"/>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idvl1_95_trf1_95_vl2_95_trf1" transform="translate(380.0,592.5)">
-            <use href="#TWO_WINDINGS_TRANSFORMER-WINDING1" transform="rotate(90.0,5.0,7.5)"/>
-            <use href="#TWO_WINDINGS_TRANSFORMER-WINDING2" transform="rotate(90.0,5.0,7.5)"/>
-        </g>
-        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" transform="translate(722.0,88.0)">
-            <use href="#THREE_WINDINGS_TRANSFORMER-WINDING1"/>
-            <use href="#THREE_WINDINGS_TRANSFORMER-WINDING2"/>
-            <use href="#THREE_WINDINGS_TRANSFORMER-WINDING3"/>
-        </g>
         <g class="sld-wire sld-constant-color" id="idedge_95_vl1_95_trf1">
             <polyline points="100.0,550.0,100.0,600.0,377.0,600.0"/>
         </g>
@@ -435,6 +426,15 @@ polyline {fill: none}
         </g>
         <g class="sld-wire sld-constant-color" id="idedge_95_vl3_95_trf2_95_one">
             <polyline points="737.0,100.0,1020.0,100.0,1020.0,130.0"/>
+        </g>
+        <g class="sld-two-wt sld-constant-color" id="idvl1_95_trf1_95_vl2_95_trf1" transform="translate(380.0,592.5)">
+            <use href="#TWO_WINDINGS_TRANSFORMER-WINDING1" transform="rotate(90.0,5.0,7.5)"/>
+            <use href="#TWO_WINDINGS_TRANSFORMER-WINDING2" transform="rotate(90.0,5.0,7.5)"/>
+        </g>
+        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2_95_one_95_vl2_95_trf2_95_one_95_vl3_95_trf2_95_one" transform="translate(722.0,88.0)">
+            <use href="#THREE_WINDINGS_TRANSFORMER-WINDING1"/>
+            <use href="#THREE_WINDINGS_TRANSFORMER-WINDING2"/>
+            <use href="#THREE_WINDINGS_TRANSFORMER-WINDING3"/>
         </g>
         <g id="LABEL_VL_vl1">
             <text class="sld-graph-label" transform="rotate(0,0,0)" x="0.0" y="10.0">vl1</text>

--- a/single-line-diagram-core/src/test/resources/vl1.svg
+++ b/single-line-diagram-core/src/test/resources/vl1.svg
@@ -145,9 +145,9 @@ polyline {fill: none}
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
             <path class="sld-sw-open" d="M8,0 0,8"/>
         </g>
-        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="translate(255.0,360.0)">
+            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
         </g>
         <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_d2" transform="translate(286.0,366.0)">
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>

--- a/single-line-diagram-core/src/test/resources/vl1_external_css.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_external_css.svg
@@ -112,9 +112,9 @@
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
             <path class="sld-sw-open" d="M8,0 0,8"/>
         </g>
-        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="translate(255.0,360.0)">
+            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
         </g>
         <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_d2" transform="translate(286.0,366.0)">
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>

--- a/single-line-diagram-core/src/test/resources/vl1_external_css_no_import.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_external_css_no_import.svg
@@ -111,9 +111,9 @@
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
             <path class="sld-sw-open" d="M8,0 0,8"/>
         </g>
-        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="translate(255.0,360.0)">
+            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
         </g>
         <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_d2" transform="translate(286.0,366.0)">
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>

--- a/single-line-diagram-core/src/test/resources/vl1_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_nominal_voltage_style.svg
@@ -47,48 +47,6 @@ polyline {fill: none}
             <line x1="0" x2="1.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs1_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">bbs1</text>
         </g>
-        <g class="sld-wire sld-constant-color sld-vl180to300 sld-feeder-disconnected-connected" id="_95_vl1_95_FICT_95_vl1_95_3WT_95_fictif_95_3WT_95_TWO">
-            <polyline points="12.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl50to70 sld-feeder-disconnected" id="_95_vl1_95_FICT_95_vl1_95_3WT_95_fictif_95_3WT_95_THREE">
-            <polyline points="12.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_bbs1_95_d">
-            <polyline points="19.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_d_95_FICT_95_vl1_95_1">
-            <polyline points="19.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_FICT_95_vl1_95_1_95_b">
-            <polyline points="19.0,49.0,19.0,39.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_b_95_l">
-            <polyline points="19.0,39.0,19.0,44.5"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_bbs1_95_d2WT_95_1">
-            <polyline points="19.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_d2WT_95_1_95_FICT_95_vl1_95_4">
-            <polyline points="19.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500 sld-feeder-connected-disconnected" id="_95_vl1_95_2WT_95_ONE_95_b2WT_95_1">
-            <polyline points="19.0,41.0,19.0,39.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_b2WT_95_1_95_FICT_95_vl1_95_4">
-            <polyline points="19.0,39.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_bbs1_95_d3WT_95_1">
-            <polyline points="19.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_d3WT_95_1_95_FICT_95_vl1_95_6">
-            <polyline points="19.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_FICT_95_vl1_95_3WT_95_fictif_95_b3WT_95_1">
-            <polyline points="19.0,61.0,19.0,59.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_b3WT_95_1_95_FICT_95_vl1_95_6">
-            <polyline points="19.0,39.0,19.0,49.0"/>
-        </g>
         <g class="sld-load sld-constant-color sld-vl300to500" id="idl" transform="translate(11.0,44.5)">
             <rect height="9" width="16"/>
             <line x1="0" x2="16" y1="0" y2="9"/>

--- a/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -195,9 +195,9 @@ polyline {fill: none}
             <use class="sld-sw-closed" href="#DISCONNECTOR-CLOSED"/>
             <use class="sld-sw-open" href="#DISCONNECTOR-OPEN"/>
         </g>
-        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-            <use class="sld-sw-closed" href="#BREAKER-CLOSED"/>
-            <use class="sld-sw-open" href="#BREAKER-OPEN"/>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="translate(255.0,360.0)">
+            <use class="sld-sw-closed" href="#BREAKER-CLOSED" transform="rotate(90.0,10.0,10.0)"/>
+            <use class="sld-sw-open" href="#BREAKER-OPEN" transform="rotate(90.0,10.0,10.0)"/>
         </g>
         <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_d2" transform="translate(286.0,366.0)">
             <use class="sld-sw-closed" href="#DISCONNECTOR-CLOSED"/>

--- a/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
@@ -145,9 +145,9 @@ polyline {fill: none}
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
             <path class="sld-sw-open" d="M8,0 0,8"/>
         </g>
-        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
-            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
-            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="translate(255.0,360.0)">
+            <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+            <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
         </g>
         <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_d2" transform="translate(286.0,366.0)">
             <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>

--- a/single-line-diagram-core/src/test/resources/vl1_tooltip_opt.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_tooltip_opt.svg
@@ -196,10 +196,10 @@ polyline {fill: none}
             <use class="sld-sw-closed" href="#DISCONNECTOR-CLOSED"/>
             <use class="sld-sw-open" href="#DISCONNECTOR-OPEN"/>
         </g>
-        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="matrix(0.0,1.0,-1.0,0.0,275.0,360.0)">
+        <g class="sld-breaker sld-constant-color sld-closed" id="idvl1_95_b1" transform="translate(255.0,360.0)">
             <title>vl1_b1</title>
-            <use class="sld-sw-closed" href="#BREAKER-CLOSED"/>
-            <use class="sld-sw-open" href="#BREAKER-OPEN"/>
+            <use class="sld-sw-closed" href="#BREAKER-CLOSED" transform="rotate(90.0,10.0,10.0)"/>
+            <use class="sld-sw-open" href="#BREAKER-OPEN" transform="rotate(90.0,10.0,10.0)"/>
         </g>
         <g class="sld-disconnector sld-constant-color sld-closed" id="idvl1_95_d2" transform="translate(286.0,366.0)">
             <title>vl1_d2</title>

--- a/single-line-diagram-core/src/test/resources/vl2_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_nominal_voltage_style.svg
@@ -47,36 +47,6 @@ polyline {fill: none}
             <line x1="0" x2="1.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs2_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">bbs2</text>
         </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500 sld-feeder-connected-disconnected" id="_95_vl2_95_FICT_95_vl2_95_3WT_95_fictif_95_3WT_95_ONE">
-            <polyline points="12.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl50to70 sld-feeder-connected-disconnected" id="_95_vl2_95_FICT_95_vl2_95_3WT_95_fictif_95_3WT_95_THREE">
-            <polyline points="12.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl2_95_bbs2_95_d2WT_95_2">
-            <polyline points="19.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl2_95_d2WT_95_2_95_FICT_95_vl2_95_2">
-            <polyline points="19.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl180to300 sld-feeder-disconnected-connected" id="_95_vl2_95_2WT_95_TWO_95_b2WT_95_2">
-            <polyline points="19.0,41.0,19.0,39.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl2_95_b2WT_95_2_95_FICT_95_vl2_95_2">
-            <polyline points="19.0,39.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl2_95_bbs2_95_d3WT_95_2">
-            <polyline points="19.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl2_95_d3WT_95_2_95_FICT_95_vl2_95_4">
-            <polyline points="19.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl2_95_FICT_95_vl2_95_3WT_95_fictif_95_b3WT_95_2">
-            <polyline points="19.0,61.0,19.0,59.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl2_95_b3WT_95_2_95_FICT_95_vl2_95_4">
-            <polyline points="19.0,39.0,19.0,49.0"/>
-        </g>
         <g class="sld-two-wt sld-constant-color" id="id2WT_95_TWO" transform="translate(14.0,41.5)">
             <circle class="sld-vl180to300" cx="5" cy="10" r="5"/>
             <circle class="sld-vl300to500" cx="5" cy="5" r="5"/>

--- a/single-line-diagram-core/src/test/resources/vl3_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_nominal_voltage_style.svg
@@ -47,24 +47,6 @@ polyline {fill: none}
             <line x1="0" x2="1.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs3_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">bbs3</text>
         </g>
-        <g class="sld-wire sld-constant-color sld-vl300to500 sld-feeder-disconnected" id="_95_vl3_95_FICT_95_vl3_95_3WT_95_fictif_95_3WT_95_ONE">
-            <polyline points="12.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl180to300 sld-feeder-disconnected-connected" id="_95_vl3_95_FICT_95_vl3_95_3WT_95_fictif_95_3WT_95_TWO">
-            <polyline points="12.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl50to70" id="_95_vl3_95_bbs3_95_d3WT_95_3">
-            <polyline points="19.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl50to70" id="_95_vl3_95_d3WT_95_3_95_FICT_95_vl3_95_2">
-            <polyline points="19.0,49.0,19.0,49.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl50to70" id="_95_vl3_95_FICT_95_vl3_95_3WT_95_fictif_95_b3WT_95_3">
-            <polyline points="19.0,61.0,19.0,59.0"/>
-        </g>
-        <g class="sld-wire sld-constant-color sld-vl50to70" id="_95_vl3_95_b3WT_95_3_95_FICT_95_vl3_95_2">
-            <polyline points="19.0,39.0,19.0,49.0"/>
-        </g>
         <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl3_95_3WT_95_fictif" transform="translate(11.0,37.0)">
             <circle class="sld-vl300to500" cx="5" cy="15" r="5"/>
             <circle class="sld-vl180to300" cx="11" cy="15" r="5"/>

--- a/single-line-diagram-core/src/test/resources/zone.svg
+++ b/single-line-diagram-core/src/test/resources/zone.svg
@@ -110,15 +110,15 @@ polyline {fill: none}
         <g class="sld-constant-color" id="idLine_95_ONE" transform="translate(70.0,700.0)">
             <text class="sld-label" id="Line_ONE__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">Line</text>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idTransformer_95_ONE_95_Transformer_95_TWO" transform="translate(65.0,392.5)">
-            <circle cx="5" cy="10" r="5" transform="rotate(180.0,5.0,7.5)"/>
-            <circle cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
-        </g>
         <g class="sld-wire sld-constant-color" id="idedge_95_Transformer_95_ONE">
             <polyline points="70.0,350.0,70.0,370.0,70.0,392.0"/>
         </g>
         <g class="sld-wire sld-constant-color" id="idedge_95_Transformer_95_TWO">
             <polyline points="70.0,408.0,70.0,430.0,70.0,450.0"/>
+        </g>
+        <g class="sld-two-wt sld-constant-color" id="idTransformer_95_ONE_95_Transformer_95_TWO" transform="translate(65.0,392.5)">
+            <circle cx="5" cy="10" r="5" transform="rotate(180.0,5.0,7.5)"/>
+            <circle cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
         </g>
         <g class="sld-busbar-section sld-constant-color" id="idBus21" transform="translate(150.0,1150.0)">
             <line x1="0" x2="40.0" y1="0" y2="0"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No, but simplifies rotation problem of issue #247 


**What kind of change does this PR introduce?**
Bug fix / refactor


**What is the current behavior?**
3WT are drawn below the connecting lines, leading to overlapping
Labels are rotated on switches if node is rotated
Complex code used to handle rotation, and node rotation changed while drawing.


**What is the new behavior (if this is a feature change)?**
3WT drawn above connecting lines
Simpler code to handle rotation, which is now carried by subcomponent elements (like it was already done for 3wt), while translation is carried by the component element. This avoids the label and decorator rotation (decorator rotation was previously avoided by adding another rotation on it)


**Does this PR introduce a breaking change or deprecate an API?** Yes, as the refactor needed has changed protected methods which might be (and in fact are) overriden
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*

