### PR TITLE
Fix insert fict node

### DIFF
--- a/single-line-diagram-core/src/main/resources/ConvergenceLibrary/vsc.svg
+++ b/single-line-diagram-core/src/main/resources/ConvergenceLibrary/vsc.svg
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" id="svg53" height="12" width="12" version="1.0">
-  <text transform="matrix(0.71088144,0.00488841,-0.01073887,1.4066305,0,0)" id="text64" y="6.6008096" x="-5.2795143">
-      <tspan y="6.6008096" x="-5.2795143" id="tspan1256">AC / DC </tspan>
-      <tspan y="15.890142" x="-5.2795143" id="tspan1258"/>
-  </text>
+<svg xmlns="http://www.w3.org/2000/svg" height="12" width="12" version="1.0">
+    <text x="-5.3" y="6.6">AC / DC</text>
 </svg>

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -115,7 +115,7 @@ public abstract class AbstractTestCase {
         }
     }
 
-    public abstract void toSVG(Graph g, String filename);
+    public abstract String toSVG(Graph g, String filename);
 
     /**
      * Between Java 9 and 14 an extra new lines is added before and after CDATA element. To support both Java 11 and 17

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
@@ -37,8 +37,8 @@ public abstract class AbstractTestCaseIidm extends AbstractTestCase {
     protected GraphBuilder graphBuilder;
 
     @Override
-    public void toSVG(Graph g, String filename) {
-        toSVG(g, filename, getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider());
+    public String toSVG(Graph g, String filename) {
+        return toSVG(g, filename, getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider());
     }
 
     protected DiagramLabelProvider getDefaultDiagramLabelProvider() {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/AbstractTestCaseRaw.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/AbstractTestCaseRaw.java
@@ -29,8 +29,8 @@ public abstract class AbstractTestCaseRaw extends AbstractTestCase {
     }
 
     @Override
-    public void toSVG(Graph graph, String filename) {
-        toSVG(graph, filename, getRawLabelProvider(graph), new BasicStyleProvider());
+    public String toSVG(Graph graph, String filename) {
+        return toSVG(graph, filename, getRawLabelProvider(graph), new BasicStyleProvider());
     }
 
     private static class RawDiagramLabelProvider implements DiagramLabelProvider {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/FeederInfoProviderTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/FeederInfoProviderTest.java
@@ -102,7 +102,7 @@ public class FeederInfoProviderTest extends AbstractTestCaseIidm {
         layoutParameters.setFeederArrowSymmetry(true);
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId(), true);
         new SmartVoltageLevelLayoutFactory(network).create(g).run(layoutParameters); // to have cell orientations (bottom / up)
-        toSVG(g, "test.svg");
+        assertEquals(toString("/feederInfoTest.svg"), toSVG(g, "/feederInfoTest.svg"));
 
         Network network2 = Network.create("testCase2", "test2");
         DefaultDiagramLabelProvider wrongLabelProvider = new DefaultDiagramLabelProvider(network2, componentLibrary, layoutParameters);

--- a/single-line-diagram-core/src/test/resources/feederInfoTest.svg
+++ b/single-line-diagram-core/src/test/resources/feederInfoTest.svg
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg height="720.0" viewBox="0 0 280.0 720.0" width="280.0" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+/* ----------------------------------------------------------------------- */
+/* File: tautologies.css ------------------------------------------------- */
+.sld-out .sld-arrow-in {visibility: hidden}
+.sld-in .sld-arrow-out {visibility: hidden}
+.sld-closed .sld-sw-open {visibility: hidden}
+.sld-open .sld-sw-closed {visibility: hidden}
+.sld-hidden-node {visibility: hidden}
+.sld-top-feeder .sld-label {dominant-baseline: auto}
+.sld-bottom-feeder .sld-label {dominant-baseline: hanging}
+.sld-arrow-p .sld-label {dominant-baseline: middle}
+.sld-arrow-q .sld-label {dominant-baseline: middle}
+/* ----------------------------------------------------------------------- */
+/* File : components.css ------------------------------------------------- */
+/* Stroke black */
+.sld-disconnector {stroke-width: 3; stroke: black; fill: none}
+/* Stroke blue */
+.sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+/* Stroke --sld-vl-color with fallback black */
+.sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
+.sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
+/* Stroke --sld-vl-color with fallback red */
+.sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
+/* Stroke --sld-vl-color with fallback blue */
+.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-load {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-three-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-winding {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-capacitor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-inductor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst-arrow {stroke: black; fill: none}
+.sld-svc {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-vsc {stroke: var(--sld-vl-color, blue); font-size: 7.43px; fill: none}
+/* Stroke none & fill: --sld-vl-color */
+.sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
+/* Stroke none & fill: black */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
+.sld-node {stroke: none; fill: black}
+.sld-flash {stroke: none; fill: black}
+.sld-lock {stroke: none; fill: black}
+/* Specific */
+.sld-grid {stroke: #003700; stroke-dasharray: 1,10}
+.sld-arrow-p {fill:black}
+.sld-arrow-q {fill:blue}
+.sld-frame {fill: var(--sld-background-color, transparent)}
+
+]]></style>
+    <rect class="sld-frame" height="100%" width="100%"/>
+    <g>
+        <g class="sld-grid" id="GRID_vl">
+            <line x1="40.0" x2="40.0" y1="80.0" y2="640.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="640.0"/>
+            <line x1="140.0" x2="140.0" y1="80.0" y2="640.0"/>
+            <line x1="190.0" x2="190.0" y1="80.0" y2="640.0"/>
+            <line x1="240.0" x2="240.0" y1="80.0" y2="640.0"/>
+            <line x1="40.0" x2="240.0" y1="330.0" y2="330.0"/>
+            <line x1="40.0" x2="240.0" y1="390.0" y2="390.0"/>
+            <line x1="40.0" x2="240.0" y1="320.0" y2="320.0"/>
+            <line x1="40.0" x2="240.0" y1="400.0" y2="400.0"/>
+        </g>
+        <g class="sld-busbar-section" id="idbbs" transform="translate(152.5,360.0)">
+            <line x1="0" x2="75.0" y1="0" y2="0"/>
+            <text class="sld-label" id="bbs_NW_LABEL" x="-5.0" y="-5.0">bbs</text>
+        </g>
+        <g class="sld-busbar-section" id="idbbs2" transform="translate(52.5,360.0)">
+            <line x1="0" x2="75.0" y1="0" y2="0"/>
+            <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
+        </g>
+        <g class="cell idEXTERN_32_0" id="idEXTERN_32_0">
+            <g class="sld-node" id="idINTERNAL_95_vl_95_vsc_95_1" transform="translate(186.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node" id="idINTERNAL_95_vl_95_svc" transform="translate(211.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-svc sld-top-feeder" id="idsvc" transform="translate(209.0,74.0)">
+                <path d="M 6,0 V 4.5 M 0,4.5 H 12 M 0,7.5 H 12 M 6,7.5 V 12"/>
+                <path d="M 0.2556,10.611 11.671,1.448 M 9.329,2.045 11.671,1.448 10.581,3.6046" style="fill:none;stroke:#0000ff;stroke-width:0.5;stroke-linejoin:miter"/>
+                <text class="sld-label" id="svc_N_LABEL" x="-5.0" y="-5.0">svc</text>
+            </g>
+            <g class="sld-node" id="idINTERNAL_95_vl_95_vsc_95_2" transform="translate(161.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-vsc sld-top-feeder" id="idvsc" transform="translate(157.0,76.0)">
+                <text id="idvsc_text64" transform="matrix(0.71088144,0.00488841,-0.01073887,1.4066305,0,0)" x="-5.2795143" y="6.6008096">
+
+                    <tspan id="tspan1256" x="-5.2795143" y="6.6008096">AC / DC </tspan>
+
+                    <tspan id="tspan1258" x="-5.2795143" y="15.890142"/>
+
+                </text>
+                <text class="sld-label" id="vsc_N_LABEL" x="-5.0" y="-5.0">Converter1</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_bbs_95_d">
+                <polyline points="165.0,360.0,190.0,360.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_vsc_95_1">
+                <polyline points="190.0,360.0,190.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_vsc_95_1">
+                <polyline points="215.0,246.0,215.0,330.0,190.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_1_95_INTERNAL_95_vl_95_vsc_95_2">
+                <polyline points="190.0,330.0,165.0,330.0,165.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_svc">
+                <polyline points="215.0,226.0,215.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_svc_95_svc">
+                <polyline points="215.0,142.0,215.0,86.0"/>
+            </g>
+            <g class="sld-arrow-p sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(210.0,99.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">100</text>
+            </g>
+            <g class="sld-arrow-q sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(210.0,119.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">50</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_2_95_vsc">
+                <polyline points="165.0,142.0,165.0,86.0"/>
+            </g>
+            <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(160.0,99.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">100</text>
+            </g>
+            <g class="sld-arrow-q sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(160.0,119.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">50</text>
+            </g>
+            <g class="sld-disconnector sld-closed" id="idd" transform="translate(186.0,356.0)">
+                <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
+                <path class="sld-sw-open" d="M8,0 0,8"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idb" transform="translate(205.0,226.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_1" id="idEXTERN_32_1">
+            <g class="sld-node" id="idINTERNAL_95_vl_95_b2" transform="translate(61.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node" id="idINTERNAL_95_vl_95_C1" transform="translate(61.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-capacitor sld-top-feeder" id="idC1" transform="translate(59.0,74.0)">
+                <line x1="6" x2="6" y1="0" y2="4.5"/>
+                <line x1="0" x2="12" y1="4.5" y2="4.5"/>
+                <line x1="0" x2="12" y1="7.5" y2="7.5"/>
+                <line x1="6" x2="6" y1="7.5" y2="12"/>
+                <text class="sld-label" id="C1_N_LABEL" x="-5.0" y="-5.0">Filter 1</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_bbs2_95_BUSCO_95_b2">
+                <polyline points="65.0,360.0,65.0,360.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_b2_95_INTERNAL_95_vl_95_b2">
+                <polyline points="65.0,356.0,65.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_b2_95_b2">
+                <polyline points="65.0,330.0,65.0,246.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b2_95_INTERNAL_95_vl_95_C1">
+                <polyline points="65.0,226.0,65.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_C1_95_C1">
+                <polyline points="65.0,142.0,65.0,86.0"/>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idC1_ARROW_ACTIVE" transform="translate(60.0,99.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idC1_ARROW_REACTIVE" transform="translate(60.0,119.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-bus-connection" id="idBUSCO_95_b2" transform="translate(61.0,356.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idb2" transform="translate(55.0,226.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_2" id="idEXTERN_32_2">
+            <g class="sld-node" id="idINTERNAL_95_vl_95_b3" transform="translate(111.0,386.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node" id="idINTERNAL_95_vl_95_dl1" transform="translate(111.0,574.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-bottom-feeder" id="iddl1" transform="translate(115.0,640.0)">
+                <text class="sld-label" id="dl1_S_LABEL" x="-5.0" y="5.0">Dangling line 1</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_bbs2_95_BUSCO_95_b3">
+                <polyline points="115.0,360.0,115.0,360.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_b3_95_INTERNAL_95_vl_95_b3">
+                <polyline points="115.0,364.0,115.0,390.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_b3_95_b3">
+                <polyline points="115.0,390.0,115.0,474.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b3_95_INTERNAL_95_vl_95_dl1">
+                <polyline points="115.0,494.0,115.0,578.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_dl1_95_dl1">
+                <polyline points="115.0,578.0,115.0,640.0"/>
+            </g>
+            <g class="sld-arrow-p sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,615.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">100</text>
+            </g>
+            <g class="sld-arrow-q sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,595.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">50</text>
+            </g>
+            <g class="sld-bus-connection" id="idBUSCO_95_b3" transform="translate(111.0,356.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idb3" transform="translate(105.0,474.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/single-line-diagram-core/src/test/resources/feederInfoTest.svg
+++ b/single-line-diagram-core/src/test/resources/feederInfoTest.svg
@@ -88,13 +88,7 @@
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-vsc sld-top-feeder" id="idvsc" transform="translate(157.0,76.0)">
-                <text id="idvsc_text64" transform="matrix(0.71088144,0.00488841,-0.01073887,1.4066305,0,0)" x="-5.2795143" y="6.6008096">
-
-                    <tspan id="tspan1256" x="-5.2795143" y="6.6008096">AC / DC </tspan>
-
-                    <tspan id="tspan1258" x="-5.2795143" y="15.890142"/>
-
-                </text>
+                <text x="-5.3" y="6.6">AC / DC</text>
                 <text class="sld-label" id="vsc_N_LABEL" x="-5.0" y="-5.0">Converter1</text>
             </g>
             <g class="sld-wire" id="_95_vl_95_bbs_95_d">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** 
Bug fix



**What is the current behavior?**
When a feeder node is connected to a bus node / to a disconnector on a bus node BUT also to something else, only one internal node is added instead of two, leading to a erroneous diagram.



**What is the new behavior (if this is a feature change)?**
When a feeder node is connected to a bus node / to a disconnector on a bus node and also to something else, two internal nodes are added to have the usual structure `LegPrimaryBlock + BodyPrimaryBlock + FeederPrimaryBlock` (to be more precise the structure is in fact `LegPrimaryBlock + BodyParallelBlock(BodyPrimaryBlock + FeederPrimaryBlock, BodyPrimaryBlock + FeederPrimaryBlock)`)



**Does this PR introduce a breaking change or deprecate an API?**
No