### PR TITLE
Two- and three-windings transformers node id equal to equipment id

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/NetworkGraphBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/NetworkGraphBuilder.java
@@ -255,10 +255,11 @@ public class NetworkGraphBuilder implements GraphBuilder {
                         FeederWithSideNode.Side.THREE, createVoltageLevelInfos(transformer.getLeg3().getTerminal()));
 
                 // create middle node
-                Middle3WTNode middleNode = new Middle3WTNode(graph, transformer.getId() + "_fictif",
-                        voltageLevelInfosBySide.get(FeederWithSideNode.Side.ONE),
-                        voltageLevelInfosBySide.get(FeederWithSideNode.Side.TWO),
-                        voltageLevelInfosBySide.get(FeederWithSideNode.Side.THREE));
+                Middle3WTNode middleNode = new Middle3WTNode(transformer.getId(),
+                    voltageLevelInfosBySide.get(FeederWithSideNode.Side.ONE),
+                    voltageLevelInfosBySide.get(FeederWithSideNode.Side.TWO),
+                    voltageLevelInfosBySide.get(FeederWithSideNode.Side.THREE),
+                    graph);
 
                 FeederWithSideNode.Side firstOtherLegSide;
                 FeederWithSideNode.Side secondOtherLegSide;
@@ -643,7 +644,7 @@ public class NetworkGraphBuilder implements GraphBuilder {
             VoltageLevelInfos voltageLevelInfos1 = new VoltageLevelInfos(vl1.getId(), vl1.getNameOrId(), vl1.getNominalV());
             VoltageLevelInfos voltageLevelInfos2 = new VoltageLevelInfos(vl2.getId(), vl2.getNameOrId(), vl2.getNominalV());
 
-            graph.addMultiTermNode(Middle2WTNode.create(graph, n1, n2, voltageLevelInfos1, voltageLevelInfos2));
+            graph.addMultiTermNode(Middle2WTNode.create(transfo.getId(), graph, n1, n2, voltageLevelInfos1, voltageLevelInfos2));
         });
     }
 
@@ -674,7 +675,7 @@ public class NetworkGraphBuilder implements GraphBuilder {
             VoltageLevelInfos voltageLevelInfos2 = new VoltageLevelInfos(vl2.getId(), vl2.getNameOrId(), vl2.getNominalV());
             VoltageLevelInfos voltageLevelInfos3 = new VoltageLevelInfos(vl3.getId(), vl3.getNameOrId(), vl3.getNominalV());
 
-            graph.addMultiTermNode(Middle3WTNode.create(graph, n1, n2, n3, voltageLevelInfos1, voltageLevelInfos2, voltageLevelInfos3));
+            graph.addMultiTermNode(Middle3WTNode.create(transfo.getId(), graph, n1, n2, n3, voltageLevelInfos1, voltageLevelInfos2, voltageLevelInfos3));
         });
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/RawGraphBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/RawGraphBuilder.java
@@ -204,7 +204,7 @@ public class RawGraphBuilder implements GraphBuilder {
             Feeder2WTLegNode feeder2WTNode2 = vl2.createFeeder2wtLegNode(id, TWO, order2, direction2);
             f2WTNodes.put(vl1, feeder2WtNode1);
             f2WTNodes.put(vl2, feeder2WTNode2);
-            ssGraph.addMultiTermNode(Middle2WTNode.create(ssGraph, feeder2WtNode1, feeder2WTNode2, vl1.voltageLevelInfos, vl2.voltageLevelInfos));
+            ssGraph.addMultiTermNode(Middle2WTNode.create(id, ssGraph, feeder2WtNode1, feeder2WTNode2, vl1.voltageLevelInfos, vl2.voltageLevelInfos));
             return f2WTNodes;
         }
 
@@ -224,7 +224,7 @@ public class RawGraphBuilder implements GraphBuilder {
             f3WTNodes.put(vl3, feeder3WTNode3);
 
             // creation of the middle node and the edges linking the transformer leg nodes to this middle node
-            ssGraph.addMultiTermNode(Middle3WTNode.create(ssGraph, feeder3WTNode1, feeder3WTNode2, feeder3WTNode3,
+            ssGraph.addMultiTermNode(Middle3WTNode.create(id, ssGraph, feeder3WTNode1, feeder3WTNode2, feeder3WTNode3,
                     vl1.voltageLevelInfos, vl2.voltageLevelInfos, vl3.voltageLevelInfos));
 
             return f3WTNodes;

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/BusConnection.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/BusConnection.java
@@ -14,6 +14,6 @@ import static com.powsybl.sld.library.ComponentTypeName.BUS_CONNECTION;
 public class BusConnection extends FictitiousNode {
 
     public BusConnection(VoltageLevelGraph graph, String id) {
-        super(graph, id, BUS_CONNECTION);
+        super(id, BUS_CONNECTION, graph);
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/FictitiousNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/FictitiousNode.java
@@ -14,7 +14,7 @@ package com.powsybl.sld.model;
  */
 public class FictitiousNode extends Node {
 
-    protected FictitiousNode(VoltageLevelGraph graph, String id, String componentType) {
+    protected FictitiousNode(String id, String componentType, VoltageLevelGraph graph) {
         super(NodeType.FICTITIOUS, id, id, id, componentType, true, graph);
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/InternalNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/InternalNode.java
@@ -14,6 +14,6 @@ import static com.powsybl.sld.library.ComponentTypeName.NODE;
 public class InternalNode extends FictitiousNode {
 
     public InternalNode(VoltageLevelGraph graph, String id) {
-        super(graph, id, NODE);
+        super(id, NODE, graph);
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Middle2WTNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Middle2WTNode.java
@@ -23,14 +23,14 @@ public class Middle2WTNode extends FictitiousNode {
 
     private final VoltageLevelInfos voltageLevelInfosLeg2;
 
-    public Middle2WTNode(VoltageLevelGraph graph, String id, VoltageLevelInfos voltageLevelInfosLeg1, VoltageLevelInfos voltageLevelInfosLeg2) {
-        super(graph, id, TWO_WINDINGS_TRANSFORMER);
+    public Middle2WTNode(String id, VoltageLevelInfos voltageLevelInfosLeg1, VoltageLevelInfos voltageLevelInfosLeg2, VoltageLevelGraph graph) {
+        super(id, TWO_WINDINGS_TRANSFORMER, graph);
         this.voltageLevelInfosLeg1 = Objects.requireNonNull(voltageLevelInfosLeg1);
         this.voltageLevelInfosLeg2 = Objects.requireNonNull(voltageLevelInfosLeg2);
     }
 
-    public static Middle2WTNode create(BaseGraph graph, Node node1, Node node2, VoltageLevelInfos vlInfos1, VoltageLevelInfos vlInfos2) {
-        Middle2WTNode middleNode = new Middle2WTNode(null, node1.getId() + "_" + node2.getId(), vlInfos1, vlInfos2);
+    public static Middle2WTNode create(String id, BaseGraph graph, Node node1, Node node2, VoltageLevelInfos vlInfos1, VoltageLevelInfos vlInfos2) {
+        Middle2WTNode middleNode = new Middle2WTNode(id, vlInfos1, vlInfos2, null);
 
         BranchEdge edge1 = graph.addTwtEdge(node1.getId() + EDGE_SUFFIX, node1, middleNode);
         BranchEdge edge2 = graph.addTwtEdge(node2.getId() + EDGE_SUFFIX, middleNode, node2);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Middle3WTNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Middle3WTNode.java
@@ -26,18 +26,16 @@ public class Middle3WTNode extends FictitiousNode {
 
     private final VoltageLevelInfos voltageLevelInfosLeg3;
 
-    public Middle3WTNode(VoltageLevelGraph graph, String id, VoltageLevelInfos voltageLevelInfosLeg1, VoltageLevelInfos voltageLevelInfosLeg2,
-                         VoltageLevelInfos voltageLevelInfosLeg3) {
-        super(graph, id, THREE_WINDINGS_TRANSFORMER);
+    public Middle3WTNode(String id, VoltageLevelInfos voltageLevelInfosLeg1, VoltageLevelInfos voltageLevelInfosLeg2, VoltageLevelInfos voltageLevelInfosLeg3, VoltageLevelGraph graph) {
+        super(id, THREE_WINDINGS_TRANSFORMER, graph);
         this.voltageLevelInfosLeg1 = Objects.requireNonNull(voltageLevelInfosLeg1);
         this.voltageLevelInfosLeg2 = Objects.requireNonNull(voltageLevelInfosLeg2);
         this.voltageLevelInfosLeg3 = Objects.requireNonNull(voltageLevelInfosLeg3);
     }
 
-    public static Middle3WTNode create(BaseGraph ssGraph, Node node1, Node node2, Node node3,
+    public static Middle3WTNode create(String id, BaseGraph ssGraph, Node node1, Node node2, Node node3,
                                        VoltageLevelInfos vlInfos1, VoltageLevelInfos vlInfos2, VoltageLevelInfos vlInfos3) {
-        Middle3WTNode middleNode = new Middle3WTNode(null, node1.getId() + "_" + node2.getId() + "_" + node3.getId(),
-                vlInfos1, vlInfos2, vlInfos3);
+        Middle3WTNode middleNode = new Middle3WTNode(id, vlInfos1, vlInfos2, vlInfos3, null);
 
         BranchEdge edge1 = ssGraph.addTwtEdge(node1.getId() + EDGE_SUFFIX, node1, middleNode);
         BranchEdge edge2 = ssGraph.addTwtEdge(node2.getId() + EDGE_SUFFIX, middleNode, node2);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Node.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Node.java
@@ -7,6 +7,7 @@
 package com.powsybl.sld.model;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.powsybl.sld.library.ComponentTypeName;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
@@ -75,6 +76,7 @@ public class Node implements BaseNode {
         String tmpId = Objects.requireNonNull(id);
         if (type == NodeType.FICTITIOUS &&
                 graph != null &&
+                !componentType.equals(ComponentTypeName.THREE_WINDINGS_TRANSFORMER) &&
                 !StringUtils.startsWith(tmpId, "FICT_" + this.graph.getVoltageLevelInfos().getId() + "_")) {
             this.id = "FICT_" + graph.getVoltageLevelInfos().getId() + "_" + tmpId;
         } else {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramLabelProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramLabelProvider.java
@@ -16,7 +16,6 @@ import com.powsybl.sld.model.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import static com.powsybl.sld.model.Node.NodeType.FEEDER;
 
@@ -146,8 +145,7 @@ public class DefaultDiagramLabelProvider implements DiagramLabelProvider {
                     break;
             }
         } else if (node instanceof Middle3WTNode) {
-            Optional<Node> feederNode = node.getAdjacentNodes().stream().filter(n -> n.getType() == FEEDER).findFirst();
-            feederNode.ifPresent(value -> addBranchStatusDecorator(nodeDecorators, node, network.getThreeWindingsTransformer(value.getEquipmentId())));
+            addBranchStatusDecorator(nodeDecorators, node, network.getThreeWindingsTransformer(node.getEquipmentId()));
         }
 
         return nodeDecorators;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSVGWriter.java
@@ -152,7 +152,7 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
         vl1Trf2Two.setX(440);
         vl1Trf2Two.setY(80);
         g1.addNode(vl1Trf2Two);
-        Middle3WTNode vl1Trf2Fict = new Middle3WTNode(g1, "vl1_trf2", voltageLevelInfosLeg1, voltageLevelInfosLeg2, voltageLevelInfosLeg3);
+        Middle3WTNode vl1Trf2Fict = new Middle3WTNode("vl1_trf2", voltageLevelInfosLeg1, voltageLevelInfosLeg2, voltageLevelInfosLeg3, g1);
         vl1Trf2Fict.setX(400);
         vl1Trf2Fict.setY(140);
         g1.addNode(vl1Trf2Fict);
@@ -237,7 +237,7 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
         vl2Trf2Two.setX(190);
         vl2Trf2Two.setY(80);
         g2.addNode(vl2Trf2Two);
-        Middle3WTNode vl2Trf2Fict = new Middle3WTNode(g2, "vl2_trf2", voltageLevelInfosLeg1, voltageLevelInfosLeg2, voltageLevelInfosLeg3);
+        Middle3WTNode vl2Trf2Fict = new Middle3WTNode("vl2_trf2", voltageLevelInfosLeg1, voltageLevelInfosLeg2, voltageLevelInfosLeg3, g2);
         vl2Trf2Fict.setX(160);
         vl2Trf2Fict.setY(140);
         g2.addNode(vl2Trf2Fict);
@@ -303,7 +303,7 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
         vl3Trf2Two.setX(190);
         vl3Trf2Two.setY(80);
         g3.addNode(vl3Trf2Two);
-        Middle3WTNode vl3Trf2Fict = new Middle3WTNode(g3, "vl3_trf2", voltageLevelInfosLeg1, voltageLevelInfosLeg2, voltageLevelInfosLeg3);
+        Middle3WTNode vl3Trf2Fict = new Middle3WTNode("vl3_trf2", voltageLevelInfosLeg1, voltageLevelInfosLeg2, voltageLevelInfosLeg3, g3);
         vl3Trf2Fict.setX(150);
         vl3Trf2Fict.setY(140);
         g3.addNode(vl3Trf2Fict);
@@ -543,7 +543,7 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
         substG.addNode(g1Graph);
         substG.addNode(g2Graph);
         substG.addNode(g3Graph);
-        Node nMulti1 = new Middle2WTNode(null, vl1Trf1.getId() + "_" + vl2Trf1.getId(), vl1Infos, vl2Infos);
+        Node nMulti1 = new Middle2WTNode(vl1Trf1.getId() + "_" + vl2Trf1.getId(), vl1Infos, vl2Infos, null);
         nMulti1.setX(365., false);
         nMulti1.setY(550., false);
         BranchEdge edge1 = substG.addEdge("edge_" + vl1Trf1.getId(), vl1Trf1, nMulti1);
@@ -554,7 +554,7 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
         nMulti1.addAdjacentEdge(edge2);
         substG.addMultiTermNode(nMulti1);
 
-        Node nMulti3 = new Middle3WTNode(null, vl1Trf2.getId() + "_" + vl2Trf2.getId() + "_" + vl3Trf2.getId(), vl1Infos, vl2Infos, vl3Infos);
+        Node nMulti3 = new Middle3WTNode(vl1Trf2.getId() + "_" + vl2Trf2.getId() + "_" + vl3Trf2.getId(), vl1Infos, vl2Infos, vl3Infos, null);
         nMulti3.setX(710., false);
         nMulti3.setY(50., false);
         BranchEdge edge21 = substG.addEdge("edge_" + vl1Trf2.getId(), vl1Trf2, nMulti3);
@@ -632,7 +632,7 @@ public class TestSVGWriter extends AbstractTestCaseIidm {
         s1Graph.addNode(vl12Graph);
         twtSide1Node.setLabel(TRANSFORMER_ID);
         twtSide2Node.setLabel(TRANSFORMER_ID);
-        Node nMulti1 = new Middle2WTNode(null, twtSide1Node.getId() + "_" + twtSide2Node.getId(), vl12Infos, vl11Infos);
+        Node nMulti1 = new Middle2WTNode(twtSide1Node.getId() + "_" + twtSide2Node.getId(), vl12Infos, vl11Infos, null);
         nMulti1.setX(50, false);
         nMulti1.setY(350, false);
         BranchEdge edge1 = s1Graph.addEdge("edge_" + twtSide1Node.getId(), twtSide1Node, nMulti1);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/util/NominalVoltageStyleTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/util/NominalVoltageStyleTest.java
@@ -146,7 +146,7 @@ public class NominalVoltageStyleTest extends AbstractTestCaseIidm {
         assertTrue(wireStyles.contains("sld-constant-color"));
         assertTrue(wireStyles.contains("sld-vl300to500"));
 
-        Node fict3WTNode = graph1.getNode("FICT_vl1_3WT_fictif");
+        Node fict3WTNode = graph1.getNode("3WT");
         List<String>  node3WTStyle = styleProvider.getSvgNodeStyles(fict3WTNode, componentLibrary, false);
         assertEquals(2, node3WTStyle.size());
         assertTrue(node3WTStyle.contains("sld-three-wt"));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
@@ -133,7 +133,7 @@ public class TopologicalStyleTest extends AbstractTestCaseIidm {
         assertTrue(wireStyles.contains("sld-constant-color"));
         assertTrue(wireStyles.contains("sld-vl300to500-0"));
 
-        Node fict3WTNode = graph1.getNode("FICT_vl1_3WT_fictif");
+        Node fict3WTNode = graph1.getNode("3WT");
         List<String> node3WTStyle = styleProvider.getSvgNodeStyles(fict3WTNode, componentLibrary, true);
         assertEquals(2, node3WTStyle.size());
         assertTrue(node3WTStyle.contains("sld-constant-color"));

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
@@ -248,7 +248,7 @@ polyline {fill: none}
             </g>
         </g>
         <g class="cell idEXTERN_32_5" id="idEXTERN_32_5">
-            <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fNode" transform="translate(366.0,361.0)">
+            <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fNode" transform="translate(366.0,361.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder sld-constant-color" id="idT3_95_12_95_TWO" transform="translate(345.0,615.0)">
@@ -257,45 +257,45 @@ polyline {fill: none}
             <g class="sld-bottom-feeder sld-constant-color" id="idT3_95_12_95_THREE" transform="translate(395.0,615.0)">
                 <text class="sld-label" id="T3_12_THREE_S_LABEL" transform="rotate(0,0,0)" x="-5.0" y="5.0">T3_12</text>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_B11_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fBc">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_B11_95_FICT_95_VL1_95_T3_95_12_95_fBc">
                 <polyline points="370.0,310.0,370.0,310.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fBc_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fNode">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fBc_95_FICT_95_VL1_95_T3_95_12_95_fNode">
                 <polyline points="370.0,314.0,370.0,365.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fNode_95_FICT_95_VL1_95_T3_95_12_95_fictif">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fNode_95_T3_95_12">
                 <polyline points="370.0,365.0,370.0,541.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_TWO">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_TWO">
                 <polyline points="363.0,553.0,345.0,553.0,345.0,615.0"/>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,340.0,590.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,340.0,590.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,340.0,570.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,340.0,570.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE">
                 <polyline points="377.0,553.0,395.0,553.0,395.0,615.0"/>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,390.0,590.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,390.0,590.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,390.0,570.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,390.0,570.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fBc" transform="translate(366.0,306.0)">
+            <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fBc" transform="translate(366.0,306.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(362.0,541.0)">
+            <g class="sld-three-wt sld-constant-color" id="idT3_95_12" transform="translate(362.0,541.0)">
                 <circle cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
                 <circle cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
                 <circle cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
@@ -451,7 +451,7 @@ polyline {fill: none}
             </g>
         </g>
         <g class="cell idEXTERN_32_10" id="idEXTERN_32_10">
-            <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fNode" transform="translate(666.0,361.0)">
+            <g class="sld-node sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fNode" transform="translate(666.0,361.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder sld-constant-color" id="idT3_95_12_95_ONE" transform="translate(645.0,615.0)">
@@ -460,45 +460,45 @@ polyline {fill: none}
             <g class="sld-bottom-feeder sld-constant-color" id="idT3_95_12_95_THREE" transform="translate(695.0,615.0)">
                 <text class="sld-label" id="T3_12_THREE_S_LABEL" transform="rotate(0,0,0)" x="-5.0" y="5.0">T3_12</text>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_B12_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fBc">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_B12_95_FICT_95_VL1_95_T3_95_12_95_fBc">
                 <polyline points="670.0,335.0,670.0,335.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fBc_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fNode">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fBc_95_FICT_95_VL1_95_T3_95_12_95_fNode">
                 <polyline points="670.0,339.0,670.0,365.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fNode_95_FICT_95_VL1_95_T3_95_12_95_fictif">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fNode_95_T3_95_12">
                 <polyline points="670.0,365.0,670.0,541.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_ONE">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_ONE">
                 <polyline points="663.0,553.0,645.0,553.0,645.0,615.0"/>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,590.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,590.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,570.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,570.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE">
                 <polyline points="677.0,553.0,695.0,553.0,695.0,615.0"/>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,690.0,590.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,690.0,590.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,690.0,570.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,690.0,570.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fBc" transform="translate(666.0,331.0)">
+            <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fBc" transform="translate(666.0,331.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(662.0,541.0)">
+            <g class="sld-three-wt sld-constant-color" id="idT3_95_12" transform="translate(662.0,541.0)">
                 <circle cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
                 <circle cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
                 <circle cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
@@ -513,7 +513,7 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="idT11_95_TWO_95_edge">
             <polyline points="403.0,0.0,545.0,0.0,545.0,30.0"/>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(390.0,-7.5)">
+        <g class="sld-two-wt sld-constant-color" id="idT11" transform="translate(390.0,-7.5)">
             <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
             <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
         </g>

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreakerH.json
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreakerH.json
@@ -1709,9 +1709,9 @@
     } ],
     "multitermNodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "T11_ONE_T11_TWO",
-      "name" : "T11_ONE_T11_TWO",
-      "equipmentId" : "T11_ONE_T11_TWO",
+      "id" : "T11",
+      "name" : "T11",
+      "equipmentId" : "T11",
       "componentType" : "TWO_WINDINGS_TRANSFORMER",
       "fictitious" : true,
       "open" : false,
@@ -1730,13 +1730,13 @@
       "id" : "T11_ONE_edge",
       "nodes" : [ {
         "node1" : "T11_ONE",
-        "node2" : "T11_ONE_T11_TWO"
+        "node2" : "T11"
       } ],
       "snakeLine" : [ 275.0, 30.0, 275.0, 0.0, 20.0, 0.0, 20.0, 322.5 ]
     }, {
       "id" : "T11_TWO_edge",
       "nodes" : [ {
-        "node1" : "T11_ONE_T11_TWO",
+        "node1" : "T11",
         "node2" : "T11_TWO"
       } ],
       "snakeLine" : [ 20.0, 322.5, 20.0, 645.0, 525.0, 645.0, 525.0, 615.0 ]
@@ -2383,9 +2383,9 @@
   } ],
   "multitermNodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "T12_ONE_T12_TWO",
-    "name" : "T12_ONE_T12_TWO",
-    "equipmentId" : "T12_ONE_T12_TWO",
+    "id" : "T12",
+    "name" : "T12",
+    "equipmentId" : "T12",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -2401,9 +2401,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
-    "name" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
-    "equipmentId" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
+    "id" : "T3_12",
+    "name" : "T3_12",
+    "equipmentId" : "T3_12",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -2427,13 +2427,13 @@
     "id" : "T12_ONE_edge",
     "nodes" : [ {
       "node1" : "T12_ONE",
-      "node2" : "T12_ONE_T12_TWO"
+      "node2" : "T12"
     } ],
     "snakeLine" : [ 575.0, 30.0, 575.0, -60.0, 750.0, -60.0 ]
   }, {
     "id" : "T12_TWO_edge",
     "nodes" : [ {
-      "node1" : "T12_ONE_T12_TWO",
+      "node1" : "T12",
       "node2" : "T12_TWO"
     } ],
     "snakeLine" : [ 750.0, -60.0, 925.0, -60.0, 925.0, 30.0 ]
@@ -2441,20 +2441,20 @@
     "id" : "T3_12_ONE_EDGE",
     "nodes" : [ {
       "node1" : "T3_12_ONE",
-      "node2" : "T3_12_ONE_T3_12_TWO_T3_12_THREE"
+      "node2" : "T3_12"
     } ],
     "snakeLine" : [ 375.0, 30.0, 375.0, -90.0, -40.0, -90.0, -40.0, 705.0, 625.0, 705.0 ]
   }, {
     "id" : "T3_12_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
+      "node1" : "T3_12",
       "node2" : "T3_12_TWO"
     } ],
     "snakeLine" : [ 625.0, 705.0, 625.0, 615.0 ]
   }, {
     "id" : "T3_12_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
+      "node1" : "T3_12",
       "node2" : "T3_12_THREE"
     } ],
     "snakeLine" : [ 625.0, 705.0, 975.0, 705.0, 975.0, 590.0 ]

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreakerV.json
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreakerV.json
@@ -1709,9 +1709,9 @@
     } ],
     "multitermNodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "T11_ONE_T11_TWO",
-      "name" : "T11_ONE_T11_TWO",
-      "equipmentId" : "T11_ONE_T11_TWO",
+      "id" : "T11",
+      "name" : "T11",
+      "equipmentId" : "T11",
       "componentType" : "TWO_WINDINGS_TRANSFORMER",
       "fictitious" : true,
       "open" : false,
@@ -1730,13 +1730,13 @@
       "id" : "T11_ONE_edge",
       "nodes" : [ {
         "node1" : "T11_ONE",
-        "node2" : "T11_ONE_T11_TWO"
+        "node2" : "T11"
       } ],
       "snakeLine" : [ 275.0, 30.0, 275.0, 0.0, 20.0, 0.0, 20.0, 322.5 ]
     }, {
       "id" : "T11_TWO_edge",
       "nodes" : [ {
-        "node1" : "T11_ONE_T11_TWO",
+        "node1" : "T11",
         "node2" : "T11_TWO"
       } ],
       "snakeLine" : [ 20.0, 322.5, 20.0, 645.0, 525.0, 645.0, 525.0, 615.0 ]
@@ -2383,9 +2383,9 @@
   } ],
   "multitermNodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "T12_ONE_T12_TWO",
-    "name" : "T12_ONE_T12_TWO",
-    "equipmentId" : "T12_ONE_T12_TWO",
+    "id" : "T12",
+    "name" : "T12",
+    "equipmentId" : "T12",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -2401,9 +2401,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
-    "name" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
-    "equipmentId" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
+    "id" : "T3_12",
+    "name" : "T3_12",
+    "equipmentId" : "T3_12",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -2427,13 +2427,13 @@
     "id" : "T12_ONE_edge",
     "nodes" : [ {
       "node1" : "T12_ONE",
-      "node2" : "T12_ONE_T12_TWO"
+      "node2" : "T12"
     } ],
     "snakeLine" : [ 575.0, 30.0, 575.0, -60.0, -40.0, -60.0, -40.0, 322.5 ]
   }, {
     "id" : "T12_TWO_edge",
     "nodes" : [ {
-      "node1" : "T12_ONE_T12_TWO",
+      "node1" : "T12",
       "node2" : "T12_TWO"
     } ],
     "snakeLine" : [ -40.0, 322.5, -40.0, 705.0, 175.0, 705.0, 175.0, 720.0 ]
@@ -2441,20 +2441,20 @@
     "id" : "T3_12_ONE_EDGE",
     "nodes" : [ {
       "node1" : "T3_12_ONE",
-      "node2" : "T3_12_ONE_T3_12_TWO_T3_12_THREE"
+      "node2" : "T3_12"
     } ],
     "snakeLine" : [ 375.0, 30.0, 375.0, -90.0, -70.0, -90.0, -70.0, 735.0, 625.0, 735.0 ]
   }, {
     "id" : "T3_12_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
+      "node1" : "T3_12",
       "node2" : "T3_12_TWO"
     } ],
     "snakeLine" : [ 625.0, 735.0, 625.0, 615.0 ]
   }, {
     "id" : "T3_12_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
+      "node1" : "T3_12",
       "node2" : "T3_12_THREE"
     } ],
     "snakeLine" : [ 625.0, 735.0, -100.0, 735.0, -100.0, 1310.0, 225.0, 1310.0, 225.0, 1280.0 ]

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
@@ -300,31 +300,31 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color" id="_95_VL1_95_BR20_95_FICT_95_VL1_95_D19Fictif">
                 <polyline points="570.0,196.0,570.0,280.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_BR20_95_FICT_95_VL1_95_T3_95_12_95_fictif">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_BR20_95_T3_95_12">
                 <polyline points="570.0,176.0,570.0,104.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_TWO">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_TWO">
                 <polyline points="563.0,92.0,545.0,92.0,545.0,30.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,540.0,45.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,540.0,45.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,540.0,65.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,540.0,65.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE">
                 <polyline points="577.0,92.0,595.0,92.0,595.0,30.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,590.0,45.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,590.0,45.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,590.0,65.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,590.0,65.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
@@ -337,7 +337,7 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(562.0,80.0)">
+            <g class="sld-three-wt sld-constant-color" id="idT3_95_12" transform="translate(562.0,80.0)">
                 <circle cx="5" cy="15" r="5"/>
                 <circle cx="11" cy="15" r="5"/>
                 <circle cx="8" cy="19" r="5"/>
@@ -543,31 +543,31 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color" id="_95_VL1_95_BR30_95_FICT_95_VL1_95_D29Fictif">
                 <polyline points="670.0,196.0,670.0,280.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_BR30_95_FICT_95_VL1_95_T3_95_12_95_fictif">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_BR30_95_T3_95_12">
                 <polyline points="670.0,176.0,670.0,104.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_ONE">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_ONE">
                 <polyline points="663.0,92.0,645.0,92.0,645.0,30.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,45.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,45.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,65.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,65.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE">
                 <polyline points="677.0,92.0,695.0,92.0,695.0,30.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,690.0,45.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,690.0,45.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,690.0,65.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,690.0,65.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
@@ -580,7 +580,7 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(662.0,80.0)">
+            <g class="sld-three-wt sld-constant-color" id="idT3_95_12" transform="translate(662.0,80.0)">
                 <circle cx="5" cy="15" r="5"/>
                 <circle cx="11" cy="15" r="5"/>
                 <circle cx="8" cy="19" r="5"/>
@@ -595,7 +595,7 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="idT11_95_TWO_95_edge">
             <polyline points="378.0,0.0,445.0,0.0,445.0,30.0"/>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(365.0,-7.5)">
+        <g class="sld-two-wt sld-constant-color" id="idT11" transform="translate(365.0,-7.5)">
             <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
             <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
         </g>

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreakerH.json
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreakerH.json
@@ -1871,9 +1871,9 @@
     } ],
     "multitermNodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "T11_ONE_T11_TWO",
-      "name" : "T11_ONE_T11_TWO",
-      "equipmentId" : "T11_ONE_T11_TWO",
+      "id" : "T11",
+      "name" : "T11",
+      "equipmentId" : "T11",
       "componentType" : "TWO_WINDINGS_TRANSFORMER",
       "fictitious" : true,
       "open" : false,
@@ -1892,13 +1892,13 @@
       "id" : "T11_ONE_edge",
       "nodes" : [ {
         "node1" : "T11_ONE",
-        "node2" : "T11_ONE_T11_TWO"
+        "node2" : "T11"
       } ],
       "snakeLine" : [ 325.0, 30.0, 325.0, 0.0, 425.0, 0.0 ]
     }, {
       "id" : "T11_TWO_edge",
       "nodes" : [ {
-        "node1" : "T11_ONE_T11_TWO",
+        "node1" : "T11",
         "node2" : "T11_TWO"
       } ],
       "snakeLine" : [ 425.0, 0.0, 525.0, 0.0, 525.0, 30.0 ]
@@ -2609,9 +2609,9 @@
   } ],
   "multitermNodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "T12_ONE_T12_TWO",
-    "name" : "T12_ONE_T12_TWO",
-    "equipmentId" : "T12_ONE_T12_TWO",
+    "id" : "T12",
+    "name" : "T12",
+    "equipmentId" : "T12",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -2627,9 +2627,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
-    "name" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
-    "equipmentId" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
+    "id" : "T3_12",
+    "name" : "T3_12",
+    "equipmentId" : "T3_12",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -2653,13 +2653,13 @@
     "id" : "T12_ONE_edge",
     "nodes" : [ {
       "node1" : "T12_ONE",
-      "node2" : "T12_ONE_T12_TWO"
+      "node2" : "T12"
     } ],
     "snakeLine" : [ 575.0, 30.0, 575.0, -60.0, 750.0, -60.0 ]
   }, {
     "id" : "T12_TWO_edge",
     "nodes" : [ {
-      "node1" : "T12_ONE_T12_TWO",
+      "node1" : "T12",
       "node2" : "T12_TWO"
     } ],
     "snakeLine" : [ 750.0, -60.0, 925.0, -60.0, 925.0, 30.0 ]
@@ -2667,20 +2667,20 @@
     "id" : "T3_12_ONE_EDGE",
     "nodes" : [ {
       "node1" : "T3_12_ONE",
-      "node2" : "T3_12_ONE_T3_12_TWO_T3_12_THREE"
+      "node2" : "T3_12"
     } ],
     "snakeLine" : [ 375.0, 30.0, 375.0, -90.0, 625.0, -90.0 ]
   }, {
     "id" : "T3_12_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
+      "node1" : "T3_12",
       "node2" : "T3_12_TWO"
     } ],
     "snakeLine" : [ 625.0, -90.0, 625.0, 30.0 ]
   }, {
     "id" : "T3_12_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
+      "node1" : "T3_12",
       "node2" : "T3_12_THREE"
     } ],
     "snakeLine" : [ 625.0, -90.0, 975.0, -90.0, 975.0, 30.0 ]

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreakerV.json
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreakerV.json
@@ -1871,9 +1871,9 @@
     } ],
     "multitermNodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "T11_ONE_T11_TWO",
