### PR TITLE
Replace feederNodeId by equipmentId + side in GraphMetadata

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -834,10 +834,11 @@ public class DefaultSVGWriter implements SVGWriter {
             points.add(new Point(feederNode.getDiagramCoordinates()));
         }
 
+        String side = feederNode instanceof FeederWithSideNode ? ((FeederWithSideNode) feederNode).getSide().name() : null;
         double shiftFeederInfo = 0;
         for (FeederInfo feederInfo : initProvider.getFeederInfos(feederNode)) {
             if (!feederInfo.isEmpty()) {
-                drawFeederInfo(prefixId, feederNode.getId(), points, root, feederInfo, shiftFeederInfo, metadata);
+                drawFeederInfo(prefixId, feederNode.getId(), feederNode.getEquipmentId(), side, points, root, feederInfo, shiftFeederInfo, metadata);
                 addInfoComponentMetadata(metadata, feederInfo.getComponentType(), true);
             }
             // Compute shifting even if not displayed to ensure aligned feeder info
@@ -856,7 +857,7 @@ public class DefaultSVGWriter implements SVGWriter {
         }
     }
 
-    private void drawFeederInfo(String prefixId, String feederNodeId, List<Point> points, Element root,
+    private void drawFeederInfo(String prefixId, String feederNodeId, String equipmentId, String side, List<Point> points, Element root,
                                  FeederInfo feederInfo, double shift, GraphMetadata metadata) {
 
         Element g = root.getOwnerDocument().createElement(GROUP);
@@ -873,7 +874,7 @@ public class DefaultSVGWriter implements SVGWriter {
         String svgId = escapeId(feederNodeId) + "_" + feederInfo.getComponentType();
         g.setAttribute("id", svgId);
 
-        metadata.addFeederInfoMetadata(new FeederInfoMetadata(svgId, feederNodeId, feederInfo.getUserDefinedId()));
+        metadata.addFeederInfoMetadata(new FeederInfoMetadata(svgId, equipmentId, side, feederInfo.getUserDefinedId()));
 
         // we draw the feeder info only if direction is present
         feederInfo.getDirection().ifPresent(direction -> {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -834,11 +834,10 @@ public class DefaultSVGWriter implements SVGWriter {
             points.add(new Point(feederNode.getDiagramCoordinates()));
         }
 
-        String side = feederNode instanceof FeederWithSideNode ? ((FeederWithSideNode) feederNode).getSide().name() : null;
         double shiftFeederInfo = 0;
         for (FeederInfo feederInfo : initProvider.getFeederInfos(feederNode)) {
             if (!feederInfo.isEmpty()) {
-                drawFeederInfo(prefixId, feederNode.getId(), feederNode.getEquipmentId(), side, points, root, feederInfo, shiftFeederInfo, metadata);
+                drawFeederInfo(prefixId, feederNode, points, root, feederInfo, shiftFeederInfo, metadata);
                 addInfoComponentMetadata(metadata, feederInfo.getComponentType(), true);
             }
             // Compute shifting even if not displayed to ensure aligned feeder info
@@ -857,7 +856,7 @@ public class DefaultSVGWriter implements SVGWriter {
         }
     }
 
-    private void drawFeederInfo(String prefixId, String feederNodeId, String equipmentId, String side, List<Point> points, Element root,
+    private void drawFeederInfo(String prefixId, FeederNode feederNode, List<Point> points, Element root,
                                  FeederInfo feederInfo, double shift, GraphMetadata metadata) {
 
         Element g = root.getOwnerDocument().createElement(GROUP);
@@ -871,10 +870,11 @@ public class DefaultSVGWriter implements SVGWriter {
 
         transformFeederInfo(points, size, shift, g);
 
-        String svgId = escapeId(feederNodeId) + "_" + feederInfo.getComponentType();
+        String svgId = escapeId(feederNode.getId()) + "_" + feederInfo.getComponentType();
         g.setAttribute("id", svgId);
 
-        metadata.addFeederInfoMetadata(new FeederInfoMetadata(svgId, equipmentId, side, feederInfo.getUserDefinedId()));
+        String side = feederNode instanceof FeederWithSideNode ? ((FeederWithSideNode) feederNode).getSide().name() : null;
+        metadata.addFeederInfoMetadata(new FeederInfoMetadata(svgId, feederNode.getEquipmentId(), side, feederInfo.getUserDefinedId()));
 
         // we draw the feeder info only if direction is present
         feederInfo.getDirection().ifPresent(direction -> {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/GraphMetadata.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/GraphMetadata.java
@@ -231,14 +231,17 @@ public class GraphMetadata {
 
         private final String id;
 
-        private final String feederNodeId;
+        private final String equipmentId;
+
+        private final String side;
 
         private final String userDefinedId;
 
         @JsonCreator
-        public FeederInfoMetadata(@JsonProperty("id") String id, @JsonProperty("feederNodeId") String feederNodeId, @JsonProperty("userDefinedId") String userDefinedId) {
+        public FeederInfoMetadata(@JsonProperty("id") String id, @JsonProperty("equipmentId") String equipmentId, @JsonProperty("side") String side, @JsonProperty("userDefinedId") String userDefinedId) {
             this.id = Objects.requireNonNull(id);
-            this.feederNodeId = Objects.requireNonNull(feederNodeId);
+            this.equipmentId = Objects.requireNonNull(equipmentId);
+            this.side = side;
             this.userDefinedId = userDefinedId;
         }
 
@@ -246,8 +249,12 @@ public class GraphMetadata {
             return id;
         }
 
-        public String getFeederNodeId() {
-            return feederNodeId;
+        public String getEquipmentId() {
+            return equipmentId;
+        }
+
+        public String getSide() {
+            return side;
         }
 
         public String getUserDefinedId() {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/GraphMetadataTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/GraphMetadataTest.java
@@ -65,7 +65,7 @@ public class GraphMetadataTest {
         metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("id1", "vid1", null, BREAKER, null, false, BusCell.Direction.UNDEFINED, false, null, labels));
         metadata.addNodeMetadata(new GraphMetadata.NodeMetadata("id2", "vid2", null, BUSBAR_SECTION, null, false, BusCell.Direction.UNDEFINED, false, null, labels));
         metadata.addWireMetadata(new GraphMetadata.WireMetadata("id3", "id1", "id2", false, false));
-        metadata.addFeederInfoMetadata(new GraphMetadata.FeederInfoMetadata("id1", "id3", "user_id"));
+        metadata.addFeederInfoMetadata(new GraphMetadata.FeederInfoMetadata("id1", "id3", "ONE", "user_id"));
         metadata.addElectricalNodeInfoMetadata(new GraphMetadata.ElectricalNodeInfoMetadata("id1", "user_id"));
         metadata.addBusInfoMetadata(new GraphMetadata.BusInfoMetadata("id6", "busNodeId1", "user_id"));
 
@@ -102,7 +102,8 @@ public class GraphMetadataTest {
         assertEquals("id2", metadata2.getWireMetadata("id3").getNodeId2());
         assertFalse(metadata2.getWireMetadata("id3").isStraight());
         assertNotNull(metadata2.getFeederInfoMetadata("id1"));
-        assertEquals("id3", metadata2.getFeederInfoMetadata("id1").getFeederNodeId());
+        assertEquals("id3", metadata2.getFeederInfoMetadata("id1").getEquipmentId());
+        assertEquals("ONE", metadata2.getFeederInfoMetadata("id1").getSide());
         assertEquals("user_id", metadata2.getFeederInfoMetadata("id1").getUserDefinedId());
 
         assertNotNull(metadata2.getElectricalNodeInfoMetadata("id1"));
@@ -142,7 +143,7 @@ public class GraphMetadataTest {
         assertEquals("id1", metadata3.getWireMetadata("id3").getNodeId1());
         assertEquals("id2", metadata3.getWireMetadata("id3").getNodeId2());
         assertFalse(metadata3.getWireMetadata("id3").isStraight());
-        assertEquals("id3", metadata3.getFeederInfoMetadata("id1").getFeederNodeId());
+        assertEquals("id3", metadata3.getFeederInfoMetadata("id1").getEquipmentId());
     }
 
     @Test

--- a/single-line-diagram-core/src/test/resources/TestSldClassSubstationMetadata.json
+++ b/single-line-diagram-core/src/test/resources/TestSldClassSubstationMetadata.json
@@ -508,28 +508,32 @@
   "lines" : [ ],
   "feederInfos" : [ {
     "id" : "idg_ARROW_ACTIVE",
-    "feederNodeId" : "g"
+    "equipmentId" : "g"
   }, {
     "id" : "idtrf_95_TWO_ARROW_ACTIVE",
-    "feederNodeId" : "trf_TWO"
+    "equipmentId" : "trf",
+    "side" : "TWO"
   }, {
     "id" : "idl_ARROW_ACTIVE",
-    "feederNodeId" : "l"
+    "equipmentId" : "l"
   }, {
     "id" : "idl_ARROW_REACTIVE",
-    "feederNodeId" : "l"
+    "equipmentId" : "l"
   }, {
     "id" : "idg_ARROW_REACTIVE",
-    "feederNodeId" : "g"
+    "equipmentId" : "g"
   }, {
     "id" : "idtrf_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf_ONE"
+    "equipmentId" : "trf",
+    "side" : "ONE"
   }, {
     "id" : "idtrf_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf_ONE"
+    "equipmentId" : "trf",
+    "side" : "ONE"
   }, {
     "id" : "idtrf_95_TWO_ARROW_REACTIVE",
-    "feederNodeId" : "trf_TWO"
+    "equipmentId" : "trf",
+    "side" : "TWO"
   } ],
   "electricalNodeInfos" : [ ],
   "busInfos" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestSldClassVlMetadata.json
+++ b/single-line-diagram-core/src/test/resources/TestSldClassVlMetadata.json
@@ -272,16 +272,18 @@
   "lines" : [ ],
   "feederInfos" : [ {
     "id" : "idl_ARROW_ACTIVE",
-    "feederNodeId" : "l"
+    "equipmentId" : "l"
   }, {
     "id" : "idl_ARROW_REACTIVE",
-    "feederNodeId" : "l"
+    "equipmentId" : "l"
   }, {
     "id" : "idtrf_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf_ONE"
+    "equipmentId" : "trf",
+    "side" : "ONE"
   }, {
     "id" : "idtrf_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf_ONE"
+    "equipmentId" : "trf",
+    "side" : "ONE"
   } ],
   "electricalNodeInfos" : [ ],
   "busInfos" : [ ],

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -2817,166 +2817,206 @@
   "lines" : [ ],
   "feederInfos" : [ {
     "id" : "idtrf4_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf4_ONE"
+    "equipmentId" : "trf4",
+    "side" : "ONE"
   }, {
     "id" : "idtrf8_95_TWO_ARROW_ACTIVE",
-    "feederNodeId" : "trf8_TWO"
+    "equipmentId" : "trf8",
+    "side" : "TWO"
   }, {
     "id" : "idload4_ARROW_REACTIVE",
-    "feederNodeId" : "load4"
+    "equipmentId" : "load4"
   }, {
     "id" : "idtrf1_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf1_ONE"
+    "equipmentId" : "trf1",
+    "side" : "ONE"
   }, {
     "id" : "idtrf7_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf7_ONE"
+    "equipmentId" : "trf7",
+    "side" : "ONE"
   }, {
     "id" : "idload4_ARROW_ACTIVE",
-    "feederNodeId" : "load4"
+    "equipmentId" : "load4"
   }, {
     "id" : "idload2_ARROW_ACTIVE",
-    "feederNodeId" : "load2"
+    "equipmentId" : "load2"
   }, {
     "id" : "idtrf3_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf3_ONE"
+    "equipmentId" : "trf3",
+    "side" : "ONE"
   }, {
     "id" : "idgen2_ARROW_REACTIVE",
-    "feederNodeId" : "gen2"
+    "equipmentId" : "gen2"
   }, {
     "id" : "idtrf5_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf5_ONE"
+    "equipmentId" : "trf5",
+    "side" : "ONE"
   }, {
     "id" : "idtrf6_95_TWO_ARROW_REACTIVE",
-    "feederNodeId" : "trf6_TWO"
+    "equipmentId" : "trf6",
+    "side" : "TWO"
   }, {
     "id" : "idtrf6_95_THREE_ARROW_REACTIVE",
-    "feederNodeId" : "trf6_THREE"
+    "equipmentId" : "trf6",
+    "side" : "THREE"
   }, {
     "id" : "idload1_ARROW_REACTIVE",
-    "feederNodeId" : "load1"
+    "equipmentId" : "load1"
   }, {
     "id" : "idtrf7_95_TWO_ARROW_ACTIVE",
-    "feederNodeId" : "trf7_TWO"
+    "equipmentId" : "trf7",
+    "side" : "TWO"
   }, {
     "id" : "idtrf7_95_TWO_ARROW_REACTIVE",
-    "feederNodeId" : "trf7_TWO"
+    "equipmentId" : "trf7",
+    "side" : "TWO"
   }, {
     "id" : "idtrf2_95_TWO_ARROW_ACTIVE",
-    "feederNodeId" : "trf2_TWO"
+    "equipmentId" : "trf2",
+    "side" : "TWO"
   }, {
     "id" : "idgen1_ARROW_ACTIVE",
-    "feederNodeId" : "gen1"
+    "equipmentId" : "gen1"
   }, {
     "id" : "idtrf7_95_THREE_ARROW_REACTIVE",
-    "feederNodeId" : "trf7_THREE"
+    "equipmentId" : "trf7",
+    "side" : "THREE"
   }, {
     "id" : "idtrf6_95_THREE_ARROW_ACTIVE",
-    "feederNodeId" : "trf6_THREE"
+    "equipmentId" : "trf6",
+    "side" : "THREE"
   }, {
     "id" : "idtrf1_95_TWO_ARROW_REACTIVE",
-    "feederNodeId" : "trf1_TWO"
+    "equipmentId" : "trf1",
+    "side" : "TWO"
   }, {
     "id" : "idtrf8_95_TWO_ARROW_REACTIVE",
-    "feederNodeId" : "trf8_TWO"
+    "equipmentId" : "trf8",
+    "side" : "TWO"
   }, {
     "id" : "idtrf1_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf1_ONE"
+    "equipmentId" : "trf1",
+    "side" : "ONE"
   }, {
     "id" : "idgen2_ARROW_ACTIVE",
-    "feederNodeId" : "gen2"
+    "equipmentId" : "gen2"
   }, {
     "id" : "idgen4_ARROW_ACTIVE",
-    "feederNodeId" : "gen4"
+    "equipmentId" : "gen4"
   }, {
     "id" : "idtrf2_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf2_ONE"
+    "equipmentId" : "trf2",
+    "side" : "ONE"
   }, {
     "id" : "idtrf6_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf6_ONE"
+    "equipmentId" : "trf6",
+    "side" : "ONE"
   }, {
     "id" : "idline1_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "line1_ONE"
+    "equipmentId" : "line1",
+    "side" : "ONE"
   }, {
     "id" : "idtrf6_95_TWO_ARROW_ACTIVE",
-    "feederNodeId" : "trf6_TWO"
+    "equipmentId" : "trf6",
+    "side" : "TWO"
   }, {
     "id" : "idtrf1_95_TWO_ARROW_ACTIVE",
-    "feederNodeId" : "trf1_TWO"
+    "equipmentId" : "trf1",
+    "side" : "TWO"
   }, {
     "id" : "idtrf2_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf2_ONE"
+    "equipmentId" : "trf2",
+    "side" : "ONE"
   }, {
     "id" : "idline1_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "line1_ONE"
+    "equipmentId" : "line1",
+    "side" : "ONE"
   }, {
     "id" : "idtrf8_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf8_ONE"
+    "equipmentId" : "trf8",
+    "side" : "ONE"
   }, {
     "id" : "idgen1_ARROW_REACTIVE",
-    "feederNodeId" : "gen1"
+    "equipmentId" : "gen1"
   }, {
     "id" : "idload1_ARROW_ACTIVE",
-    "feederNodeId" : "load1"
+    "equipmentId" : "load1"
   }, {
     "id" : "idtrf5_95_TWO_ARROW_ACTIVE",
-    "feederNodeId" : "trf5_TWO"
+    "equipmentId" : "trf5",
+    "side" : "TWO"
   }, {
     "id" : "idtrf8_95_THREE_ARROW_ACTIVE",
-    "feederNodeId" : "trf8_THREE"
+    "equipmentId" : "trf8",
+    "side" : "THREE"
   }, {
     "id" : "idload3_ARROW_ACTIVE",
-    "feederNodeId" : "load3"
+    "equipmentId" : "load3"
   }, {
     "id" : "idtrf3_95_TWO_ARROW_REACTIVE",
-    "feederNodeId" : "trf3_TWO"
+    "equipmentId" : "trf3",
+    "side" : "TWO"
   }, {
     "id" : "idtrf5_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf5_ONE"
+    "equipmentId" : "trf5",
+    "side" : "ONE"
   }, {
     "id" : "idtrf3_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf3_ONE"
+    "equipmentId" : "trf3",
+    "side" : "ONE"
   }, {
     "id" : "idtrf2_95_TWO_ARROW_REACTIVE",
-    "feederNodeId" : "trf2_TWO"
+    "equipmentId" : "trf2",
+    "side" : "TWO"
   }, {
     "id" : "idtrf7_95_THREE_ARROW_ACTIVE",
-    "feederNodeId" : "trf7_THREE"
+    "equipmentId" : "trf7",
+    "side" : "THREE"
   }, {
     "id" : "idtrf4_95_TWO_ARROW_ACTIVE",
-    "feederNodeId" : "trf4_TWO"
+    "equipmentId" : "trf4",
+    "side" : "TWO"
   }, {
     "id" : "idload2_ARROW_REACTIVE",
-    "feederNodeId" : "load2"
+    "equipmentId" : "load2"
   }, {
     "id" : "idtrf6_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf6_ONE"
+    "equipmentId" : "trf6",
+    "side" : "ONE"
   }, {
     "id" : "idtrf8_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf8_ONE"
+    "equipmentId" : "trf8",
+    "side" : "ONE"
   }, {
     "id" : "idgen4_ARROW_REACTIVE",
-    "feederNodeId" : "gen4"
+    "equipmentId" : "gen4"
   }, {
     "id" : "idtrf5_95_TWO_ARROW_REACTIVE",
-    "feederNodeId" : "trf5_TWO"
+    "equipmentId" : "trf5",
+    "side" : "TWO"
   }, {
     "id" : "idtrf7_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf7_ONE"
+    "equipmentId" : "trf7",
+    "side" : "ONE"
   }, {
     "id" : "idload3_ARROW_REACTIVE",
-    "feederNodeId" : "load3"
+    "equipmentId" : "load3"
   }, {
     "id" : "idtrf4_95_TWO_ARROW_REACTIVE",
-    "feederNodeId" : "trf4_TWO"
+    "equipmentId" : "trf4",
+    "side" : "TWO"
   }, {
     "id" : "idtrf3_95_TWO_ARROW_ACTIVE",
-    "feederNodeId" : "trf3_TWO"
+    "equipmentId" : "trf3",
+    "side" : "TWO"
   }, {
     "id" : "idtrf8_95_THREE_ARROW_REACTIVE",
-    "feederNodeId" : "trf8_THREE"
+    "equipmentId" : "trf8",
+    "side" : "THREE"
   }, {
     "id" : "idtrf4_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf4_ONE"
+    "equipmentId" : "trf4",
+    "side" : "ONE"
   } ],
   "electricalNodeInfos" : [ ],
   "busInfos" : [ ],

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -1362,94 +1362,116 @@
   "lines" : [ ],
   "feederInfos" : [ {
     "id" : "idgen1_ARROW_REACTIVE",
-    "feederNodeId" : "gen1"
+    "equipmentId" : "gen1"
   }, {
     "id" : "idload1_ARROW_ACTIVE",
-    "feederNodeId" : "load1"
+    "equipmentId" : "load1"
   }, {
     "id" : "idtrf8_95_TWO_ARROW_ACTIVE",
-    "feederNodeId" : "trf8_TWO"
+    "equipmentId" : "trf8",
+    "side" : "TWO"
   }, {
     "id" : "idtrf4_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf4_ONE"
+    "equipmentId" : "trf4",
+    "side" : "ONE"
   }, {
     "id" : "idtrf1_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf1_ONE"
+    "equipmentId" : "trf1",
+    "side" : "ONE"
   }, {
     "id" : "idtrf8_95_THREE_ARROW_ACTIVE",
-    "feederNodeId" : "trf8_THREE"
+    "equipmentId" : "trf8",
+    "side" : "THREE"
   }, {
     "id" : "idload2_ARROW_ACTIVE",
-    "feederNodeId" : "load2"
+    "equipmentId" : "load2"
   }, {
     "id" : "idtrf3_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf3_ONE"
+    "equipmentId" : "trf3",
+    "side" : "ONE"
   }, {
     "id" : "idgen2_ARROW_REACTIVE",
-    "feederNodeId" : "gen2"
+    "equipmentId" : "gen2"
   }, {
     "id" : "idtrf5_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf5_ONE"
+    "equipmentId" : "trf5",
+    "side" : "ONE"
   }, {
     "id" : "idtrf6_95_TWO_ARROW_REACTIVE",
-    "feederNodeId" : "trf6_TWO"
+    "equipmentId" : "trf6",
+    "side" : "TWO"
   }, {
     "id" : "idtrf6_95_THREE_ARROW_REACTIVE",
-    "feederNodeId" : "trf6_THREE"
+    "equipmentId" : "trf6",
+    "side" : "THREE"
   }, {
     "id" : "idload1_ARROW_REACTIVE",
-    "feederNodeId" : "load1"
+    "equipmentId" : "load1"
   }, {
     "id" : "idtrf5_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf5_ONE"
+    "equipmentId" : "trf5",
+    "side" : "ONE"
   }, {
     "id" : "idtrf3_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf3_ONE"
+    "equipmentId" : "trf3",
+    "side" : "ONE"
   }, {
     "id" : "idtrf7_95_TWO_ARROW_ACTIVE",
-    "feederNodeId" : "trf7_TWO"
+    "equipmentId" : "trf7",
+    "side" : "TWO"
   }, {
     "id" : "idtrf7_95_TWO_ARROW_REACTIVE",
-    "feederNodeId" : "trf7_TWO"
+    "equipmentId" : "trf7",
+    "side" : "TWO"
   }, {
     "id" : "idtrf7_95_THREE_ARROW_ACTIVE",
-    "feederNodeId" : "trf7_THREE"
+    "equipmentId" : "trf7",
+    "side" : "THREE"
   }, {
     "id" : "idload2_ARROW_REACTIVE",
-    "feederNodeId" : "load2"
+    "equipmentId" : "load2"
   }, {
     "id" : "idgen1_ARROW_ACTIVE",
-    "feederNodeId" : "gen1"
+    "equipmentId" : "gen1"
   }, {
     "id" : "idtrf7_95_THREE_ARROW_REACTIVE",
-    "feederNodeId" : "trf7_THREE"
+    "equipmentId" : "trf7",
+    "side" : "THREE"
   }, {
     "id" : "idtrf6_95_THREE_ARROW_ACTIVE",
-    "feederNodeId" : "trf6_THREE"
+    "equipmentId" : "trf6",
+    "side" : "THREE"
   }, {
     "id" : "idtrf8_95_TWO_ARROW_REACTIVE",
-    "feederNodeId" : "trf8_TWO"
+    "equipmentId" : "trf8",
+    "side" : "TWO"
   }, {
     "id" : "idtrf1_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf1_ONE"
+    "equipmentId" : "trf1",
+    "side" : "ONE"
   }, {
     "id" : "idgen2_ARROW_ACTIVE",
-    "feederNodeId" : "gen2"
+    "equipmentId" : "gen2"
   }, {
     "id" : "idtrf2_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf2_ONE"
+    "equipmentId" : "trf2",
+    "side" : "ONE"
   }, {
     "id" : "idtrf6_95_TWO_ARROW_ACTIVE",
-    "feederNodeId" : "trf6_TWO"
+    "equipmentId" : "trf6",
+    "side" : "TWO"
   }, {
     "id" : "idtrf8_95_THREE_ARROW_REACTIVE",
-    "feederNodeId" : "trf8_THREE"
+    "equipmentId" : "trf8",
+    "side" : "THREE"
   }, {
     "id" : "idtrf2_95_ONE_ARROW_REACTIVE",
-    "feederNodeId" : "trf2_ONE"
+    "equipmentId" : "trf2",
+    "side" : "ONE"
   }, {
     "id" : "idtrf4_95_ONE_ARROW_ACTIVE",
-    "feederNodeId" : "trf4_ONE"
+    "equipmentId" : "trf4",
+    "side" : "ONE"
   } ],
   "electricalNodeInfos" : [ {
     "id" : "NODE_vl1_0"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
Fixes #360 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
In metadata, there are 2-3 parameters for each feederInfo:

- the id of the feeder info in the SVG
- the corresponding feeder node id (single-line-diagram internal id)
- the user defined id if non-null


**What is the new behavior (if this is a feature change)?**
In metadata, one should be able to get the equipment id corresponding to the feeder info, but also the side if it is a branch.


**Does this PR introduce a breaking change or deprecate an API?**
No