### PR TITLE
Cleanup graph serializing

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBaseGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBaseGraph.java
@@ -47,20 +47,20 @@ public abstract class AbstractBaseGraph extends AbstractLineGraph implements Bas
         multiTermNodes.add(node);
     }
 
-    protected void writeBranchFields(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+    protected void writeBranchFields(JsonGenerator generator, boolean includeCoordinates) throws IOException {
         generator.writeArrayFieldStart("multitermNodes");
         for (Node multitermNode : multiTermNodes) {
-            multitermNode.writeJson(generator, isGenerateCoordsInJson);
+            multitermNode.writeJson(generator, includeCoordinates);
         }
         generator.writeEndArray();
         generator.writeArrayFieldStart("twtEdges");
         for (BranchEdge edge : twtEdges) {
-            edge.writeJson(generator, isGenerateCoordsInJson);
+            edge.writeJson(generator, includeCoordinates);
         }
         generator.writeEndArray();
         generator.writeArrayFieldStart("lineEdges");
         for (BranchEdge edge : getLineEdges()) {
-            edge.writeJson(generator, isGenerateCoordsInJson);
+            edge.writeJson(generator, includeCoordinates);
         }
         generator.writeEndArray();
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBaseGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBaseGraph.java
@@ -47,20 +47,20 @@ public abstract class AbstractBaseGraph extends AbstractLineGraph implements Bas
         multiTermNodes.add(node);
     }
 
-    protected void writeBranchFields(JsonGenerator generator) throws IOException {
+    protected void writeBranchFields(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
         generator.writeArrayFieldStart("multitermNodes");
         for (Node multitermNode : multiTermNodes) {
-            multitermNode.writeJson(generator, isGenerateCoordsInJson());
+            multitermNode.writeJson(generator, isGenerateCoordsInJson);
         }
         generator.writeEndArray();
         generator.writeArrayFieldStart("twtEdges");
         for (BranchEdge edge : twtEdges) {
-            edge.writeJson(generator, isGenerateCoordsInJson());
+            edge.writeJson(generator, isGenerateCoordsInJson);
         }
         generator.writeEndArray();
         generator.writeArrayFieldStart("lineEdges");
         for (BranchEdge edge : getLineEdges()) {
-            edge.writeJson(generator, isGenerateCoordsInJson());
+            edge.writeJson(generator, isGenerateCoordsInJson);
         }
         generator.writeEndArray();
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBlock.java
@@ -217,10 +217,10 @@ public abstract class AbstractBlock implements Block {
         return this.type;
     }
 
-    protected abstract void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException;
+    protected abstract void writeJsonContent(JsonGenerator generator, boolean includeCoordinates) throws IOException;
 
     @Override
-    public void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+    public void writeJson(JsonGenerator generator, boolean includeCoordinates) throws IOException {
         generator.writeStartObject();
         generator.writeStringField("type", type.name());
         generator.writeArrayFieldStart("cardinalities");
@@ -231,13 +231,13 @@ public abstract class AbstractBlock implements Block {
         }
         generator.writeEndArray();
         generator.writeFieldName("position");
-        position.writeJsonContent(generator, isGenerateCoordsInJson);
+        position.writeJsonContent(generator, includeCoordinates);
 
-        if (isGenerateCoordsInJson) {
+        if (includeCoordinates) {
             generator.writeFieldName("coord");
             coord.writeJsonContent(generator);
         }
-        writeJsonContent(generator, isGenerateCoordsInJson);
+        writeJsonContent(generator, includeCoordinates);
         generator.writeEndObject();
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBlock.java
@@ -217,10 +217,10 @@ public abstract class AbstractBlock implements Block {
         return this.type;
     }
 
-    protected abstract void writeJsonContent(JsonGenerator generator) throws IOException;
+    protected abstract void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException;
 
     @Override
-    public void writeJson(JsonGenerator generator) throws IOException {
+    public void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
         generator.writeStartObject();
         generator.writeStringField("type", type.name());
         generator.writeArrayFieldStart("cardinalities");
@@ -231,13 +231,13 @@ public abstract class AbstractBlock implements Block {
         }
         generator.writeEndArray();
         generator.writeFieldName("position");
-        position.writeJsonContent(generator, getVoltageLevelGraph().isGenerateCoordsInJson());
+        position.writeJsonContent(generator, isGenerateCoordsInJson);
 
-        if (getVoltageLevelGraph().isGenerateCoordsInJson()) {
+        if (isGenerateCoordsInJson) {
             generator.writeFieldName("coord");
             coord.writeJsonContent(generator);
         }
-        writeJsonContent(generator);
+        writeJsonContent(generator, isGenerateCoordsInJson);
         generator.writeEndObject();
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBusCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBusCell.java
@@ -88,9 +88,9 @@ public abstract class AbstractBusCell extends AbstractCell implements BusCell {
     }
 
     @Override
-    protected void writeJsonContent(JsonGenerator generator) throws IOException {
-        super.writeJsonContent(generator);
-        if (graph.isGenerateCoordsInJson()) {
+    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+        super.writeJsonContent(generator, isGenerateCoordsInJson);
+        if (isGenerateCoordsInJson) {
             generator.writeStringField("direction", getDirection().name());
             if (order != null) {
                 generator.writeNumberField("order", order);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBusCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBusCell.java
@@ -88,9 +88,9 @@ public abstract class AbstractBusCell extends AbstractCell implements BusCell {
     }
 
     @Override
-    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
-        super.writeJsonContent(generator, isGenerateCoordsInJson);
-        if (isGenerateCoordsInJson) {
+    protected void writeJsonContent(JsonGenerator generator, boolean includeCoordinates) throws IOException {
+        super.writeJsonContent(generator, includeCoordinates);
+        if (includeCoordinates) {
             generator.writeStringField("direction", getDirection().name());
             if (order != null) {
                 generator.writeNumberField("order", order);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractCell.java
@@ -80,17 +80,17 @@ public abstract class AbstractCell implements Cell {
         return number;
     }
 
-    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+    protected void writeJsonContent(JsonGenerator generator, boolean includeCoordinates) throws IOException {
         generator.writeStringField("type", type.name());
         generator.writeNumberField("number", number);
     }
 
-    public void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+    public void writeJson(JsonGenerator generator, boolean includeCoordinates) throws IOException {
         generator.writeStartObject();
-        writeJsonContent(generator, isGenerateCoordsInJson);
+        writeJsonContent(generator, includeCoordinates);
         if (rootBlock != null) {
             generator.writeFieldName("rootBlock");
-            rootBlock.writeJson(generator, isGenerateCoordsInJson);
+            rootBlock.writeJson(generator, includeCoordinates);
         }
         generator.writeEndObject();
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractCell.java
@@ -80,17 +80,17 @@ public abstract class AbstractCell implements Cell {
         return number;
     }
 
-    protected void writeJsonContent(JsonGenerator generator) throws IOException {
+    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
         generator.writeStringField("type", type.name());
         generator.writeNumberField("number", number);
     }
 
-    public void writeJson(JsonGenerator generator) throws IOException {
+    public void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
         generator.writeStartObject();
-        writeJsonContent(generator);
+        writeJsonContent(generator, isGenerateCoordsInJson);
         if (rootBlock != null) {
             generator.writeFieldName("rootBlock");
-            rootBlock.writeJson(generator);
+            rootBlock.writeJson(generator, isGenerateCoordsInJson);
         }
         generator.writeEndObject();
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractComposedBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractComposedBlock.java
@@ -107,11 +107,11 @@ public abstract class AbstractComposedBlock extends AbstractBlock implements Com
     }
 
     @Override
-    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+    protected void writeJsonContent(JsonGenerator generator, boolean includeCoordinates) throws IOException {
         generator.writeFieldName("subBlocks");
         generator.writeStartArray();
         for (Block subBlock : subBlocks) {
-            subBlock.writeJson(generator, isGenerateCoordsInJson);
+            subBlock.writeJson(generator, includeCoordinates);
         }
         generator.writeEndArray();
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractComposedBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractComposedBlock.java
@@ -107,11 +107,11 @@ public abstract class AbstractComposedBlock extends AbstractBlock implements Com
     }
 
     @Override
-    protected void writeJsonContent(JsonGenerator generator) throws IOException {
+    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
         generator.writeFieldName("subBlocks");
         generator.writeStartArray();
         for (Block subBlock : subBlocks) {
-            subBlock.writeJson(generator);
+            subBlock.writeJson(generator, isGenerateCoordsInJson);
         }
         generator.writeEndArray();
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractGraph.java
@@ -22,18 +22,13 @@ import java.util.Objects;
  */
 public abstract class AbstractGraph implements Graph {
 
-    private boolean generateCoordsInJson = true;
+    private boolean coordinatesSerialized = true;
     private double width;
     private double height;
 
     @Override
-    public void setGenerateCoordsInJson(boolean generateCoordsInJson) {
-        this.generateCoordsInJson = generateCoordsInJson;
-    }
-
-    @Override
-    public boolean isGenerateCoordsInJson() {
-        return generateCoordsInJson;
+    public void setCoordinatesSerialized(boolean coordinatesSerialized) {
+        this.coordinatesSerialized = coordinatesSerialized;
     }
 
     @Override
@@ -51,13 +46,13 @@ public abstract class AbstractGraph implements Graph {
         try (JsonGenerator generator = new JsonFactory()
             .createGenerator(writer)
             .useDefaultPrettyPrinter()) {
-            writeJson(generator);
+            writeJson(generator, coordinatesSerialized);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
     }
 
-    protected abstract void writeJson(JsonGenerator generator) throws IOException;
+    protected abstract void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException;
 
     @Override
     public double getWidth() {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractGraph.java
@@ -52,7 +52,7 @@ public abstract class AbstractGraph implements Graph {
         }
     }
 
-    protected abstract void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException;
+    protected abstract void writeJson(JsonGenerator generator, boolean includeCoordinates) throws IOException;
 
     @Override
     public double getWidth() {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractPrimaryBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractPrimaryBlock.java
@@ -98,7 +98,7 @@ public abstract class AbstractPrimaryBlock extends AbstractBlock implements Prim
     }
 
     @Override
-    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+    protected void writeJsonContent(JsonGenerator generator, boolean includeCoordinates) throws IOException {
         generator.writeFieldName("nodes");
         generator.writeStartArray();
         for (int i = 1; i <= nodes.size(); ++i) {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractPrimaryBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractPrimaryBlock.java
@@ -98,7 +98,7 @@ public abstract class AbstractPrimaryBlock extends AbstractBlock implements Prim
     }
 
     @Override
-    protected void writeJsonContent(JsonGenerator generator) throws IOException {
+    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
         generator.writeFieldName("nodes");
         generator.writeStartArray();
         for (int i = 1; i <= nodes.size(); ++i) {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Block.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Block.java
@@ -107,6 +107,6 @@ public interface Block {
 
     Type getType();
 
-    void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException;
+    void writeJson(JsonGenerator generator, boolean includeCoordinates) throws IOException;
 
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Block.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Block.java
@@ -107,6 +107,6 @@ public interface Block {
 
     Type getType();
 
-    void writeJson(JsonGenerator generator) throws IOException;
+    void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException;
 
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/BranchEdge.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/BranchEdge.java
@@ -46,13 +46,13 @@ public class BranchEdge extends Edge {
         writeJson(generator, false);
     }
 
-    void writeJson(JsonGenerator generator, boolean generateCoordsInJson) throws IOException {
+    void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
         generator.writeStartObject();
         generator.writeStringField("id", id);
         generator.writeArrayFieldStart("nodes");
         super.writeJson(generator);
         generator.writeEndArray();
-        if (generateCoordsInJson) {
+        if (isGenerateCoordsInJson) {
             generator.writeArrayFieldStart("snakeLine");
             for (Point point : getSnakeLine()) {
                 generator.writeNumber(point.getX());

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/BranchEdge.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/BranchEdge.java
@@ -46,13 +46,13 @@ public class BranchEdge extends Edge {
         writeJson(generator, false);
     }
 
-    void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+    void writeJson(JsonGenerator generator, boolean includeCoordinates) throws IOException {
         generator.writeStartObject();
         generator.writeStringField("id", id);
         generator.writeArrayFieldStart("nodes");
         super.writeJson(generator);
         generator.writeEndArray();
-        if (isGenerateCoordsInJson) {
+        if (includeCoordinates) {
             generator.writeArrayFieldStart("snakeLine");
             for (Point point : getSnakeLine()) {
                 generator.writeNumber(point.getX());

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/BusNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/BusNode.java
@@ -98,8 +98,8 @@ public class BusNode extends Node {
     }
 
     @Override
-    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
-        super.writeJsonContent(generator, isGenerateCoordsInJson);
+    protected void writeJsonContent(JsonGenerator generator, boolean includeCoordinates) throws IOException {
+        super.writeJsonContent(generator, includeCoordinates);
         generator.writeNumberField("pxWidth", pxWidth);
         generator.writeNumberField("busbarIndex", busbarIndex);
         generator.writeNumberField("sectionIndex", sectionIndex);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Cell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Cell.java
@@ -53,7 +53,7 @@ public interface Cell {
 
     double calculateHeight(LayoutParameters layoutParam);
 
-    void writeJson(JsonGenerator generator) throws IOException;
+    void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException;
 
     String getId();
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Cell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Cell.java
@@ -53,7 +53,7 @@ public interface Cell {
 
     double calculateHeight(LayoutParameters layoutParam);
 
-    void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException;
+    void writeJson(JsonGenerator generator, boolean includeCoordinates) throws IOException;
 
     String getId();
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/FeederNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/FeederNode.java
@@ -54,14 +54,14 @@ public class FeederNode extends Node {
     }
 
     @Override
-    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
-        super.writeJsonContent(generator, isGenerateCoordsInJson);
+    protected void writeJsonContent(JsonGenerator generator, boolean includeCoordinates) throws IOException {
+        super.writeJsonContent(generator, includeCoordinates);
         generator.writeStringField("feederType", feederType.name());
         Optional<Integer> order = getOrder();
         if (order.isPresent()) {
             generator.writeNumberField("order", order.get());
         }
-        if (isGenerateCoordsInJson) {
+        if (includeCoordinates) {
             generator.writeStringField("direction", getDirection().name());
         }
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/FeederWithSideNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/FeederWithSideNode.java
@@ -53,8 +53,8 @@ public class FeederWithSideNode extends FeederNode {
     }
 
     @Override
-    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
-        super.writeJsonContent(generator, isGenerateCoordsInJson);
+    protected void writeJsonContent(JsonGenerator generator, boolean includeCoordinates) throws IOException {
+        super.writeJsonContent(generator, includeCoordinates);
         generator.writeStringField("side", side.name());
         if (otherSideVoltageLevelInfos != null) {
             generator.writeFieldName("otherSideVoltageLevelInfos");

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Graph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Graph.java
@@ -25,9 +25,7 @@ public interface Graph {
 
     Stream<Node> getAllNodesStream();
 
-    void setGenerateCoordsInJson(boolean generateCoordsInJson);
-
-    boolean isGenerateCoordsInJson();
+    void setCoordinatesSerialized(boolean coordinatesSerialized);
 
     double getWidth();
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/MiddleTwtNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/MiddleTwtNode.java
@@ -37,8 +37,8 @@ public class MiddleTwtNode extends FictitiousNode {
     }
 
     @Override
-    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
-        super.writeJsonContent(generator, isGenerateCoordsInJson);
+    protected void writeJsonContent(JsonGenerator generator, boolean includeCoordinates) throws IOException {
+        super.writeJsonContent(generator, includeCoordinates);
         int side = 1;
         for (VoltageLevelInfos voltageLevelInfos : voltageLevelInfosLeg) {
             generator.writeFieldName("voltageLevelInfosLeg" + (side++));

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Node.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Node.java
@@ -286,7 +286,9 @@ public class Node implements BaseNode {
         if (name != null) {
             generator.writeStringField("name", name);
         }
-        generator.writeStringField("equipmentId", equipmentId);
+        if (equipmentId != null) {
+            generator.writeStringField("equipmentId", equipmentId);
+        }
         generator.writeStringField("componentType", componentType);
         generator.writeBooleanField("fictitious", fictitious);
         if (isGenerateCoordsInJson) {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Node.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Node.java
@@ -280,7 +280,7 @@ public class Node implements BaseNode {
                 || (n.getType() == NodeType.FICTITIOUS && n.adjacentEdges.size() == 1);
     }
 
-    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+    protected void writeJsonContent(JsonGenerator generator, boolean includeCoordinates) throws IOException {
         generator.writeStringField("type", type.name());
         generator.writeStringField("id", id);
         if (name != null) {
@@ -291,7 +291,7 @@ public class Node implements BaseNode {
         }
         generator.writeStringField("componentType", componentType);
         generator.writeBooleanField("fictitious", fictitious);
-        if (isGenerateCoordsInJson) {
+        if (includeCoordinates) {
             generator.writeNumberField("x", getX());
             generator.writeNumberField("y", getY());
         }
@@ -304,9 +304,9 @@ public class Node implements BaseNode {
         }
     }
 
-    public void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+    public void writeJson(JsonGenerator generator, boolean includeCoordinates) throws IOException {
         generator.writeStartObject();
-        writeJsonContent(generator, isGenerateCoordsInJson);
+        writeJsonContent(generator, includeCoordinates);
         generator.writeEndObject();
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/SubstationGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/SubstationGraph.java
@@ -118,16 +118,16 @@ public class SubstationGraph extends AbstractBaseGraph {
     }
 
     @Override
-    public void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+    public void writeJson(JsonGenerator generator, boolean includeCoordinates) throws IOException {
         generator.writeStartObject();
         generator.writeStringField("substationId", substationId);
         generator.writeArrayFieldStart("voltageLevels");
         for (VoltageLevelGraph graph : voltageLevels) {
-            graph.writeJson(generator, isGenerateCoordsInJson);
+            graph.writeJson(generator, includeCoordinates);
         }
         generator.writeEndArray();
 
-        writeBranchFields(generator, isGenerateCoordsInJson);
+        writeBranchFields(generator, includeCoordinates);
 
         generator.writeEndObject();
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/SubstationGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/SubstationGraph.java
@@ -118,17 +118,16 @@ public class SubstationGraph extends AbstractBaseGraph {
     }
 
     @Override
-    public void writeJson(JsonGenerator generator) throws IOException {
+    public void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
         generator.writeStartObject();
         generator.writeStringField("substationId", substationId);
         generator.writeArrayFieldStart("voltageLevels");
         for (VoltageLevelGraph graph : voltageLevels) {
-            graph.setGenerateCoordsInJson(isGenerateCoordsInJson());
-            graph.writeJson(generator);
+            graph.writeJson(generator, isGenerateCoordsInJson);
         }
         generator.writeEndArray();
 
-        writeBranchFields(generator);
+        writeBranchFields(generator, isGenerateCoordsInJson);
 
         generator.writeEndObject();
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/SwitchNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/SwitchNode.java
@@ -47,8 +47,8 @@ public class SwitchNode extends Node {
     }
 
     @Override
-    protected void writeJsonContent(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
-        super.writeJsonContent(generator, isGenerateCoordsInJson);
+    protected void writeJsonContent(JsonGenerator generator, boolean includeCoordinates) throws IOException {
+        super.writeJsonContent(generator, includeCoordinates);
         generator.writeStringField("kind", kind.name());
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/VoltageLevelGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/VoltageLevelGraph.java
@@ -598,13 +598,13 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
     }
 
     @Override
-    public void writeJson(JsonGenerator generator) throws IOException {
+    public void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
         generator.writeStartObject();
 
         generator.writeFieldName("voltageLevelInfos");
         voltageLevelInfos.writeJsonContent(generator);
 
-        if (isGenerateCoordsInJson()) {
+        if (isGenerateCoordsInJson) {
             generator.writeNumberField("x", getX());
             generator.writeNumberField("y", getY());
         }
@@ -612,13 +612,13 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
         generator.writeArrayFieldStart("nodes");
         Iterator<Node> nodesIt = nodes.stream().sorted(Comparator.comparing(Node::getId)).iterator();
         while (nodesIt.hasNext()) {
-            nodesIt.next().writeJson(generator, isGenerateCoordsInJson());
+            nodesIt.next().writeJson(generator, isGenerateCoordsInJson);
         }
         generator.writeEndArray();
 
         generator.writeArrayFieldStart("cells");
         for (Cell cell : cells) {
-            cell.writeJson(generator);
+            cell.writeJson(generator, isGenerateCoordsInJson);
         }
         generator.writeEndArray();
 
@@ -628,7 +628,7 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
         }
         generator.writeEndArray();
 
-        writeBranchFields(generator);
+        writeBranchFields(generator, isGenerateCoordsInJson);
 
         generator.writeEndObject();
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/VoltageLevelGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/VoltageLevelGraph.java
@@ -598,13 +598,13 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
     }
 
     @Override
-    public void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+    public void writeJson(JsonGenerator generator, boolean includeCoordinates) throws IOException {
         generator.writeStartObject();
 
         generator.writeFieldName("voltageLevelInfos");
         voltageLevelInfos.writeJsonContent(generator);
 
-        if (isGenerateCoordsInJson) {
+        if (includeCoordinates) {
             generator.writeNumberField("x", getX());
             generator.writeNumberField("y", getY());
         }
@@ -612,13 +612,13 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
         generator.writeArrayFieldStart("nodes");
         Iterator<Node> nodesIt = nodes.stream().sorted(Comparator.comparing(Node::getId)).iterator();
         while (nodesIt.hasNext()) {
-            nodesIt.next().writeJson(generator, isGenerateCoordsInJson);
+            nodesIt.next().writeJson(generator, includeCoordinates);
         }
         generator.writeEndArray();
 
         generator.writeArrayFieldStart("cells");
         for (Cell cell : cells) {
-            cell.writeJson(generator, isGenerateCoordsInJson);
+            cell.writeJson(generator, includeCoordinates);
         }
         generator.writeEndArray();
 
@@ -628,7 +628,7 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
         }
         generator.writeEndArray();
 
-        writeBranchFields(generator, isGenerateCoordsInJson);
+        writeBranchFields(generator, includeCoordinates);
 
         generator.writeEndObject();
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/VoltageLevelGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/VoltageLevelGraph.java
@@ -610,8 +610,9 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
         }
 
         generator.writeArrayFieldStart("nodes");
-        for (Node node : nodes.stream().sorted(Comparator.comparing(Node::getId)).collect(Collectors.toList())) {
-            node.writeJson(generator, isGenerateCoordsInJson());
+        Iterator<Node> nodesIt = nodes.stream().sorted(Comparator.comparing(Node::getId)).iterator();
+        while (nodesIt.hasNext()) {
+            nodesIt.next().writeJson(generator, isGenerateCoordsInJson());
         }
         generator.writeEndArray();
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/ZoneGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/ZoneGraph.java
@@ -87,17 +87,16 @@ public class ZoneGraph extends AbstractLineGraph {
         return edgesById.get(lineId);
     }
 
-    public void writeJson(JsonGenerator generator) throws IOException {
+    public void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
         generator.writeStartObject();
         generator.writeArrayFieldStart("substations");
         for (SubstationGraph substationGraph : substations) {
-            substationGraph.setGenerateCoordsInJson(isGenerateCoordsInJson());
-            substationGraph.writeJson(generator);
+            substationGraph.writeJson(generator, isGenerateCoordsInJson);
         }
         generator.writeEndArray();
         generator.writeArrayFieldStart("lineEdges");
         for (BranchEdge edge : getLineEdges()) {
-            edge.writeJson(generator, isGenerateCoordsInJson());
+            edge.writeJson(generator, isGenerateCoordsInJson);
         }
         generator.writeEndArray();
         generator.writeEndObject();

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/ZoneGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/ZoneGraph.java
@@ -87,16 +87,16 @@ public class ZoneGraph extends AbstractLineGraph {
         return edgesById.get(lineId);
     }
 
-    public void writeJson(JsonGenerator generator, boolean isGenerateCoordsInJson) throws IOException {
+    public void writeJson(JsonGenerator generator, boolean includeCoordinates) throws IOException {
         generator.writeStartObject();
         generator.writeArrayFieldStart("substations");
         for (SubstationGraph substationGraph : substations) {
-            substationGraph.writeJson(generator, isGenerateCoordsInJson);
+            substationGraph.writeJson(generator, includeCoordinates);
         }
         generator.writeEndArray();
         generator.writeArrayFieldStart("lineEdges");
         for (BranchEdge edge : getLineEdges()) {
-            edge.writeJson(generator, isGenerateCoordsInJson);
+            edge.writeJson(generator, includeCoordinates);
         }
         generator.writeEndArray();
         generator.writeEndObject();

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -207,8 +207,8 @@ public abstract class AbstractTestCase {
         }
     }
 
-    public String toJson(Graph graph, String filename, boolean isGenerateCoordsInJson) {
-        graph.setCoordinatesSerialized(isGenerateCoordsInJson);
+    public String toJson(Graph graph, String filename, boolean includeCoordinates) {
+        graph.setCoordinatesSerialized(includeCoordinates);
         return toJson(graph, filename);
     }
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -207,8 +207,8 @@ public abstract class AbstractTestCase {
         }
     }
 
-    public String toJson(Graph graph, String filename, boolean genCoords) {
-        graph.setGenerateCoordsInJson(genCoords);
+    public String toJson(Graph graph, String filename, boolean isGenerateCoordsInJson) {
+        graph.setCoordinatesSerialized(isGenerateCoordsInJson);
         return toJson(graph, filename);
     }
 

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreakerH.json
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreakerH.json
@@ -61,7 +61,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_BR1",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 75.0,
@@ -70,7 +69,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_BR1",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 25.0,
@@ -79,7 +77,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_G",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 375.0,
@@ -88,7 +85,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_L11_ONE",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 175.0,
@@ -97,7 +93,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_L11_TWO",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 425.0,
@@ -106,7 +101,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_L12_ONE",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 275.0,
@@ -115,7 +109,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_LD1",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 125.0,
@@ -124,7 +117,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T11_ONE",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 225.0,
@@ -133,7 +125,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T11_TWO",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 475.0,
@@ -142,7 +133,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T12_ONE",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 525.0,
@@ -151,7 +141,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T3_12_ONE",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 325.0,
@@ -160,7 +149,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T3_12_TWO",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 575.0,
@@ -182,7 +170,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_BR1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -192,7 +179,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_BR1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -202,7 +188,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_G_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -211,7 +196,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_G_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -220,7 +204,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L11_ONE_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -229,7 +212,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L11_ONE_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -238,7 +220,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L11_TWO_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -247,7 +228,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L11_TWO_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -256,7 +236,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L12_ONE_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -265,7 +244,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L12_ONE_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -274,7 +252,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_LD1_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -283,7 +260,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_LD1_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -292,7 +268,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T11_ONE_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -301,7 +276,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T11_ONE_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -310,7 +284,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T11_TWO_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -319,7 +292,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T11_TWO_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -328,7 +300,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T12_ONE_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -337,7 +308,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T12_ONE_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -346,7 +316,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T3_12_ONE_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -355,7 +324,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T3_12_ONE_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -364,7 +332,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T3_12_TWO_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -373,7 +340,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T3_12_TWO_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -1747,7 +1713,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_L12_TWO",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 75.0,
@@ -1756,7 +1721,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_LD2",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 25.0,
@@ -1765,7 +1729,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T12_TWO",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 125.0,
@@ -1774,7 +1737,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T3_12_THREE",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 175.0,
@@ -1783,7 +1745,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_L12_TWO_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -1792,7 +1753,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_L12_TWO_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -1801,7 +1761,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_LD2_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -1810,7 +1769,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_LD2_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -1819,7 +1777,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_T12_TWO_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -1828,7 +1785,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_T12_TWO_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -1837,7 +1793,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_T3_12_THREE_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -1846,7 +1801,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_T3_12_THREE_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreakerV.json
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreakerV.json
@@ -61,7 +61,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_BR1",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 75.0,
@@ -70,7 +69,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_BR1",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 25.0,
@@ -79,7 +77,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_G",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 375.0,
@@ -88,7 +85,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_L11_ONE",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 175.0,
@@ -97,7 +93,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_L11_TWO",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 425.0,
@@ -106,7 +101,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_L12_ONE",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 275.0,
@@ -115,7 +109,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_LD1",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 125.0,
@@ -124,7 +117,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T11_ONE",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 225.0,
@@ -133,7 +125,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T11_TWO",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 475.0,
@@ -142,7 +133,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T12_ONE",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 525.0,
@@ -151,7 +141,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T3_12_ONE",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 325.0,
@@ -160,7 +149,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T3_12_TWO",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 575.0,
@@ -182,7 +170,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_BR1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -192,7 +179,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_BR1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -202,7 +188,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_G_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -211,7 +196,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_G_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -220,7 +204,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L11_ONE_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -229,7 +212,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L11_ONE_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -238,7 +220,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L11_TWO_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -247,7 +228,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L11_TWO_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -256,7 +236,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L12_ONE_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -265,7 +244,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L12_ONE_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -274,7 +252,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_LD1_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -283,7 +260,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_LD1_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -292,7 +268,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T11_ONE_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -301,7 +276,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T11_ONE_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -310,7 +284,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T11_TWO_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -319,7 +292,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T11_TWO_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -328,7 +300,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T12_ONE_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -337,7 +308,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T12_ONE_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -346,7 +316,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T3_12_ONE_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -355,7 +324,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T3_12_ONE_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -364,7 +332,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T3_12_TWO_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -373,7 +340,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T3_12_TWO_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -1747,7 +1713,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_L12_TWO",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 75.0,
@@ -1756,7 +1721,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_LD2",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 25.0,
@@ -1765,7 +1729,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T12_TWO",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 125.0,
@@ -1774,7 +1737,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "BUSCO_T3_12_THREE",
-      "equipmentId" : null,
       "componentType" : "BUS_CONNECTION",
       "fictitious" : true,
       "x" : 175.0,
@@ -1783,7 +1745,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_L12_TWO_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -1792,7 +1753,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_L12_TWO_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -1801,7 +1761,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_LD2_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -1810,7 +1769,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_LD2_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -1819,7 +1777,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_T12_TWO_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -1828,7 +1785,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_T12_TWO_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -1837,7 +1793,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_T3_12_THREE_1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -1846,7 +1801,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_T3_12_THREE_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreakerH.json
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreakerH.json
@@ -316,7 +316,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D10",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -326,7 +325,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D11",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -335,7 +333,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D13",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -344,7 +341,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D15",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -353,7 +349,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D17",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -362,7 +357,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D19",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -371,7 +365,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D20",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -381,7 +374,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D21",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -390,7 +382,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D23",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -399,7 +390,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D25",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -408,7 +398,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D27",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -417,7 +406,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D29",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -426,7 +414,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_G",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -435,7 +422,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -444,7 +430,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L11_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -453,7 +438,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L11_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -462,7 +446,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L12_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -471,7 +454,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T11_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -480,7 +462,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T11_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -489,7 +470,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T12_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -498,7 +478,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T3_12_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -507,7 +486,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T3_12_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -1989,7 +1967,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_D31",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -1998,7 +1975,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_D33",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -2007,7 +1983,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_D35",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2016,7 +1991,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_D37",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2025,7 +1999,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_L12_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -2034,7 +2007,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_L2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -2043,7 +2015,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_T12_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2052,7 +2023,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_T3_12_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreakerV.json
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreakerV.json
@@ -316,7 +316,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D10",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -326,7 +325,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D11",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -335,7 +333,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D13",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -344,7 +341,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D15",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -353,7 +349,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D17",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -362,7 +357,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D19",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -371,7 +365,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D20",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -381,7 +374,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D21",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -390,7 +382,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D23",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -399,7 +390,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D25",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -408,7 +398,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D27",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -417,7 +406,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_D29",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -426,7 +414,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_G",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -435,7 +422,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -444,7 +430,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L11_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -453,7 +438,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L11_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -462,7 +446,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_L12_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -471,7 +454,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T11_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -480,7 +462,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T11_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -489,7 +470,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T12_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -498,7 +478,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T3_12_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -507,7 +486,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL1_T3_12_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -1989,7 +1967,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_D31",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -1998,7 +1975,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_D33",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -2007,7 +1983,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_D35",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2016,7 +1991,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_D37",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2025,7 +1999,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_L12_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -2034,7 +2007,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_L2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -2043,7 +2015,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_T12_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2052,7 +2023,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_VL2_T3_12_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,

--- a/single-line-diagram-core/src/test/resources/TestCase1.json
+++ b/single-line-diagram-core/src/test/resources/TestCase1.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphH.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphH.json
@@ -11,7 +11,6 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dgen1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -20,7 +19,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dgen2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 675.0,
@@ -29,7 +27,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dline11_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -38,7 +35,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dload1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -47,7 +43,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dload2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -56,7 +51,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect11",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 400.0,
@@ -66,7 +60,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect12",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 450.0,
@@ -76,7 +69,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect21",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 400.0,
@@ -86,7 +78,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect22",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 450.0,
@@ -96,7 +87,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf11",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -105,7 +95,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf12",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 625.0,
@@ -114,7 +103,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf13",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -123,7 +111,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf14",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -132,7 +119,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf15",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -141,7 +127,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf16",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -150,7 +135,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf17",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -159,7 +143,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf18",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -168,7 +151,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_gen1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -177,7 +159,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_gen2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 675.0,
@@ -186,7 +167,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_line1_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -195,7 +175,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_load1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -204,7 +183,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_load2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -213,7 +191,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf1_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -222,7 +199,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf2_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 625.0,
@@ -231,7 +207,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf3_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -240,7 +215,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf4_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -249,7 +223,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf5_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -258,7 +231,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf6_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -267,7 +239,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf7_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -276,7 +247,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf8_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -2544,7 +2514,6 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dgen4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -2553,7 +2522,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dload3",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2562,7 +2530,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dscpl1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -2572,7 +2539,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dscpl2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -2582,7 +2548,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf21",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2591,7 +2556,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf22",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -2600,7 +2564,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf23",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -2609,7 +2572,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf24",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -2618,7 +2580,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf26",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -2627,7 +2588,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf27",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -2636,7 +2596,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf28",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -2645,7 +2604,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_gen4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -2654,7 +2612,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_load3",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2663,7 +2620,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf1_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2672,7 +2628,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf2_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -2681,7 +2636,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf3_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -2690,7 +2644,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf4_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -2699,7 +2652,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf6_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -2708,7 +2660,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf7_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -2717,7 +2668,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf8_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -4229,7 +4179,6 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dload4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -4238,7 +4187,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf25",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -4247,7 +4195,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf36",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -4256,7 +4203,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf37",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -4265,7 +4211,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf38",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -4274,7 +4219,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_load4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -4283,7 +4227,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf5_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -4292,7 +4235,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf6_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -4301,7 +4243,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf7_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -4310,7 +4251,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf8_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphSmart.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphSmart.json
@@ -9,42 +9,36 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dgen1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dgen2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dline11_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dload1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dload2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect11",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -52,7 +46,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect12",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -60,7 +53,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect21",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -68,7 +60,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect22",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -76,147 +67,126 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf11",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf12",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf13",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf14",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf15",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf16",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf17",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf18",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_gen1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_gen2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_line1_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_load1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_load2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf1_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf2_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf3_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf4_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf5_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf6_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf7_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf8_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
@@ -1921,21 +1891,18 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dgen4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dload3",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dscpl1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -1943,7 +1910,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dscpl2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -1951,112 +1917,96 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf21",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf22",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf23",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf24",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf26",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf27",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf28",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_gen4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_load3",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf1_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf2_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf3_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf4_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf6_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf7_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf8_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
@@ -3193,70 +3143,60 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dload4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf25",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf36",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf37",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf38",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_load4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf5_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf6_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf7_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf8_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphSmartHorizontal.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphSmartHorizontal.json
@@ -9,42 +9,36 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dgen1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dgen2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dline11_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dload1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dload2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect11",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -52,7 +46,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect12",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -60,7 +53,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect21",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -68,7 +60,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect22",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -76,147 +67,126 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf11",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf12",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf13",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf14",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf15",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf16",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf17",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf18",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_gen1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_gen2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_line1_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_load1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_load2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf1_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf2_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf3_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf4_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf5_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf6_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf7_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf8_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
@@ -1921,21 +1891,18 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dgen4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dload3",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dscpl1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -1943,7 +1910,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dscpl2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -1951,112 +1917,96 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf21",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf22",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf23",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf24",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf26",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf27",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf28",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_gen4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_load3",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf1_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf2_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf3_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf4_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf6_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf7_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf8_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
@@ -3193,70 +3143,60 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dload4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf25",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf36",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf37",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf38",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_load4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf5_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf6_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf7_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf8_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphSmartVertical.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphSmartVertical.json
@@ -9,42 +9,36 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dgen1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dgen2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dline11_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dload1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dload2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect11",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -52,7 +46,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect12",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -60,7 +53,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect21",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -68,7 +60,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect22",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -76,147 +67,126 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf11",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf12",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf13",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf14",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf15",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf16",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf17",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf18",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_gen1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_gen2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_line1_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_load1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_load2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf1_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf2_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf3_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf4_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf5_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf6_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf7_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf8_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
@@ -1921,21 +1891,18 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dgen4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dload3",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dscpl1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -1943,7 +1910,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dscpl2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "rotationAngle" : 90.0,
@@ -1951,112 +1917,96 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf21",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf22",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf23",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf24",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf26",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf27",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf28",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_gen4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_load3",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf1_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf2_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf3_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf4_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf6_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf7_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf8_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
@@ -3193,70 +3143,60 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dload4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf25",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf36",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf37",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf38",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_load4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf5_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf6_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf7_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf8_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "open" : false

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphV.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphV.json
@@ -11,7 +11,6 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dgen1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -20,7 +19,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dgen2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 675.0,
@@ -29,7 +27,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dline11_2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -38,7 +35,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dload1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -47,7 +43,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dload2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -56,7 +51,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect11",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 400.0,
@@ -66,7 +60,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect12",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 450.0,
@@ -76,7 +69,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect21",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 400.0,
@@ -86,7 +78,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dsect22",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 450.0,
@@ -96,7 +87,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf11",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -105,7 +95,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf12",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 625.0,
@@ -114,7 +103,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf13",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -123,7 +111,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf14",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -132,7 +119,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf15",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -141,7 +127,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf16",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -150,7 +135,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf17",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -159,7 +143,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_dtrf18",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -168,7 +151,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_gen1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -177,7 +159,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_gen2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 675.0,
@@ -186,7 +167,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_line1_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -195,7 +175,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_load1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -204,7 +183,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_load2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -213,7 +191,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf1_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -222,7 +199,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf2_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 625.0,
@@ -231,7 +207,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf3_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -240,7 +215,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf4_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -249,7 +223,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf5_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -258,7 +231,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf6_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -267,7 +239,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf7_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -276,7 +247,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl1_trf8_ONE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -2544,7 +2514,6 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dgen4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -2553,7 +2522,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dload3",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2562,7 +2530,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dscpl1",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -2572,7 +2539,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dscpl2",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -2582,7 +2548,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf21",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2591,7 +2556,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf22",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -2600,7 +2564,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf23",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -2609,7 +2572,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf24",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -2618,7 +2580,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf26",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -2627,7 +2588,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf27",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -2636,7 +2596,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_dtrf28",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -2645,7 +2604,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_gen4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -2654,7 +2612,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_load3",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2663,7 +2620,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf1_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2672,7 +2628,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf2_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -2681,7 +2636,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf3_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -2690,7 +2644,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf4_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -2699,7 +2652,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf6_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -2708,7 +2660,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf7_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -2717,7 +2668,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl2_trf8_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -4229,7 +4179,6 @@
     "nodes" : [ {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dload4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -4238,7 +4187,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf25",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -4247,7 +4195,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf36",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -4256,7 +4203,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf37",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -4265,7 +4211,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_dtrf38",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -4274,7 +4219,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_load4",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -4283,7 +4227,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf5_TWO",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -4292,7 +4235,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf6_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -4301,7 +4243,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf7_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -4310,7 +4251,6 @@
     }, {
       "type" : "FICTITIOUS",
       "id" : "INTERNAL_vl3_trf8_THREE",
-      "equipmentId" : null,
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dgen1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dgen2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1240.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dload1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 40.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dload2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 840.0,
@@ -45,7 +41,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dsect11",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 720.0,
@@ -55,7 +50,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dsect12",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 800.0,
@@ -65,7 +59,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dsect21",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 720.0,
@@ -75,7 +68,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dsect22",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 800.0,
@@ -85,7 +77,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dtrf11",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 120.0,
@@ -94,7 +85,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dtrf12",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1160.0,
@@ -103,7 +93,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dtrf13",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 280.0,
@@ -112,7 +101,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dtrf14",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1080.0,
@@ -121,7 +109,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dtrf15",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 360.0,
@@ -130,7 +117,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dtrf16",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 480.0,
@@ -139,7 +125,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dtrf17",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 640.0,
@@ -148,7 +133,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_dtrf18",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 960.0,
@@ -157,7 +141,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_gen1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -166,7 +149,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_gen2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1240.0,
@@ -175,7 +157,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_load1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 40.0,
@@ -184,7 +165,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_load2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 840.0,
@@ -193,7 +173,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_trf1_ONE",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 120.0,
@@ -202,7 +181,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_trf2_ONE",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1160.0,
@@ -211,7 +189,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_trf3_ONE",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 280.0,
@@ -220,7 +197,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_trf4_ONE",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1080.0,
@@ -229,7 +205,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_trf5_ONE",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 360.0,

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_dgen4",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 360.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_dload3",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_dscpl1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 120.0,
@@ -37,7 +34,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_dscpl2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 40.0,
@@ -47,7 +43,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_dtrf21",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 280.0,
@@ -56,7 +51,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_dtrf22",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1000.0,
@@ -65,7 +59,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_dtrf23",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1080.0,
@@ -74,7 +67,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_dtrf24",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 440.0,
@@ -83,7 +75,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_dtrf26",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 720.0,
@@ -92,7 +83,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_dtrf27",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 560.0,
@@ -101,7 +91,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_dtrf28",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 880.0,
@@ -110,7 +99,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_gen4",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 360.0,
@@ -119,7 +107,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_load3",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -128,7 +115,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_trf1_TWO",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 280.0,
@@ -137,7 +123,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_trf2_TWO",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1000.0,
@@ -146,7 +131,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_trf3_TWO",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1080.0,
@@ -155,7 +139,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_trf4_TWO",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 440.0,

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL3.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL3.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_dload4",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 40.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_dself4",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 120.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_dself5",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 760.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_dself6",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 840.0,
@@ -45,7 +41,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_dtrf25",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -54,7 +49,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_dtrf36",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 320.0,
@@ -63,7 +57,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_dtrf37",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 480.0,
@@ -72,7 +65,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_dtrf38",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 640.0,
@@ -81,7 +73,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_load4",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 40.0,
@@ -90,7 +81,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_self4",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 120.0,
@@ -99,7 +89,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_self5",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 760.0,
@@ -108,7 +97,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_self6",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 840.0,
@@ -117,7 +105,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl3_trf5_TWO",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,

--- a/single-line-diagram-core/src/test/resources/TestCase1BusBreaker.json
+++ b/single-line-diagram-core/src/test/resources/TestCase1BusBreaker.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_l",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 125.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_sw",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 75.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_sw",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 25.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -45,7 +41,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l_2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -54,7 +49,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_sw",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -64,7 +58,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_sw",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,

--- a/single-line-diagram-core/src/test/resources/TestCase1inverted.json
+++ b/single-line-diagram-core/src/test/resources/TestCase1inverted.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,

--- a/single-line-diagram-core/src/test/resources/TestCase2Stacked.json
+++ b/single-line-diagram-core/src/test/resources/TestCase2Stacked.json
@@ -18,7 +18,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,

--- a/single-line-diagram-core/src/test/resources/TestCase2UnStackedCell.json
+++ b/single-line-diagram-core/src/test/resources/TestCase2UnStackedCell.json
@@ -18,7 +18,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vlUnstack_l",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,

--- a/single-line-diagram-core/src/test/resources/TestCase3Coupling.json
+++ b/single-line-diagram-core/src/test/resources/TestCase3Coupling.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -19,7 +18,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,

--- a/single-line-diagram-core/src/test/resources/TestCase3TripleCoupling.json
+++ b/single-line-diagram-core/src/test/resources/TestCase3TripleCoupling.json
@@ -19,7 +19,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -29,7 +28,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -39,7 +37,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d5",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -49,7 +46,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d6",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 275.0,
@@ -59,7 +55,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d7",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,

--- a/single-line-diagram-core/src/test/resources/TestCase3TripleCoupling_disconnectorOpen.json
+++ b/single-line-diagram-core/src/test/resources/TestCase3TripleCoupling_disconnectorOpen.json
@@ -19,7 +19,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -29,7 +28,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -39,7 +37,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d5",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -49,7 +46,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d6",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 275.0,
@@ -59,7 +55,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d7",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,

--- a/single-line-diagram-core/src/test/resources/TestCase4NotParallelel.json
+++ b/single-line-diagram-core/src/test/resources/TestCase4NotParallelel.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss1_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss1_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -45,7 +43,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dc1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -54,7 +51,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_gc",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -63,7 +59,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_la",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -72,7 +67,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_lb",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -81,7 +75,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_ss1_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -91,7 +84,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_ss1_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,

--- a/single-line-diagram-core/src/test/resources/TestCase5H.json
+++ b/single-line-diagram-core/src/test/resources/TestCase5H.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 3.1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 3.2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_da",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_db",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -45,7 +41,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_la",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -54,7 +49,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_lb",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,

--- a/single-line-diagram-core/src/test/resources/TestCase5V.json
+++ b/single-line-diagram-core/src/test/resources/TestCase5V.json
@@ -18,7 +18,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 3.1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -27,7 +26,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 3.2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -36,7 +34,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_da",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -45,7 +42,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_la",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -54,7 +50,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_lb",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,

--- a/single-line-diagram-core/src/test/resources/TestCase6CouplingNonFlatHorizontal.json
+++ b/single-line-diagram-core/src/test/resources/TestCase6CouplingNonFlatHorizontal.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ds1_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ds1_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ds2_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ds2_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -45,7 +41,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -55,7 +50,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -65,7 +59,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_ds1_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -75,7 +68,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_ds1_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -85,7 +77,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_ds2_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -95,7 +86,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_ds2_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,

--- a/single-line-diagram-core/src/test/resources/TestCase6InternalConnection.json
+++ b/single-line-diagram-core/src/test/resources/TestCase6InternalConnection.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ds2_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ds2_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -37,7 +34,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -47,7 +43,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_ds2_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -57,7 +52,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_ds2_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,

--- a/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.json
+++ b/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -19,7 +18,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_f1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -29,7 +27,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_f2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,

--- a/single-line-diagram-core/src/test/resources/TestCaseGraphAdaptCellHeightToContent.json
+++ b/single-line-diagram-core/src/test/resources/TestCaseGraphAdaptCellHeightToContent.json
@@ -191,7 +191,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_gen1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 375.0,
@@ -200,7 +199,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_gen2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 300.0,
@@ -209,7 +207,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_load1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -218,7 +215,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_load2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,

--- a/single-line-diagram-core/src/test/resources/TestCaseGraphExternCellHeightFixed.json
+++ b/single-line-diagram-core/src/test/resources/TestCaseGraphExternCellHeightFixed.json
@@ -191,7 +191,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_gen1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 375.0,
@@ -200,7 +199,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_gen2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 300.0,
@@ -209,7 +207,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_load1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -218,7 +215,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_load2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,

--- a/single-line-diagram-core/src/test/resources/TestCaseShuntArrangementNo.json
+++ b/single-line-diagram-core/src/test/resources/TestCaseShuntArrangementNo.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 11.1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 11.2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 300.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 14.1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 250.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 14.2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 400.0,
@@ -45,7 +41,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 8.1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -54,7 +49,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 8.2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -63,7 +57,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_commonFG",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 450.0,
@@ -72,7 +65,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dA",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -81,7 +73,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_f",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -90,7 +81,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_fB",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -99,7 +89,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_fC",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -108,7 +97,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_fD",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 275.0,
@@ -117,7 +105,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_fE",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 375.0,
@@ -126,7 +113,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_fF",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 450.0,
@@ -135,7 +121,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_fLoadG",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 475.0,
@@ -144,7 +129,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_fShuntA",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -153,7 +137,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_fShuntB",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -162,7 +145,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_fg1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -171,7 +153,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_fg2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 325.0,
@@ -180,7 +161,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_gen1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -189,7 +169,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_gen2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 325.0,
@@ -198,7 +177,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -207,7 +185,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadA",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -216,7 +193,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadB",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -225,7 +201,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadC",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -234,7 +209,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadD",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 275.0,
@@ -243,7 +217,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadE",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 375.0,
@@ -252,7 +225,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadF",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 425.0,
@@ -261,7 +233,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadG",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 475.0,

--- a/single-line-diagram-core/src/test/resources/TestCaseShuntArrangementYes.json
+++ b/single-line-diagram-core/src/test/resources/TestCaseShuntArrangementYes.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 11.1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 300.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 11.2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 350.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 14.1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 450.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 14.2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 500.0,
@@ -45,7 +41,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 8.1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -54,7 +49,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_Shunt 8.2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -63,7 +57,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_commonFG",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 550.0,
@@ -72,7 +65,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dA",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -81,7 +73,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_f",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -90,7 +81,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_fB",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -99,7 +89,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_fC",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 425.0,
@@ -108,7 +97,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_fD",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -117,7 +105,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_fE",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 625.0,
@@ -126,7 +113,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_fF",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 550.0,
@@ -135,7 +121,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_fLoadG",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 525.0,
@@ -144,7 +129,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_fShuntA",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -153,7 +137,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_fShuntB",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -162,7 +145,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_fg1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 275.0,
@@ -171,7 +153,6 @@
   }, {
     "type" : "SHUNT",
     "id" : "INTERNAL_vl_fg2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 375.0,
@@ -180,7 +161,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_gen1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 275.0,
@@ -189,7 +169,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_gen2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 375.0,
@@ -198,7 +177,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -207,7 +185,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadA",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -216,7 +193,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadB",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -225,7 +201,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadC",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 425.0,
@@ -234,7 +209,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadD",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -243,7 +217,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadE",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 625.0,
@@ -252,7 +225,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadF",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 575.0,
@@ -261,7 +233,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_loadG",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 525.0,

--- a/single-line-diagram-core/src/test/resources/TestFeederOnBus.json
+++ b/single-line-diagram-core/src/test/resources/TestFeederOnBus.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_line_ONE",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 25.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_line_ONE_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_line_ONE_2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,

--- a/single-line-diagram-core/src/test/resources/TestFeederOnBusDisconnector.json
+++ b/single-line-diagram-core/src/test/resources/TestFeederOnBusDisconnector.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_line_ONE_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_line_ONE_2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,

--- a/single-line-diagram-core/src/test/resources/TestIncompleteFeederIssue.json
+++ b/single-line-diagram-core/src/test/resources/TestIncompleteFeederIssue.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_INTERNAL_vl_fict2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,

--- a/single-line-diagram-core/src/test/resources/TestInternCellExplicitPosition.json
+++ b/single-line-diagram-core/src/test/resources/TestInternCellExplicitPosition.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dc11",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -19,7 +18,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dc12",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -29,7 +27,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dc21",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 275.0,
@@ -39,7 +36,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dc22",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -49,7 +45,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dl1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -58,7 +53,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dl2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -67,7 +61,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -76,7 +69,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,

--- a/single-line-diagram-core/src/test/resources/TestInternCellShapes.json
+++ b/single-line-diagram-core/src/test/resources/TestInternCellShapes.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_flatDisconector_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 150.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_flatDisconector_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 200.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dCrossOverBk1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -37,7 +34,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dCrossOverBk2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -47,7 +43,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dF1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 275.0,
@@ -56,7 +51,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dFlatBk1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -66,7 +60,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dFlatBk2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -76,7 +69,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dVerticalBk1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -86,7 +78,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dVerticalBk2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -96,7 +87,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_flatDisconector_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -106,7 +96,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_flatDisconector_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,

--- a/single-line-diagram-core/src/test/resources/TestUndefinedBlockExternCell.json
+++ b/single-line-diagram-core/src/test/resources/TestUndefinedBlockExternCell.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_f0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 0.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_f1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 0.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_f2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 0.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 0.0,
@@ -45,7 +41,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 0.0,

--- a/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork1.json
+++ b/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork1.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,

--- a/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork2.json
+++ b/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork2.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,

--- a/single-line-diagram-core/src/test/resources/orderConsistencyClust1.json
+++ b/single-line-diagram-core/src/test/resources/orderConsistencyClust1.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss1_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 150.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss1_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 200.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss2_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss2_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -45,7 +41,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_f",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -54,7 +49,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_f1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -63,7 +57,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_f2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -72,7 +65,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_l",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -81,7 +73,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_l1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -90,7 +81,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_l2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -99,7 +89,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_ss1_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -109,7 +98,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_ss1_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -119,7 +107,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_ss2_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -129,7 +116,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_ss2_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,

--- a/single-line-diagram-core/src/test/resources/orderConsistencyClust2.json
+++ b/single-line-diagram-core/src/test/resources/orderConsistencyClust2.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss1_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss1_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss2_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 150.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss2_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 200.0,
@@ -45,7 +41,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_f",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -54,7 +49,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_f1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -63,7 +57,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_f2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -72,7 +65,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_l",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -81,7 +73,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_l1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -90,7 +81,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_l2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -99,7 +89,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_ss1_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -109,7 +98,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_ss1_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -119,7 +107,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_ss2_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -129,7 +116,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_ss2_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,

--- a/single-line-diagram-core/src/test/resources/orderConsistencyExt1.json
+++ b/single-line-diagram-core/src/test/resources/orderConsistencyExt1.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss1_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 150.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss1_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 200.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss2_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss2_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -45,7 +41,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_f",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -54,7 +49,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_f1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -63,7 +57,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_f2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -72,7 +65,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_l",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -81,7 +73,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_l1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -90,7 +81,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_l2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -99,7 +89,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_ss1_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -109,7 +98,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_ss1_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -119,7 +107,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_ss2_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -129,7 +116,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl1_ss2_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,

--- a/single-line-diagram-core/src/test/resources/orderConsistencyExt2.json
+++ b/single-line-diagram-core/src/test/resources/orderConsistencyExt2.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss1_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss1_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss2_0",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 150.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "BUSCO_ss2_1",
-    "equipmentId" : null,
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 200.0,
@@ -45,7 +41,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_f",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -54,7 +49,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_f1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -63,7 +57,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_f2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -72,7 +65,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_l",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -81,7 +73,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_l1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -90,7 +81,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_l2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -99,7 +89,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_ss1_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -109,7 +98,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_ss1_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -119,7 +107,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_ss2_0",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -129,7 +116,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl2_ss2_1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,

--- a/single-line-diagram-core/src/test/resources/testLanesWithUnileg.json
+++ b/single-line-diagram-core/src/test/resources/testLanesWithUnileg.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_dF1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_db11",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -28,7 +26,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_db12",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -38,7 +35,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_db31",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -48,7 +44,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_db32",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,

--- a/single-line-diagram-core/src/test/resources/testParallelFeedersOrders.json
+++ b/single-line-diagram-core/src/test/resources/testParallelFeedersOrders.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_d",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -18,7 +17,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_f",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -27,7 +25,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -36,7 +33,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_l2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,

--- a/single-line-diagram-core/src/test/resources/testSerialBlocksInternCells.json
+++ b/single-line-diagram-core/src/test/resources/testSerialBlocksInternCells.json
@@ -9,7 +9,6 @@
   "nodes" : [ {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_f1",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -19,7 +18,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_f2",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -29,7 +27,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_sd11",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -39,7 +36,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_sd12",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -49,7 +45,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_sd21",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -59,7 +54,6 @@
   }, {
     "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_sd22",
-    "equipmentId" : null,
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Cleanup/refactor


**What is the current behavior?** 
* Unnecessary list of all nodes created
* equipmentId field serialized when null in json
* parameter isGenerateCoordsInJson is passed to sub-elements through voltageLevelGraph, but it can be null

**What is the new behavior (if this is a feature change)?**
* Iterator used instead of creating list
* equipmentId field not serialized when null in json
* Passing parameter isGenerateCoordsInJson through method calls



**Does this PR introduce a breaking change or deprecate an API?**
No