-      "name" : "T11_ONE_T11_TWO",
-      "equipmentId" : "T11_ONE_T11_TWO",
+      "id" : "T11",
+      "name" : "T11",
+      "equipmentId" : "T11",
       "componentType" : "TWO_WINDINGS_TRANSFORMER",
       "fictitious" : true,
       "open" : false,
@@ -1892,13 +1892,13 @@
       "id" : "T11_ONE_edge",
       "nodes" : [ {
         "node1" : "T11_ONE",
-        "node2" : "T11_ONE_T11_TWO"
+        "node2" : "T11"
       } ],
       "snakeLine" : [ 325.0, 30.0, 325.0, 0.0, 425.0, 0.0 ]
     }, {
       "id" : "T11_TWO_edge",
       "nodes" : [ {
-        "node1" : "T11_ONE_T11_TWO",
+        "node1" : "T11",
         "node2" : "T11_TWO"
       } ],
       "snakeLine" : [ 425.0, 0.0, 525.0, 0.0, 525.0, 30.0 ]
@@ -2609,9 +2609,9 @@
   } ],
   "multitermNodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "T12_ONE_T12_TWO",
-    "name" : "T12_ONE_T12_TWO",
-    "equipmentId" : "T12_ONE_T12_TWO",
+    "id" : "T12",
+    "name" : "T12",
+    "equipmentId" : "T12",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -2627,9 +2627,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
-    "name" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
-    "equipmentId" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
+    "id" : "T3_12",
+    "name" : "T3_12",
+    "equipmentId" : "T3_12",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -2653,13 +2653,13 @@
     "id" : "T12_ONE_edge",
     "nodes" : [ {
       "node1" : "T12_ONE",
-      "node2" : "T12_ONE_T12_TWO"
+      "node2" : "T12"
     } ],
     "snakeLine" : [ 575.0, 30.0, 575.0, -60.0, 20.0, -60.0, 20.0, 292.5 ]
   }, {
     "id" : "T12_TWO_edge",
     "nodes" : [ {
-      "node1" : "T12_ONE_T12_TWO",
+      "node1" : "T12",
       "node2" : "T12_TWO"
     } ],
     "snakeLine" : [ 20.0, 292.5, 20.0, 645.0, 175.0, 645.0, 175.0, 720.0 ]
@@ -2667,20 +2667,20 @@
     "id" : "T3_12_ONE_EDGE",
     "nodes" : [ {
       "node1" : "T3_12_ONE",
-      "node2" : "T3_12_ONE_T3_12_TWO_T3_12_THREE"
+      "node2" : "T3_12"
     } ],
     "snakeLine" : [ 375.0, 30.0, 375.0, -90.0, 625.0, -90.0 ]
   }, {
     "id" : "T3_12_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
+      "node1" : "T3_12",
       "node2" : "T3_12_TWO"
     } ],
     "snakeLine" : [ 625.0, -90.0, 625.0, 30.0 ]
   }, {
     "id" : "T3_12_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "T3_12_ONE_T3_12_TWO_T3_12_THREE",
+      "node1" : "T3_12",
       "node2" : "T3_12_THREE"
     } ],
     "snakeLine" : [ 625.0, -90.0, 675.0, -90.0, 675.0, 675.0, 225.0, 675.0, 225.0, 720.0 ]

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
@@ -257,7 +257,7 @@ polyline {fill: none}
             </g>
         </g>
         <g class="cell idEXTERN_32_5" id="idEXTERN_32_5">
