### PR TITLE
Get voltage level graph

### DIFF
--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesZoneLayout.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/CgmesZoneLayout.java
@@ -60,7 +60,7 @@ public class CgmesZoneLayout extends AbstractCgmesLayout {
             setNodeCoordinates(vl, vlGraph, diagramName, layoutParam.isUseName());
         }
         for (BranchEdge edge : graph.getLineEdges()) {
-            VoltageLevel vl = network.getVoltageLevel(edge.getNode1().getGraph().getVoltageLevelInfos().getId());
+            VoltageLevel vl = network.getVoltageLevel(edge.getNode1().getVoltageLevelGraph().getVoltageLevelInfos().getId());
             setLineCoordinates(vl, edge, diagramName);
         }
         // shift coordinates

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/RawGraphBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/RawGraphBuilder.java
@@ -49,17 +49,17 @@ public class RawGraphBuilder implements GraphBuilder {
     public class VoltageLevelBuilder {
 
         private VoltageLevelInfos voltageLevelInfos;
-        private final VoltageLevelGraph graph;
+        private final VoltageLevelGraph voltageLevelGraph;
 
         private SubstationBuilder substationBuilder;
 
         public VoltageLevelBuilder(VoltageLevelInfos voltageLevelInfos, boolean forVoltageLevelDiagram) {
             this.voltageLevelInfos = voltageLevelInfos;
-            graph = VoltageLevelGraph.create(voltageLevelInfos, forVoltageLevelDiagram);
+            voltageLevelGraph = VoltageLevelGraph.create(voltageLevelInfos, forVoltageLevelDiagram);
         }
 
         public VoltageLevelGraph getGraph() {
-            return graph;
+            return voltageLevelGraph;
         }
 
         public SubstationBuilder getSubstationBuilder() {
@@ -71,27 +71,27 @@ public class RawGraphBuilder implements GraphBuilder {
         }
 
         public BusNode createBusBarSection(String id, int busbarIndex, int sectionIndex) {
-            BusNode busNode = BusNode.create(graph, id, id);
-            graph.addNode(busNode);
+            BusNode busNode = BusNode.create(voltageLevelGraph, id, id);
+            voltageLevelGraph.addNode(busNode);
             busNode.setBusBarIndexSectionIndex(busbarIndex, sectionIndex);
             return busNode;
         }
 
         public BusNode createBusBarSection(String id) {
-            BusNode busNode = BusNode.create(graph, id, id);
-            graph.addNode(busNode);
+            BusNode busNode = BusNode.create(voltageLevelGraph, id, id);
+            voltageLevelGraph.addNode(busNode);
             return busNode;
         }
 
         public SwitchNode createSwitchNode(SwitchNode.SwitchKind sk, String id, boolean fictitious, boolean open) {
-            SwitchNode sw = new SwitchNode(id, id, sk.name(), fictitious, graph, sk, open);
-            graph.addNode(sw);
+            SwitchNode sw = new SwitchNode(id, id, sk.name(), fictitious, voltageLevelGraph, sk, open);
+            voltageLevelGraph.addNode(sw);
             return sw;
         }
 
         public SwitchNode createSwitchNode(SwitchNode.SwitchKind sk, String id, boolean fictitious, boolean open, Integer order, BusCell.Direction direction) {
-            SwitchNode sw = new SwitchNode(id, id, sk.name(), fictitious, graph, sk, open);
-            graph.addNode(sw);
+            SwitchNode sw = new SwitchNode(id, id, sk.name(), fictitious, voltageLevelGraph, sk, open);
+            voltageLevelGraph.addNode(sw);
             if (direction != null || order != null) {
                 addExtension(sw, order, direction);
             }
@@ -99,18 +99,18 @@ public class RawGraphBuilder implements GraphBuilder {
         }
 
         public void connectNode(Node node1, Node node2) {
-            graph.addEdge(node1, node2);
+            voltageLevelGraph.addEdge(node1, node2);
         }
 
         public FictitiousNode createFictitiousNode(int id) {
-            InternalNode fictitiousNode = new InternalNode(id, graph);
-            graph.addNode(fictitiousNode);
+            InternalNode fictitiousNode = new InternalNode(id, voltageLevelGraph);
+            voltageLevelGraph.addNode(fictitiousNode);
             return fictitiousNode;
         }
 
         public FictitiousNode createFictitiousNode(String id) {
-            InternalNode fictitiousNode = new InternalNode(id, graph);
-            graph.addNode(fictitiousNode);
+            InternalNode fictitiousNode = new InternalNode(id, voltageLevelGraph);
+            voltageLevelGraph.addNode(fictitiousNode);
             return fictitiousNode;
         }
 
@@ -123,7 +123,7 @@ public class RawGraphBuilder implements GraphBuilder {
 
         private void commonFeederSetting(FeederNode node, String id, int order, BusCell.Direction direction) {
             node.setLabel(id);
-            graph.addNode(node);
+            voltageLevelGraph.addNode(node);
             if (direction != null) {
                 addExtension(node, order, direction);
             }
@@ -134,7 +134,7 @@ public class RawGraphBuilder implements GraphBuilder {
         }
 
         public FeederNode createLoad(String id, int order, BusCell.Direction direction) {
-            FeederInjectionNode fn = FeederInjectionNode.createLoad(graph, id, id);
+            FeederInjectionNode fn = FeederInjectionNode.createLoad(voltageLevelGraph, id, id);
             commonFeederSetting(fn, id, order, direction);
             return fn;
         }
@@ -144,33 +144,33 @@ public class RawGraphBuilder implements GraphBuilder {
         }
 
         public FeederNode createGenerator(String id, int order, BusCell.Direction direction) {
-            FeederInjectionNode fn = FeederInjectionNode.createGenerator(graph, id, id);
+            FeederInjectionNode fn = FeederInjectionNode.createGenerator(voltageLevelGraph, id, id);
             commonFeederSetting(fn, id, order, direction);
             return fn;
         }
 
         public FeederLineNode createFeederLineNode(String id, String otherVlId, FeederWithSideNode.Side side, int order, BusCell.Direction direction) {
-            FeederLineNode fln = FeederLineNode.create(graph, id + "_" + side, id, id, side, getVoltageLevelInfosFromId(otherVlId));
+            FeederLineNode fln = FeederLineNode.create(voltageLevelGraph, id + "_" + side, id, id, side, getVoltageLevelInfosFromId(otherVlId));
             commonFeederSetting(fln, id, order, direction);
             return fln;
         }
 
         public Feeder2WTNode createFeeder2WTNode(String id, String otherVlId, FeederWithSideNode.Side side,
                                                  int order, BusCell.Direction direction) {
-            Feeder2WTNode f2WTe = Feeder2WTNode.create(graph, id + "_" + side, id, id, side, getVoltageLevelInfosFromId(otherVlId));
+            Feeder2WTNode f2WTe = Feeder2WTNode.create(voltageLevelGraph, id + "_" + side, id, id, side, getVoltageLevelInfosFromId(otherVlId));
             commonFeederSetting(f2WTe, id, order, direction);
             return f2WTe;
         }
 
         public Feeder2WTLegNode createFeeder2wtLegNode(String id, FeederWithSideNode.Side side,
                                                        int order, BusCell.Direction direction) {
-            Feeder2WTLegNode f2WTe = Feeder2WTLegNode.create(graph, id + "_" + side, id, id, side);
+            Feeder2WTLegNode f2WTe = Feeder2WTLegNode.create(voltageLevelGraph, id + "_" + side, id, id, side);
             commonFeederSetting(f2WTe, id, order, direction);
             return f2WTe;
         }
 
         public Feeder3WTLegNode createFeeder3wtLegNode(String id, FeederWithSideNode.Side side, int order, BusCell.Direction direction) {
-            Feeder3WTLegNode f3WTe = Feeder3WTLegNode.createForSubstationDiagram(graph, id + "_" + side, id, id, side);
+            Feeder3WTLegNode f3WTe = Feeder3WTLegNode.createForSubstationDiagram(voltageLevelGraph, id + "_" + side, id, id, side);
             commonFeederSetting(f3WTe, id + side.getIntValue(), order, direction);
             return f3WTe;
         }
@@ -191,7 +191,7 @@ public class RawGraphBuilder implements GraphBuilder {
             substationGraph = SubstationGraph.create(id);
         }
 
-        public SubstationGraph getSubstationGraph() {
+        public SubstationGraph getGraph() {
             return substationGraph;
         }
 
@@ -260,7 +260,7 @@ public class RawGraphBuilder implements GraphBuilder {
 
     public SubstationGraph buildSubstationGraph(String id) {
         SubstationBuilder sGraphBuilder = ssBuilders.get(id);
-        SubstationGraph ssGraph = sGraphBuilder.getSubstationGraph();
+        SubstationGraph ssGraph = sGraphBuilder.getGraph();
         sGraphBuilder.voltageLevelBuilders.stream()
             .map(VoltageLevelBuilder::getGraph)
             .sorted(Comparator.comparingDouble(vlGraph -> -vlGraph.getVoltageLevelInfos().getNominalVoltage()))

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractLayout.java
@@ -100,7 +100,7 @@ public abstract class AbstractLayout implements Layout {
                 nbSnakeLinesTopBottom.compute(dNode2, (k, v) -> v + 1);
             }
 
-            VoltageLevelGraph rightestVoltageLevel = node1.getGraph().getX() > node2.getGraph().getX() ? node1.getGraph() : node2.getGraph();
+            VoltageLevelGraph rightestVoltageLevel = node1.getVoltageLevelGraph().getX() > node2.getVoltageLevelGraph().getX() ? node1.getVoltageLevelGraph() : node2.getVoltageLevelGraph();
             double xMaxGraph = rightestVoltageLevel.getX();
             String idMaxGraph = rightestVoltageLevel.getId();
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CellBlockDecomposer.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CellBlockDecomposer.java
@@ -49,7 +49,7 @@ final class CellBlockDecomposer {
     private static void determineBusCellBlocks(BusCell busCell, boolean exceptionIfPatternNotHandled) {
         if (busCell.getType() == Cell.CellType.INTERN && busCell.getNodes().size() == 3) {
             SwitchNode switchNode = (SwitchNode) busCell.getNodes().get(1);
-            busCell.getGraph().extendSwitchBetweenBus(switchNode);
+            busCell.getVoltageLevelGraph().extendSwitchBetweenBus(switchNode);
             List<Node> adj = switchNode.getAdjacentNodes();
             busCell.addNodes(adj);
             busCell.addNodes(adj.stream()

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ForceSubstationLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ForceSubstationLayout.java
@@ -186,7 +186,7 @@ public class ForceSubstationLayout extends AbstractSubstationLayout {
         BusCell.Direction dNode2 = getNodeDirection(node2, 2);
 
         // increment not needed for 3WT for the common node
-        String vl1 = node1.getGraph().getVoltageLevelInfos().getId();
+        String vl1 = node1.getVoltageLevelGraph().getVoltageLevelInfos().getId();
         int nbSnakeLinesH1 = increment
             ? infosNbSnakeLines.incrementAndGetNbSnakeLinesTopBottom(vl1, dNode1)
             : infosNbSnakeLines.getNbSnakeLinesTopBottom(vl1, dNode1);
@@ -205,14 +205,14 @@ public class ForceSubstationLayout extends AbstractSubstationLayout {
                 polyline.add(new Point(x1, ySnakeLine));
             }
         } else {
-            String vl2 = node2.getGraph().getVoltageLevelInfos().getId();
+            String vl2 = node2.getVoltageLevelGraph().getVoltageLevelInfos().getId();
             int nbSnakeLinesH2 = infosNbSnakeLines.incrementAndGetNbSnakeLinesTopBottom(vl2, dNode2);
             double decal2V = Math.max(nbSnakeLinesH2 - 1, 0) * layoutParam.getVerticalSnakeLinePadding();
 
             double ySnakeLine1 = getYSnakeLine(node1, dNode1, decal1V, layoutParam);
             double ySnakeLine2 = getYSnakeLine(node2, dNode2, decal2V, layoutParam);
 
-            VoltageLevelGraph rightestVl = node1.getGraph().getX() > node2.getGraph().getX() ? node1.getGraph() : node2.getGraph();
+            VoltageLevelGraph rightestVl = node1.getVoltageLevelGraph().getX() > node2.getVoltageLevelGraph().getX() ? node1.getVoltageLevelGraph() : node2.getVoltageLevelGraph();
             int nbSnakeLinesV = infosNbSnakeLines.incrementAndGetNbSnakeLinesLeft(rightestVl.getId());
             double decalH = Math.max(nbSnakeLinesV - 1, 0) * layoutParam.getHorizontalSnakeLinePadding();
             double xSnakeLine = rightestVl.getX() - decalH;
@@ -230,7 +230,7 @@ public class ForceSubstationLayout extends AbstractSubstationLayout {
         } else {
             if (compactionType != ForceSubstationLayoutFactory.CompactionType.VERTICAL) {
                 List<String> vls = infosNbSnakeLines.getYSortedVls();
-                int iVl = vls.indexOf(node.getGraph().getId());
+                int iVl = vls.indexOf(node.getVoltageLevelGraph().getId());
                 if (iVl == 0) {
                     return node.getDiagramY() - vlPadding.getTop() - decalV;
                 } else {
@@ -256,8 +256,8 @@ public class ForceSubstationLayout extends AbstractSubstationLayout {
 
     private boolean adjacentGraphs(Node nodeA, Node nodeB) {
         List<String> ySortedVl = infosNbSnakeLines.getYSortedVls();
-        int i1 = ySortedVl.indexOf(nodeA.getGraph().getId());
-        int i2 = ySortedVl.indexOf(nodeB.getGraph().getId());
+        int i1 = ySortedVl.indexOf(nodeA.getVoltageLevelGraph().getId());
+        int i2 = ySortedVl.indexOf(nodeB.getVoltageLevelGraph().getId());
         return i2 - i1 == 1;
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LBSCluster.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LBSCluster.java
@@ -73,7 +73,7 @@ public class LBSCluster {
         }
     }
 
-    VoltageLevelGraph getGraph() {
+    VoltageLevelGraph getVoltageLevelGraph() {
         return horizontalBusLanes.get(0).getBusNodes().get(0).getVoltageLevelGraph();
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LBSCluster.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LBSCluster.java
@@ -74,7 +74,7 @@ public class LBSCluster {
     }
 
     VoltageLevelGraph getGraph() {
-        return horizontalBusLanes.get(0).getBusNodes().get(0).getGraph();
+        return horizontalBusLanes.get(0).getBusNodes().get(0).getVoltageLevelGraph();
     }
 
     public HorizontalBusLane getHorizontalLaneFromSideBus(BusNode busNode, Side side) {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Subsection.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Subsection.java
@@ -82,7 +82,7 @@ public class Subsection {
 
     static List<Subsection> createSubsections(VoltageLevelGraph graph, LBSCluster lbsCluster, boolean handleShunts) {
         List<Subsection> subsections = new ArrayList<>();
-        Optional<VoltageLevelGraph> oVLGraph = lbsCluster.getLbsList().get(0).getBusNodeSet().stream().filter(Objects::nonNull).findAny().map(BusNode::getGraph);
+        Optional<VoltageLevelGraph> oVLGraph = lbsCluster.getLbsList().get(0).getBusNodeSet().stream().filter(Objects::nonNull).findAny().map(BusNode::getVoltageLevelGraph);
         if (!oVLGraph.isPresent()) {
             return subsections;
         }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalSubstationLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/VerticalSubstationLayout.java
@@ -102,10 +102,10 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
     protected List<Point> calculatePolylineSnakeLine(LayoutParameters layoutParam, Node node1, Node node2,
                                                      boolean increment) {
         List<Point> polyline;
-        if (node1.getGraph() == node2.getGraph()) { // in the same VL (so far always horizontal layout)
-            String graphId = node1.getGraph().getId();
+        if (node1.getVoltageLevelGraph() == node2.getVoltageLevelGraph()) { // in the same VL (so far always horizontal layout)
+            String graphId = node1.getVoltageLevelGraph().getId();
 
-            InfosNbSnakeLinesHorizontal infosNbSnakeLinesH = InfosNbSnakeLinesHorizontal.create(node1.getGraph());
+            InfosNbSnakeLinesHorizontal infosNbSnakeLinesH = InfosNbSnakeLinesHorizontal.create(node1.getVoltageLevelGraph());
 
             // Reset the horizontal layout numbers to current graph numbers
             int currentNbBottom = infosNbSnakeLines.getNbSnakeLinesHorizontalBetween(graphId, BusCell.Direction.BOTTOM);
@@ -142,7 +142,7 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
         BusCell.Direction dNode2 = getNodeDirection(node2, 2);
 
         // increment not needed for 3WT for the common node
-        String vl1 = node1.getGraph().getVoltageLevelInfos().getId();
+        String vl1 = node1.getVoltageLevelGraph().getVoltageLevelInfos().getId();
         int nbSnakeLines1 = increment
             ? infosNbSnakeLines.incrementAndGetNbSnakeLinesTopBottom(vl1, dNode1)
             : infosNbSnakeLines.getNbSnakeLinesHorizontalBetween(vl1, dNode1);
@@ -161,7 +161,7 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
                 polyline.add(new Point(x1, ySnakeLine));
             }
         } else {
-            String vl2 = node2.getGraph().getVoltageLevelInfos().getId();
+            String vl2 = node2.getVoltageLevelGraph().getVoltageLevelInfos().getId();
             int nbSnakeLines2 = infosNbSnakeLines.incrementAndGetNbSnakeLinesTopBottom(vl2, dNode2);
             double decal2V = getVerticalShift(layoutParam, dNode2, nbSnakeLines2);
 
@@ -191,7 +191,7 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
 
     private double getXSnakeLine(Node node, Side side, LayoutParameters layoutParam) {
         double shiftLeftRight = Math.max(infosNbSnakeLines.getNbSnakeLinesLeftRight().compute(side, (k, v) -> v + 1) - 1, 0) * layoutParam.getHorizontalSnakeLinePadding();
-        return node.getGraph().getX() - layoutParam.getVoltageLevelPadding().getLeft()
+        return node.getVoltageLevelGraph().getX() - layoutParam.getVoltageLevelPadding().getLeft()
             + (side == Side.LEFT ? -shiftLeftRight : shiftLeftRight + maxVoltageLevelWidth);
     }
 
@@ -200,7 +200,7 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
             return node.getDiagramY() + decalV;
         } else {
             List<VoltageLevelGraph> vls = getGraph().getVoltageLevels();
-            int iVl = vls.indexOf(node.getGraph());
+            int iVl = vls.indexOf(node.getVoltageLevelGraph());
             if (iVl == 0) {
                 return node.getDiagramY() - decalV;
             } else {
@@ -215,7 +215,7 @@ public class VerticalSubstationLayout extends AbstractSubstationLayout {
     private boolean facingNodes(Node node1, Node node2) {
         BusCell.Direction dNode1 = getNodeDirection(node1, 1);
         BusCell.Direction dNode2 = getNodeDirection(node2, 2);
-        return (dNode1 == BusCell.Direction.BOTTOM && dNode2 == BusCell.Direction.TOP && getGraph().graphAdjacents(node1.getGraph(), node2.getGraph()))
-            || (dNode1 == BusCell.Direction.TOP && dNode2 == BusCell.Direction.BOTTOM && getGraph().graphAdjacents(node2.getGraph(), node1.getGraph()));
+        return (dNode1 == BusCell.Direction.BOTTOM && dNode2 == BusCell.Direction.TOP && getGraph().graphAdjacents(node1.getVoltageLevelGraph(), node2.getVoltageLevelGraph()))
+            || (dNode1 == BusCell.Direction.TOP && dNode2 == BusCell.Direction.BOTTOM && getGraph().graphAdjacents(node2.getVoltageLevelGraph(), node1.getVoltageLevelGraph()));
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBlock.java
@@ -196,11 +196,11 @@ public abstract class AbstractBlock implements Block {
         }
         switch (((BusCell) cell).getDirection()) {
             case BOTTOM:
-                return cell.getGraph().getLastBusY(layoutParam) + dyToBus;
+                return cell.getVoltageLevelGraph().getLastBusY(layoutParam) + dyToBus;
             case TOP:
-                return cell.getGraph().getFirstBusY(layoutParam) - dyToBus;
+                return cell.getVoltageLevelGraph().getFirstBusY(layoutParam) - dyToBus;
             case MIDDLE:
-                return cell.getGraph().getFirstBusY(layoutParam) + (getPosition().get(V) - 1) * layoutParam.getVerticalSpaceBus();
+                return cell.getVoltageLevelGraph().getFirstBusY(layoutParam) + (getPosition().get(V) - 1) * layoutParam.getVerticalSpaceBus();
             default:
                 return 0;
         }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBlock.java
@@ -182,7 +182,7 @@ public abstract class AbstractBlock implements Block {
     private double getRootBlockSpan(LayoutParameters layoutParam) {
         // The Y span of root block does not consider the space needed for the FeederPrimaryBlock (feeder span)
         // nor the one needed for the LegPrimaryBlock (layoutParam.getStackHeight())
-        return getGraph().getExternCellHeight(((BusCell) cell).getDirection()) - PositionVoltageLevelLayout.getFeederSpan(layoutParam);
+        return getVoltageLevelGraph().getExternCellHeight(((BusCell) cell).getDirection()) - PositionVoltageLevelLayout.getFeederSpan(layoutParam);
     }
 
     private double getRootYCoord(double spanY, LayoutParameters layoutParam) {
@@ -231,9 +231,9 @@ public abstract class AbstractBlock implements Block {
         }
         generator.writeEndArray();
         generator.writeFieldName("position");
-        position.writeJsonContent(generator, getGraph().isGenerateCoordsInJson());
+        position.writeJsonContent(generator, getVoltageLevelGraph().isGenerateCoordsInJson());
 
-        if (getGraph().isGenerateCoordsInJson()) {
+        if (getVoltageLevelGraph().isGenerateCoordsInJson()) {
             generator.writeFieldName("coord");
             coord.writeJsonContent(generator);
         }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractCell.java
@@ -108,7 +108,7 @@ public abstract class AbstractCell implements Cell {
         return type + " " + nodes;
     }
 
-    public VoltageLevelGraph getGraph() {
+    public VoltageLevelGraph getVoltageLevelGraph() {
         return graph;
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractComposedBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractComposedBlock.java
@@ -32,8 +32,8 @@ public abstract class AbstractComposedBlock extends AbstractBlock implements Com
     }
 
     @Override
-    public VoltageLevelGraph getGraph() {
-        return subBlocks.get(0).getGraph();
+    public VoltageLevelGraph getVoltageLevelGraph() {
+        return subBlocks.get(0).getVoltageLevelGraph();
     }
 
     public List<Block> getSubBlocks() {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractPrimaryBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractPrimaryBlock.java
@@ -60,7 +60,7 @@ public abstract class AbstractPrimaryBlock extends AbstractBlock implements Prim
 
     @Override
     public VoltageLevelGraph getGraph() {
-        return nodes.get(0).getGraph();
+        return nodes.get(0).getVoltageLevelGraph();
     }
 
     @Override

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractPrimaryBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractPrimaryBlock.java
@@ -59,7 +59,7 @@ public abstract class AbstractPrimaryBlock extends AbstractBlock implements Prim
     }
 
     @Override
-    public VoltageLevelGraph getGraph() {
+    public VoltageLevelGraph getVoltageLevelGraph() {
         return nodes.get(0).getVoltageLevelGraph();
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Block.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Block.java
@@ -41,7 +41,7 @@ public interface Block {
         START, END;
     }
 
-    VoltageLevelGraph getGraph();
+    VoltageLevelGraph getVoltageLevelGraph();
 
     Node getExtremityNode(Extremity extremity);
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/BusNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/BusNode.java
@@ -48,7 +48,7 @@ public class BusNode extends Node {
         double elementaryWidth = layoutParameters.getCellWidth() / 2;
         double busPadding = layoutParameters.getBusPadding();
         setCoordinates(position.get(H) * elementaryWidth + busPadding,
-            getGraph().getFirstBusY(layoutParameters) + position.get(V) * layoutParameters.getVerticalSpaceBus());
+            getVoltageLevelGraph().getFirstBusY(layoutParameters) + position.get(V) * layoutParameters.getVerticalSpaceBus());
         setPxWidth(position.getSpan(H) * elementaryWidth - 2 * busPadding);
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Cell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Cell.java
@@ -59,5 +59,5 @@ public interface Cell {
 
     String getFullId();
 
-    VoltageLevelGraph getGraph();
+    VoltageLevelGraph getVoltageLevelGraph();
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/LegPrimaryBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/LegPrimaryBlock.java
@@ -113,8 +113,8 @@ public class LegPrimaryBlock extends AbstractPrimaryBlock implements LegBlock {
         getLegNode().setX(getCoord().get(X));
         if (getCell().getType() == INTERN && ((InternCell) getCell()).checkisShape(UNILEG)) {
             getLegNode().setY(getOrientation() == UP
-                ? getGraph().getFirstBusY(layoutParam) - layoutParam.getInternCellHeight()
-                : getGraph().getLastBusY(layoutParam) + layoutParam.getInternCellHeight());
+                ? getVoltageLevelGraph().getFirstBusY(layoutParam) - layoutParam.getInternCellHeight()
+                : getVoltageLevelGraph().getLastBusY(layoutParam) + layoutParam.getInternCellHeight());
         }
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Node.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/Node.java
@@ -88,7 +88,7 @@ public class Node implements BaseNode {
         this.cell = cell;
     }
 
-    public VoltageLevelGraph getGraph() {
+    public VoltageLevelGraph getVoltageLevelGraph() {
         return graph;
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/ShuntCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/ShuntCell.java
@@ -27,7 +27,7 @@ public final class ShuntCell extends AbstractCell {
     }
 
     public static ShuntCell create(ExternCell cell1, ExternCell cell2, List<Node> nodes) {
-        ShuntCell shuntCell = new ShuntCell(cell1.getGraph());
+        ShuntCell shuntCell = new ShuntCell(cell1.getVoltageLevelGraph());
         if (cell1.getNodes().contains(nodes.get(0)) && cell2.getNodes().contains(nodes.get(nodes.size() - 1))) {
             shuntCell.cells.put(Side.LEFT, cell1);
             shuntCell.cells.put(Side.RIGHT, cell2);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/SubstationGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/SubstationGraph.java
@@ -101,11 +101,11 @@ public class SubstationGraph extends AbstractBaseGraph {
             // edges are added between its adjacent nodes
             List<Node> adjacentNodes = multiNode.getAdjacentNodes();
 
-            graph.addEdge(adjacentNodes.get(0).getGraph(), adjacentNodes.get(1).getGraph());
+            graph.addEdge(adjacentNodes.get(0).getVoltageLevelGraph(), adjacentNodes.get(1).getVoltageLevelGraph());
 
             if (adjacentNodes.size() == 3) {
-                graph.addEdge(adjacentNodes.get(0).getGraph(), adjacentNodes.get(2).getGraph());
-                graph.addEdge(adjacentNodes.get(1).getGraph(), adjacentNodes.get(2).getGraph());
+                graph.addEdge(adjacentNodes.get(0).getVoltageLevelGraph(), adjacentNodes.get(2).getVoltageLevelGraph());
+                graph.addEdge(adjacentNodes.get(1).getVoltageLevelGraph(), adjacentNodes.get(2).getVoltageLevelGraph());
             }
         }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramLabelProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultDiagramLabelProvider.java
@@ -147,7 +147,7 @@ public class DefaultDiagramLabelProvider implements DiagramLabelProvider {
                 default:
                     break;
             }
-        } else if (node instanceof Middle3WTNode && node.getGraph() != null) {
+        } else if (node instanceof Middle3WTNode && node.getVoltageLevelGraph() != null) {
             addBranchStatusDecorator(nodeDecorators, node, network.getThreeWindingsTransformer(node.getEquipmentId()));
         }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -1035,8 +1035,8 @@ public class DefaultSVGWriter implements SVGWriter {
         Node n1 = edge.getNode1();
         Node n2 = edge.getNode2();
 
-        VoltageLevelGraph g1 = n1.getGraph();
-        VoltageLevelGraph g2 = n2.getGraph();
+        VoltageLevelGraph g1 = n1.getVoltageLevelGraph();
+        VoltageLevelGraph g2 = n2.getVoltageLevelGraph();
 
         int n = pol.size();
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/AbstractBaseVoltageDiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/AbstractBaseVoltageDiagramStyleProvider.java
@@ -48,7 +48,7 @@ public abstract class AbstractBaseVoltageDiagramStyleProvider extends BasicStyle
     public List<String> getSvgNodeStyles(Node node, ComponentLibrary componentLibrary, boolean showInternalNodes) {
         List<String> styles = super.getSvgNodeStyles(node, componentLibrary, showInternalNodes);
 
-        VoltageLevelGraph g = node.getGraph();
+        VoltageLevelGraph g = node.getVoltageLevelGraph();
         if (g != null) {  // node inside a voltageLevel graph
             // Middle3WTNode and Feeder2WTNode have style depending on their subcomponents -> see getSvgNodeSubcomponentStyles
             if (!(node instanceof Middle3WTNode) && !(node instanceof Feeder2WTNode)) {
@@ -80,7 +80,7 @@ public abstract class AbstractBaseVoltageDiagramStyleProvider extends BasicStyle
                     otherSide = side == FeederWithSideNode.Side.ONE ? FeederWithSideNode.Side.TWO : FeederWithSideNode.Side.ONE;
                 }
             } else if (n.getFeederType() == FeederType.THREE_WINDINGS_TRANSFORMER_LEG) {
-                String idVl = n.getGraph().getVoltageLevelInfos().getId();
+                String idVl = n.getVoltageLevelGraph().getVoltageLevelInfos().getId();
                 ThreeWindingsTransformer transformer = network.getThreeWindingsTransformer(n.getEquipmentId());
                 if (transformer != null) {
                     if (transformer.getTerminal(ThreeWindingsTransformer.Side.ONE).getVoltageLevel().getId().equals(idVl)) {
@@ -131,7 +131,7 @@ public abstract class AbstractBaseVoltageDiagramStyleProvider extends BasicStyle
 
         List<String> styles = new ArrayList<>();
 
-        VoltageLevelGraph g = node.getGraph();
+        VoltageLevelGraph g = node.getVoltageLevelGraph();
         if (g != null) {
             // node inside a voltageLevel graph
             VoltageLevelInfos vlInfo = null;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Refactor


**What is the current behavior?** 
Graph keyword is often used for VoltageLevelGraph (whose old name was Graph), making it ambiguous when calling getGraph



**What is the new behavior (if this is a feature change)?**
Graph keyword is used for Graph interface, VoltageLevelGraph keyword used instead when ambiguous


**Does this PR introduce a breaking change or deprecate an API?** **Yes**
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
