### PR TITLE
Force layout: avoid duplicating force in case of duplicated edge

### DIFF
--- a/single-line-diagram-force-layout/src/main/java/com/powsybl/sld/force/layout/Spring.java
+++ b/single-line-diagram-force-layout/src/main/java/com/powsybl/sld/force/layout/Spring.java
@@ -8,6 +8,7 @@ package com.powsybl.sld.force.layout;
 
 import java.io.PrintWriter;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * @author Mathilde Grapin <mathilde.grapin at rte-france.com>
@@ -57,5 +58,22 @@ public class Spring {
         Vector screenPosition2 = canvas.toScreen(source.getPosition());
         printWriter.printf(Locale.US, "<line x1=\"%.2f\" y1=\"%.2f\" x2=\"%.2f\" y2=\"%.2f\"/>%n",
             screenPosition1.getX(), screenPosition1.getY(), screenPosition2.getX(), screenPosition2.getY());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Spring spring = (Spring) o;
+        return source == spring.source && target == spring.target;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(source, target);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
Force layout algorithm is not robust to duplicated edges


**What is the new behavior (if this is a feature change)?**
Force layout algorithm robust to duplicated edges



**Does this PR introduce a breaking change or deprecate an API?**
No

**Other information**:
Duplicated edges in the force layout unit test. The force layout algorithm was diverging.