-            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fNode" transform="translate(366.0,361.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_T3_95_12_95_fNode" transform="translate(366.0,361.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder sld-constant-color" id="idT3_95_12_95_TWO" transform="translate(345.0,615.0)">
@@ -266,45 +266,45 @@ polyline {fill: none}
             <g class="sld-bottom-feeder sld-constant-color" id="idT3_95_12_95_THREE" transform="translate(395.0,615.0)">
                 <text class="sld-label" id="T3_12_THREE_S_LABEL" transform="rotate(0,0,0)" x="-5.0" y="5.0">T3_12</text>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_B11_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fBc">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_B11_95_FICT_95_VL1_95_T3_95_12_95_fBc">
                 <polyline points="370.0,310.0,370.0,310.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fBc_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fNode">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fBc_95_FICT_95_VL1_95_T3_95_12_95_fNode">
                 <polyline points="370.0,314.0,370.0,365.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fNode_95_FICT_95_VL1_95_T3_95_12_95_fictif">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fNode_95_T3_95_12">
                 <polyline points="370.0,365.0,370.0,541.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_TWO">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_TWO">
                 <polyline points="363.0,553.0,345.0,553.0,345.0,615.0"/>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,340.0,590.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,340.0,590.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,340.0,570.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,340.0,570.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE">
                 <polyline points="377.0,553.0,395.0,553.0,395.0,615.0"/>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,390.0,590.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,390.0,590.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,390.0,570.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,390.0,570.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fBc" transform="translate(366.0,306.0)">
+            <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fBc" transform="translate(366.0,306.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(362.0,541.0)">
+            <g class="sld-three-wt sld-constant-color" id="idT3_95_12" transform="translate(362.0,541.0)">
                 <circle cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
                 <circle cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
                 <circle cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
@@ -472,7 +472,7 @@ polyline {fill: none}
             </g>
         </g>
         <g class="cell idEXTERN_32_10" id="idEXTERN_32_10">
-            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fNode" transform="translate(666.0,361.0)">
+            <g class="sld-node sld-constant-color sld-hidden-node" id="idFICT_95_VL1_95_T3_95_12_95_fNode" transform="translate(666.0,361.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder sld-constant-color" id="idT3_95_12_95_ONE" transform="translate(645.0,615.0)">
@@ -481,45 +481,45 @@ polyline {fill: none}
             <g class="sld-bottom-feeder sld-constant-color" id="idT3_95_12_95_THREE" transform="translate(695.0,615.0)">
                 <text class="sld-label" id="T3_12_THREE_S_LABEL" transform="rotate(0,0,0)" x="-5.0" y="5.0">T3_12</text>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_B12_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fBc">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_B12_95_FICT_95_VL1_95_T3_95_12_95_fBc">
                 <polyline points="670.0,335.0,670.0,335.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fBc_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fNode">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fBc_95_FICT_95_VL1_95_T3_95_12_95_fNode">
                 <polyline points="670.0,339.0,670.0,365.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_fNode_95_FICT_95_VL1_95_T3_95_12_95_fictif">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fNode_95_T3_95_12">
                 <polyline points="670.0,365.0,670.0,541.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_ONE">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_ONE">
                 <polyline points="663.0,553.0,645.0,553.0,645.0,615.0"/>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,590.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,590.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,570.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,570.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE">
                 <polyline points="677.0,553.0,695.0,553.0,695.0,615.0"/>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,690.0,590.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,690.0,590.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,690.0,570.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,690.0,570.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif_95_fBc" transform="translate(666.0,331.0)">
+            <g class="sld-bus-connection sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fBc" transform="translate(666.0,331.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(662.0,541.0)">
+            <g class="sld-three-wt sld-constant-color" id="idT3_95_12" transform="translate(662.0,541.0)">
                 <circle cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
                 <circle cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
                 <circle cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>
@@ -537,7 +537,7 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="idT11_95_TWO_95_edge">
             <polyline points="403.0,0.0,545.0,0.0,545.0,30.0"/>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(390.0,-7.5)">
+        <g class="sld-two-wt sld-constant-color" id="idT11" transform="translate(390.0,-7.5)">
             <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
             <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
         </g>

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
@@ -590,7 +590,7 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="idT11_95_TWO_95_edge">
             <polyline points="453.0,50.0,545.0,50.0,545.0,80.0"/>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(440.0,42.5)">
+        <g class="sld-two-wt sld-constant-color" id="idT11" transform="translate(440.0,42.5)">
             <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
             <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
         </g>
@@ -804,11 +804,11 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="idT3_95_12_95_THREE_95_EDGE">
             <polyline points="652.0,-40.0,995.0,-40.0,995.0,80.0"/>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idT12_95_ONE_95_T12_95_TWO" transform="translate(765.0,-17.5)">
+        <g class="sld-two-wt sld-constant-color" id="idT12" transform="translate(765.0,-17.5)">
             <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
             <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idT3_95_12_95_ONE_95_T3_95_12_95_TWO_95_T3_95_12_95_THREE" transform="translate(637.0,-52.0)">
+        <g class="sld-three-wt sld-constant-color" id="idT3_95_12" transform="translate(637.0,-52.0)">
             <circle cx="5" cy="15" r="5"/>
             <circle cx="11" cy="15" r="5"/>
             <circle cx="8" cy="19" r="5"/>

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
@@ -333,31 +333,31 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color" id="_95_VL1_95_BR20_95_FICT_95_VL1_95_D19Fictif">
                 <polyline points="570.0,196.0,570.0,280.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_BR20_95_FICT_95_VL1_95_T3_95_12_95_fictif">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_BR20_95_T3_95_12">
                 <polyline points="570.0,176.0,570.0,104.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_TWO">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_TWO">
                 <polyline points="563.0,92.0,545.0,92.0,545.0,30.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,540.0,45.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,540.0,45.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,540.0,65.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,540.0,65.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE">
                 <polyline points="577.0,92.0,595.0,92.0,595.0,30.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,590.0,45.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,590.0,45.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,590.0,65.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,590.0,65.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
@@ -376,7 +376,7 @@ polyline {fill: none}
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(21.0,0.0)"/>
                 </g>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(562.0,80.0)">
+            <g class="sld-three-wt sld-constant-color" id="idT3_95_12" transform="translate(562.0,80.0)">
                 <circle cx="5" cy="15" r="5"/>
                 <circle cx="11" cy="15" r="5"/>
                 <circle cx="8" cy="19" r="5"/>
@@ -606,31 +606,31 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color" id="_95_VL1_95_BR30_95_FICT_95_VL1_95_D29Fictif">
                 <polyline points="670.0,196.0,670.0,280.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_BR30_95_FICT_95_VL1_95_T3_95_12_95_fictif">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_BR30_95_T3_95_12">
                 <polyline points="670.0,176.0,670.0,104.0"/>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_ONE">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_ONE">
                 <polyline points="663.0,92.0,645.0,92.0,645.0,30.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,45.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_ONE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,640.0,45.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,65.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_ONE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,640.0,65.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE">
+            <g class="sld-wire sld-constant-color" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE">
                 <polyline points="677.0,92.0,695.0,92.0,695.0,30.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,690.0,45.0)">
+            <g class="sld-arrow-p sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,690.0,45.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_VL1_95_FICT_95_VL1_95_T3_95_12_95_fictif_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,690.0,65.0)">
+            <g class="sld-arrow-q sld-down" id="_95_VL1_95_T3_95_12_95_T3_95_12_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,690.0,65.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
@@ -649,7 +649,7 @@ polyline {fill: none}
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(21.0,0.0)"/>
                 </g>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_VL1_95_T3_95_12_95_fictif" transform="translate(662.0,80.0)">
+            <g class="sld-three-wt sld-constant-color" id="idT3_95_12" transform="translate(662.0,80.0)">
                 <circle cx="5" cy="15" r="5"/>
                 <circle cx="11" cy="15" r="5"/>
                 <circle cx="8" cy="19" r="5"/>
@@ -664,7 +664,7 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="idT11_95_TWO_95_edge">
             <polyline points="378.0,0.0,445.0,0.0,445.0,30.0"/>
         </g>
-        <g class="sld-two-wt sld-constant-color" id="idT11_95_ONE_95_T11_95_TWO" transform="translate(365.0,-7.5)">
+        <g class="sld-two-wt sld-constant-color" id="idT11" transform="translate(365.0,-7.5)">
             <circle cx="5" cy="10" r="5" transform="rotate(90.0,5.0,7.5)"/>
             <circle cx="5" cy="5" r="5" transform="rotate(90.0,5.0,7.5)"/>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphH.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphH.json
@@ -5133,9 +5133,9 @@
   } ],
   "multitermNodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "trf1_ONE_trf1_TWO",
-    "name" : "trf1_ONE_trf1_TWO",
-    "equipmentId" : "trf1_ONE_trf1_TWO",
+    "id" : "trf1",
+    "name" : "trf1",
+    "equipmentId" : "trf1",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5151,9 +5151,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf2_ONE_trf2_TWO",
-    "name" : "trf2_ONE_trf2_TWO",
-    "equipmentId" : "trf2_ONE_trf2_TWO",
+    "id" : "trf2",
+    "name" : "trf2",
+    "equipmentId" : "trf2",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5169,9 +5169,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf3_ONE_trf3_TWO",
-    "name" : "trf3_ONE_trf3_TWO",
-    "equipmentId" : "trf3_ONE_trf3_TWO",
+    "id" : "trf3",
+    "name" : "trf3",
+    "equipmentId" : "trf3",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5187,9 +5187,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf4_ONE_trf4_TWO",
-    "name" : "trf4_ONE_trf4_TWO",
-    "equipmentId" : "trf4_ONE_trf4_TWO",
+    "id" : "trf4",
+    "name" : "trf4",
+    "equipmentId" : "trf4",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5205,9 +5205,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf5_ONE_trf5_TWO",
-    "name" : "trf5_ONE_trf5_TWO",
-    "equipmentId" : "trf5_ONE_trf5_TWO",
+    "id" : "trf5",
+    "name" : "trf5",
+    "equipmentId" : "trf5",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5223,9 +5223,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf6_ONE_trf6_TWO_trf6_THREE",
-    "name" : "trf6_ONE_trf6_TWO_trf6_THREE",
-    "equipmentId" : "trf6_ONE_trf6_TWO_trf6_THREE",
+    "id" : "trf6",
+    "name" : "trf6",
+    "equipmentId" : "trf6",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5246,9 +5246,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf7_ONE_trf7_TWO_trf7_THREE",
-    "name" : "trf7_ONE_trf7_TWO_trf7_THREE",
-    "equipmentId" : "trf7_ONE_trf7_TWO_trf7_THREE",
+    "id" : "trf7",
+    "name" : "trf7",
+    "equipmentId" : "trf7",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5269,9 +5269,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf8_ONE_trf8_TWO_trf8_THREE",
-    "name" : "trf8_ONE_trf8_TWO_trf8_THREE",
-    "equipmentId" : "trf8_ONE_trf8_TWO_trf8_THREE",
+    "id" : "trf8",
+    "name" : "trf8",
+    "equipmentId" : "trf8",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5295,13 +5295,13 @@
     "id" : "trf1_ONE_edge",
     "nodes" : [ {
       "node1" : "trf1_ONE",
-      "node2" : "trf1_ONE_trf1_TWO"
+      "node2" : "trf1"
     } ],
     "snakeLine" : [ 125.0, 30.0, 125.0, 0.0, 600.0, 0.0 ]
   }, {
     "id" : "trf1_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf1_ONE_trf1_TWO",
+      "node1" : "trf1",
       "node2" : "trf1_TWO"
     } ],
     "snakeLine" : [ 600.0, 0.0, 1075.0, 0.0, 1075.0, 30.0 ]
@@ -5309,13 +5309,13 @@
     "id" : "trf2_ONE_edge",
     "nodes" : [ {
       "node1" : "trf2_ONE",
-      "node2" : "trf2_ONE_trf2_TWO"
+      "node2" : "trf2"
     } ],
     "snakeLine" : [ 675.0, 30.0, 675.0, -30.0, 870.0, -30.0, 870.0, 307.5 ]
   }, {
     "id" : "trf2_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf2_ONE_trf2_TWO",
+      "node1" : "trf2",
       "node2" : "trf2_TWO"
     } ],
     "snakeLine" : [ 870.0, 307.5, 870.0, 645.0, 1375.0, 645.0, 1375.0, 615.0 ]
@@ -5323,13 +5323,13 @@
     "id" : "trf3_ONE_edge",
     "nodes" : [ {
       "node1" : "trf3_ONE",
-      "node2" : "trf3_ONE_trf3_TWO"
+      "node2" : "trf3"
     } ],
     "snakeLine" : [ 225.0, 615.0, 225.0, 675.0, 825.0, 675.0 ]
   }, {
     "id" : "trf3_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf3_ONE_trf3_TWO",
+      "node1" : "trf3",
       "node2" : "trf3_TWO"
     } ],
     "snakeLine" : [ 825.0, 675.0, 1425.0, 675.0, 1425.0, 615.0 ]
@@ -5337,13 +5337,13 @@
     "id" : "trf4_ONE_edge",
     "nodes" : [ {
       "node1" : "trf4_ONE",
-      "node2" : "trf4_ONE_trf4_TWO"
+      "node2" : "trf4"
     } ],
     "snakeLine" : [ 625.0, 615.0, 625.0, 705.0, 840.0, 705.0, 840.0, 322.5 ]
   }, {
     "id" : "trf4_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf4_ONE_trf4_TWO",
+      "node1" : "trf4",
       "node2" : "trf4_TWO"
     } ],
     "snakeLine" : [ 840.0, 322.5, 840.0, -60.0, 1175.0, -60.0, 1175.0, 30.0 ]
@@ -5351,13 +5351,13 @@
     "id" : "trf5_ONE_edge",
     "nodes" : [ {
       "node1" : "trf5_ONE",
-      "node2" : "trf5_ONE_trf5_TWO"
+      "node2" : "trf5"
     } ],
     "snakeLine" : [ 275.0, 30.0, 275.0, -90.0, 1570.0, -90.0, 1570.0, 310.0 ]
   }, {
     "id" : "trf5_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf5_ONE_trf5_TWO",
+      "node1" : "trf5",
       "node2" : "trf5_TWO"
     } ],
     "snakeLine" : [ 1570.0, 310.0, 1570.0, 710.0, 1675.0, 710.0, 1675.0, 590.0 ]
@@ -5365,20 +5365,20 @@
     "id" : "trf6_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf6_ONE",
-      "node2" : "trf6_ONE_trf6_TWO_trf6_THREE"
+      "node2" : "trf6"
     } ],
     "snakeLine" : [ 325.0, 30.0, 325.0, -120.0, 1275.0, -120.0 ]
   }, {
     "id" : "trf6_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf6_ONE_trf6_TWO_trf6_THREE",
+      "node1" : "trf6",
       "node2" : "trf6_TWO"
     } ],
     "snakeLine" : [ 1275.0, -120.0, 1275.0, 30.0 ]
   }, {
     "id" : "trf6_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf6_ONE_trf6_TWO_trf6_THREE",
+      "node1" : "trf6",
       "node2" : "trf6_THREE"
     } ],
     "snakeLine" : [ 1275.0, -120.0, 1725.0, -120.0, 1725.0, 30.0 ]
@@ -5386,20 +5386,20 @@
     "id" : "trf7_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf7_ONE",
-      "node2" : "trf7_ONE_trf7_TWO_trf7_THREE"
+      "node2" : "trf7"
     } ],
     "snakeLine" : [ 375.0, 615.0, 375.0, 765.0, 810.0, 765.0, 810.0, -150.0, 1225.0, -150.0 ]
   }, {
     "id" : "trf7_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf7_ONE_trf7_TWO_trf7_THREE",
+      "node1" : "trf7",
       "node2" : "trf7_TWO"
     } ],
     "snakeLine" : [ 1225.0, -150.0, 1225.0, 30.0 ]
   }, {
     "id" : "trf7_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf7_ONE_trf7_TWO_trf7_THREE",
+      "node1" : "trf7",
       "node2" : "trf7_THREE"
     } ],
     "snakeLine" : [ 1225.0, -150.0, 1540.0, -150.0, 1540.0, 740.0, 1775.0, 740.0, 1775.0, 590.0 ]
@@ -5407,20 +5407,20 @@
     "id" : "trf8_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf8_ONE",
-      "node2" : "trf8_ONE_trf8_TWO_trf8_THREE"
+      "node2" : "trf8"
     } ],
     "snakeLine" : [ 575.0, 30.0, 575.0, -180.0, 780.0, -180.0, 780.0, 795.0, 1325.0, 795.0 ]
   }, {
     "id" : "trf8_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf8_ONE_trf8_TWO_trf8_THREE",
+      "node1" : "trf8",
       "node2" : "trf8_TWO"
     } ],
     "snakeLine" : [ 1325.0, 795.0, 1325.0, 615.0 ]
   }, {
     "id" : "trf8_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf8_ONE_trf8_TWO_trf8_THREE",
+      "node1" : "trf8",
       "node2" : "trf8_THREE"
     } ],
     "snakeLine" : [ 1325.0, 795.0, 1510.0, 795.0, 1510.0, -180.0, 1825.0, -180.0, 1825.0, 30.0 ]

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphSmart.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphSmart.json
@@ -3917,9 +3917,9 @@
   } ],
   "multitermNodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "trf1_ONE_trf1_TWO",
-    "name" : "trf1_ONE_trf1_TWO",
-    "equipmentId" : "trf1_ONE_trf1_TWO",
+    "id" : "trf1",
+    "name" : "trf1",
+    "equipmentId" : "trf1",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -3935,9 +3935,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf2_ONE_trf2_TWO",
-    "name" : "trf2_ONE_trf2_TWO",
-    "equipmentId" : "trf2_ONE_trf2_TWO",
+    "id" : "trf2",
+    "name" : "trf2",
+    "equipmentId" : "trf2",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -3953,9 +3953,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf3_ONE_trf3_TWO",
-    "name" : "trf3_ONE_trf3_TWO",
-    "equipmentId" : "trf3_ONE_trf3_TWO",
+    "id" : "trf3",
+    "name" : "trf3",
+    "equipmentId" : "trf3",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -3971,9 +3971,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf4_ONE_trf4_TWO",
-    "name" : "trf4_ONE_trf4_TWO",
-    "equipmentId" : "trf4_ONE_trf4_TWO",
+    "id" : "trf4",
+    "name" : "trf4",
+    "equipmentId" : "trf4",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -3989,9 +3989,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf5_ONE_trf5_TWO",
-    "name" : "trf5_ONE_trf5_TWO",
-    "equipmentId" : "trf5_ONE_trf5_TWO",
+    "id" : "trf5",
+    "name" : "trf5",
+    "equipmentId" : "trf5",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -4007,9 +4007,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf6_ONE_trf6_TWO_trf6_THREE",
-    "name" : "trf6_ONE_trf6_TWO_trf6_THREE",
-    "equipmentId" : "trf6_ONE_trf6_TWO_trf6_THREE",
+    "id" : "trf6",
+    "name" : "trf6",
+    "equipmentId" : "trf6",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -4030,9 +4030,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf7_ONE_trf7_TWO_trf7_THREE",
-    "name" : "trf7_ONE_trf7_TWO_trf7_THREE",
-    "equipmentId" : "trf7_ONE_trf7_TWO_trf7_THREE",
+    "id" : "trf7",
+    "name" : "trf7",
+    "equipmentId" : "trf7",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -4053,9 +4053,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf8_ONE_trf8_TWO_trf8_THREE",
-    "name" : "trf8_ONE_trf8_TWO_trf8_THREE",
-    "equipmentId" : "trf8_ONE_trf8_TWO_trf8_THREE",
+    "id" : "trf8",
+    "name" : "trf8",
+    "equipmentId" : "trf8",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -4079,114 +4079,114 @@
     "id" : "trf1_ONE_edge",
     "nodes" : [ {
       "node1" : "trf1_ONE",
-      "node2" : "trf1_ONE_trf1_TWO"
+      "node2" : "trf1"
     } ]
   }, {
     "id" : "trf1_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf1_ONE_trf1_TWO",
+      "node1" : "trf1",
       "node2" : "trf1_TWO"
     } ]
   }, {
     "id" : "trf2_ONE_edge",
     "nodes" : [ {
       "node1" : "trf2_ONE",
-      "node2" : "trf2_ONE_trf2_TWO"
+      "node2" : "trf2"
     } ]
   }, {
     "id" : "trf2_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf2_ONE_trf2_TWO",
+      "node1" : "trf2",
       "node2" : "trf2_TWO"
     } ]
   }, {
     "id" : "trf3_ONE_edge",
     "nodes" : [ {
       "node1" : "trf3_ONE",
-      "node2" : "trf3_ONE_trf3_TWO"
+      "node2" : "trf3"
     } ]
   }, {
     "id" : "trf3_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf3_ONE_trf3_TWO",
+      "node1" : "trf3",
       "node2" : "trf3_TWO"
     } ]
   }, {
     "id" : "trf4_ONE_edge",
     "nodes" : [ {
       "node1" : "trf4_ONE",
-      "node2" : "trf4_ONE_trf4_TWO"
+      "node2" : "trf4"
     } ]
   }, {
     "id" : "trf4_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf4_ONE_trf4_TWO",
+      "node1" : "trf4",
       "node2" : "trf4_TWO"
     } ]
   }, {
     "id" : "trf5_ONE_edge",
     "nodes" : [ {
       "node1" : "trf5_ONE",
-      "node2" : "trf5_ONE_trf5_TWO"
+      "node2" : "trf5"
     } ]
   }, {
     "id" : "trf5_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf5_ONE_trf5_TWO",
+      "node1" : "trf5",
       "node2" : "trf5_TWO"
     } ]
   }, {
     "id" : "trf6_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf6_ONE",
-      "node2" : "trf6_ONE_trf6_TWO_trf6_THREE"
+      "node2" : "trf6"
     } ]
   }, {
     "id" : "trf6_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf6_ONE_trf6_TWO_trf6_THREE",
+      "node1" : "trf6",
       "node2" : "trf6_TWO"
     } ]
   }, {
     "id" : "trf6_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf6_ONE_trf6_TWO_trf6_THREE",
+      "node1" : "trf6",
       "node2" : "trf6_THREE"
     } ]
   }, {
     "id" : "trf7_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf7_ONE",
-      "node2" : "trf7_ONE_trf7_TWO_trf7_THREE"
+      "node2" : "trf7"
     } ]
   }, {
     "id" : "trf7_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf7_ONE_trf7_TWO_trf7_THREE",
+      "node1" : "trf7",
       "node2" : "trf7_TWO"
     } ]
   }, {
     "id" : "trf7_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf7_ONE_trf7_TWO_trf7_THREE",
+      "node1" : "trf7",
       "node2" : "trf7_THREE"
     } ]
   }, {
     "id" : "trf8_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf8_ONE",
-      "node2" : "trf8_ONE_trf8_TWO_trf8_THREE"
+      "node2" : "trf8"
     } ]
   }, {
     "id" : "trf8_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf8_ONE_trf8_TWO_trf8_THREE",
+      "node1" : "trf8",
       "node2" : "trf8_TWO"
     } ]
   }, {
     "id" : "trf8_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf8_ONE_trf8_TWO_trf8_THREE",
+      "node1" : "trf8",
       "node2" : "trf8_THREE"
     } ]
   } ],

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphSmartHorizontal.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphSmartHorizontal.json
@@ -3917,9 +3917,9 @@
   } ],
   "multitermNodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "trf1_ONE_trf1_TWO",
