### PR TITLE
Intern cell explicit positionning iidm extension

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/RawGraphBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/RawGraphBuilder.java
@@ -93,7 +93,7 @@ public class RawGraphBuilder implements GraphBuilder {
             SwitchNode sw = new SwitchNode(id, id, sk.name(), fictitious, graph, sk, open);
             graph.addNode(sw);
             if (direction != null || order != null) {
-                addExtension(sw, order, direction);
+                addNodeOrderAndDirection(sw, order, direction);
             }
             return sw;
         }
@@ -114,7 +114,7 @@ public class RawGraphBuilder implements GraphBuilder {
             return fictitiousNode;
         }
 
-        public void addExtension(Node fn, Integer order, BusCell.Direction direction) {
+        public void addNodeOrderAndDirection(Node fn, Integer order, BusCell.Direction direction) {
             if (order != null) {
                 fn.setOrder(order);
             }
@@ -125,7 +125,7 @@ public class RawGraphBuilder implements GraphBuilder {
             node.setLabel(id);
             graph.addNode(node);
             if (direction != null) {
-                addExtension(node, order, direction);
+                addNodeOrderAndDirection(node, order, direction);
             }
         }
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
@@ -246,11 +246,11 @@ public abstract class AbstractTestCaseIidm extends AbstractTestCase {
     }
 
     private static void addFeederPosition(Extendable<?> extendable, String feederName, Integer feederOrder, ConnectablePosition.Direction direction) {
-        ConnectablePositionAdder.FeederAdder feederAdder = extendable.newExtension(ConnectablePositionAdder.class).newFeeder();
+        ConnectablePositionAdder.InfoAdder infoAdder = extendable.newExtension(ConnectablePositionAdder.class).newInfo();
         if (feederOrder != null) {
-            feederAdder.withOrder(feederOrder);
+            infoAdder.withOrder(feederOrder);
         }
-        feederAdder.withDirection(direction).withName(feederName).add()
+        infoAdder.withDirection(direction).withName(feederName).add()
                 .add();
     }
 
@@ -258,16 +258,16 @@ public abstract class AbstractTestCaseIidm extends AbstractTestCase {
                                               String feederName1, Integer feederOrder1, ConnectablePosition.Direction direction1,
                                               String feederName2, Integer feederOrder2, ConnectablePosition.Direction direction2) {
         ConnectablePositionAdder extensionAdder = extendable.newExtension(ConnectablePositionAdder.class);
-        ConnectablePositionAdder.FeederAdder feederAdder1 = extensionAdder.newFeeder1();
+        ConnectablePositionAdder.InfoAdder infoAdder1 = extensionAdder.newInfo1();
         if (feederOrder1 != null) {
-            feederAdder1.withOrder(feederOrder1);
+            infoAdder1.withOrder(feederOrder1);
         }
-        feederAdder1.withName(feederName1).withDirection(direction1).add();
-        ConnectablePositionAdder.FeederAdder feederAdder2 = extensionAdder.newFeeder2();
+        infoAdder1.withName(feederName1).withDirection(direction1).add();
+        ConnectablePositionAdder.InfoAdder infoAdder2 = extensionAdder.newInfo2();
         if (feederOrder2 != null) {
-            feederAdder2.withOrder(feederOrder2);
+            infoAdder2.withOrder(feederOrder2);
         }
-        feederAdder2.withName(feederName2).withDirection(direction2).add();
+        infoAdder2.withName(feederName2).withDirection(direction2).add();
         extensionAdder.add();
     }
 
@@ -276,21 +276,21 @@ public abstract class AbstractTestCaseIidm extends AbstractTestCase {
                                                 String feederName2, Integer feederOrder2, ConnectablePosition.Direction direction2,
                                                 String feederName3, Integer feederOrder3, ConnectablePosition.Direction direction3) {
         ConnectablePositionAdder extensionAdder = extendable.newExtension(ConnectablePositionAdder.class);
-        ConnectablePositionAdder.FeederAdder feederAdder1 = extensionAdder.newFeeder1();
+        ConnectablePositionAdder.InfoAdder infoAdder1 = extensionAdder.newInfo1();
         if (feederOrder1 != null) {
-            feederAdder1.withOrder(feederOrder1);
+            infoAdder1.withOrder(feederOrder1);
         }
-        feederAdder1.withName(feederName1).withDirection(direction1).add();
-        ConnectablePositionAdder.FeederAdder feederAdder2 = extensionAdder.newFeeder2();
+        infoAdder1.withName(feederName1).withDirection(direction1).add();
+        ConnectablePositionAdder.InfoAdder infoAdder2 = extensionAdder.newInfo2();
         if (feederOrder2 != null) {
-            feederAdder2.withOrder(feederOrder2);
+            infoAdder2.withOrder(feederOrder2);
         }
-        feederAdder2.withName(feederName2).withDirection(direction2).add();
-        ConnectablePositionAdder.FeederAdder feederAdder3 = extensionAdder.newFeeder3();
+        infoAdder2.withName(feederName2).withDirection(direction2).add();
+        ConnectablePositionAdder.InfoAdder infoAdder3 = extensionAdder.newInfo3();
         if (feederOrder3 != null) {
-            feederAdder3.withOrder(feederOrder3);
+            infoAdder3.withOrder(feederOrder3);
         }
-        feederAdder3.withName(feederName3).withDirection(direction3).add();
+        infoAdder3.withName(feederName3).withDirection(direction3).add();
         extensionAdder.add();
     }
 }

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/ConnectablePosition.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/ConnectablePosition.java
@@ -16,9 +16,9 @@ import java.util.Optional;
  */
 public interface ConnectablePosition<C extends Connectable<C>> extends Extension<C> {
 
-    static final String NAME = "position";
+    String NAME = "position";
 
-    public enum Direction {
+    enum Direction {
         TOP,
         BOTTOM,
         UNDEFINED
@@ -29,49 +29,49 @@ public interface ConnectablePosition<C extends Connectable<C>> extends Extension
         return NAME;
     }
 
-    public interface Feeder {
+    interface Info {
         String getName();
 
-        Feeder setName(String name);
+        Info setName(String name);
 
         Optional<Integer> getOrder();
 
-        Feeder setOrder(int order);
+        Info setOrder(int order);
 
-        Feeder removeOrder();
+        Info removeOrder();
 
         Direction getDirection();
 
-        Feeder setDirection(Direction direction);
+        Info setDirection(Direction direction);
     }
 
-    public Feeder getFeeder();
+    Info getInfo();
 
-    public Feeder getFeeder1();
+    Info getInfo1();
 
-    public Feeder getFeeder2();
+    Info getInfo2();
 
-    public Feeder getFeeder3();
+    Info getInfo3();
 
-    public static void check(Feeder feeder, Feeder feeder1, Feeder feeder2, Feeder feeder3) {
-        if (feeder == null && feeder1 == null && feeder2 == null && feeder3 == null) {
-            throw new IllegalArgumentException("invalid feeder");
+    static void check(Info info, Info info1, Info info2, Info info3) {
+        if (info == null && info1 == null && info2 == null && info3 == null) {
+            throw new IllegalArgumentException("invalid info");
         }
-        if (feeder != null && (feeder1 != null || feeder2 != null || feeder3 != null)) {
-            throw new IllegalArgumentException("feeder and feeder 1|2|3 are exclusives");
+        if (info != null && (info1 != null || info2 != null || info3 != null)) {
+            throw new IllegalArgumentException("info and info 1|2|3 are exclusives");
         }
         boolean error = false;
-        if (feeder1 != null) {
-            if (feeder2 == null && feeder3 != null) {
+        if (info1 != null) {
+            if (info2 == null && info3 != null) {
                 error = true;
             }
         } else {
-            if (feeder2 != null || feeder3 != null) {
+            if (info2 != null || info3 != null) {
                 error = true;
             }
         }
         if (error) {
-            throw new IllegalArgumentException("feeder 1|2|3 have to be set in the right order");
+            throw new IllegalArgumentException("info 1|2|3 have to be set in the right order");
         }
     }
 

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/ConnectablePositionAdder.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/ConnectablePositionAdder.java
@@ -20,24 +20,24 @@ public interface ConnectablePositionAdder<C extends Connectable<C>>
         return ConnectablePosition.class;
     }
 
-    interface FeederAdder<C extends Connectable<C>> {
+    interface InfoAdder<C extends Connectable<C>> {
 
-        public FeederAdder<C> withName(String name);
+        public InfoAdder<C> withName(String name);
 
-        public FeederAdder<C> withOrder(int order);
+        public InfoAdder<C> withOrder(int order);
 
-        public FeederAdder<C> withDirection(Direction direction);
+        public InfoAdder<C> withDirection(Direction direction);
 
         public ConnectablePositionAdder<C> add();
 
     }
 
-    FeederAdder<C> newFeeder();
+    InfoAdder<C> newInfo();
 
-    FeederAdder<C> newFeeder1();
+    InfoAdder<C> newInfo1();
 
-    FeederAdder<C> newFeeder2();
+    InfoAdder<C> newInfo2();
 
-    FeederAdder<C> newFeeder3();
+    InfoAdder<C> newInfo3();
 
 }

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/ConnectablePositionAdderImpl.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/ConnectablePositionAdderImpl.java
@@ -16,33 +16,33 @@ public class ConnectablePositionAdderImpl<C extends Connectable<C>>
         extends AbstractExtensionAdder<C, ConnectablePosition<C>>
         implements ConnectablePositionAdder<C> {
 
-    private ConnectablePositionImpl.FeederImpl feeder;
-    private ConnectablePositionImpl.FeederImpl feeder1;
-    private ConnectablePositionImpl.FeederImpl feeder2;
-    private ConnectablePositionImpl.FeederImpl feeder3;
+    private ConnectablePositionImpl.InfoImpl info;
+    private ConnectablePositionImpl.InfoImpl info1;
+    private ConnectablePositionImpl.InfoImpl info2;
+    private ConnectablePositionImpl.InfoImpl info3;
 
     ConnectablePositionAdderImpl(C connectable) {
         super(connectable);
     }
 
-    private abstract static class AbstractFeederImplAdder<C extends Connectable<C>> implements FeederAdder<C> {
+    private abstract static class AbstractInfoImplAdder<C extends Connectable<C>> implements InfoAdder<C> {
         protected String name;
 
         protected Integer order;
 
         protected ConnectablePosition.Direction direction;
 
-        public FeederAdder<C> withName(String name) {
+        public InfoAdder<C> withName(String name) {
             this.name = name;
             return this;
         }
 
-        public FeederAdder<C> withOrder(int order) {
+        public InfoAdder<C> withOrder(int order) {
             this.order = order;
             return this;
         }
 
-        public FeederAdder<C> withDirection(ConnectablePosition.Direction direction) {
+        public InfoAdder<C> withDirection(ConnectablePosition.Direction direction) {
             this.direction = direction;
             return this;
         }
@@ -51,48 +51,48 @@ public class ConnectablePositionAdderImpl<C extends Connectable<C>>
 
     @Override
     public ConnectablePositionImpl<C> createExtension(C extendable) {
-        return new ConnectablePositionImpl<>(extendable, feeder, feeder1, feeder2, feeder3);
+        return new ConnectablePositionImpl<>(extendable, info, info1, info2, info3);
     }
 
     @Override
-    public FeederAdder<C> newFeeder() {
-        return new AbstractFeederImplAdder<C>() {
+    public InfoAdder<C> newInfo() {
+        return new AbstractInfoImplAdder<C>() {
             @Override
             public ConnectablePositionAdder<C> add() {
-                ConnectablePositionAdderImpl.this.feeder = new ConnectablePositionImpl.FeederImpl(name, order, direction);
+                ConnectablePositionAdderImpl.this.info = new ConnectablePositionImpl.InfoImpl(name, order, direction);
                 return ConnectablePositionAdderImpl.this;
             }
         };
     }
 
     @Override
-    public FeederAdder<C> newFeeder1() {
-        return new AbstractFeederImplAdder<C>() {
+    public InfoAdder<C> newInfo1() {
+        return new AbstractInfoImplAdder<C>() {
             @Override
             public ConnectablePositionAdder<C> add() {
-                ConnectablePositionAdderImpl.this.feeder1 = new ConnectablePositionImpl.FeederImpl(name, order, direction);
+                ConnectablePositionAdderImpl.this.info1 = new ConnectablePositionImpl.InfoImpl(name, order, direction);
                 return ConnectablePositionAdderImpl.this;
             }
         };
     }
 
     @Override
-    public FeederAdder<C> newFeeder2() {
-        return new AbstractFeederImplAdder<C>() {
+    public InfoAdder<C> newInfo2() {
+        return new AbstractInfoImplAdder<C>() {
             @Override
             public ConnectablePositionAdder<C> add() {
-                ConnectablePositionAdderImpl.this.feeder2 = new ConnectablePositionImpl.FeederImpl(name, order, direction);
+                ConnectablePositionAdderImpl.this.info2 = new ConnectablePositionImpl.InfoImpl(name, order, direction);
                 return ConnectablePositionAdderImpl.this;
             }
         };
     }
 
     @Override
-    public FeederAdder<C> newFeeder3() {
-        return new AbstractFeederImplAdder<C>() {
+    public InfoAdder<C> newInfo3() {
+        return new AbstractInfoImplAdder<C>() {
             @Override
             public ConnectablePositionAdder<C> add() {
-                ConnectablePositionAdderImpl.this.feeder3 = new ConnectablePositionImpl.FeederImpl(name, order, direction);
+                ConnectablePositionAdderImpl.this.info3 = new ConnectablePositionImpl.InfoImpl(name, order, direction);
                 return ConnectablePositionAdderImpl.this;
             }
         };

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/ConnectablePositionImpl.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/ConnectablePositionImpl.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 public class ConnectablePositionImpl<C extends Connectable<C>> extends AbstractExtension<C>
         implements ConnectablePosition<C> {
 
-    public static class FeederImpl implements Feeder {
+    public static class InfoImpl implements Info {
 
         private String name;
 
@@ -26,19 +26,19 @@ public class ConnectablePositionImpl<C extends Connectable<C>> extends AbstractE
 
         private Direction direction;
 
-        public FeederImpl(String name) {
+        public InfoImpl(String name) {
             this(name, null, null);
         }
 
-        public FeederImpl(String name, int order) {
+        public InfoImpl(String name, int order) {
             this(name, order, null);
         }
 
-        public FeederImpl(String name, Direction direction) {
+        public InfoImpl(String name, Direction direction) {
             this(name, null, direction);
         }
 
-        public FeederImpl(String name, Integer order, Direction direction) {
+        public InfoImpl(String name, Integer order, Direction direction) {
             this.name = Objects.requireNonNull(name);
             this.order = order;
             this.direction = Objects.requireNonNullElse(direction, Direction.UNDEFINED);
@@ -50,7 +50,7 @@ public class ConnectablePositionImpl<C extends Connectable<C>> extends AbstractE
         }
 
         @Override
-        public Feeder setName(String name) {
+        public Info setName(String name) {
             this.name = Objects.requireNonNull(name);
             return this;
         }
@@ -61,13 +61,13 @@ public class ConnectablePositionImpl<C extends Connectable<C>> extends AbstractE
         }
 
         @Override
-        public Feeder setOrder(int order) {
+        public Info setOrder(int order) {
             this.order = order;
             return this;
         }
 
         @Override
-        public Feeder removeOrder() {
+        public Info removeOrder() {
             this.order = null;
             return this;
         }
@@ -78,43 +78,43 @@ public class ConnectablePositionImpl<C extends Connectable<C>> extends AbstractE
         }
 
         @Override
-        public Feeder setDirection(Direction direction) {
+        public Info setDirection(Direction direction) {
             this.direction = Objects.requireNonNull(direction);
             return this;
         }
     }
 
-    private FeederImpl feeder;
-    private FeederImpl feeder1;
-    private FeederImpl feeder2;
-    private FeederImpl feeder3;
+    private final InfoImpl info;
+    private final InfoImpl info1;
+    private final InfoImpl info2;
+    private final InfoImpl info3;
 
-    public ConnectablePositionImpl(C connectable, FeederImpl feeder, FeederImpl feeder1, FeederImpl feeder2, FeederImpl feeder3) {
+    public ConnectablePositionImpl(C connectable, InfoImpl info, InfoImpl info1, InfoImpl info2, InfoImpl info3) {
         super(connectable);
-        ConnectablePosition.check(feeder, feeder1, feeder2, feeder3);
-        this.feeder = feeder;
-        this.feeder1 = feeder1;
-        this.feeder2 = feeder2;
-        this.feeder3 = feeder3;
+        ConnectablePosition.check(info, info1, info2, info3);
+        this.info = info;
+        this.info1 = info1;
+        this.info2 = info2;
+        this.info3 = info3;
     }
 
     @Override
-    public FeederImpl getFeeder() {
-        return feeder;
+    public InfoImpl getInfo() {
+        return info;
     }
 
     @Override
-    public FeederImpl getFeeder1() {
-        return feeder1;
+    public InfoImpl getInfo1() {
+        return info1;
     }
 
     @Override
-    public FeederImpl getFeeder2() {
-        return feeder2;
+    public InfoImpl getInfo2() {
+        return info2;
     }
 
     @Override
-    public FeederImpl getFeeder3() {
-        return feeder3;
+    public InfoImpl getInfo3() {
+        return info3;
     }
 }

--- a/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/ConnectablePositionXmlSerializer.java
+++ b/single-line-diagram-iidm-extensions/src/main/java/com/powsybl/sld/iidm/extensions/ConnectablePositionXmlSerializer.java
@@ -58,33 +58,33 @@ public class ConnectablePositionXmlSerializer<C extends Connectable<C>> implemen
         return "cp";
     }
 
-    private void writePosition(ConnectablePosition.Feeder feeder, Integer i, XmlWriterContext context) throws XMLStreamException {
-        context.getExtensionsWriter().writeEmptyElement(getNamespaceUri(), "feeder" + (i != null ? i : ""));
-        context.getExtensionsWriter().writeAttribute("name", feeder.getName());
-        Optional<Integer> oOrder = feeder.getOrder();
+    private void writePosition(ConnectablePosition.Info info, Integer i, XmlWriterContext context) throws XMLStreamException {
+        context.getExtensionsWriter().writeEmptyElement(getNamespaceUri(), "info" + (i != null ? i : ""));
+        context.getExtensionsWriter().writeAttribute("name", info.getName());
+        Optional<Integer> oOrder = info.getOrder();
         if (oOrder.isPresent()) {
             XmlUtil.writeInt("order", oOrder.get(), context.getExtensionsWriter());
         }
-        context.getExtensionsWriter().writeAttribute("direction", feeder.getDirection().name());
+        context.getExtensionsWriter().writeAttribute("direction", info.getDirection().name());
     }
 
     @Override
     public void write(ConnectablePosition connectablePosition, XmlWriterContext context) throws XMLStreamException {
-        if (connectablePosition.getFeeder() != null) {
-            writePosition(connectablePosition.getFeeder(), null, context);
+        if (connectablePosition.getInfo() != null) {
+            writePosition(connectablePosition.getInfo(), null, context);
         }
-        if (connectablePosition.getFeeder1() != null) {
-            writePosition(connectablePosition.getFeeder1(), 1, context);
+        if (connectablePosition.getInfo1() != null) {
+            writePosition(connectablePosition.getInfo1(), 1, context);
         }
-        if (connectablePosition.getFeeder2() != null) {
-            writePosition(connectablePosition.getFeeder2(), 2, context);
+        if (connectablePosition.getInfo2() != null) {
+            writePosition(connectablePosition.getInfo2(), 2, context);
         }
-        if (connectablePosition.getFeeder3() != null) {
-            writePosition(connectablePosition.getFeeder3(), 3, context);
+        if (connectablePosition.getInfo3() != null) {
+            writePosition(connectablePosition.getInfo3(), 3, context);
         }
     }
 
-    private void readPosition(XmlReaderContext context, ConnectablePositionAdder.FeederAdder adder) {
+    private void readPosition(XmlReaderContext context, ConnectablePositionAdder.InfoAdder adder) {
         String name = context.getReader().getAttributeValue(null, "name");
         Optional.ofNullable(XmlUtil.readOptionalIntegerAttribute(context.getReader(), "order")).
                 ifPresent(adder::withOrder);
@@ -98,20 +98,20 @@ public class ConnectablePositionXmlSerializer<C extends Connectable<C>> implemen
         XmlUtil.readUntilEndElement(getExtensionName(), context.getReader(), () -> {
 
             switch (context.getReader().getLocalName()) {
-                case "feeder":
-                    readPosition(context, adder.newFeeder());
+                case "info":
+                    readPosition(context, adder.newInfo());
                     break;
 
-                case "feeder1":
-                    readPosition(context, adder.newFeeder1());
+                case "info1":
+                    readPosition(context, adder.newInfo1());
                     break;
 
-                case "feeder2":
-                    readPosition(context, adder.newFeeder2());
+                case "info2":
+                    readPosition(context, adder.newInfo2());
                     break;
 
-                case "feeder3":
-                    readPosition(context, adder.newFeeder3());
+                case "info3":
+                    readPosition(context, adder.newInfo3());
                     break;
 
                 default:

--- a/single-line-diagram-iidm-extensions/src/test/java/com/powsybl/sld/iidm/extensions/ConnectablePositionXmlTest.java
+++ b/single-line-diagram-iidm-extensions/src/test/java/com/powsybl/sld/iidm/extensions/ConnectablePositionXmlTest.java
@@ -86,7 +86,7 @@ public class ConnectablePositionXmlTest extends AbstractConverterTest {
         Generator generator = network.getGenerator("G");
         assertNotNull(generator);
         ConnectablePosition<Generator> generationPosition = new ConnectablePositionImpl<>(generator,
-                new ConnectablePositionImpl.FeederImpl("G", 10, ConnectablePosition.Direction.TOP),
+                new ConnectablePositionImpl.InfoImpl("G", 10, ConnectablePosition.Direction.TOP),
                 null,
                 null,
                 null);
@@ -97,8 +97,8 @@ public class ConnectablePositionXmlTest extends AbstractConverterTest {
         assertNotNull(line);
         ConnectablePosition<Line> linePosition = new ConnectablePositionImpl<>(line,
                 null,
-                new ConnectablePositionImpl.FeederImpl("L", 10, ConnectablePosition.Direction.TOP),
-                new ConnectablePositionImpl.FeederImpl("L", 20, ConnectablePosition.Direction.BOTTOM),
+                new ConnectablePositionImpl.InfoImpl("L", 10, ConnectablePosition.Direction.TOP),
+                new ConnectablePositionImpl.InfoImpl("L", 20, ConnectablePosition.Direction.BOTTOM),
                 null);
         line.addExtension(ConnectablePosition.class, linePosition);
 
@@ -111,24 +111,24 @@ public class ConnectablePositionXmlTest extends AbstractConverterTest {
         assertNotNull(generator);
         ConnectablePosition generatorPosition2 = generator2.getExtension(ConnectablePosition.class);
         assertNotNull(generatorPosition2);
-        assertNotNull(generatorPosition2.getFeeder());
-        assertNull(generatorPosition2.getFeeder1());
-        assertNull(generatorPosition2.getFeeder2());
-        assertNull(generatorPosition2.getFeeder3());
-        assertEquals(generatorPosition2.getFeeder().getOrder(), generationPosition.getFeeder().getOrder());
-        assertEquals(generatorPosition2.getFeeder().getDirection(), generationPosition.getFeeder().getDirection());
+        assertNotNull(generatorPosition2.getInfo());
+        assertNull(generatorPosition2.getInfo1());
+        assertNull(generatorPosition2.getInfo2());
+        assertNull(generatorPosition2.getInfo3());
+        assertEquals(generatorPosition2.getInfo().getOrder(), generationPosition.getInfo().getOrder());
+        assertEquals(generatorPosition2.getInfo().getDirection(), generationPosition.getInfo().getDirection());
 
         Line line2 = network2.getLine("L");
         assertNotNull(line2);
         ConnectablePosition linePosition2 = line2.getExtension(ConnectablePosition.class);
         assertNotNull(linePosition2);
-        assertNull(linePosition2.getFeeder());
-        assertNotNull(linePosition2.getFeeder1());
-        assertNotNull(linePosition2.getFeeder2());
-        assertNull(linePosition2.getFeeder3());
-        assertEquals(linePosition2.getFeeder1().getOrder(), linePosition2.getFeeder1().getOrder());
-        assertEquals(linePosition2.getFeeder1().getDirection(), linePosition2.getFeeder1().getDirection());
-        assertEquals(linePosition2.getFeeder2().getOrder(), linePosition2.getFeeder2().getOrder());
-        assertEquals(linePosition2.getFeeder2().getDirection(), linePosition2.getFeeder2().getDirection());
+        assertNull(linePosition2.getInfo());
+        assertNotNull(linePosition2.getInfo1());
+        assertNotNull(linePosition2.getInfo2());
+        assertNull(linePosition2.getInfo3());
+        assertEquals(linePosition2.getInfo1().getOrder(), linePosition2.getInfo1().getOrder());
+        assertEquals(linePosition2.getInfo1().getDirection(), linePosition2.getInfo1().getDirection());
+        assertEquals(linePosition2.getInfo2().getOrder(), linePosition2.getInfo2().getOrder());
+        assertEquals(linePosition2.getInfo2().getDirection(), linePosition2.getInfo2().getDirection());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** 
Feature


**What is the current behavior?**
Order/Direction can be given to feeders through ConnectablePosition extension, but for intern cells the extension cannot be used.



**What is the new behavior (if this is a feature change)?**
Order/Direction can be given to feeders **and switches** through ConnectablePosition extension



**Does this PR introduce a breaking change or deprecate an API?** 
Yes
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*

