### PR TITLE
Fix NPE when element ID does not exist

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagram.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagram.java
@@ -74,6 +74,9 @@ public final class SingleLineDiagram {
         Objects.requireNonNull(id);
 
         Identifiable<?> identifiable = network.getIdentifiable(id);
+        if (identifiable == null) {
+            throw new PowsyblException("Network element '" + id + "' not found");
+        }
         if (identifiable.getType() == VOLTAGE_LEVEL) {
             drawVoltageLevel(network, id, svgFile, layoutParameters, componentLibrary, vLayoutFactory, initProvider, styleProvider, prefixId);
         } else if (identifiable.getType() == SUBSTATION) {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSingleLineDiagramClass.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSingleLineDiagramClass.java
@@ -132,6 +132,13 @@ public class TestSingleLineDiagramClass extends AbstractTestCaseIidm {
         assertEquals("Given id 'bbs2' is not a substation or voltage level id in given network 'TestSingleLineDiagramClass'", e2.getMessage());
     }
 
+    @Test
+    public void IdNotFoundTest() {
+        Path svgPath = tmpDir.resolve("result.svg");
+        PowsyblException exception = assertThrows(PowsyblException.class, () -> SingleLineDiagram.draw(network, "foo", svgPath));
+        assertEquals("Network element 'foo' not found", exception.getMessage());
+    }
+
     private String toDefaultSVG(Network network, String id, String filename, String jsonFilename) {
         try (StringWriter writer = new StringWriter();
              StringWriter metadataWriter = new StringWriter()) {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSingleLineDiagramClass.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSingleLineDiagramClass.java
@@ -133,7 +133,7 @@ public class TestSingleLineDiagramClass extends AbstractTestCaseIidm {
     }
 
     @Test
-    public void IdNotFoundTest() {
+    public void testIdNotFound() {
         Path svgPath = tmpDir.resolve("result.svg");
         PowsyblException exception = assertThrows(PowsyblException.class, () -> SingleLineDiagram.draw(network, "foo", svgPath));
         assertEquals("Network element 'foo' not found", exception.getMessage());


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
A NullPointerException is thrown when the ID is not a valid network element.


**What is the new behavior (if this is a feature change)?**
A proper exception is thrown to explain that no element with such ID has been found


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