-    "name" : "trf1_ONE_trf1_TWO",
-    "equipmentId" : "trf1_ONE_trf1_TWO",
+    "id" : "trf1",
+    "name" : "trf1",
+    "equipmentId" : "trf1",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -3935,9 +3935,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf2_ONE_trf2_TWO",
-    "name" : "trf2_ONE_trf2_TWO",
-    "equipmentId" : "trf2_ONE_trf2_TWO",
+    "id" : "trf2",
+    "name" : "trf2",
+    "equipmentId" : "trf2",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -3953,9 +3953,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf3_ONE_trf3_TWO",
-    "name" : "trf3_ONE_trf3_TWO",
-    "equipmentId" : "trf3_ONE_trf3_TWO",
+    "id" : "trf3",
+    "name" : "trf3",
+    "equipmentId" : "trf3",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -3971,9 +3971,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf4_ONE_trf4_TWO",
-    "name" : "trf4_ONE_trf4_TWO",
-    "equipmentId" : "trf4_ONE_trf4_TWO",
+    "id" : "trf4",
+    "name" : "trf4",
+    "equipmentId" : "trf4",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -3989,9 +3989,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf5_ONE_trf5_TWO",
-    "name" : "trf5_ONE_trf5_TWO",
-    "equipmentId" : "trf5_ONE_trf5_TWO",
+    "id" : "trf5",
+    "name" : "trf5",
+    "equipmentId" : "trf5",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -4007,9 +4007,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf6_ONE_trf6_TWO_trf6_THREE",
-    "name" : "trf6_ONE_trf6_TWO_trf6_THREE",
-    "equipmentId" : "trf6_ONE_trf6_TWO_trf6_THREE",
+    "id" : "trf6",
+    "name" : "trf6",
+    "equipmentId" : "trf6",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -4030,9 +4030,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf7_ONE_trf7_TWO_trf7_THREE",
-    "name" : "trf7_ONE_trf7_TWO_trf7_THREE",
-    "equipmentId" : "trf7_ONE_trf7_TWO_trf7_THREE",
+    "id" : "trf7",
+    "name" : "trf7",
+    "equipmentId" : "trf7",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -4053,9 +4053,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf8_ONE_trf8_TWO_trf8_THREE",
-    "name" : "trf8_ONE_trf8_TWO_trf8_THREE",
-    "equipmentId" : "trf8_ONE_trf8_TWO_trf8_THREE",
+    "id" : "trf8",
+    "name" : "trf8",
+    "equipmentId" : "trf8",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -4079,114 +4079,114 @@
     "id" : "trf1_ONE_edge",
     "nodes" : [ {
       "node1" : "trf1_ONE",
-      "node2" : "trf1_ONE_trf1_TWO"
+      "node2" : "trf1"
     } ]
   }, {
     "id" : "trf1_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf1_ONE_trf1_TWO",
+      "node1" : "trf1",
       "node2" : "trf1_TWO"
     } ]
   }, {
     "id" : "trf2_ONE_edge",
     "nodes" : [ {
       "node1" : "trf2_ONE",
-      "node2" : "trf2_ONE_trf2_TWO"
+      "node2" : "trf2"
     } ]
   }, {
     "id" : "trf2_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf2_ONE_trf2_TWO",
+      "node1" : "trf2",
       "node2" : "trf2_TWO"
     } ]
   }, {
     "id" : "trf3_ONE_edge",
     "nodes" : [ {
       "node1" : "trf3_ONE",
-      "node2" : "trf3_ONE_trf3_TWO"
+      "node2" : "trf3"
     } ]
   }, {
     "id" : "trf3_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf3_ONE_trf3_TWO",
+      "node1" : "trf3",
       "node2" : "trf3_TWO"
     } ]
   }, {
     "id" : "trf4_ONE_edge",
     "nodes" : [ {
       "node1" : "trf4_ONE",
-      "node2" : "trf4_ONE_trf4_TWO"
+      "node2" : "trf4"
     } ]
   }, {
     "id" : "trf4_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf4_ONE_trf4_TWO",
+      "node1" : "trf4",
       "node2" : "trf4_TWO"
     } ]
   }, {
     "id" : "trf5_ONE_edge",
     "nodes" : [ {
       "node1" : "trf5_ONE",
-      "node2" : "trf5_ONE_trf5_TWO"
+      "node2" : "trf5"
     } ]
   }, {
     "id" : "trf5_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf5_ONE_trf5_TWO",
+      "node1" : "trf5",
       "node2" : "trf5_TWO"
     } ]
   }, {
     "id" : "trf6_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf6_ONE",
-      "node2" : "trf6_ONE_trf6_TWO_trf6_THREE"
+      "node2" : "trf6"
     } ]
   }, {
     "id" : "trf6_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf6_ONE_trf6_TWO_trf6_THREE",
+      "node1" : "trf6",
       "node2" : "trf6_TWO"
     } ]
   }, {
     "id" : "trf6_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf6_ONE_trf6_TWO_trf6_THREE",
+      "node1" : "trf6",
       "node2" : "trf6_THREE"
     } ]
   }, {
     "id" : "trf7_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf7_ONE",
-      "node2" : "trf7_ONE_trf7_TWO_trf7_THREE"
+      "node2" : "trf7"
     } ]
   }, {
     "id" : "trf7_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf7_ONE_trf7_TWO_trf7_THREE",
+      "node1" : "trf7",
       "node2" : "trf7_TWO"
     } ]
   }, {
     "id" : "trf7_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf7_ONE_trf7_TWO_trf7_THREE",
+      "node1" : "trf7",
       "node2" : "trf7_THREE"
     } ]
   }, {
     "id" : "trf8_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf8_ONE",
-      "node2" : "trf8_ONE_trf8_TWO_trf8_THREE"
+      "node2" : "trf8"
     } ]
   }, {
     "id" : "trf8_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf8_ONE_trf8_TWO_trf8_THREE",
+      "node1" : "trf8",
       "node2" : "trf8_TWO"
     } ]
   }, {
     "id" : "trf8_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf8_ONE_trf8_TWO_trf8_THREE",
+      "node1" : "trf8",
       "node2" : "trf8_THREE"
     } ]
   } ],

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphSmartVertical.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphSmartVertical.json
@@ -3917,9 +3917,9 @@
   } ],
   "multitermNodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "trf1_ONE_trf1_TWO",
-    "name" : "trf1_ONE_trf1_TWO",
-    "equipmentId" : "trf1_ONE_trf1_TWO",
+    "id" : "trf1",
+    "name" : "trf1",
+    "equipmentId" : "trf1",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -3935,9 +3935,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf2_ONE_trf2_TWO",
-    "name" : "trf2_ONE_trf2_TWO",
-    "equipmentId" : "trf2_ONE_trf2_TWO",
+    "id" : "trf2",
+    "name" : "trf2",
+    "equipmentId" : "trf2",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -3953,9 +3953,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf3_ONE_trf3_TWO",
-    "name" : "trf3_ONE_trf3_TWO",
-    "equipmentId" : "trf3_ONE_trf3_TWO",
+    "id" : "trf3",
+    "name" : "trf3",
+    "equipmentId" : "trf3",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -3971,9 +3971,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf4_ONE_trf4_TWO",
-    "name" : "trf4_ONE_trf4_TWO",
-    "equipmentId" : "trf4_ONE_trf4_TWO",
+    "id" : "trf4",
+    "name" : "trf4",
+    "equipmentId" : "trf4",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -3989,9 +3989,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf5_ONE_trf5_TWO",
-    "name" : "trf5_ONE_trf5_TWO",
-    "equipmentId" : "trf5_ONE_trf5_TWO",
+    "id" : "trf5",
+    "name" : "trf5",
+    "equipmentId" : "trf5",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -4007,9 +4007,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf6_ONE_trf6_TWO_trf6_THREE",
-    "name" : "trf6_ONE_trf6_TWO_trf6_THREE",
-    "equipmentId" : "trf6_ONE_trf6_TWO_trf6_THREE",
+    "id" : "trf6",
+    "name" : "trf6",
+    "equipmentId" : "trf6",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -4030,9 +4030,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf7_ONE_trf7_TWO_trf7_THREE",
-    "name" : "trf7_ONE_trf7_TWO_trf7_THREE",
-    "equipmentId" : "trf7_ONE_trf7_TWO_trf7_THREE",
+    "id" : "trf7",
+    "name" : "trf7",
+    "equipmentId" : "trf7",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -4053,9 +4053,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf8_ONE_trf8_TWO_trf8_THREE",
-    "name" : "trf8_ONE_trf8_TWO_trf8_THREE",
-    "equipmentId" : "trf8_ONE_trf8_TWO_trf8_THREE",
+    "id" : "trf8",
+    "name" : "trf8",
+    "equipmentId" : "trf8",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -4079,114 +4079,114 @@
     "id" : "trf1_ONE_edge",
     "nodes" : [ {
       "node1" : "trf1_ONE",
-      "node2" : "trf1_ONE_trf1_TWO"
+      "node2" : "trf1"
     } ]
   }, {
     "id" : "trf1_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf1_ONE_trf1_TWO",
+      "node1" : "trf1",
       "node2" : "trf1_TWO"
     } ]
   }, {
     "id" : "trf2_ONE_edge",
     "nodes" : [ {
       "node1" : "trf2_ONE",
-      "node2" : "trf2_ONE_trf2_TWO"
+      "node2" : "trf2"
     } ]
   }, {
     "id" : "trf2_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf2_ONE_trf2_TWO",
+      "node1" : "trf2",
       "node2" : "trf2_TWO"
     } ]
   }, {
     "id" : "trf3_ONE_edge",
     "nodes" : [ {
       "node1" : "trf3_ONE",
-      "node2" : "trf3_ONE_trf3_TWO"
+      "node2" : "trf3"
     } ]
   }, {
     "id" : "trf3_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf3_ONE_trf3_TWO",
+      "node1" : "trf3",
       "node2" : "trf3_TWO"
     } ]
   }, {
     "id" : "trf4_ONE_edge",
     "nodes" : [ {
       "node1" : "trf4_ONE",
-      "node2" : "trf4_ONE_trf4_TWO"
+      "node2" : "trf4"
     } ]
   }, {
     "id" : "trf4_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf4_ONE_trf4_TWO",
+      "node1" : "trf4",
       "node2" : "trf4_TWO"
     } ]
   }, {
     "id" : "trf5_ONE_edge",
     "nodes" : [ {
       "node1" : "trf5_ONE",
-      "node2" : "trf5_ONE_trf5_TWO"
+      "node2" : "trf5"
     } ]
   }, {
     "id" : "trf5_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf5_ONE_trf5_TWO",
+      "node1" : "trf5",
       "node2" : "trf5_TWO"
     } ]
   }, {
     "id" : "trf6_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf6_ONE",
-      "node2" : "trf6_ONE_trf6_TWO_trf6_THREE"
+      "node2" : "trf6"
     } ]
   }, {
     "id" : "trf6_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf6_ONE_trf6_TWO_trf6_THREE",
+      "node1" : "trf6",
       "node2" : "trf6_TWO"
     } ]
   }, {
     "id" : "trf6_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf6_ONE_trf6_TWO_trf6_THREE",
+      "node1" : "trf6",
       "node2" : "trf6_THREE"
     } ]
   }, {
     "id" : "trf7_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf7_ONE",
-      "node2" : "trf7_ONE_trf7_TWO_trf7_THREE"
+      "node2" : "trf7"
     } ]
   }, {
     "id" : "trf7_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf7_ONE_trf7_TWO_trf7_THREE",
+      "node1" : "trf7",
       "node2" : "trf7_TWO"
     } ]
   }, {
     "id" : "trf7_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf7_ONE_trf7_TWO_trf7_THREE",
+      "node1" : "trf7",
       "node2" : "trf7_THREE"
     } ]
   }, {
     "id" : "trf8_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf8_ONE",
-      "node2" : "trf8_ONE_trf8_TWO_trf8_THREE"
+      "node2" : "trf8"
     } ]
   }, {
     "id" : "trf8_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf8_ONE_trf8_TWO_trf8_THREE",
+      "node1" : "trf8",
       "node2" : "trf8_TWO"
     } ]
   }, {
     "id" : "trf8_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf8_ONE_trf8_TWO_trf8_THREE",
+      "node1" : "trf8",
       "node2" : "trf8_THREE"
     } ]
   } ],

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphV.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphV.json
@@ -5133,9 +5133,9 @@
   } ],
   "multitermNodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "trf1_ONE_trf1_TWO",
-    "name" : "trf1_ONE_trf1_TWO",
-    "equipmentId" : "trf1_ONE_trf1_TWO",
+    "id" : "trf1",
+    "name" : "trf1",
+    "equipmentId" : "trf1",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5151,9 +5151,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf2_ONE_trf2_TWO",
-    "name" : "trf2_ONE_trf2_TWO",
-    "equipmentId" : "trf2_ONE_trf2_TWO",
+    "id" : "trf2",
+    "name" : "trf2",
+    "equipmentId" : "trf2",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5169,9 +5169,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf3_ONE_trf3_TWO",
-    "name" : "trf3_ONE_trf3_TWO",
-    "equipmentId" : "trf3_ONE_trf3_TWO",
+    "id" : "trf3",
+    "name" : "trf3",
+    "equipmentId" : "trf3",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5187,9 +5187,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf4_ONE_trf4_TWO",
-    "name" : "trf4_ONE_trf4_TWO",
-    "equipmentId" : "trf4_ONE_trf4_TWO",
+    "id" : "trf4",
+    "name" : "trf4",
+    "equipmentId" : "trf4",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5205,9 +5205,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf5_ONE_trf5_TWO",
-    "name" : "trf5_ONE_trf5_TWO",
-    "equipmentId" : "trf5_ONE_trf5_TWO",
+    "id" : "trf5",
+    "name" : "trf5",
+    "equipmentId" : "trf5",
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5223,9 +5223,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf6_ONE_trf6_TWO_trf6_THREE",
-    "name" : "trf6_ONE_trf6_TWO_trf6_THREE",
-    "equipmentId" : "trf6_ONE_trf6_TWO_trf6_THREE",
+    "id" : "trf6",
+    "name" : "trf6",
+    "equipmentId" : "trf6",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5246,9 +5246,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf7_ONE_trf7_TWO_trf7_THREE",
-    "name" : "trf7_ONE_trf7_TWO_trf7_THREE",
-    "equipmentId" : "trf7_ONE_trf7_TWO_trf7_THREE",
+    "id" : "trf7",
+    "name" : "trf7",
+    "equipmentId" : "trf7",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5269,9 +5269,9 @@
     }
   }, {
     "type" : "FICTITIOUS",
-    "id" : "trf8_ONE_trf8_TWO_trf8_THREE",
-    "name" : "trf8_ONE_trf8_TWO_trf8_THREE",
-    "equipmentId" : "trf8_ONE_trf8_TWO_trf8_THREE",
+    "id" : "trf8",
+    "name" : "trf8",
+    "equipmentId" : "trf8",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "fictitious" : true,
     "open" : false,
@@ -5295,13 +5295,13 @@
     "id" : "trf1_ONE_edge",
     "nodes" : [ {
       "node1" : "trf1_ONE",
-      "node2" : "trf1_ONE_trf1_TWO"
+      "node2" : "trf1"
     } ],
     "snakeLine" : [ 125.0, 30.0, 125.0, 0.0, 20.0, 0.0, 20.0, 322.5 ]
   }, {
     "id" : "trf1_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf1_ONE_trf1_TWO",
+      "node1" : "trf1",
       "node2" : "trf1_TWO"
     } ],
     "snakeLine" : [ 20.0, 322.5, 20.0, 645.0, 225.0, 645.0, 225.0, 720.0 ]
@@ -5309,13 +5309,13 @@
     "id" : "trf2_ONE_edge",
     "nodes" : [ {
       "node1" : "trf2_ONE",
-      "node2" : "trf2_ONE_trf2_TWO"
+      "node2" : "trf2"
     } ],
     "snakeLine" : [ 675.0, 30.0, 675.0, -30.0, -10.0, -30.0, -10.0, 652.5 ]
   }, {
     "id" : "trf2_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf2_ONE_trf2_TWO",
+      "node1" : "trf2",
       "node2" : "trf2_TWO"
     } ],
     "snakeLine" : [ -10.0, 652.5, -10.0, 1335.0, 525.0, 1335.0, 525.0, 1305.0 ]
@@ -5323,13 +5323,13 @@
     "id" : "trf3_ONE_edge",
     "nodes" : [ {
       "node1" : "trf3_ONE",
-      "node2" : "trf3_ONE_trf3_TWO"
+      "node2" : "trf3"
     } ],
     "snakeLine" : [ 225.0, 615.0, 225.0, 675.0, 775.0, 675.0, 775.0, 1020.0 ]
   }, {
     "id" : "trf3_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf3_ONE_trf3_TWO",
+      "node1" : "trf3",
       "node2" : "trf3_TWO"
     } ],
     "snakeLine" : [ 775.0, 1020.0, 775.0, 1365.0, 575.0, 1365.0, 575.0, 1305.0 ]
@@ -5337,13 +5337,13 @@
     "id" : "trf4_ONE_edge",
     "nodes" : [ {
       "node1" : "trf4_ONE",
-      "node2" : "trf4_ONE_trf4_TWO"
+      "node2" : "trf4"
     } ],
     "snakeLine" : [ 625.0, 615.0, 625.0, 705.0, 475.0, 705.0 ]
   }, {
     "id" : "trf4_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf4_ONE_trf4_TWO",
+      "node1" : "trf4",
       "node2" : "trf4_TWO"
     } ],
     "snakeLine" : [ 475.0, 705.0, 325.0, 705.0, 325.0, 720.0 ]
@@ -5351,13 +5351,13 @@
     "id" : "trf5_ONE_edge",
     "nodes" : [ {
       "node1" : "trf5_ONE",
-      "node2" : "trf5_ONE_trf5_TWO"
+      "node2" : "trf5"
     } ],
     "snakeLine" : [ 275.0, 30.0, 275.0, -60.0, -40.0, -60.0, -40.0, 970.0 ]
   }, {
     "id" : "trf5_TWO_edge",
     "nodes" : [ {
-      "node1" : "trf5_ONE_trf5_TWO",
+      "node1" : "trf5",
       "node2" : "trf5_TWO"
     } ],
     "snakeLine" : [ -40.0, 970.0, -40.0, 2000.0, 125.0, 2000.0, 125.0, 1970.0 ]
@@ -5365,20 +5365,20 @@
     "id" : "trf6_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf6_ONE",
-      "node2" : "trf6_ONE_trf6_TWO_trf6_THREE"
+      "node2" : "trf6"
     } ],
     "snakeLine" : [ 325.0, 30.0, 325.0, -90.0, -70.0, -90.0, -70.0, 735.0, 425.0, 735.0 ]
   }, {
     "id" : "trf6_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf6_ONE_trf6_TWO_trf6_THREE",
+      "node1" : "trf6",
       "node2" : "trf6_TWO"
     } ],
     "snakeLine" : [ 425.0, 735.0, 425.0, 720.0 ]
   }, {
     "id" : "trf6_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf6_ONE_trf6_TWO_trf6_THREE",
+      "node1" : "trf6",
       "node2" : "trf6_THREE"
     } ],
     "snakeLine" : [ 425.0, 735.0, 805.0, 735.0, 805.0, 1395.0, 175.0, 1395.0, 175.0, 1410.0 ]
@@ -5386,20 +5386,20 @@
     "id" : "trf7_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf7_ONE",
-      "node2" : "trf7_ONE_trf7_TWO_trf7_THREE"
+      "node2" : "trf7"
     } ],
     "snakeLine" : [ 375.0, 615.0, 375.0, 765.0 ]
   }, {
     "id" : "trf7_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf7_ONE_trf7_TWO_trf7_THREE",
+      "node1" : "trf7",
       "node2" : "trf7_TWO"
     } ],
     "snakeLine" : [ 375.0, 765.0, 375.0, 720.0 ]
   }, {
     "id" : "trf7_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf7_ONE_trf7_TWO_trf7_THREE",
+      "node1" : "trf7",
       "node2" : "trf7_THREE"
     } ],
     "snakeLine" : [ 375.0, 765.0, 835.0, 765.0, 835.0, 2030.0, 225.0, 2030.0, 225.0, 1970.0 ]
