### PR TITLE
TopologicalStyleProvider corrections

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologicalStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/TopologicalStyleProvider.java
@@ -25,8 +25,8 @@ import java.util.stream.Collectors;
  */
 public class TopologicalStyleProvider extends AbstractBaseVoltageDiagramStyleProvider {
 
-    private final Map<String, Map<String, String>> voltageLevelStyleMap = new HashMap<>();
-    private final Map<Node, Set<Node>> connectedNodesMap = new LinkedHashMap<>();
+    private final Map<String, Map<String, String>> vlNodeIdStyleMap = new HashMap<>();
+    private final Map<String, Map<String, String>> vlEquipmentIdStyleMap = new HashMap<>();
 
     public TopologicalStyleProvider(Network network) {
         this(BaseVoltageStyle.fromPlatformConfig(), network);
@@ -63,47 +63,44 @@ public class TopologicalStyleProvider extends AbstractBaseVoltageDiagramStylePro
 
     @Override
     public void reset() {
-        voltageLevelStyleMap.clear();
-        connectedNodesMap.clear();
+        vlNodeIdStyleMap.clear();
+        vlEquipmentIdStyleMap.clear();
     }
 
-    private Map<String, String> createStyleMap(String baseVoltageLevelStyle, VoltageLevelInfos voltageLevelInfos) {
+    private Map<String, String> createEquipmentIdStyleMap(String baseVoltageLevelStyle, VoltageLevelInfos voltageLevelInfos) {
         VoltageLevel vl = network.getVoltageLevel(voltageLevelInfos.getId());
         List<Bus> buses = vl.getBusView().getBusStream().collect(Collectors.toList());
 
-        Map<String, String> styleMap = new HashMap<>();
+        Map<String, String> equipmentIdStyleMap = new HashMap<>();
         AtomicInteger idxStyle = new AtomicInteger(0);
         buses.forEach(b -> {
             String style = baseVoltageLevelStyle + '-' + idxStyle.getAndIncrement();
-            b.visitConnectedEquipments(new TopologyVisitorId(equipmentId -> styleMap.put(equipmentId, style)));
+            b.visitConnectedEquipments(new TopologyVisitorId(equipmentId -> equipmentIdStyleMap.put(equipmentId, style)));
         });
 
-        return styleMap;
+        return equipmentIdStyleMap;
     }
 
     private Optional<String> getNodeTopologicalStyle(String baseVoltageLevelStyle, VoltageLevelInfos
             voltageLevelInfos, Node node) {
-        Map<String, String> styleMap = getVoltageLevelStyleMap(baseVoltageLevelStyle, voltageLevelInfos);
-        String nodeTopologicalStyle = styleMap.computeIfAbsent(
-            node.getEquipmentId(), id -> findConnectedStyle(styleMap, node).orElse(null));
+        Map<String, String> equipmentIdStyleMap = getEquipmentIdStyleMap(baseVoltageLevelStyle, voltageLevelInfos);
+        Map<String, String> nodeIdStyleMap = vlNodeIdStyleMap.computeIfAbsent(voltageLevelInfos.getId(), k -> new HashMap<>());
+        String nodeTopologicalStyle = nodeIdStyleMap.getOrDefault(node.getId(), findConnectedStyle(equipmentIdStyleMap, nodeIdStyleMap, node));
         return Optional.ofNullable(nodeTopologicalStyle);
     }
 
-    private Optional<String> findConnectedStyle(Map<String, String> styleMap, Node node) {
-        Set<Node> connectedNodes = connectedNodesMap.getOrDefault(node, findConnectedNodes(node));
-        return connectedNodes.stream().map(c -> styleMap.get(c.getEquipmentId())).filter(Objects::nonNull).findFirst();
+    private String findConnectedStyle(Map<String, String> equipmentIdStyleMap, Map<String, String> nodeIdStyleMap, Node node) {
+        Set<Node> connectedNodes = new HashSet<>();
+        findConnectedNodes(node, connectedNodes);
+        String connectedStyle = connectedNodes.stream().map(c -> equipmentIdStyleMap.get(c.getEquipmentId())).filter(Objects::nonNull).findFirst().orElse(null);
+        connectedNodes.forEach(n -> nodeIdStyleMap.put(n.getId(), connectedStyle));
+        return connectedStyle;
     }
 
-    private Map<String, String> getVoltageLevelStyleMap(String baseVoltageLevelStyle, VoltageLevelInfos
+    private Map<String, String> getEquipmentIdStyleMap(String baseVoltageLevelStyle, VoltageLevelInfos
             voltageLevelInfos) {
-        return voltageLevelStyleMap.computeIfAbsent(
-                voltageLevelInfos.getId(), k -> createStyleMap(baseVoltageLevelStyle, voltageLevelInfos));
-    }
-
-    private Set<Node> findConnectedNodes(Node node) {
-        Set<Node> visitedNodes = new HashSet<>();
-        findConnectedNodes(node, visitedNodes);
-        return visitedNodes;
+        return vlEquipmentIdStyleMap.computeIfAbsent(
+                voltageLevelInfos.getId(), k -> createEquipmentIdStyleMap(baseVoltageLevelStyle, voltageLevelInfos));
     }
 
     private void findConnectedNodes(Node node, Set<Node> visitedNodes) {
@@ -114,7 +111,6 @@ public class TopologicalStyleProvider extends AbstractBaseVoltageDiagramStylePro
             return;
         }
         visitedNodes.add(node);
-        connectedNodesMap.put(node, visitedNodes);
         for (Node adjNode : node.getAdjacentNodes()) {
             findConnectedNodes(adjNode, visitedNodes);
         }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
@@ -145,5 +145,14 @@ public class TopologicalStyleTest extends AbstractTestCaseIidm {
         assertTrue(node2WTStyle.contains("sld-constant-color"));
         assertTrue(node2WTStyle.contains("sld-two-wt"));
 
+        network.getSwitch("b3WT_3").setOpen(true);
+        styleProvider.reset();
+
+        nodeStyle3 = styleProvider.getSvgNodeStyles(node3, componentLibrary, true);
+        assertEquals(3, nodeStyle3.size());
+        assertTrue(nodeStyle3.contains("sld-busbar-section"));
+        assertTrue(nodeStyle3.contains("sld-constant-color"));
+        assertTrue(nodeStyle3.contains(DiagramStyles.DISCONNECTED_STYLE_CLASS));
+
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** 
Bug fix



**What is the current behavior?**
- TopologicalStyleProvider calculates the connected set for each node instead of calculating it once
- TopologicalStyleProvider calculations are based on a map of equipment ids, but nothing ensures that those equipment ids are unique and not null (see fictitious internal nodes, for which it doesn't really make sense)



**What is the new behavior (if this is a feature change)?**
- TopologicalStyleProvider does not recalculate the connected set if already known
- TopologicalStyleProvider calculations is based on a map of equipment ids, for iidm components, and on a map of ids, for single-line-diagram nodes

**Does this PR introduce a breaking change or deprecate an API?** 
No