@@ -5407,20 +5407,20 @@
     "id" : "trf8_ONE_EDGE",
     "nodes" : [ {
       "node1" : "trf8_ONE",
-      "node2" : "trf8_ONE_trf8_TWO_trf8_THREE"
+      "node2" : "trf8"
     } ],
     "snakeLine" : [ 575.0, 30.0, 575.0, -120.0, -100.0, -120.0, -100.0, 1425.0, 475.0, 1425.0 ]
   }, {
     "id" : "trf8_TWO_EDGE",
     "nodes" : [ {
-      "node1" : "trf8_ONE_trf8_TWO_trf8_THREE",
+      "node1" : "trf8",
       "node2" : "trf8_TWO"
     } ],
     "snakeLine" : [ 475.0, 1425.0, 475.0, 1305.0 ]
   }, {
     "id" : "trf8_THREE_EDGE",
     "nodes" : [ {
-      "node1" : "trf8_ONE_trf8_TWO_trf8_THREE",
+      "node1" : "trf8",
       "node2" : "trf8_THREE"
     } ],
     "snakeLine" : [ 475.0, 1425.0, 275.0, 1425.0, 275.0, 1410.0 ]

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.json
@@ -261,81 +261,6 @@
     "y" : 42.0,
     "open" : false
   }, {
-    "type" : "FICTITIOUS",
-    "id" : "FICT_vl1_trf6_fictif",
-    "name" : "trf6_fictif",
-    "equipmentId" : "trf6_fictif",
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "fictitious" : true,
-    "x" : 480.0,
-    "y" : 42.0,
-    "open" : false,
-    "voltageLevelInfosLeg1" : {
-      "id" : "vl1",
-      "name" : "vl1",
-      "nominalVoltage" : 380.0
-    },
-    "voltageLevelInfosLeg2" : {
-      "id" : "vl2",
-      "name" : "vl2",
-      "nominalVoltage" : 225.0
-    },
-    "voltageLevelInfosLeg3" : {
-      "id" : "vl3",
-      "name" : "vl3",
-      "nominalVoltage" : 63.0
-    }
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "FICT_vl1_trf7_fictif",
-    "name" : "trf7_fictif",
-    "equipmentId" : "trf7_fictif",
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "fictitious" : true,
-    "x" : 640.0,
-    "y" : 503.0,
-    "open" : false,
-    "voltageLevelInfosLeg1" : {
-      "id" : "vl1",
-      "name" : "vl1",
-      "nominalVoltage" : 380.0
-    },
-    "voltageLevelInfosLeg2" : {
-      "id" : "vl2",
-      "name" : "vl2",
-      "nominalVoltage" : 225.0
-    },
-    "voltageLevelInfosLeg3" : {
-      "id" : "vl3",
-      "name" : "vl3",
-      "nominalVoltage" : 63.0
-    }
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "FICT_vl1_trf8_fictif",
-    "name" : "trf8_fictif",
-    "equipmentId" : "trf8_fictif",
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "fictitious" : true,
-    "x" : 960.0,
-    "y" : 42.0,
-    "open" : false,
-    "voltageLevelInfosLeg1" : {
-      "id" : "vl1",
-      "name" : "vl1",
-      "nominalVoltage" : 380.0
-    },
-    "voltageLevelInfosLeg2" : {
-      "id" : "vl2",
-      "name" : "vl2",
-      "nominalVoltage" : 225.0
-    },
-    "voltageLevelInfosLeg3" : {
-      "id" : "vl3",
-      "name" : "vl3",
-      "nominalVoltage" : 63.0
-    }
-  }, {
     "type" : "BUS",
     "id" : "bbs1",
     "name" : "bbs1",
@@ -900,6 +825,31 @@
       "nominalVoltage" : 63.0
     }
   }, {
+    "type" : "FICTITIOUS",
+    "id" : "trf6",
+    "name" : "trf6",
+    "equipmentId" : "trf6",
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "fictitious" : true,
+    "x" : 480.0,
+    "y" : 42.0,
+    "open" : false,
+    "voltageLevelInfosLeg1" : {
+      "id" : "vl1",
+      "name" : "vl1",
+      "nominalVoltage" : 380.0
+    },
+    "voltageLevelInfosLeg2" : {
+      "id" : "vl2",
+      "name" : "vl2",
+      "nominalVoltage" : 225.0
+    },
+    "voltageLevelInfosLeg3" : {
+      "id" : "vl3",
+      "name" : "vl3",
+      "nominalVoltage" : 63.0
+    }
+  }, {
     "type" : "FEEDER",
     "id" : "trf6_THREE",
     "name" : "trf6",
@@ -940,6 +890,31 @@
       "nominalVoltage" : 225.0
     }
   }, {
+    "type" : "FICTITIOUS",
+    "id" : "trf7",
+    "name" : "trf7",
+    "equipmentId" : "trf7",
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "fictitious" : true,
+    "x" : 640.0,
+    "y" : 503.0,
+    "open" : false,
+    "voltageLevelInfosLeg1" : {
+      "id" : "vl1",
+      "name" : "vl1",
+      "nominalVoltage" : 380.0
+    },
+    "voltageLevelInfosLeg2" : {
+      "id" : "vl2",
+      "name" : "vl2",
+      "nominalVoltage" : 225.0
+    },
+    "voltageLevelInfosLeg3" : {
+      "id" : "vl3",
+      "name" : "vl3",
+      "nominalVoltage" : 63.0
+    }
+  }, {
     "type" : "FEEDER",
     "id" : "trf7_THREE",
     "name" : "trf7",
@@ -978,6 +953,31 @@
       "id" : "vl2",
       "name" : "vl2",
       "nominalVoltage" : 225.0
+    }
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "trf8",
+    "name" : "trf8",
+    "equipmentId" : "trf8",
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "fictitious" : true,
+    "x" : 960.0,
+    "y" : 42.0,
+    "open" : false,
+    "voltageLevelInfosLeg1" : {
+      "id" : "vl1",
+      "name" : "vl1",
+      "nominalVoltage" : 380.0
+    },
+    "voltageLevelInfosLeg2" : {
+      "id" : "vl2",
+      "name" : "vl2",
+      "nominalVoltage" : 225.0
+    },
+    "voltageLevelInfosLeg3" : {
+      "id" : "vl3",
+      "name" : "vl3",
+      "nominalVoltage" : 63.0
     }
   }, {
     "type" : "FEEDER",
@@ -1534,7 +1534,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "FICT_vl1_dtrf16Fictif", "btrf16", "FICT_vl1_trf6_fictif" ]
+        "nodes" : [ "FICT_vl1_dtrf16Fictif", "btrf16", "trf6" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1575,7 +1575,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl1_trf6_fictif", "trf6_TWO" ]
+          "nodes" : [ "trf6", "trf6_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1596,7 +1596,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl1_trf6_fictif", "trf6_THREE" ]
+          "nodes" : [ "trf6", "trf6_THREE" ]
         } ]
       } ]
     }
@@ -1846,7 +1846,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "FICT_vl1_dtrf18Fictif", "btrf18", "FICT_vl1_trf8_fictif" ]
+        "nodes" : [ "FICT_vl1_dtrf18Fictif", "btrf18", "trf8" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1887,7 +1887,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl1_trf8_fictif", "trf8_TWO" ]
+          "nodes" : [ "trf8", "trf8_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1908,7 +1908,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl1_trf8_fictif", "trf8_THREE" ]
+          "nodes" : [ "trf8", "trf8_THREE" ]
         } ]
       } ]
     }
@@ -2158,7 +2158,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "FICT_vl1_dtrf17Fictif", "btrf17", "FICT_vl1_trf7_fictif" ]
+        "nodes" : [ "FICT_vl1_dtrf17Fictif", "btrf17", "trf7" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -2199,7 +2199,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl1_trf7_fictif", "trf7_TWO" ]
+          "nodes" : [ "trf7", "trf7_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2220,7 +2220,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl1_trf7_fictif", "trf7_THREE" ]
+          "nodes" : [ "trf7", "trf7_THREE" ]
         } ]
       } ]
     }
@@ -2406,22 +2406,22 @@
     }
   } ],
   "edges" : [ {
-    "node1" : "FICT_vl1_trf6_fictif",
+    "node1" : "trf6",
     "node2" : "trf6_TWO"
   }, {
-    "node1" : "FICT_vl1_trf6_fictif",
+    "node1" : "trf6",
     "node2" : "trf6_THREE"
   }, {
-    "node1" : "FICT_vl1_trf7_fictif",
+    "node1" : "trf7",
     "node2" : "trf7_TWO"
   }, {
-    "node1" : "FICT_vl1_trf7_fictif",
+    "node1" : "trf7",
     "node2" : "trf7_THREE"
   }, {
-    "node1" : "FICT_vl1_trf8_fictif",
+    "node1" : "trf8",
     "node2" : "trf8_TWO"
   }, {
-    "node1" : "FICT_vl1_trf8_fictif",
+    "node1" : "trf8",
     "node2" : "trf8_THREE"
   }, {
     "node1" : "bbs1",
@@ -2467,19 +2467,19 @@
     "node2" : "dtrf16"
   }, {
     "node1" : "btrf16",
-    "node2" : "FICT_vl1_trf6_fictif"
+    "node2" : "trf6"
   }, {
     "node1" : "bbs3",
     "node2" : "dtrf17"
   }, {
     "node1" : "btrf17",
-    "node2" : "FICT_vl1_trf7_fictif"
+    "node2" : "trf7"
   }, {
     "node1" : "bbs2",
     "node2" : "dtrf18"
   }, {
     "node1" : "btrf18",
-    "node2" : "FICT_vl1_trf8_fictif"
+    "node2" : "trf8"
   }, {
     "node1" : "bload1",
     "node2" : "FICT_vl1_load1Fictif"

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.json
@@ -179,81 +179,6 @@
     "y" : 42.0,
     "open" : false
   }, {
-    "type" : "FICTITIOUS",
-    "id" : "FICT_vl2_trf6_fictif",
-    "name" : "trf6_fictif",
-    "equipmentId" : "trf6_fictif",
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "fictitious" : true,
-    "x" : 720.0,
-    "y" : 42.0,
-    "open" : false,
-    "voltageLevelInfosLeg1" : {
-      "id" : "vl1",
-      "name" : "vl1",
-      "nominalVoltage" : 380.0
-    },
-    "voltageLevelInfosLeg2" : {
-      "id" : "vl2",
-      "name" : "vl2",
-      "nominalVoltage" : 225.0
-    },
-    "voltageLevelInfosLeg3" : {
-      "id" : "vl3",
-      "name" : "vl3",
-      "nominalVoltage" : 63.0
-    }
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "FICT_vl2_trf7_fictif",
-    "name" : "trf7_fictif",
-    "equipmentId" : "trf7_fictif",
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "fictitious" : true,
-    "x" : 560.0,
-    "y" : 42.0,
-    "open" : false,
-    "voltageLevelInfosLeg1" : {
-      "id" : "vl1",
-      "name" : "vl1",
-      "nominalVoltage" : 380.0
-    },
-    "voltageLevelInfosLeg2" : {
-      "id" : "vl2",
-      "name" : "vl2",
-      "nominalVoltage" : 225.0
-    },
-    "voltageLevelInfosLeg3" : {
-      "id" : "vl3",
-      "name" : "vl3",
-      "nominalVoltage" : 63.0
-    }
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "FICT_vl2_trf8_fictif",
-    "name" : "trf8_fictif",
-    "equipmentId" : "trf8_fictif",
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "fictitious" : true,
-    "x" : 880.0,
-    "y" : 503.0,
-    "open" : false,
-    "voltageLevelInfosLeg1" : {
-      "id" : "vl1",
-      "name" : "vl1",
-      "nominalVoltage" : 380.0
-    },
-    "voltageLevelInfosLeg2" : {
-      "id" : "vl2",
-      "name" : "vl2",
-      "nominalVoltage" : 225.0
-    },
-    "voltageLevelInfosLeg3" : {
-      "id" : "vl3",
-      "name" : "vl3",
-      "nominalVoltage" : 63.0
-    }
-  }, {
     "type" : "BUS",
     "id" : "bbs5",
     "name" : "bbs5",
@@ -632,6 +557,31 @@
       "nominalVoltage" : 380.0
     }
   }, {
+    "type" : "FICTITIOUS",
+    "id" : "trf6",
+    "name" : "trf6",
+    "equipmentId" : "trf6",
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "fictitious" : true,
+    "x" : 720.0,
+    "y" : 42.0,
+    "open" : false,
+    "voltageLevelInfosLeg1" : {
+      "id" : "vl1",
+      "name" : "vl1",
+      "nominalVoltage" : 380.0
+    },
+    "voltageLevelInfosLeg2" : {
+      "id" : "vl2",
+      "name" : "vl2",
+      "nominalVoltage" : 225.0
+    },
+    "voltageLevelInfosLeg3" : {
+      "id" : "vl3",
+      "name" : "vl3",
+      "nominalVoltage" : 63.0
+    }
+  }, {
     "type" : "FEEDER",
     "id" : "trf6_ONE",
     "name" : "trf6",
@@ -672,6 +622,31 @@
       "nominalVoltage" : 63.0
     }
   }, {
+    "type" : "FICTITIOUS",
+    "id" : "trf7",
+    "name" : "trf7",
+    "equipmentId" : "trf7",
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "fictitious" : true,
+    "x" : 560.0,
+    "y" : 42.0,
+    "open" : false,
+    "voltageLevelInfosLeg1" : {
+      "id" : "vl1",
+      "name" : "vl1",
+      "nominalVoltage" : 380.0
+    },
+    "voltageLevelInfosLeg2" : {
+      "id" : "vl2",
+      "name" : "vl2",
+      "nominalVoltage" : 225.0
+    },
+    "voltageLevelInfosLeg3" : {
+      "id" : "vl3",
+      "name" : "vl3",
+      "nominalVoltage" : 63.0
+    }
+  }, {
     "type" : "FEEDER",
     "id" : "trf7_ONE",
     "name" : "trf7",
@@ -707,6 +682,31 @@
     "direction" : "TOP",
     "side" : "THREE",
     "otherSideVoltageLevelInfos" : {
+      "id" : "vl3",
+      "name" : "vl3",
+      "nominalVoltage" : 63.0
+    }
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "trf8",
+    "name" : "trf8",
+    "equipmentId" : "trf8",
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "fictitious" : true,
+    "x" : 880.0,
+    "y" : 503.0,
+    "open" : false,
+    "voltageLevelInfosLeg1" : {
+      "id" : "vl1",
+      "name" : "vl1",
+      "nominalVoltage" : 380.0
+    },
+    "voltageLevelInfosLeg2" : {
+      "id" : "vl2",
+      "name" : "vl2",
+      "nominalVoltage" : 225.0
+    },
+    "voltageLevelInfosLeg3" : {
       "id" : "vl3",
       "name" : "vl3",
       "nominalVoltage" : 63.0
@@ -1176,7 +1176,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "FICT_vl2_dtrf27Fictif", "btrf27", "FICT_vl2_trf7_fictif" ]
+        "nodes" : [ "FICT_vl2_dtrf27Fictif", "btrf27", "trf7" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1217,7 +1217,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl2_trf7_fictif", "trf7_ONE" ]
+          "nodes" : [ "trf7", "trf7_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1238,7 +1238,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl2_trf7_fictif", "trf7_THREE" ]
+          "nodes" : [ "trf7", "trf7_THREE" ]
         } ]
       } ]
     }
@@ -1578,7 +1578,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "FICT_vl2_dtrf26Fictif", "btrf26", "FICT_vl2_trf6_fictif" ]
+        "nodes" : [ "FICT_vl2_dtrf26Fictif", "btrf26", "trf6" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1619,7 +1619,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl2_trf6_fictif", "trf6_ONE" ]
+          "nodes" : [ "trf6", "trf6_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1640,7 +1640,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl2_trf6_fictif", "trf6_THREE" ]
+          "nodes" : [ "trf6", "trf6_THREE" ]
         } ]
       } ]
     }
@@ -1710,7 +1710,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "FICT_vl2_dtrf28Fictif", "btrf28", "FICT_vl2_trf8_fictif" ]
+        "nodes" : [ "FICT_vl2_dtrf28Fictif", "btrf28", "trf8" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1751,7 +1751,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl2_trf8_fictif", "trf8_ONE" ]
+          "nodes" : [ "trf8", "trf8_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1772,28 +1772,28 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl2_trf8_fictif", "trf8_THREE" ]
+          "nodes" : [ "trf8", "trf8_THREE" ]
         } ]
       } ]
     }
   } ],
   "edges" : [ {
-    "node1" : "FICT_vl2_trf6_fictif",
+    "node1" : "trf6",
     "node2" : "trf6_ONE"
   }, {
-    "node1" : "FICT_vl2_trf6_fictif",
+    "node1" : "trf6",
     "node2" : "trf6_THREE"
   }, {
-    "node1" : "FICT_vl2_trf7_fictif",
+    "node1" : "trf7",
     "node2" : "trf7_ONE"
   }, {
-    "node1" : "FICT_vl2_trf7_fictif",
+    "node1" : "trf7",
     "node2" : "trf7_THREE"
   }, {
-    "node1" : "FICT_vl2_trf8_fictif",
+    "node1" : "trf8",
     "node2" : "trf8_ONE"
   }, {
-    "node1" : "FICT_vl2_trf8_fictif",
+    "node1" : "trf8",
     "node2" : "trf8_THREE"
   }, {
     "node1" : "bbs5",
@@ -1824,19 +1824,19 @@
     "node2" : "dtrf26"
   }, {
     "node1" : "btrf26",
-    "node2" : "FICT_vl2_trf6_fictif"
+    "node2" : "trf6"
   }, {
     "node1" : "bbs5",
     "node2" : "dtrf27"
   }, {
     "node1" : "btrf27",
-    "node2" : "FICT_vl2_trf7_fictif"
+    "node2" : "trf7"
   }, {
     "node1" : "bbs6",
     "node2" : "dtrf28"
   }, {
     "node1" : "btrf28",
-    "node2" : "FICT_vl2_trf8_fictif"
+    "node2" : "trf8"
   }, {
     "node1" : "bload3",
     "node2" : "FICT_vl2_load3Fictif"

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL3.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL3.json
@@ -137,81 +137,6 @@
     "y" : 478.0,
     "open" : false
   }, {
-    "type" : "FICTITIOUS",
-    "id" : "FICT_vl3_trf6_fictif",
-    "name" : "trf6_fictif",
-    "equipmentId" : "trf6_fictif",
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "fictitious" : true,
-    "x" : 320.0,
-    "y" : 42.0,
-    "open" : false,
-    "voltageLevelInfosLeg1" : {
-      "id" : "vl1",
-      "name" : "vl1",
-      "nominalVoltage" : 380.0
-    },
-    "voltageLevelInfosLeg2" : {
-      "id" : "vl2",
-      "name" : "vl2",
-      "nominalVoltage" : 225.0
-    },
-    "voltageLevelInfosLeg3" : {
-      "id" : "vl3",
-      "name" : "vl3",
-      "nominalVoltage" : 63.0
-    }
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "FICT_vl3_trf7_fictif",
-    "name" : "trf7_fictif",
-    "equipmentId" : "trf7_fictif",
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "fictitious" : true,
-    "x" : 480.0,
-    "y" : 478.0,
-    "open" : false,
-    "voltageLevelInfosLeg1" : {
-      "id" : "vl1",
-      "name" : "vl1",
-      "nominalVoltage" : 380.0
-    },
-    "voltageLevelInfosLeg2" : {
-      "id" : "vl2",
-      "name" : "vl2",
-      "nominalVoltage" : 225.0
-    },
-    "voltageLevelInfosLeg3" : {
-      "id" : "vl3",
-      "name" : "vl3",
-      "nominalVoltage" : 63.0
-    }
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "FICT_vl3_trf8_fictif",
-    "name" : "trf8_fictif",
-    "equipmentId" : "trf8_fictif",
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "fictitious" : true,
-    "x" : 640.0,
-    "y" : 42.0,
-    "open" : false,
-    "voltageLevelInfosLeg1" : {
-      "id" : "vl1",
-      "name" : "vl1",
-      "nominalVoltage" : 380.0
-    },
-    "voltageLevelInfosLeg2" : {
-      "id" : "vl2",
-      "name" : "vl2",
-      "nominalVoltage" : 225.0
-    },
-    "voltageLevelInfosLeg3" : {
-      "id" : "vl3",
-      "name" : "vl3",
-      "nominalVoltage" : 63.0
-    }
-  }, {
     "type" : "BUS",
     "id" : "bbs7",
     "name" : "bbs7",
@@ -502,6 +427,31 @@
       "nominalVoltage" : 380.0
     }
   }, {
+    "type" : "FICTITIOUS",
+    "id" : "trf6",
+    "name" : "trf6",
+    "equipmentId" : "trf6",
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "fictitious" : true,
+    "x" : 320.0,
+    "y" : 42.0,
+    "open" : false,
+    "voltageLevelInfosLeg1" : {
+      "id" : "vl1",
+      "name" : "vl1",
+      "nominalVoltage" : 380.0
+    },
+    "voltageLevelInfosLeg2" : {
+      "id" : "vl2",
+      "name" : "vl2",
+      "nominalVoltage" : 225.0
+    },
+    "voltageLevelInfosLeg3" : {
+      "id" : "vl3",
+      "name" : "vl3",
+      "nominalVoltage" : 63.0
+    }
+  }, {
     "type" : "FEEDER",
     "id" : "trf6_ONE",
     "name" : "trf6",
@@ -542,6 +492,31 @@
       "nominalVoltage" : 225.0
     }
   }, {
+    "type" : "FICTITIOUS",
+    "id" : "trf7",
+    "name" : "trf7",
+    "equipmentId" : "trf7",
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "fictitious" : true,
+    "x" : 480.0,
+    "y" : 478.0,
+    "open" : false,
+    "voltageLevelInfosLeg1" : {
+      "id" : "vl1",
+      "name" : "vl1",
+      "nominalVoltage" : 380.0
+    },
+    "voltageLevelInfosLeg2" : {
+      "id" : "vl2",
+      "name" : "vl2",
+      "nominalVoltage" : 225.0
+    },
+    "voltageLevelInfosLeg3" : {
+      "id" : "vl3",
+      "name" : "vl3",
+      "nominalVoltage" : 63.0
+    }
+  }, {
     "type" : "FEEDER",
     "id" : "trf7_ONE",
     "name" : "trf7",
@@ -580,6 +555,31 @@
       "id" : "vl2",
       "name" : "vl2",
       "nominalVoltage" : 225.0
+    }
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "trf8",
+    "name" : "trf8",
+    "equipmentId" : "trf8",
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "fictitious" : true,
+    "x" : 640.0,
+    "y" : 42.0,
+    "open" : false,
+    "voltageLevelInfosLeg1" : {
+      "id" : "vl1",
+      "name" : "vl1",
+      "nominalVoltage" : 380.0
+    },
+    "voltageLevelInfosLeg2" : {
+      "id" : "vl2",
+      "name" : "vl2",
+      "nominalVoltage" : 225.0
+    },
+    "voltageLevelInfosLeg3" : {
+      "id" : "vl3",
+      "name" : "vl3",
+      "nominalVoltage" : 63.0
     }
   }, {
     "type" : "FEEDER",
@@ -958,7 +958,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "FICT_vl3_dtrf36Fictif", "btrf36", "FICT_vl3_trf6_fictif" ]
+        "nodes" : [ "FICT_vl3_dtrf36Fictif", "btrf36", "trf6" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -999,7 +999,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl3_trf6_fictif", "trf6_ONE" ]
+          "nodes" : [ "trf6", "trf6_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1020,7 +1020,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl3_trf6_fictif", "trf6_TWO" ]
+          "nodes" : [ "trf6", "trf6_TWO" ]
         } ]
       } ]
     }
@@ -1090,7 +1090,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "FICT_vl3_dtrf37Fictif", "btrf37", "FICT_vl3_trf7_fictif" ]
+        "nodes" : [ "FICT_vl3_dtrf37Fictif", "btrf37", "trf7" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1131,7 +1131,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl3_trf7_fictif", "trf7_ONE" ]
+          "nodes" : [ "trf7", "trf7_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1152,7 +1152,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl3_trf7_fictif", "trf7_TWO" ]
+          "nodes" : [ "trf7", "trf7_TWO" ]
         } ]
       } ]
     }
@@ -1222,7 +1222,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "FICT_vl3_dtrf38Fictif", "btrf38", "FICT_vl3_trf8_fictif" ]
+        "nodes" : [ "FICT_vl3_dtrf38Fictif", "btrf38", "trf8" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1263,7 +1263,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl3_trf8_fictif", "trf8_ONE" ]
+          "nodes" : [ "trf8", "trf8_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1284,7 +1284,7 @@
             "xSpan" : 80.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "FICT_vl3_trf8_fictif", "trf8_TWO" ]
+          "nodes" : [ "trf8", "trf8_TWO" ]
         } ]
       } ]
     }
@@ -1470,22 +1470,22 @@
     }
   } ],
   "edges" : [ {
-    "node1" : "FICT_vl3_trf6_fictif",
+    "node1" : "trf6",
     "node2" : "trf6_ONE"
   }, {
-    "node1" : "FICT_vl3_trf6_fictif",
+    "node1" : "trf6",
     "node2" : "trf6_TWO"
   }, {
-    "node1" : "FICT_vl3_trf7_fictif",
+    "node1" : "trf7",
     "node2" : "trf7_ONE"
   }, {
-    "node1" : "FICT_vl3_trf7_fictif",
+    "node1" : "trf7",
     "node2" : "trf7_TWO"
   }, {
-    "node1" : "FICT_vl3_trf8_fictif",
+    "node1" : "trf8",
     "node2" : "trf8_ONE"
   }, {
-    "node1" : "FICT_vl3_trf8_fictif",
+    "node1" : "trf8",
     "node2" : "trf8_TWO"
   }, {
     "node1" : "bbs7",
@@ -1501,19 +1501,19 @@
     "node2" : "dtrf36"
   }, {
     "node1" : "btrf36",
-    "node2" : "FICT_vl3_trf6_fictif"
+    "node2" : "trf6"
   }, {
     "node1" : "bbs7",
     "node2" : "dtrf37"
   }, {
     "node1" : "btrf37",
-    "node2" : "FICT_vl3_trf7_fictif"
+    "node2" : "trf7"
   }, {
     "node1" : "bbs7",
     "node2" : "dtrf38"
   }, {
     "node1" : "btrf38",
-    "node2" : "FICT_vl3_trf8_fictif"
+    "node2" : "trf8"
   }, {
     "node1" : "bbs7",
     "node2" : "dself5"

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -304,31 +304,31 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_btrf16_95_FICT_95_vl1_95_dtrf16Fictif">
                 <polyline points="500.0,250.0,500.0,280.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_btrf16_95_FICT_95_vl1_95_trf6_95_fictif">
+            <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_btrf16_95_trf6">
                 <polyline points="500.0,230.0,500.0,212.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO">
+            <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl1_95_trf6_95_trf6_95_TWO">
                 <polyline points="493.0,200.0,460.0,200.0,460.0,138.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,153.0)">
+            <g class="sld-arrow-p sld-down" id="_95_vl1_95_trf6_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,153.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,173.0)">
+            <g class="sld-arrow-q sld-down" id="_95_vl1_95_trf6_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,173.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl50to70" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE">
+            <g class="sld-wire sld-constant-color sld-vl50to70" id="_95_vl1_95_trf6_95_trf6_95_THREE">
                 <polyline points="507.0,200.0,540.0,200.0,540.0,138.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,153.0)">
+            <g class="sld-arrow-p sld-down" id="_95_vl1_95_trf6_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,153.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,173.0)">
+            <g class="sld-arrow-q sld-down" id="_95_vl1_95_trf6_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,173.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
@@ -341,7 +341,7 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf6_95_fictif" transform="translate(492.0,188.0)">
+            <g class="sld-three-wt sld-constant-color" id="idtrf6" transform="translate(492.0,188.0)">
                 <circle class="sld-vl180to300" cx="5" cy="15" r="5"/>
                 <circle class="sld-vl50to70" cx="11" cy="15" r="5"/>
                 <circle class="sld-vl300to500" cx="8" cy="19" r="5"/>
@@ -459,31 +459,31 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_btrf18_95_FICT_95_vl1_95_dtrf18Fictif">
                 <polyline points="980.0,250.0,980.0,280.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_btrf18_95_FICT_95_vl1_95_trf8_95_fictif">
+            <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_btrf18_95_trf8">
                 <polyline points="980.0,230.0,980.0,212.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO">
+            <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl1_95_trf8_95_trf8_95_TWO">
                 <polyline points="973.0,200.0,940.0,200.0,940.0,138.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,153.0)">
+            <g class="sld-arrow-p sld-down" id="_95_vl1_95_trf8_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,153.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,173.0)">
+            <g class="sld-arrow-q sld-down" id="_95_vl1_95_trf8_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,173.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl50to70" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE">
+            <g class="sld-wire sld-constant-color sld-vl50to70" id="_95_vl1_95_trf8_95_trf8_95_THREE">
                 <polyline points="987.0,200.0,1020.0,200.0,1020.0,138.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,153.0)">
+            <g class="sld-arrow-p sld-down" id="_95_vl1_95_trf8_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,153.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,173.0)">
+            <g class="sld-arrow-q sld-down" id="_95_vl1_95_trf8_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,173.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
@@ -496,7 +496,7 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf8_95_fictif" transform="translate(972.0,188.0)">
+            <g class="sld-three-wt sld-constant-color" id="idtrf8" transform="translate(972.0,188.0)">
                 <circle class="sld-vl180to300" cx="5" cy="15" r="5"/>
                 <circle class="sld-vl50to70" cx="11" cy="15" r="5"/>
                 <circle class="sld-vl300to500" cx="8" cy="19" r="5"/>
@@ -614,31 +614,31 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_btrf17_95_FICT_95_vl1_95_dtrf17Fictif">
                 <polyline points="660.0,395.0,660.0,365.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_btrf17_95_FICT_95_vl1_95_trf7_95_fictif">
+            <g class="sld-wire sld-constant-color sld-vl300to500" id="_95_vl1_95_btrf17_95_trf7">
                 <polyline points="660.0,415.0,660.0,433.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO">
+            <g class="sld-wire sld-constant-color sld-vl180to300" id="_95_vl1_95_trf7_95_trf7_95_TWO">
                 <polyline points="653.0,445.0,620.0,445.0,620.0,507.0"/>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,482.0)">
+            <g class="sld-arrow-q sld-down" id="_95_vl1_95_trf7_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,482.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,462.0)">
+            <g class="sld-arrow-p sld-down" id="_95_vl1_95_trf7_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,462.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl50to70" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE">
+            <g class="sld-wire sld-constant-color sld-vl50to70" id="_95_vl1_95_trf7_95_trf7_95_THREE">
                 <polyline points="667.0,445.0,700.0,445.0,700.0,507.0"/>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,482.0)">
+            <g class="sld-arrow-q sld-down" id="_95_vl1_95_trf7_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,482.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,462.0)">
+            <g class="sld-arrow-p sld-down" id="_95_vl1_95_trf7_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,462.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
@@ -651,7 +651,7 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf7_95_fictif" transform="translate(652.0,433.0)">
+            <g class="sld-three-wt sld-constant-color" id="idtrf7" transform="translate(652.0,433.0)">
                 <circle class="sld-vl50to70" cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
                 <circle class="sld-vl180to300" cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
                 <circle class="sld-vl300to500" cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -369,31 +369,31 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_btrf16_95_FICT_95_vl1_95_dtrf16Fictif">
                 <polyline points="500.0,250.0,500.0,280.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_btrf16_95_FICT_95_vl1_95_trf6_95_fictif">
+            <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_btrf16_95_trf6">
                 <polyline points="500.0,230.0,500.0,212.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl180to300-0" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO">
+            <g class="sld-wire sld-constant-color sld-vl180to300-0" id="_95_vl1_95_trf6_95_trf6_95_TWO">
                 <polyline points="493.0,200.0,460.0,200.0,460.0,138.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,153.0)">
+            <g class="sld-arrow-p sld-down" id="_95_vl1_95_trf6_95_trf6_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,153.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,173.0)">
+            <g class="sld-arrow-q sld-down" id="_95_vl1_95_trf6_95_trf6_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,173.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl50to70-0" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE">
+            <g class="sld-wire sld-constant-color sld-vl50to70-0" id="_95_vl1_95_trf6_95_trf6_95_THREE">
                 <polyline points="507.0,200.0,540.0,200.0,540.0,138.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,153.0)">
+            <g class="sld-arrow-p sld-down" id="_95_vl1_95_trf6_95_trf6_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,535.0,153.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,173.0)">
+            <g class="sld-arrow-q sld-down" id="_95_vl1_95_trf6_95_trf6_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,535.0,173.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
@@ -406,7 +406,7 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf6_95_fictif" transform="translate(492.0,188.0)">
+            <g class="sld-three-wt sld-constant-color" id="idtrf6" transform="translate(492.0,188.0)">
                 <circle class="sld-vl180to300-0" cx="5" cy="15" r="5"/>
                 <circle class="sld-vl50to70-0" cx="11" cy="15" r="5"/>
                 <circle class="sld-vl300to500-0" cx="8" cy="19" r="5"/>
@@ -524,31 +524,31 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_btrf18_95_FICT_95_vl1_95_dtrf18Fictif">
                 <polyline points="980.0,250.0,980.0,280.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_btrf18_95_FICT_95_vl1_95_trf8_95_fictif">
+            <g class="sld-wire sld-constant-color sld-vl300to500-0" id="_95_vl1_95_btrf18_95_trf8">
                 <polyline points="980.0,230.0,980.0,212.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl180to300-0" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO">
+            <g class="sld-wire sld-constant-color sld-vl180to300-0" id="_95_vl1_95_trf8_95_trf8_95_TWO">
                 <polyline points="973.0,200.0,940.0,200.0,940.0,138.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,153.0)">
+            <g class="sld-arrow-p sld-down" id="_95_vl1_95_trf8_95_trf8_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,935.0,153.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,173.0)">
+            <g class="sld-arrow-q sld-down" id="_95_vl1_95_trf8_95_trf8_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,935.0,173.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl50to70-0" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE">
+            <g class="sld-wire sld-constant-color sld-vl50to70-0" id="_95_vl1_95_trf8_95_trf8_95_THREE">
                 <polyline points="987.0,200.0,1020.0,200.0,1020.0,138.0"/>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,153.0)">
+            <g class="sld-arrow-p sld-down" id="_95_vl1_95_trf8_95_trf8_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,153.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,173.0)">
+            <g class="sld-arrow-q sld-down" id="_95_vl1_95_trf8_95_trf8_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1015.0,173.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
@@ -561,7 +561,7 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf8_95_fictif" transform="translate(972.0,188.0)">
+            <g class="sld-three-wt sld-constant-color" id="idtrf8" transform="translate(972.0,188.0)">
                 <circle class="sld-vl180to300-0" cx="5" cy="15" r="5"/>
                 <circle class="sld-vl50to70-0" cx="11" cy="15" r="5"/>
                 <circle class="sld-vl300to500-0" cx="8" cy="19" r="5"/>
@@ -679,31 +679,31 @@ polyline {fill: none}
             <g class="sld-wire sld-constant-color sld-vl300to500-1" id="_95_vl1_95_btrf17_95_FICT_95_vl1_95_dtrf17Fictif">
                 <polyline points="660.0,395.0,660.0,365.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl300to500-1" id="_95_vl1_95_btrf17_95_FICT_95_vl1_95_trf7_95_fictif">
+            <g class="sld-wire sld-constant-color sld-vl300to500-1" id="_95_vl1_95_btrf17_95_trf7">
                 <polyline points="660.0,415.0,660.0,433.0"/>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl180to300-0" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO">
+            <g class="sld-wire sld-constant-color sld-vl180to300-0" id="_95_vl1_95_trf7_95_trf7_95_TWO">
                 <polyline points="653.0,445.0,620.0,445.0,620.0,507.0"/>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,482.0)">
+            <g class="sld-arrow-q sld-down" id="_95_vl1_95_trf7_95_trf7_95_TWO_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,615.0,482.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,462.0)">
+            <g class="sld-arrow-p sld-down" id="_95_vl1_95_trf7_95_trf7_95_TWO_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,615.0,462.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-wire sld-constant-color sld-vl50to70-0" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE">
+            <g class="sld-wire sld-constant-color sld-vl50to70-0" id="_95_vl1_95_trf7_95_trf7_95_THREE">
                 <polyline points="667.0,445.0,700.0,445.0,700.0,507.0"/>
             </g>
-            <g class="sld-arrow-q sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,482.0)">
+            <g class="sld-arrow-q sld-down" id="_95_vl1_95_trf7_95_trf7_95_THREE_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,482.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-p sld-down" id="_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,462.0)">
+            <g class="sld-arrow-p sld-down" id="_95_vl1_95_trf7_95_trf7_95_THREE_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,462.0)">
                 <polygon class="sld-arrow-down" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-up" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">0</text>
@@ -716,7 +716,7 @@ polyline {fill: none}
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_trf7_95_fictif" transform="translate(652.0,433.0)">
+            <g class="sld-three-wt sld-constant-color" id="idtrf7" transform="translate(652.0,433.0)">
                 <circle class="sld-vl50to70-0" cx="5" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
                 <circle class="sld-vl180to300-0" cx="11" cy="15" r="5" transform="rotate(180.0,8.0,12.0)"/>
                 <circle class="sld-vl300to500-1" cx="8" cy="19" r="5" transform="rotate(180.0,8.0,12.0)"/>

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -281,16 +281,6 @@
     "vlabel" : false,
     "equipmentId" : "gen1Fictif"
   }, {
-    "id" : "idtrf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE",
-    "vid" : "",
-    "nextVId" : null,
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false,
-    "equipmentId" : "trf6_ONE_trf6_TWO_trf6_THREE"
-  }, {
     "id" : "idFICT_95_vl1_95_trf8_95_ONEFictif",
     "vid" : "vl1",
     "nextVId" : null,
@@ -571,16 +561,6 @@
     "vlabel" : false,
     "equipmentId" : "trf8_THREEFictif"
   }, {
-    "id" : "idtrf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE",
-    "vid" : "",
-    "nextVId" : null,
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "rotationAngle" : 180.0,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false,
-    "equipmentId" : "trf8_ONE_trf8_TWO_trf8_THREE"
-  }, {
     "id" : "iddtrf18",
     "vid" : "vl1",
     "nextVId" : null,
@@ -801,16 +781,6 @@
     "vlabel" : false,
     "equipmentId" : "dsect22"
   }, {
-    "id" : "idtrf3_95_ONE_95_trf3_95_TWO",
-    "vid" : "",
-    "nextVId" : null,
-    "componentType" : "TWO_WINDINGS_TRANSFORMER",
-    "rotationAngle" : 90.0,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false,
-    "equipmentId" : "trf3_ONE_trf3_TWO"
-  }, {
     "id" : "idFICT_95_vl1_95_gen2Fictif",
     "vid" : "vl1",
     "nextVId" : null,
@@ -1021,16 +991,6 @@
     "vlabel" : false,
     "equipmentId" : "bload2"
   }, {
-    "id" : "idtrf4_95_ONE_95_trf4_95_TWO",
-    "vid" : "",
-    "nextVId" : null,
-    "componentType" : "TWO_WINDINGS_TRANSFORMER",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false,
-    "equipmentId" : "trf4_ONE_trf4_TWO"
-  }, {
     "id" : "idbload1",
     "vid" : "vl1",
     "nextVId" : null,
@@ -1230,16 +1190,6 @@
     "direction" : "UNDEFINED",
     "vlabel" : false,
     "equipmentId" : "dgen1Fictif"
-  }, {
-    "id" : "idtrf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE",
-    "vid" : "",
-    "nextVId" : null,
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false,
-    "equipmentId" : "trf7_ONE_trf7_TWO_trf7_THREE"
   }, {
     "id" : "idFICT_95_vl1_95_dtrf12Fictif",
     "vid" : "vl1",
@@ -1551,16 +1501,6 @@
     "vlabel" : false,
     "equipmentId" : "btrf27"
   }, {
-    "id" : "idtrf5_95_ONE_95_trf5_95_TWO",
-    "vid" : "",
-    "nextVId" : null,
-    "componentType" : "TWO_WINDINGS_TRANSFORMER",
-    "rotationAngle" : 180.0,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false,
-    "equipmentId" : "trf5_ONE_trf5_TWO"
-  }, {
     "id" : "idbtrf22",
     "vid" : "vl2",
     "nextVId" : null,
@@ -1651,6 +1591,26 @@
     "vlabel" : false,
     "equipmentId" : "btrf23"
   }, {
+    "id" : "idtrf1",
+    "vid" : "",
+    "nextVId" : null,
+    "componentType" : "TWO_WINDINGS_TRANSFORMER",
+    "rotationAngle" : 90.0,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false,
+    "equipmentId" : "trf1"
+  }, {
+    "id" : "idtrf2",
+    "vid" : "",
+    "nextVId" : null,
+    "componentType" : "TWO_WINDINGS_TRANSFORMER",
+    "rotationAngle" : 180.0,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false,
+    "equipmentId" : "trf2"
+  }, {
     "id" : "idFICT_95_vl2_95_trf8_95_TWOFictif",
     "vid" : "vl2",
     "nextVId" : null,
@@ -1661,7 +1621,7 @@
     "vlabel" : false,
     "equipmentId" : "trf8_TWOFictif"
   }, {
-    "id" : "idtrf1_95_ONE_95_trf1_95_TWO",
+    "id" : "idtrf3",
     "vid" : "",
     "nextVId" : null,
     "componentType" : "TWO_WINDINGS_TRANSFORMER",
@@ -1669,7 +1629,17 @@
     "open" : false,
     "direction" : "UNDEFINED",
     "vlabel" : false,
-    "equipmentId" : "trf1_ONE_trf1_TWO"
+    "equipmentId" : "trf3"
+  }, {
+    "id" : "idtrf4",
+    "vid" : "",
+    "nextVId" : null,
+    "componentType" : "TWO_WINDINGS_TRANSFORMER",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false,
+    "equipmentId" : "trf4"
   }, {
     "id" : "idFICT_95_vl2_95_trf4_95_TWOFictif",
     "vid" : "vl2",
@@ -1701,6 +1671,26 @@
     "vlabel" : false,
     "equipmentId" : "trf2_TWOFictif"
   }, {
+    "id" : "idtrf5",
+    "vid" : "",
+    "nextVId" : null,
+    "componentType" : "TWO_WINDINGS_TRANSFORMER",
+    "rotationAngle" : 180.0,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false,
+    "equipmentId" : "trf5"
+  }, {
+    "id" : "idtrf6",
+    "vid" : "",
+    "nextVId" : null,
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false,
+    "equipmentId" : "trf6"
+  }, {
     "id" : "iddgen1",
     "vid" : "vl1",
     "nextVId" : null,
@@ -1710,6 +1700,16 @@
     "direction" : "UNDEFINED",
     "vlabel" : false,
     "equipmentId" : "dgen1"
+  }, {
+    "id" : "idtrf7",
+    "vid" : "",
+    "nextVId" : null,
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false,
+    "equipmentId" : "trf7"
   }, {
     "id" : "iddgen2",
     "vid" : "vl1",
@@ -1721,15 +1721,15 @@
     "vlabel" : false,
     "equipmentId" : "dgen2"
   }, {
-    "id" : "idtrf2_95_ONE_95_trf2_95_TWO",
+    "id" : "idtrf8",
     "vid" : "",
     "nextVId" : null,
-    "componentType" : "TWO_WINDINGS_TRANSFORMER",
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
     "rotationAngle" : 180.0,
     "open" : false,
     "direction" : "UNDEFINED",
     "vlabel" : false,
-    "equipmentId" : "trf2_ONE_trf2_TWO"
+    "equipmentId" : "trf8"
   }, {
     "id" : "idtrf8_95_TWO",
     "vid" : "vl2",
@@ -1991,7 +1991,7 @@
     "snakeLine" : false
   }, {
     "id" : "idtrf3_95_TWO_95_edge",
-    "nodeId1" : "idtrf3_95_ONE_95_trf3_95_TWO",
+    "nodeId1" : "idtrf3",
     "nodeId2" : "idtrf3_95_TWO",
     "straight" : false,
     "snakeLine" : true
@@ -2003,7 +2003,7 @@
     "snakeLine" : false
   }, {
     "id" : "idtrf6_95_TWO_95_EDGE",
-    "nodeId1" : "idtrf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE",
+    "nodeId1" : "idtrf6",
     "nodeId2" : "idtrf6_95_TWO",
     "straight" : false,
     "snakeLine" : true
@@ -2064,7 +2064,7 @@
   }, {
     "id" : "idtrf7_95_ONE_95_EDGE",
     "nodeId1" : "idtrf7_95_ONE",
-    "nodeId2" : "idtrf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE",
+    "nodeId2" : "idtrf7",
     "straight" : false,
     "snakeLine" : true
   }, {
@@ -2106,7 +2106,7 @@
   }, {
     "id" : "idtrf4_95_ONE_95_edge",
     "nodeId1" : "idtrf4_95_ONE",
-    "nodeId2" : "idtrf4_95_ONE_95_trf4_95_TWO",
+    "nodeId2" : "idtrf4",
     "straight" : false,
     "snakeLine" : true
   }, {
@@ -2255,7 +2255,7 @@
     "snakeLine" : false
   }, {
     "id" : "idtrf7_95_TWO_95_EDGE",
-    "nodeId1" : "idtrf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE",
+    "nodeId1" : "idtrf7",
     "nodeId2" : "idtrf7_95_TWO",
     "straight" : false,
     "snakeLine" : true
@@ -2268,7 +2268,7 @@
   }, {
     "id" : "idtrf6_95_ONE_95_EDGE",
     "nodeId1" : "idtrf6_95_ONE",
-    "nodeId2" : "idtrf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE",
+    "nodeId2" : "idtrf6",
     "straight" : false,
     "snakeLine" : true
   }, {
@@ -2339,7 +2339,7 @@
     "snakeLine" : false
   }, {
     "id" : "idtrf7_95_THREE_95_EDGE",
-    "nodeId1" : "idtrf7_95_ONE_95_trf7_95_TWO_95_trf7_95_THREE",
+    "nodeId1" : "idtrf7",
     "nodeId2" : "idtrf7_95_THREE",
     "straight" : false,
     "snakeLine" : true
@@ -2357,14 +2357,14 @@
     "snakeLine" : false
   }, {
     "id" : "idtrf2_95_TWO_95_edge",
-    "nodeId1" : "idtrf2_95_ONE_95_trf2_95_TWO",
+    "nodeId1" : "idtrf2",
     "nodeId2" : "idtrf2_95_TWO",
     "straight" : false,
     "snakeLine" : true
   }, {
     "id" : "idtrf3_95_ONE_95_edge",
     "nodeId1" : "idtrf3_95_ONE",
-    "nodeId2" : "idtrf3_95_ONE_95_trf3_95_TWO",
+    "nodeId2" : "idtrf3",
     "straight" : false,
     "snakeLine" : true
   }, {
@@ -2405,7 +2405,7 @@
     "snakeLine" : false
   }, {
     "id" : "idtrf6_95_THREE_95_EDGE",
-    "nodeId1" : "idtrf6_95_ONE_95_trf6_95_TWO_95_trf6_95_THREE",
+    "nodeId1" : "idtrf6",
     "nodeId2" : "idtrf6_95_THREE",
     "straight" : false,
     "snakeLine" : true
@@ -2478,7 +2478,7 @@
   }, {
     "id" : "idtrf8_95_ONE_95_EDGE",
     "nodeId1" : "idtrf8_95_ONE",
-    "nodeId2" : "idtrf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE",
+    "nodeId2" : "idtrf8",
     "straight" : false,
     "snakeLine" : true
   }, {
@@ -2507,7 +2507,7 @@
     "snakeLine" : false
   }, {
     "id" : "idtrf4_95_TWO_95_edge",
-    "nodeId1" : "idtrf4_95_ONE_95_trf4_95_TWO",
+    "nodeId1" : "idtrf4",
     "nodeId2" : "idtrf4_95_TWO",
     "straight" : false,
     "snakeLine" : true
@@ -2526,7 +2526,7 @@
   }, {
     "id" : "idtrf1_95_ONE_95_edge",
     "nodeId1" : "idtrf1_95_ONE",
-    "nodeId2" : "idtrf1_95_ONE_95_trf1_95_TWO",
+    "nodeId2" : "idtrf1",
     "straight" : false,
     "snakeLine" : true
   }, {
@@ -2580,7 +2580,7 @@
   }, {
     "id" : "idtrf2_95_ONE_95_edge",
     "nodeId1" : "idtrf2_95_ONE",
-    "nodeId2" : "idtrf2_95_ONE_95_trf2_95_TWO",
+    "nodeId2" : "idtrf2",
     "straight" : false,
     "snakeLine" : true
   }, {
@@ -2603,7 +2603,7 @@
     "snakeLine" : false
   }, {
     "id" : "idtrf8_95_TWO_95_EDGE",
-    "nodeId1" : "idtrf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE",
+    "nodeId1" : "idtrf8",
     "nodeId2" : "idtrf8_95_TWO",
     "straight" : false,
     "snakeLine" : true
@@ -2651,7 +2651,7 @@
     "snakeLine" : false
   }, {
     "id" : "idtrf1_95_TWO_95_edge",
-    "nodeId1" : "idtrf1_95_ONE_95_trf1_95_TWO",
+    "nodeId1" : "idtrf1",
     "nodeId2" : "idtrf1_95_TWO",
     "straight" : false,
     "snakeLine" : true
@@ -2706,7 +2706,7 @@
   }, {
     "id" : "idtrf5_95_ONE_95_edge",
     "nodeId1" : "idtrf5_95_ONE",
-    "nodeId2" : "idtrf5_95_ONE_95_trf5_95_TWO",
+    "nodeId2" : "idtrf5",
     "straight" : false,
     "snakeLine" : true
   }, {
@@ -2873,7 +2873,7 @@
     "snakeLine" : false
   }, {
     "id" : "idtrf8_95_THREE_95_EDGE",
-    "nodeId1" : "idtrf8_95_ONE_95_trf8_95_TWO_95_trf8_95_THREE",
+    "nodeId1" : "idtrf8",
     "nodeId2" : "idtrf8_95_THREE",
     "straight" : false,
     "snakeLine" : true
@@ -2897,7 +2897,7 @@
     "snakeLine" : false
   }, {
     "id" : "idtrf5_95_TWO_95_edge",
-    "nodeId1" : "idtrf5_95_ONE_95_trf5_95_TWO",
+    "nodeId1" : "idtrf5",
     "nodeId2" : "idtrf5_95_TWO",
     "straight" : false,
     "snakeLine" : true

--- a/single-line-diagram-core/src/test/resources/vl1.svg
+++ b/single-line-diagram-core/src/test/resources/vl1.svg
@@ -106,33 +106,33 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1">
             <polyline points="100.0,370.0,90.0,370.0"/>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="380.0,150.0,380.0,210.0,413.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="460.0,150.0,460.0,210.0,427.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
             <polyline points="420.0,222.0,420.0,240.0"/>
         </g>
         <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2">
@@ -186,7 +186,7 @@ polyline {fill: none}
         <g class="sld-constant-color" id="idvl1_95_trf2_95_two" transform="translate(460.0,150.0)">
             <text class="sld-label" id="vl1_trf2_two__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_trf2</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,198.0)">
+        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2" transform="translate(412.0,198.0)">
             <circle cx="5" cy="15" r="5"/>
             <circle cx="11" cy="15" r="5"/>
             <circle cx="8" cy="19" r="5"/>

--- a/single-line-diagram-core/src/test/resources/vl1_external_css.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_external_css.svg
@@ -73,33 +73,33 @@
         <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1">
             <polyline points="100.0,370.0,90.0,370.0"/>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="380.0,150.0,380.0,210.0,413.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="460.0,150.0,460.0,210.0,427.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
             <polyline points="420.0,222.0,420.0,240.0"/>
         </g>
         <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2">
@@ -153,7 +153,7 @@
         <g class="sld-constant-color" id="idvl1_95_trf2_95_two" transform="translate(460.0,150.0)">
             <text class="sld-label" id="vl1_trf2_two__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_trf2</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,198.0)">
+        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2" transform="translate(412.0,198.0)">
             <circle cx="5" cy="15" r="5"/>
             <circle cx="11" cy="15" r="5"/>
             <circle cx="8" cy="19" r="5"/>

--- a/single-line-diagram-core/src/test/resources/vl1_external_css_no_import.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_external_css_no_import.svg
@@ -72,33 +72,33 @@
         <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1">
             <polyline points="100.0,370.0,90.0,370.0"/>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="380.0,150.0,380.0,210.0,413.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="460.0,150.0,460.0,210.0,427.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
             <polyline points="420.0,222.0,420.0,240.0"/>
         </g>
         <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2">
@@ -152,7 +152,7 @@
         <g class="sld-constant-color" id="idvl1_95_trf2_95_two" transform="translate(460.0,150.0)">
             <text class="sld-label" id="vl1_trf2_two__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_trf2</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,198.0)">
+        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2" transform="translate(412.0,198.0)">
             <circle cx="5" cy="15" r="5"/>
             <circle cx="11" cy="15" r="5"/>
             <circle cx="8" cy="19" r="5"/>

--- a/single-line-diagram-core/src/test/resources/vl1_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_nominal_voltage_style.svg
@@ -58,7 +58,7 @@ polyline {fill: none}
             <circle class="sld-vl180to300" cx="5" cy="5" r="5"/>
             <text class="sld-label" id="2WT_ONE__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">2WT_1</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_3WT_95_fictif" transform="translate(11.0,37.0)">
+        <g class="sld-three-wt sld-constant-color" id="id3WT" transform="translate(11.0,37.0)">
             <circle class="sld-vl180to300" cx="5" cy="15" r="5"/>
             <circle class="sld-vl50to70" cx="11" cy="15" r="5"/>
             <circle class="sld-vl300to500" cx="8" cy="19" r="5"/>

--- a/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -156,33 +156,33 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1">
             <polyline points="100.0,370.0,90.0,370.0"/>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="380.0,150.0,380.0,210.0,413.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="460.0,150.0,460.0,210.0,427.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
             <polyline points="420.0,222.0,420.0,240.0"/>
         </g>
         <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2">
@@ -234,7 +234,7 @@ polyline {fill: none}
         <g class="sld-constant-color" id="idvl1_95_trf2_95_two" transform="translate(460.0,150.0)">
             <text class="sld-label" id="vl1_trf2_two__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_trf2</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,198.0)">
+        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2" transform="translate(412.0,198.0)">
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING1"/>
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING2"/>
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING3"/>

--- a/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
@@ -106,33 +106,33 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1">
             <polyline points="100.0,370.0,90.0,370.0"/>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="380.0,150.0,413.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(0.8762,-0.4819,0.4819,0.8762,382.8477,165.5528)">
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2_ARROW1" transform="matrix(0.8762,-0.4819,0.4819,0.8762,382.8477,165.5528)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(0.8762,-0.4819,0.4819,0.8762,392.4861,183.0772)">
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2_ARROW2" transform="matrix(0.8762,-0.4819,0.4819,0.8762,392.4861,183.0772)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="460.0,150.0,427.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(0.8762,0.4819,-0.4819,0.8762,448.3901,160.7336)">
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2_ARROW1" transform="matrix(0.8762,0.4819,-0.4819,0.8762,448.3901,160.7336)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(0.8762,0.4819,-0.4819,0.8762,438.7518,178.258)">
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2_ARROW2" transform="matrix(0.8762,0.4819,-0.4819,0.8762,438.7518,178.258)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
             <polyline points="420.0,222.0,420.0,240.0"/>
         </g>
         <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2">
@@ -186,7 +186,7 @@ polyline {fill: none}
         <g class="sld-constant-color" id="idvl1_95_trf2_95_two" transform="translate(460.0,150.0)">
             <text class="sld-label" id="vl1_trf2_two__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_trf2</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,198.0)">
+        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2" transform="translate(412.0,198.0)">
             <circle cx="5" cy="15" r="5"/>
             <circle cx="11" cy="15" r="5"/>
             <circle cx="8" cy="19" r="5"/>

--- a/single-line-diagram-core/src/test/resources/vl1_tooltip_opt.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_tooltip_opt.svg
@@ -156,33 +156,33 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_dtrf1_95_vl1_95_bbs1">
             <polyline points="100.0,370.0,90.0,370.0"/>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="380.0,150.0,380.0,210.0,413.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,375.0,165.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,375.0,185.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="460.0,150.0,460.0,210.0,427.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,455.0,165.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_FICT_95_vl1_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,455.0,185.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl1_95_FICT_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_trf2_95_vl1_95_btrf2">
             <polyline points="420.0,222.0,420.0,240.0"/>
         </g>
         <g class="sld-wire sld-constant-color" id="_95_vl1_95_vl1_95_btrf2_95_vl1_95_dtrf2">
@@ -243,7 +243,7 @@ polyline {fill: none}
         <g class="sld-constant-color" id="idvl1_95_trf2_95_two" transform="translate(460.0,150.0)">
             <text class="sld-label" id="vl1_trf2_two__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl1_trf2</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl1_95_vl1_95_trf2" transform="translate(412.0,198.0)">
+        <g class="sld-three-wt sld-constant-color" id="idvl1_95_trf2" transform="translate(412.0,198.0)">
             <title>vl1_trf2</title>
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING1"/>
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING2"/>

--- a/single-line-diagram-core/src/test/resources/vl2.svg
+++ b/single-line-diagram-core/src/test/resources/vl2.svg
@@ -87,33 +87,33 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1">
             <polyline points="670.0,370.0,680.0,370.0"/>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_trf2">
             <polyline points="700.0,150.0,700.0,210.0,723.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,165.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,185.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_trf2_95_two_95_vl2_95_trf2">
             <polyline points="760.0,150.0,760.0,210.0,737.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,755.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl2_95_vl2_95_trf2_95_two_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,755.0,165.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,755.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl2_95_vl2_95_trf2_95_two_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,755.0,185.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl2_95_FICT_95_vl2_95_vl2_95_trf2_95_vl2_95_btrf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_trf2_95_vl2_95_btrf2">
             <polyline points="730.0,222.0,730.0,240.0"/>
         </g>
         <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2">
@@ -155,7 +155,7 @@ polyline {fill: none}
         <g class="sld-constant-color" id="idvl2_95_trf2_95_two" transform="translate(760.0,150.0)">
             <text class="sld-label" id="vl2_trf2_two__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl2_trf2</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl2_95_vl2_95_trf2" transform="translate(722.0,198.0)">
+        <g class="sld-three-wt sld-constant-color" id="idvl2_95_trf2" transform="translate(722.0,198.0)">
             <circle cx="5" cy="15" r="5"/>
             <circle cx="11" cy="15" r="5"/>
             <circle cx="8" cy="19" r="5"/>

--- a/single-line-diagram-core/src/test/resources/vl2_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_nominal_voltage_style.svg
@@ -52,7 +52,7 @@ polyline {fill: none}
             <circle class="sld-vl300to500" cx="5" cy="5" r="5"/>
             <text class="sld-label" id="2WT_TWO__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">2WT_2</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl2_95_3WT_95_fictif" transform="translate(11.0,37.0)">
+        <g class="sld-three-wt sld-constant-color" id="id3WT" transform="translate(11.0,37.0)">
             <circle class="sld-vl300to500" cx="5" cy="15" r="5"/>
             <circle class="sld-vl50to70" cx="11" cy="15" r="5"/>
             <circle class="sld-vl180to300" cx="8" cy="19" r="5"/>

--- a/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -137,33 +137,33 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_dtrf1_95_vl2_95_bbs1">
             <polyline points="670.0,370.0,680.0,370.0"/>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_trf2">
             <polyline points="700.0,150.0,700.0,210.0,723.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,695.0,165.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,695.0,185.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_trf2_95_two_95_vl2_95_trf2">
             <polyline points="760.0,150.0,760.0,210.0,737.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,755.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl2_95_vl2_95_trf2_95_two_95_vl2_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,755.0,165.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl2_95_vl2_95_trf2_95_two_95_FICT_95_vl2_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,755.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl2_95_vl2_95_trf2_95_two_95_vl2_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,755.0,185.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl2_95_FICT_95_vl2_95_vl2_95_trf2_95_vl2_95_btrf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_trf2_95_vl2_95_btrf2">
             <polyline points="730.0,222.0,730.0,240.0"/>
         </g>
         <g class="sld-wire sld-constant-color" id="_95_vl2_95_vl2_95_btrf2_95_vl2_95_dtrf2">
@@ -203,7 +203,7 @@ polyline {fill: none}
         <g class="sld-constant-color" id="idvl2_95_trf2_95_two" transform="translate(760.0,150.0)">
             <text class="sld-label" id="vl2_trf2_two__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl2_trf2</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl2_95_vl2_95_trf2" transform="translate(722.0,198.0)">
+        <g class="sld-three-wt sld-constant-color" id="idvl2_95_trf2" transform="translate(722.0,198.0)">
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING1"/>
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING2"/>
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING3"/>

--- a/single-line-diagram-core/src/test/resources/vl3.svg
+++ b/single-line-diagram-core/src/test/resources/vl3.svg
@@ -68,33 +68,33 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1">
             <polyline points="910.0,370.0,900.0,370.0"/>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_trf2">
             <polyline points="980.0,150.0,980.0,210.0,1013.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,975.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,975.0,165.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,975.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,975.0,185.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_trf2_95_two_95_vl3_95_trf2">
             <polyline points="1060.0,150.0,1060.0,210.0,1027.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl3_95_vl3_95_trf2_95_two_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,165.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl3_95_vl3_95_trf2_95_two_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,185.0)">
             <polygon class="sld-arrow-down" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-up" points="5,0 10,10 0,10"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl3_95_FICT_95_vl3_95_vl3_95_trf2_95_vl3_95_btrf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_trf2_95_vl3_95_btrf2">
             <polyline points="1020.0,222.0,1020.0,240.0"/>
         </g>
         <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2">
@@ -124,7 +124,7 @@ polyline {fill: none}
         <g class="sld-constant-color" id="idvl3_95_trf2_95_two" transform="translate(1060.0,150.0)">
             <text class="sld-label" id="vl3_trf2_two__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl3_trf2</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl3_95_vl3_95_trf2" transform="translate(1012.0,198.0)">
+        <g class="sld-three-wt sld-constant-color" id="idvl3_95_trf2" transform="translate(1012.0,198.0)">
             <circle cx="5" cy="15" r="5"/>
             <circle cx="11" cy="15" r="5"/>
             <circle cx="8" cy="19" r="5"/>

--- a/single-line-diagram-core/src/test/resources/vl3_nominal_voltage_style.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_nominal_voltage_style.svg
@@ -47,7 +47,7 @@ polyline {fill: none}
             <line x1="0" x2="1.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs3_NW_LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">bbs3</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl3_95_3WT_95_fictif" transform="translate(11.0,37.0)">
+        <g class="sld-three-wt sld-constant-color" id="id3WT" transform="translate(11.0,37.0)">
             <circle class="sld-vl300to500" cx="5" cy="15" r="5"/>
             <circle class="sld-vl180to300" cx="11" cy="15" r="5"/>
             <circle class="sld-vl50to70" cx="8" cy="19" r="5"/>

--- a/single-line-diagram-core/src/test/resources/vl3_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_optimized.svg
@@ -111,33 +111,33 @@ polyline {fill: none}
         <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_dcapa1_95_vl3_95_bbs1">
             <polyline points="910.0,370.0,900.0,370.0"/>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_trf2">
             <polyline points="980.0,150.0,980.0,210.0,1013.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,975.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,975.0,165.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,975.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,975.0,185.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_trf2_95_two_95_vl3_95_trf2">
             <polyline points="1060.0,150.0,1060.0,210.0,1027.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-up" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,165.0)">
+        <g class="sld-arrow-p sld-up" id="_95_vl3_95_vl3_95_trf2_95_two_95_vl3_95_trf2_ARROW1" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,165.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-down" id="_95_vl3_95_vl3_95_trf2_95_two_95_FICT_95_vl3_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,185.0)">
+        <g class="sld-arrow-q sld-down" id="_95_vl3_95_vl3_95_trf2_95_two_95_vl3_95_trf2_ARROW2" transform="matrix(1.0,0.0,-0.0,1.0,1055.0,185.0)">
             <use class="sld-arrow-down" href="#ARROW-DOWN"/>
             <use class="sld-arrow-up" href="#ARROW-UP"/>
             <text class="sld-label" transform="rotate(0,0,0)" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-wire sld-constant-color" id="_95_vl3_95_FICT_95_vl3_95_vl3_95_trf2_95_vl3_95_btrf2">
+        <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_trf2_95_vl3_95_btrf2">
             <polyline points="1020.0,222.0,1020.0,240.0"/>
         </g>
         <g class="sld-wire sld-constant-color" id="_95_vl3_95_vl3_95_btrf2_95_vl3_95_dtrf2">
@@ -164,7 +164,7 @@ polyline {fill: none}
         <g class="sld-constant-color" id="idvl3_95_trf2_95_two" transform="translate(1060.0,150.0)">
             <text class="sld-label" id="vl3_trf2_two__LABEL" transform="rotate(0,0,0)" x="-5.0" y="-5.0">vl3_trf2</text>
         </g>
-        <g class="sld-three-wt sld-constant-color" id="idFICT_95_vl3_95_vl3_95_trf2" transform="translate(1012.0,198.0)">
+        <g class="sld-three-wt sld-constant-color" id="idvl3_95_trf2" transform="translate(1012.0,198.0)">
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING1"/>
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING2"/>
             <use href="#THREE_WINDINGS_TRANSFORMER-WINDING3"/>

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -309,16 +309,6 @@
     "vlabel" : false,
     "equipmentId" : "dgen1Fictif"
   }, {
-    "id" : "idFICT_95_vl1_95_trf6_95_fictif",
-    "vid" : "vl1",
-    "nextVId" : null,
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false,
-    "equipmentId" : "trf6_fictif"
-  }, {
     "id" : "iddload2",
     "vid" : "vl1",
     "nextVId" : null,
@@ -549,16 +539,6 @@
     "vlabel" : false,
     "equipmentId" : "dtrf18Fictif"
   }, {
-    "id" : "idFICT_95_vl1_95_trf8_95_fictif",
-    "vid" : "vl1",
-    "nextVId" : null,
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "rotationAngle" : null,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false,
-    "equipmentId" : "trf8_fictif"
-  }, {
     "id" : "idFICT_95_vl1_95_dsect12Fictif",
     "vid" : "vl1",
     "nextVId" : null,
@@ -749,6 +729,16 @@
     "vlabel" : false,
     "equipmentId" : "dtrf12"
   }, {
+    "id" : "idtrf6",
+    "vid" : "vl1",
+    "nextVId" : null,
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false,
+    "equipmentId" : "trf6"
+  }, {
     "id" : "iddgen1",
     "vid" : "vl1",
     "nextVId" : null,
@@ -759,6 +749,16 @@
     "vlabel" : false,
     "equipmentId" : "dgen1"
   }, {
+    "id" : "idtrf7",
+    "vid" : "vl1",
+    "nextVId" : null,
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "rotationAngle" : 180.0,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false,
+    "equipmentId" : "trf7"
+  }, {
     "id" : "idFICT_95_vl1_95_dgen2Fictif",
     "vid" : "vl1",
     "nextVId" : null,
@@ -768,6 +768,16 @@
     "direction" : "UNDEFINED",
     "vlabel" : false,
     "equipmentId" : "dgen2Fictif"
+  }, {
+    "id" : "idtrf8",
+    "vid" : "vl1",
+    "nextVId" : null,
+    "componentType" : "THREE_WINDINGS_TRANSFORMER",
+    "rotationAngle" : null,
+    "open" : false,
+    "direction" : "UNDEFINED",
+    "vlabel" : false,
+    "equipmentId" : "trf8"
   }, {
     "id" : "iddgen2",
     "vid" : "vl1",
@@ -929,16 +939,6 @@
     "vlabel" : false,
     "equipmentId" : "bload2"
   }, {
-    "id" : "idFICT_95_vl1_95_trf7_95_fictif",
-    "vid" : "vl1",
-    "nextVId" : null,
-    "componentType" : "THREE_WINDINGS_TRANSFORMER",
-    "rotationAngle" : 180.0,
-    "open" : false,
-    "direction" : "UNDEFINED",
-    "vlabel" : false,
-    "equipmentId" : "trf7_fictif"
-  }, {
     "id" : "idbload1",
     "vid" : "vl1",
     "nextVId" : null,
@@ -1020,6 +1020,12 @@
     "equipmentId" : "trf4"
   } ],
   "wires" : [ {
+    "id" : "_95_vl1_95_trf7_95_trf7_95_THREE",
+    "nodeId1" : "idtrf7",
+    "nodeId2" : "idtrf7_95_THREE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_bload2_95_FICT_95_vl1_95_dload2Fictif",
     "nodeId1" : "idbload2",
     "nodeId2" : "idFICT_95_vl1_95_dload2Fictif",
@@ -1029,12 +1035,6 @@
     "id" : "_95_vl1_95_btrf13_95_FICT_95_vl1_95_trf3_95_ONEFictif",
     "nodeId1" : "idbtrf13",
     "nodeId2" : "idFICT_95_vl1_95_trf3_95_ONEFictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE",
-    "nodeId1" : "idFICT_95_vl1_95_trf6_95_fictif",
-    "nodeId2" : "idtrf6_95_THREE",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1059,12 +1059,6 @@
     "id" : "_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE",
     "nodeId1" : "idFICT_95_vl1_95_trf2_95_ONEFictif",
     "nodeId2" : "idtrf2_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_btrf17_95_FICT_95_vl1_95_trf7_95_fictif",
-    "nodeId1" : "idbtrf17",
-    "nodeId2" : "idFICT_95_vl1_95_trf7_95_fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1104,12 +1098,6 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO",
-    "nodeId1" : "idFICT_95_vl1_95_trf7_95_fictif",
-    "nodeId2" : "idtrf7_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_bbs3_95_dtrf13",
     "nodeId1" : "idbbs3",
     "nodeId2" : "iddtrf13",
@@ -1122,21 +1110,27 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl1_95_trf6_95_trf6_95_THREE",
+    "nodeId1" : "idtrf6",
+    "nodeId2" : "idtrf6_95_THREE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_dtrf17_95_FICT_95_vl1_95_dtrf17Fictif",
     "nodeId1" : "iddtrf17",
     "nodeId2" : "idFICT_95_vl1_95_dtrf17Fictif",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_bbs1_95_dsect11",
-    "nodeId1" : "idbbs1",
-    "nodeId2" : "iddsect11",
+    "id" : "_95_vl1_95_btrf17_95_trf7",
+    "nodeId1" : "idbtrf17",
+    "nodeId2" : "idtrf7",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO",
-    "nodeId1" : "idFICT_95_vl1_95_trf6_95_fictif",
-    "nodeId2" : "idtrf6_95_TWO",
+    "id" : "_95_vl1_95_bbs1_95_dsect11",
+    "nodeId1" : "idbbs1",
+    "nodeId2" : "iddsect11",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1188,15 +1182,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_btrf18_95_FICT_95_vl1_95_trf8_95_fictif",
-    "nodeId1" : "idbtrf18",
-    "nodeId2" : "idFICT_95_vl1_95_trf8_95_fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_btrf11_95_FICT_95_vl1_95_dtrf11Fictif",
     "nodeId1" : "idbtrf11",
     "nodeId2" : "idFICT_95_vl1_95_dtrf11Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_trf6_95_trf6_95_TWO",
+    "nodeId1" : "idtrf6",
+    "nodeId2" : "idtrf6_95_TWO",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1314,12 +1308,6 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE",
-    "nodeId1" : "idFICT_95_vl1_95_trf8_95_fictif",
-    "nodeId2" : "idtrf8_95_THREE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_bgen1_95_FICT_95_vl1_95_gen1Fictif",
     "nodeId1" : "idbgen1",
     "nodeId2" : "idFICT_95_vl1_95_gen1Fictif",
@@ -1332,8 +1320,8 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO",
-    "nodeId1" : "idFICT_95_vl1_95_trf8_95_fictif",
+    "id" : "_95_vl1_95_trf8_95_trf8_95_TWO",
+    "nodeId1" : "idtrf8",
     "nodeId2" : "idtrf8_95_TWO",
     "straight" : false,
     "snakeLine" : false
@@ -1344,15 +1332,33 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl1_95_btrf18_95_trf8",
+    "nodeId1" : "idbtrf18",
+    "nodeId2" : "idtrf8",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_btrf15_95_FICT_95_vl1_95_trf5_95_ONEFictif",
     "nodeId1" : "idbtrf15",
     "nodeId2" : "idFICT_95_vl1_95_trf5_95_ONEFictif",
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl1_95_trf7_95_trf7_95_TWO",
+    "nodeId1" : "idtrf7",
+    "nodeId2" : "idtrf7_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE",
     "nodeId1" : "idFICT_95_vl1_95_trf1_95_ONEFictif",
     "nodeId2" : "idtrf1_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_trf8_95_trf8_95_THREE",
+    "nodeId1" : "idtrf8",
+    "nodeId2" : "idtrf8_95_THREE",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1398,12 +1404,6 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_btrf16_95_FICT_95_vl1_95_trf6_95_fictif",
-    "nodeId1" : "idbtrf16",
-    "nodeId2" : "idFICT_95_vl1_95_trf6_95_fictif",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_dsect11_95_FICT_95_vl1_95_dsect11Fictif",
     "nodeId1" : "iddsect11",
     "nodeId2" : "idFICT_95_vl1_95_dsect11Fictif",
@@ -1419,6 +1419,12 @@
     "id" : "_95_vl1_95_dtrct21_95_FICT_95_vl1_95_dsect21Fictif",
     "nodeId1" : "iddtrct21",
     "nodeId2" : "idFICT_95_vl1_95_dsect21Fictif",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_btrf16_95_trf6",
+    "nodeId1" : "idbtrf16",
+    "nodeId2" : "idtrf6",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1458,12 +1464,6 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE",
-    "nodeId1" : "idFICT_95_vl1_95_trf7_95_fictif",
-    "nodeId2" : "idtrf7_95_THREE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_btrf17_95_FICT_95_vl1_95_dtrf17Fictif",
     "nodeId1" : "idbtrf17",
     "nodeId2" : "idFICT_95_vl1_95_dtrf17Fictif",
@@ -1480,6 +1480,14 @@
     "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf3_95_ONEFictif_95_trf3_95_ONE",
     "distance" : 20.0
   }, {
+    "id" : "_95_vl1_95_trf7_95_trf7_95_THREE_ARROW2",
+    "wireId" : "_95_vl1_95_trf7_95_trf7_95_THREE",
+    "distance" : 20.0
+  }, {
+    "id" : "_95_vl1_95_trf7_95_trf7_95_THREE_ARROW1",
+    "wireId" : "_95_vl1_95_trf7_95_trf7_95_THREE",
+    "distance" : 20.0
+  }, {
     "id" : "_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE_ARROW1",
     "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf2_95_ONEFictif_95_trf2_95_ONE",
     "distance" : 20.0
@@ -1492,28 +1500,24 @@
     "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE",
     "distance" : 20.0
   }, {
+    "id" : "_95_vl1_95_trf6_95_trf6_95_TWO_ARROW1",
+    "wireId" : "_95_vl1_95_trf6_95_trf6_95_TWO",
+    "distance" : 20.0
+  }, {
     "id" : "_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE_ARROW2",
     "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf1_95_ONEFictif_95_trf1_95_ONE",
+    "distance" : 20.0
+  }, {
+    "id" : "_95_vl1_95_trf6_95_trf6_95_TWO_ARROW2",
+    "wireId" : "_95_vl1_95_trf6_95_trf6_95_TWO",
     "distance" : 20.0
   }, {
     "id" : "_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW1",
     "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE",
     "distance" : 20.0
   }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW1",
-    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO",
-    "distance" : 20.0
-  }, {
     "id" : "_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE_ARROW2",
     "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf5_95_ONEFictif_95_trf5_95_ONE",
-    "distance" : 20.0
-  }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO_ARROW2",
-    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_TWO",
-    "distance" : 20.0
-  }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW2",
-    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO",
     "distance" : 20.0
   }, {
     "id" : "_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW2",
@@ -1522,10 +1526,6 @@
   }, {
     "id" : "_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE_ARROW1",
     "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf4_95_ONEFictif_95_trf4_95_ONE",
-    "distance" : 20.0
-  }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO_ARROW1",
-    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_TWO",
     "distance" : 20.0
   }, {
     "id" : "_95_vl1_95_FICT_95_vl1_95_gen2Fictif_95_gen2_ARROW1",
@@ -1544,52 +1544,52 @@
     "wireId" : "_95_vl1_95_FICT_95_vl1_95_load1Fictif_95_load1",
     "distance" : 20.0
   }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW1",
-    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO",
+    "id" : "_95_vl1_95_trf8_95_trf8_95_THREE_ARROW2",
+    "wireId" : "_95_vl1_95_trf8_95_trf8_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO_ARROW2",
-    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_TWO",
+    "id" : "_95_vl1_95_trf8_95_trf8_95_THREE_ARROW1",
+    "wireId" : "_95_vl1_95_trf8_95_trf8_95_THREE",
     "distance" : 20.0
   }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW2",
-    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE",
+    "id" : "_95_vl1_95_trf8_95_trf8_95_TWO_ARROW1",
+    "wireId" : "_95_vl1_95_trf8_95_trf8_95_TWO",
     "distance" : 20.0
   }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE_ARROW1",
-    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf6_95_fictif_95_trf6_95_THREE",
-    "distance" : 20.0
-  }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW2",
-    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE",
-    "distance" : 20.0
-  }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE_ARROW1",
-    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf7_95_fictif_95_trf7_95_THREE",
+    "id" : "_95_vl1_95_trf8_95_trf8_95_TWO_ARROW2",
+    "wireId" : "_95_vl1_95_trf8_95_trf8_95_TWO",
     "distance" : 20.0
   }, {
     "id" : "_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW2",
     "wireId" : "_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2",
     "distance" : 20.0
   }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW1",
-    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE",
-    "distance" : 20.0
-  }, {
     "id" : "_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2_ARROW1",
     "wireId" : "_95_vl1_95_FICT_95_vl1_95_load2Fictif_95_load2",
     "distance" : 20.0
   }, {
-    "id" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE_ARROW2",
-    "wireId" : "_95_vl1_95_FICT_95_vl1_95_trf8_95_fictif_95_trf8_95_THREE",
+    "id" : "_95_vl1_95_trf6_95_trf6_95_THREE_ARROW2",
+    "wireId" : "_95_vl1_95_trf6_95_trf6_95_THREE",
     "distance" : 20.0
   }, {
     "id" : "_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW1",
     "wireId" : "_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1",
     "distance" : 20.0
   }, {
+    "id" : "_95_vl1_95_trf6_95_trf6_95_THREE_ARROW1",
+    "wireId" : "_95_vl1_95_trf6_95_trf6_95_THREE",
+    "distance" : 20.0
+  }, {
     "id" : "_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1_ARROW2",
     "wireId" : "_95_vl1_95_FICT_95_vl1_95_gen1Fictif_95_gen1",
+    "distance" : 20.0
+  }, {
+    "id" : "_95_vl1_95_trf7_95_trf7_95_TWO_ARROW2",
+    "wireId" : "_95_vl1_95_trf7_95_trf7_95_TWO",
+    "distance" : 20.0
+  }, {
+    "id" : "_95_vl1_95_trf7_95_trf7_95_TWO_ARROW1",
+    "wireId" : "_95_vl1_95_trf7_95_trf7_95_TWO",
     "distance" : 20.0
   } ],
   "layoutParams" : {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
Yes, fixes #246 


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
Equipment id of Middle2wt and Middle3wt do not correspond to corresponding transformer


**What is the new behavior (if this is a feature change)?**
Equipment id of Middle2wt and Middle3wt do correspond to corresponding transformer



**Does this PR introduce a breaking change or deprecate an API?**
No
