### PR TITLE
Adding one cell on previous subsection only at right or left side

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockOrganizer.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockOrganizer.java
@@ -9,6 +9,7 @@ package com.powsybl.sld.layout;
 import com.powsybl.sld.layout.positionfromextension.PositionFromExtension;
 import com.powsybl.sld.layout.positionbyclustering.PositionByClustering;
 import com.powsybl.sld.model.*;
+import com.powsybl.sld.model.coordinate.Side;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,7 @@ public class BlockOrganizer {
 
     private final boolean exceptionIfPatternNotHandled;
 
-    private final boolean addCellForBusInfo;
+    private final Map<String, Side> busInfoMap;
 
     public BlockOrganizer() {
         this(new PositionFromExtension(), true);
@@ -53,19 +54,19 @@ public class BlockOrganizer {
     }
 
     public BlockOrganizer(PositionFinder positionFinder, boolean stack, boolean exceptionIfPatternNotHandled) {
-        this(positionFinder, stack, exceptionIfPatternNotHandled, false, false);
+        this(positionFinder, stack, exceptionIfPatternNotHandled, false, Collections.emptyMap());
     }
 
     public BlockOrganizer(PositionFinder positionFinder, boolean stack, boolean exceptionIfPatternNotHandled, boolean handleShunt) {
-        this(positionFinder, stack, exceptionIfPatternNotHandled, handleShunt, false);
+        this(positionFinder, stack, exceptionIfPatternNotHandled, handleShunt, Collections.emptyMap());
     }
 
-    public BlockOrganizer(PositionFinder positionFinder, boolean stack, boolean exceptionIfPatternNotHandled, boolean handleShunt, boolean addCellForBusInfo) {
+    public BlockOrganizer(PositionFinder positionFinder, boolean stack, boolean exceptionIfPatternNotHandled, boolean handleShunt, Map<String, Side> busInfoMap) {
         this.positionFinder = Objects.requireNonNull(positionFinder);
         this.stack = stack;
         this.exceptionIfPatternNotHandled = exceptionIfPatternNotHandled;
         this.handleShunt = handleShunt;
-        this.addCellForBusInfo = addCellForBusInfo;
+        this.busInfoMap = busInfoMap;
     }
 
     /**
@@ -99,7 +100,7 @@ public class BlockOrganizer {
 
         graph.getCells().forEach(Cell::blockSizing);
 
-        new BlockPositionner().determineBlockPositions(graph, subsections, addCellForBusInfo);
+        new BlockPositionner().determineBlockPositions(graph, subsections, busInfoMap);
     }
 
     /**

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockPositionner.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockPositionner.java
@@ -89,7 +89,7 @@ class BlockPositionner {
             BusNode prevBusNode = prevSS.getBusNode(v);
             BusNode actualBusNode = ss.getBusNode(v);
             if (prevBusNode != null && (actualBusNode == null || prevBusNode != actualBusNode)) {
-               busNodesToClose.add(prevBusNode);
+                busNodesToClose.add(prevBusNode);
             }
         }
         return busNodesToClose;

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockPositionner.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockPositionner.java
@@ -8,7 +8,6 @@ package com.powsybl.sld.layout;
 
 import com.powsybl.sld.model.*;
 import com.powsybl.sld.model.BusCell.Direction;
-import com.powsybl.sld.model.coordinate.Position;
 import com.powsybl.sld.model.coordinate.Side;
 
 import java.util.*;
@@ -21,7 +20,7 @@ import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
  */
 class BlockPositionner {
 
-    void determineBlockPositions(VoltageLevelGraph graph, List<Subsection> subsections, boolean addCellForBusInfo) {
+    void determineBlockPositions(VoltageLevelGraph graph, List<Subsection> subsections, Map<String, Side> busInfoMap) {
         int hPos = 0;
         int prevHPos = 0;
         int hSpace = 0;
@@ -37,7 +36,7 @@ class BlockPositionner {
             List<BusNode> busNodesToClose = getBusNodesToClose(prevSs, ss);
             List<BusNode> busNodesToOpen = getBusNodesToOpen(prevSs, ss);
 
-            if (busNodesToClose.stream().anyMatch(busNode -> busInfoMap.get(busNode.getId()) == RIGHT)) {
+            if (busNodesToClose.stream().anyMatch(busNode -> busInfoMap.get(busNode.getId()) == Side.RIGHT)) {
                 // Adding one cell on previous subsection right side
                 hPos += 2; // A cell is 2 units wide
             }
@@ -50,14 +49,8 @@ class BlockPositionner {
                 openBusNode(busNode, hPos);
             }
 
-            if (busNodesToOpen.stream().anyMatch(busNode -> busInfoMap.get(busNode.getId()) == LEFT)) {
+            if (busNodesToOpen.stream().anyMatch(busNode -> busInfoMap.get(busNode.getId()) == Side.LEFT)) {
                 // Adding one cell on current subsection left side
-                hPos += 2; // A cell is 2 units wide
-            }
-
-
-            if (addCellForBusInfo) {
-                // Adding cell on busbar left side
                 hPos += 2; // A cell is 2 units wide
             }
 
@@ -78,7 +71,7 @@ class BlockPositionner {
         }
 
         List<BusNode> busNodesToClose = getBusNodesToClose(prevSs, new Subsection(maxV));
-        if (busNodesToClose.stream().anyMatch(busNode -> busInfoMap.get(busNode.getId()) == RIGHT)) {
+        if (busNodesToClose.stream().anyMatch(busNode -> busInfoMap.get(busNode.getId()) == Side.RIGHT)) {
             // Adding one cell on previous subsection right side
             hPos += 2; // A cell is 2 units wide
         }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactory.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactory.java
@@ -8,7 +8,10 @@ package com.powsybl.sld.layout;
 
 import com.powsybl.sld.layout.positionfromextension.PositionFromExtension;
 import com.powsybl.sld.model.VoltageLevelGraph;
+import com.powsybl.sld.model.coordinate.Side;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -30,7 +33,7 @@ public class PositionVoltageLevelLayoutFactory implements VoltageLevelLayoutFact
 
     private boolean handleShunts = false;
 
-    private boolean addCellForBusInfo = false;
+    private Map<String, Side> busInfoMap = new HashMap<>();
 
     public PositionVoltageLevelLayoutFactory() {
         this(new PositionFromExtension());
@@ -85,12 +88,12 @@ public class PositionVoltageLevelLayoutFactory implements VoltageLevelLayoutFact
         return this;
     }
 
-    public boolean isAddCellForBusInfo() {
-        return addCellForBusInfo;
+    public Map<String, Side> getBusInfoMap() {
+        return busInfoMap;
     }
 
-    public PositionVoltageLevelLayoutFactory setAddCellForBusInfo(boolean addCellForBusInfo) {
-        this.addCellForBusInfo = addCellForBusInfo;
+    public PositionVoltageLevelLayoutFactory setBusInfoMap(Map<String, Side> busInfoMap) {
+        this.busInfoMap = busInfoMap;
         return this;
     }
 
@@ -101,7 +104,7 @@ public class PositionVoltageLevelLayoutFactory implements VoltageLevelLayoutFact
                 .detectCells(graph);
 
         // build blocks from cells
-        new BlockOrganizer(positionFinder, feederStacked, exceptionIfPatternNotHandled, handleShunts, addCellForBusInfo).organize(graph);
+        new BlockOrganizer(positionFinder, feederStacked, exceptionIfPatternNotHandled, handleShunts, busInfoMap).organize(graph);
 
         return new PositionVoltageLevelLayout(graph);
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DiagramLabelProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DiagramLabelProvider.java
@@ -10,9 +10,11 @@ import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.FeederNode;
 import com.powsybl.sld.model.Node;
 import com.powsybl.sld.model.VoltageLevelGraph;
+import com.powsybl.sld.model.coordinate.Side;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -89,5 +91,9 @@ public interface DiagramLabelProvider {
 
     default Optional<BusInfo> getBusInfo(BusNode node) {
         return Optional.empty();
+    }
+
+    default Map<String, Side> getBusInfoSides(VoltageLevelGraph graph) {
+        return Collections.emptyMap();
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DiagramLabelProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DiagramLabelProvider.java
@@ -12,10 +12,7 @@ import com.powsybl.sld.model.Node;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import com.powsybl.sld.model.coordinate.Side;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
@@ -94,6 +91,8 @@ public interface DiagramLabelProvider {
     }
 
     default Map<String, Side> getBusInfoSides(VoltageLevelGraph graph) {
-        return Collections.emptyMap();
+        Map<String, Side> result = new HashMap<>();
+        graph.getNodeBuses().forEach(busNode -> getBusInfo(busNode).ifPresent(busInfo -> result.put(busNode.getId(), busInfo.getAnchor())));
+        return result;
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -36,7 +36,7 @@ public abstract class AbstractTestCase {
     private static final Pattern SVG_FIX_PATTERN = Pattern.compile(">\\s*(<\\!\\[CDATA\\[.*?]]>)\\s*</", Pattern.DOTALL);
 
     protected boolean debugJsonFiles = false;
-    protected boolean debugSvgFiles = true;
+    protected boolean debugSvgFiles = false;
     protected boolean overrideTestReferences = false;
 
     protected final ResourcesComponentLibrary componentLibrary = getResourcesComponentLibrary();

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -36,7 +36,7 @@ public abstract class AbstractTestCase {
     private static final Pattern SVG_FIX_PATTERN = Pattern.compile(">\\s*(<\\!\\[CDATA\\[.*?]]>)\\s*</", Pattern.DOTALL);
 
     protected boolean debugJsonFiles = false;
-    protected boolean debugSvgFiles = false;
+    protected boolean debugSvgFiles = true;
     protected boolean overrideTestReferences = false;
 
     protected final ResourcesComponentLibrary componentLibrary = getResourcesComponentLibrary();

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
@@ -101,18 +101,6 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
                 }
                 return Optional.ofNullable(result);
             }
-
-            @Override
-            public Map<String, Side> getBusInfoSides(VoltageLevelGraph graph) {
-                // BusInfoMap
-                Map<String, Side> busInfoMap = new HashMap<>();
-                busInfoMap.put("bbs21", Side.LEFT);
-                busInfoMap.put("bbs1", Side.RIGHT);
-                busInfoMap.put("bbs13", Side.RIGHT);
-                busInfoMap.put("bbs22", Side.LEFT);
-                busInfoMap.put("bbs23", Side.LEFT);
-                return busInfoMap;
-            }
         };
     }
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
@@ -53,8 +53,6 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
 
     private DiagramLabelProvider withBusInfoProvider;
 
-    private Map<String, Side> busInfoMap;
-
     @Before
     public void setUp() throws IOException {
         int order = 0;
@@ -103,15 +101,19 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
                 }
                 return Optional.ofNullable(result);
             }
-        };
 
-        // BusInfoMap
-        busInfoMap = new HashMap<>();
-        busInfoMap.put("bbs21", Side.LEFT);
-        busInfoMap.put("bbs1", Side.RIGHT);
-        busInfoMap.put("bbs13", Side.RIGHT);
-        busInfoMap.put("bbs22", Side.LEFT);
-        busInfoMap.put("bbs23", Side.LEFT);
+            @Override
+            public Map<String, Side> getBusInfoSides(VoltageLevelGraph graph) {
+                // BusInfoMap
+                Map<String, Side> busInfoMap = new HashMap<>();
+                busInfoMap.put("bbs21", Side.LEFT);
+                busInfoMap.put("bbs1", Side.RIGHT);
+                busInfoMap.put("bbs13", Side.RIGHT);
+                busInfoMap.put("bbs22", Side.LEFT);
+                busInfoMap.put("bbs23", Side.LEFT);
+                return busInfoMap;
+            }
+        };
     }
 
     @Override
@@ -150,7 +152,7 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
 
         // Run layout
         new ImplicitCellDetector().detectCells(g);
-        new BlockOrganizer(new PositionFromExtension(), true, true, true, busInfoMap).organize(g);
+        new BlockOrganizer(new PositionFromExtension(), true, true, true, withBusInfoProvider.getBusInfoSides(g)).organize(g);
         new PositionVoltageLevelLayout(g).run(layoutParameters);
 
         // write SVG and compare to reference

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
@@ -53,6 +53,8 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
 
     private DiagramLabelProvider withBusInfoProvider;
 
+    private Map<String, Side> busInfoMap;
+
     @Before
     public void setUp() throws IOException {
         int order = 0;
@@ -102,6 +104,14 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
                 return Optional.ofNullable(result);
             }
         };
+
+        // BusInfoMap
+        busInfoMap = new HashMap<>();
+        busInfoMap.put("bbs21", Side.LEFT);
+        busInfoMap.put("bbs1", Side.RIGHT);
+        busInfoMap.put("bbs13", Side.RIGHT);
+        busInfoMap.put("bbs22", Side.LEFT);
+        busInfoMap.put("bbs23", Side.LEFT);
     }
 
     @Override
@@ -140,7 +150,7 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
 
         // Run layout
         new ImplicitCellDetector().detectCells(g);
-        new BlockOrganizer(new PositionFromExtension(), true, true, true, true).organize(g);
+        new BlockOrganizer(new PositionFromExtension(), true, true, true, busInfoMap).organize(g);
         new PositionVoltageLevelLayout(g).run(layoutParameters);
 
         // write SVG and compare to reference

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
@@ -51,7 +51,9 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
         }
     }
 
-    private DiagramLabelProvider withBusInfoProvider;
+    private DiagramLabelProvider withFullBusInfoProvider;
+
+    private DiagramLabelProvider withIncompleteBusInfoProvider;
 
     @Before
     public void setUp() throws IOException {
@@ -81,7 +83,7 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
 
         createSwitch(vl, "link", "link", SwitchKind.BREAKER, false, false, false, 5, 9);
 
-        withBusInfoProvider = new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters) {
+        withFullBusInfoProvider = new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters) {
             @Override
             public Optional<BusInfo> getBusInfo(BusNode node) {
                 Objects.requireNonNull(node);
@@ -102,11 +104,36 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
                 return Optional.ofNullable(result);
             }
         };
+
+        withIncompleteBusInfoProvider = new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters) {
+            @Override
+            public Optional<BusInfo> getBusInfo(BusNode node) {
+                Objects.requireNonNull(node);
+                BusInfo result = null;
+                switch (node.getId()) {
+                    case "bbs21":
+                        result = new BusVoltageInfo(false);
+                        break;
+                    case "bbs13":
+                        result = new BusVoltageInfo(true, "Top", null, Side.RIGHT);
+                        break;
+                    case "bbs23":
+                        result = new BusVoltageInfo(false, null, "Bottom", Side.LEFT);
+                        break;
+                }
+                return Optional.ofNullable(result);
+            }
+        };
     }
 
     @Override
     protected ResourcesComponentLibrary getResourcesComponentLibrary() {
         return new ResourcesComponentLibrary("VoltageIndicator", "/ConvergenceLibrary", "/VoltageIndicatorLibrary");
+    }
+
+    @Test
+    public void testWithoutBusInfo() {
+        runTest(new BasicStyleProvider(),  "/TestCase15GraphWithoutVoltageIndicator.svg", new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters));
     }
 
     @Test
@@ -117,7 +144,7 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
                 return Optional.of(((BusVoltageInfo) info).isPowered() ? "sld-powered" : "sld-unpowered");
             }
         };
-        runTest(styleProvider,  "/TestCase15GraphWithVoltageIndicator.svg");
+        runTest(styleProvider,  "/TestCase15GraphWithVoltageIndicator.svg", withIncompleteBusInfoProvider);
     }
 
     @Test
@@ -128,10 +155,10 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
                 return Optional.of(((BusVoltageInfo) info).isPowered() ? "sld-powered" : "sld-unpowered");
             }
         };
-        runTest(styleProvider, "/TestCase15GraphWithVoltageIndicatorTopological.svg");
+        runTest(styleProvider, "/TestCase15GraphWithVoltageIndicatorTopological.svg", withFullBusInfoProvider);
     }
 
-    private void runTest(DiagramStyleProvider styleProvider, String filename) {
+    private void runTest(DiagramStyleProvider styleProvider, String filename, DiagramLabelProvider labelProvider) {
         layoutParameters.setAdaptCellHeightToContent(true)
                 .setBusInfoMargin(5);
 
@@ -140,10 +167,10 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
 
         // Run layout
         new ImplicitCellDetector().detectCells(g);
-        new BlockOrganizer(new PositionFromExtension(), true, true, true, withBusInfoProvider.getBusInfoSides(g)).organize(g);
+        new BlockOrganizer(new PositionFromExtension(), true, true, true, labelProvider.getBusInfoSides(g)).organize(g);
         new PositionVoltageLevelLayout(g).run(layoutParameters);
 
         // write SVG and compare to reference
-        assertEquals(toString(filename), toSVG(g, filename, withBusInfoProvider, styleProvider));
+        assertEquals(toString(filename), toSVG(g, filename, labelProvider, styleProvider));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactoryTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactoryTest.java
@@ -6,7 +6,11 @@
  */
 package com.powsybl.sld.layout;
 
+import com.powsybl.sld.model.coordinate.Side;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -35,8 +39,10 @@ public class PositionVoltageLevelLayoutFactoryTest {
         factory.setHandleShunts(true);
         assertTrue(factory.isHandleShunts());
 
-        assertFalse(factory.isAddCellForBusInfo());
-        factory.setAddCellForBusInfo(true);
-        assertTrue(factory.isAddCellForBusInfo());
+        assertTrue(factory.getBusInfoMap().isEmpty());
+        Map<String, Side> busInfoMap = new HashMap<>();
+        busInfoMap.put("???", Side.LEFT);
+        factory.setBusInfoMap(busInfoMap);
+        assertFalse(factory.getBusInfoMap().isEmpty());
     }
 }

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg height="357.0" viewBox="0 0 580.0 357.0" width="580.0" xmlns="http://www.w3.org/2000/svg">
+<svg height="357.0" viewBox="0 0 530.0 357.0" width="530.0" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 /* ----------------------------------------------------------------------- */
 /* File: tautologies.css ------------------------------------------------- */
@@ -70,29 +70,28 @@
             <line x1="390.0" x2="390.0" y1="80.0" y2="277.0"/>
             <line x1="440.0" x2="440.0" y1="80.0" y2="277.0"/>
             <line x1="490.0" x2="490.0" y1="80.0" y2="277.0"/>
-            <line x1="540.0" x2="540.0" y1="80.0" y2="277.0"/>
-            <line x1="40.0" x2="540.0" y1="222.0" y2="222.0"/>
-            <line x1="40.0" x2="540.0" y1="212.0" y2="212.0"/>
-            <line x1="40.0" x2="540.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="490.0" y1="222.0" y2="222.0"/>
+            <line x1="40.0" x2="490.0" y1="212.0" y2="212.0"/>
+            <line x1="40.0" x2="490.0" y1="142.0" y2="142.0"/>
         </g>
         <g class="sld-busbar-section" id="idbbs1" transform="translate(52.5,252.0)">
-            <line x1="0" x2="275.0" y1="0" y2="0"/>
+            <line x1="0" x2="225.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
-            <g class="sld-voltage-indicator sld-powered" id="idbbs1_VOLTAGE_INDICATOR" transform="translate(250.0,-5.0)">
+            <g class="sld-voltage-indicator sld-powered" id="idbbs1_VOLTAGE_INDICATOR" transform="translate(200.0,-5.0)">
                 <rect class="sld-powered" height="10" rx="1" ry="1" width="20"/>
                 <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
                 <text class="sld-label" x="0.0" y="-5.0">Top</text>
             </g>
         </g>
         <g class="sld-busbar-section" id="idbbs21" transform="translate(52.5,277.0)">
-            <line x1="0" x2="125.0" y1="0" y2="0"/>
+            <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs21_NW_LABEL" x="-5.0" y="-5.0">bbs21</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs21_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
                 <rect class="sld-powered" height="10" rx="1" ry="1" width="20"/>
                 <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
             </g>
         </g>
-        <g class="sld-busbar-section" id="idbbs22" transform="translate(202.5,277.0)">
+        <g class="sld-busbar-section" id="idbbs22" transform="translate(152.5,277.0)">
             <line x1="0" x2="125.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs22_NW_LABEL" x="-5.0" y="-5.0">bbs22</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs22_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
@@ -101,7 +100,7 @@
                 <text class="sld-label" x="0.0" y="15.0">Bottom</text>
             </g>
         </g>
-        <g class="sld-busbar-section" id="idbbs13" transform="translate(352.5,252.0)">
+        <g class="sld-busbar-section" id="idbbs13" transform="translate(302.5,252.0)">
             <line x1="0" x2="175.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs13_NW_LABEL" x="-5.0" y="-5.0">bbs13</text>
             <g class="sld-voltage-indicator sld-powered" id="idbbs13_VOLTAGE_INDICATOR" transform="translate(150.0,-5.0)">
@@ -110,7 +109,7 @@
                 <text class="sld-label" x="0.0" y="-5.0">Top</text>
             </g>
         </g>
-        <g class="sld-busbar-section" id="idbbs23" transform="translate(352.5,277.0)">
+        <g class="sld-busbar-section" id="idbbs23" transform="translate(302.5,277.0)">
             <line x1="0" x2="175.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs23_NW_LABEL" x="-5.0" y="-5.0">bbs23</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs23_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
@@ -171,178 +170,178 @@
             </g>
         </g>
         <g class="cell idEXTERN_32_2" id="idEXTERN_32_2">
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadB" transform="translate(261.0,138.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadB" transform="translate(211.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load sld-top-feeder" id="idloadB" transform="translate(257.0,75.5)">
+            <g class="sld-load sld-top-feeder" id="idloadB" transform="translate(207.0,75.5)">
                 <rect height="9" width="16"/>
                 <line x1="0" x2="16" y1="0" y2="9"/>
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadB_N_LABEL" x="-5.0" y="-5.0">loadB</text>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_5" transform="translate(261.0,218.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="265.0,222.0,265.0,192.0"/>
+                <polyline points="215.0,222.0,215.0,192.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_fB_95_INTERNAL_95_vl1_95_loadB">
-                <polyline points="265.0,172.0,265.0,142.0"/>
+                <polyline points="215.0,172.0,215.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadB_95_loadB">
-                <polyline points="265.0,142.0,265.0,84.5"/>
+                <polyline points="215.0,142.0,215.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadB_ARROW_ACTIVE" transform="translate(260.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadB_ARROW_ACTIVE" transform="translate(210.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadB_ARROW_REACTIVE" transform="translate(260.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadB_ARROW_REACTIVE" transform="translate(210.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="265.0,277.0,265.0,222.0"/>
+                <polyline points="215.0,277.0,215.0,222.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="265.0,252.0,265.0,222.0"/>
+                <polyline points="215.0,252.0,215.0,222.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_4_46_1">
-                <polyline points="265.0,222.0,290.0,222.0,290.0,182.0"/>
+                <polyline points="215.0,222.0,240.0,222.0,240.0,182.0"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idfB" transform="translate(255.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idfB" transform="translate(205.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idb1" transform="translate(261.0,273.0)">
+            <g class="sld-disconnector sld-closed" id="idb1" transform="translate(211.0,273.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idb2" transform="translate(261.0,248.0)">
+            <g class="sld-disconnector sld-closed" id="idb2" transform="translate(211.0,248.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_3" id="idEXTERN_32_3">
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadC" transform="translate(436.0,138.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadC" transform="translate(386.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_c1" transform="translate(461.0,218.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_c1" transform="translate(411.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_c2" transform="translate(411.0,218.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_c2" transform="translate(361.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load sld-top-feeder" id="idloadC" transform="translate(432.0,75.5)">
+            <g class="sld-load sld-top-feeder" id="idloadC" transform="translate(382.0,75.5)">
                 <rect height="9" width="16"/>
                 <line x1="0" x2="16" y1="0" y2="9"/>
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadC_N_LABEL" x="-5.0" y="-5.0">loadC</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="465.0,172.0,465.0,142.0,440.0,142.0"/>
+                <polyline points="415.0,172.0,415.0,142.0,390.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="415.0,172.0,415.0,142.0,440.0,142.0"/>
+                <polyline points="365.0,172.0,365.0,142.0,390.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
-                <polyline points="440.0,142.0,440.0,84.5"/>
+                <polyline points="390.0,142.0,390.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(435.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(385.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(435.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(385.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_INTERNAL_95_vl1_95_Shunt_32_4_46_2">
-                <polyline points="440.0,142.0,390.0,142.0,390.0,182.0"/>
+                <polyline points="390.0,142.0,340.0,142.0,340.0,182.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c1_95_c1">
-                <polyline points="465.0,222.0,465.0,192.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
-                <polyline points="465.0,273.0,465.0,222.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
                 <polyline points="415.0,222.0,415.0,192.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
-                <polyline points="415.0,248.0,415.0,222.0"/>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
+                <polyline points="415.0,273.0,415.0,222.0"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idc1" transform="translate(455.0,172.0)">
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
+                <polyline points="365.0,222.0,365.0,192.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
+                <polyline points="365.0,248.0,365.0,222.0"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idc1" transform="translate(405.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection" id="idBUSCO_95_c1" transform="translate(461.0,273.0)">
+            <g class="sld-bus-connection" id="idBUSCO_95_c1" transform="translate(411.0,273.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idc2" transform="translate(405.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idc2" transform="translate(355.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection" id="idBUSCO_95_c2" transform="translate(411.0,248.0)">
+            <g class="sld-bus-connection" id="idBUSCO_95_c2" transform="translate(361.0,248.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
         </g>
         <g class="cell idSHUNT_32_4" id="idSHUNT_32_4">
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_5" transform="translate(261.0,218.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_Shunt_32_4_46_1" transform="translate(286.0,178.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_Shunt_32_4_46_1" transform="translate(236.0,178.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_Shunt_32_4_46_2" transform="translate(386.0,178.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_Shunt_32_4_46_2" transform="translate(336.0,178.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadC" transform="translate(436.0,138.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadC" transform="translate(386.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="265.0,222.0,265.0,192.0"/>
+                <polyline points="215.0,222.0,215.0,192.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="265.0,277.0,265.0,222.0"/>
+                <polyline points="215.0,277.0,215.0,222.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="265.0,252.0,265.0,222.0"/>
+                <polyline points="215.0,252.0,215.0,222.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_4_46_1">
-                <polyline points="265.0,222.0,290.0,222.0,290.0,182.0"/>
+                <polyline points="215.0,222.0,240.0,222.0,240.0,182.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_4_46_1">
-                <polyline points="330.0,182.0,290.0,182.0"/>
+                <polyline points="280.0,182.0,240.0,182.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_4_46_2">
-                <polyline points="350.0,182.0,390.0,182.0"/>
+                <polyline points="300.0,182.0,340.0,182.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_INTERNAL_95_vl1_95_Shunt_32_4_46_2">
-                <polyline points="440.0,142.0,390.0,142.0,390.0,182.0"/>
+                <polyline points="390.0,142.0,340.0,142.0,340.0,182.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="465.0,172.0,465.0,142.0,440.0,142.0"/>
+                <polyline points="415.0,172.0,415.0,142.0,390.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="415.0,172.0,415.0,142.0,440.0,142.0"/>
+                <polyline points="365.0,172.0,365.0,142.0,390.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
-                <polyline points="440.0,142.0,440.0,84.5"/>
+                <polyline points="390.0,142.0,390.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(435.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(385.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(435.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(385.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-breaker sld-closed" id="idlink" transform="translate(330.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idlink" transform="translate(280.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg height="357.0" viewBox="0 0 580.0 357.0" width="580.0" xmlns="http://www.w3.org/2000/svg">
+<svg height="357.0" viewBox="0 0 530.0 357.0" width="530.0" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 /* ----------------------------------------------------------------------- */
 /* File: tautologies.css ------------------------------------------------- */
@@ -148,29 +148,28 @@
             <line x1="390.0" x2="390.0" y1="80.0" y2="277.0"/>
             <line x1="440.0" x2="440.0" y1="80.0" y2="277.0"/>
             <line x1="490.0" x2="490.0" y1="80.0" y2="277.0"/>
-            <line x1="540.0" x2="540.0" y1="80.0" y2="277.0"/>
-            <line x1="40.0" x2="540.0" y1="222.0" y2="222.0"/>
-            <line x1="40.0" x2="540.0" y1="212.0" y2="212.0"/>
-            <line x1="40.0" x2="540.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="490.0" y1="222.0" y2="222.0"/>
+            <line x1="40.0" x2="490.0" y1="212.0" y2="212.0"/>
+            <line x1="40.0" x2="490.0" y1="142.0" y2="142.0"/>
         </g>
         <g class="sld-busbar-section sld-vl300to500-0" id="idbbs1" transform="translate(52.5,252.0)">
-            <line x1="0" x2="275.0" y1="0" y2="0"/>
+            <line x1="0" x2="225.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
-            <g class="sld-voltage-indicator sld-powered" id="idbbs1_VOLTAGE_INDICATOR" transform="translate(250.0,-5.0)">
+            <g class="sld-voltage-indicator sld-powered" id="idbbs1_VOLTAGE_INDICATOR" transform="translate(200.0,-5.0)">
                 <rect class="sld-powered" height="10" rx="1" ry="1" width="20"/>
                 <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
                 <text class="sld-label" x="0.0" y="-5.0">Top</text>
             </g>
         </g>
         <g class="sld-busbar-section sld-vl300to500-0" id="idbbs21" transform="translate(52.5,277.0)">
-            <line x1="0" x2="125.0" y1="0" y2="0"/>
+            <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs21_NW_LABEL" x="-5.0" y="-5.0">bbs21</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs21_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
                 <rect class="sld-powered" height="10" rx="1" ry="1" width="20"/>
                 <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
             </g>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs22" transform="translate(202.5,277.0)">
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs22" transform="translate(152.5,277.0)">
             <line x1="0" x2="125.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs22_NW_LABEL" x="-5.0" y="-5.0">bbs22</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs22_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
@@ -179,7 +178,7 @@
                 <text class="sld-label" x="0.0" y="15.0">Bottom</text>
             </g>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs13" transform="translate(352.5,252.0)">
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs13" transform="translate(302.5,252.0)">
             <line x1="0" x2="175.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs13_NW_LABEL" x="-5.0" y="-5.0">bbs13</text>
             <g class="sld-voltage-indicator sld-powered" id="idbbs13_VOLTAGE_INDICATOR" transform="translate(150.0,-5.0)">
@@ -188,7 +187,7 @@
                 <text class="sld-label" x="0.0" y="-5.0">Top</text>
             </g>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs23" transform="translate(352.5,277.0)">
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs23" transform="translate(302.5,277.0)">
             <line x1="0" x2="175.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs23_NW_LABEL" x="-5.0" y="-5.0">bbs23</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs23_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
@@ -249,178 +248,178 @@
             </g>
         </g>
         <g class="cell idEXTERN_32_2" id="idEXTERN_32_2">
-            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadB" transform="translate(261.0,138.0)">
+            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadB" transform="translate(211.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load sld-top-feeder sld-vl300to500-0" id="idloadB" transform="translate(257.0,75.5)">
+            <g class="sld-load sld-top-feeder sld-vl300to500-0" id="idloadB" transform="translate(207.0,75.5)">
                 <rect height="9" width="16"/>
                 <line x1="0" x2="16" y1="0" y2="9"/>
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadB_N_LABEL" x="-5.0" y="-5.0">loadB</text>
             </g>
-            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(261.0,218.0)">
+            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="265.0,222.0,265.0,192.0"/>
+                <polyline points="215.0,222.0,215.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_fB_95_INTERNAL_95_vl1_95_loadB">
-                <polyline points="265.0,172.0,265.0,142.0"/>
+                <polyline points="215.0,172.0,215.0,142.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadB_95_loadB">
-                <polyline points="265.0,142.0,265.0,84.5"/>
+                <polyline points="215.0,142.0,215.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadB_ARROW_ACTIVE" transform="translate(260.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadB_ARROW_ACTIVE" transform="translate(210.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadB_ARROW_REACTIVE" transform="translate(260.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadB_ARROW_REACTIVE" transform="translate(210.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="265.0,277.0,265.0,222.0"/>
+                <polyline points="215.0,277.0,215.0,222.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="265.0,252.0,265.0,222.0"/>
+                <polyline points="215.0,252.0,215.0,222.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_4_46_1">
-                <polyline points="265.0,222.0,290.0,222.0,290.0,182.0"/>
+                <polyline points="215.0,222.0,240.0,222.0,240.0,182.0"/>
             </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idfB" transform="translate(255.0,172.0)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idfB" transform="translate(205.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idb1" transform="translate(261.0,273.0)">
+            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idb1" transform="translate(211.0,273.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idb2" transform="translate(261.0,248.0)">
+            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idb2" transform="translate(211.0,248.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_3" id="idEXTERN_32_3">
-            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC" transform="translate(436.0,138.0)">
+            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC" transform="translate(386.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_c1" transform="translate(461.0,218.0)">
+            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_c1" transform="translate(411.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_c2" transform="translate(411.0,218.0)">
+            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_c2" transform="translate(361.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load sld-top-feeder sld-vl300to500-0" id="idloadC" transform="translate(432.0,75.5)">
+            <g class="sld-load sld-top-feeder sld-vl300to500-0" id="idloadC" transform="translate(382.0,75.5)">
                 <rect height="9" width="16"/>
                 <line x1="0" x2="16" y1="0" y2="9"/>
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadC_N_LABEL" x="-5.0" y="-5.0">loadC</text>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="465.0,172.0,465.0,142.0,440.0,142.0"/>
+                <polyline points="415.0,172.0,415.0,142.0,390.0,142.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="415.0,172.0,415.0,142.0,440.0,142.0"/>
+                <polyline points="365.0,172.0,365.0,142.0,390.0,142.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
-                <polyline points="440.0,142.0,440.0,84.5"/>
+                <polyline points="390.0,142.0,390.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(435.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(385.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(435.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(385.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_INTERNAL_95_vl1_95_Shunt_32_4_46_2">
-                <polyline points="440.0,142.0,390.0,142.0,390.0,182.0"/>
+                <polyline points="390.0,142.0,340.0,142.0,340.0,182.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_c1_95_c1">
-                <polyline points="465.0,222.0,465.0,192.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
-                <polyline points="465.0,273.0,465.0,222.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
                 <polyline points="415.0,222.0,415.0,192.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
-                <polyline points="415.0,248.0,415.0,222.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
+                <polyline points="415.0,273.0,415.0,222.0"/>
             </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idc1" transform="translate(455.0,172.0)">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
+                <polyline points="365.0,222.0,365.0,192.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
+                <polyline points="365.0,248.0,365.0,222.0"/>
+            </g>
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idc1" transform="translate(405.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-vl300to500-0" id="idBUSCO_95_c1" transform="translate(461.0,273.0)">
+            <g class="sld-bus-connection sld-vl300to500-0" id="idBUSCO_95_c1" transform="translate(411.0,273.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idc2" transform="translate(405.0,172.0)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idc2" transform="translate(355.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-vl300to500-0" id="idBUSCO_95_c2" transform="translate(411.0,248.0)">
+            <g class="sld-bus-connection sld-vl300to500-0" id="idBUSCO_95_c2" transform="translate(361.0,248.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
         </g>
         <g class="cell idSHUNT_32_4" id="idSHUNT_32_4">
-            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(261.0,218.0)">
+            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_Shunt_32_4_46_1" transform="translate(286.0,178.0)">
+            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_Shunt_32_4_46_1" transform="translate(236.0,178.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_Shunt_32_4_46_2" transform="translate(386.0,178.0)">
+            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_Shunt_32_4_46_2" transform="translate(336.0,178.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC" transform="translate(436.0,138.0)">
+            <g class="sld-node sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC" transform="translate(386.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="265.0,222.0,265.0,192.0"/>
+                <polyline points="215.0,222.0,215.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="265.0,277.0,265.0,222.0"/>
+                <polyline points="215.0,277.0,215.0,222.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="265.0,252.0,265.0,222.0"/>
+                <polyline points="215.0,252.0,215.0,222.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_4_46_1">
-                <polyline points="265.0,222.0,290.0,222.0,290.0,182.0"/>
+                <polyline points="215.0,222.0,240.0,222.0,240.0,182.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_4_46_1">
-                <polyline points="330.0,182.0,290.0,182.0"/>
+                <polyline points="280.0,182.0,240.0,182.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_4_46_2">
-                <polyline points="350.0,182.0,390.0,182.0"/>
+                <polyline points="300.0,182.0,340.0,182.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_INTERNAL_95_vl1_95_Shunt_32_4_46_2">
-                <polyline points="440.0,142.0,390.0,142.0,390.0,182.0"/>
+                <polyline points="390.0,142.0,340.0,142.0,340.0,182.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="465.0,172.0,465.0,142.0,440.0,142.0"/>
+                <polyline points="415.0,172.0,415.0,142.0,390.0,142.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="415.0,172.0,415.0,142.0,440.0,142.0"/>
+                <polyline points="365.0,172.0,365.0,142.0,390.0,142.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
-                <polyline points="440.0,142.0,440.0,84.5"/>
+                <polyline points="390.0,142.0,390.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(435.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(385.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(435.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(385.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idlink" transform="translate(330.0,172.0)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idlink" transform="translate(280.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg height="357.0" viewBox="0 0 430.0 357.0" width="430.0" xmlns="http://www.w3.org/2000/svg">
+<svg height="357.0" viewBox="0 0 330.0 357.0" width="330.0" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 /* ----------------------------------------------------------------------- */
 /* File: tautologies.css ------------------------------------------------- */
@@ -66,270 +66,254 @@
             <line x1="190.0" x2="190.0" y1="80.0" y2="277.0"/>
             <line x1="240.0" x2="240.0" y1="80.0" y2="277.0"/>
             <line x1="290.0" x2="290.0" y1="80.0" y2="277.0"/>
-            <line x1="340.0" x2="340.0" y1="80.0" y2="277.0"/>
-            <line x1="390.0" x2="390.0" y1="80.0" y2="277.0"/>
-            <line x1="40.0" x2="390.0" y1="222.0" y2="222.0"/>
-            <line x1="40.0" x2="390.0" y1="212.0" y2="212.0"/>
-            <line x1="40.0" x2="390.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="290.0" y1="222.0" y2="222.0"/>
+            <line x1="40.0" x2="290.0" y1="212.0" y2="212.0"/>
+            <line x1="40.0" x2="290.0" y1="142.0" y2="142.0"/>
         </g>
         <g class="sld-busbar-section" id="idbbs1" transform="translate(52.5,252.0)">
-            <line x1="0" x2="125.0" y1="0" y2="0"/>
+            <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
         </g>
         <g class="sld-busbar-section" id="idbbs21" transform="translate(52.5,277.0)">
-            <line x1="0" x2="75.0" y1="0" y2="0"/>
+            <line x1="0" x2="25.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs21_NW_LABEL" x="-5.0" y="-5.0">bbs21</text>
-            <g class="sld-voltage-indicator sld-unpowered" id="idbbs21_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
-                <rect class="sld-powered" height="10" rx="1" ry="1" width="20"/>
-                <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
-            </g>
         </g>
-        <g class="sld-busbar-section" id="idbbs22" transform="translate(152.5,277.0)">
+        <g class="sld-busbar-section" id="idbbs22" transform="translate(102.5,277.0)">
             <line x1="0" x2="25.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs22_NW_LABEL" x="-5.0" y="-5.0">bbs22</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs13" transform="translate(202.5,252.0)">
-            <line x1="0" x2="175.0" y1="0" y2="0"/>
+        <g class="sld-busbar-section" id="idbbs13" transform="translate(152.5,252.0)">
+            <line x1="0" x2="125.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs13_NW_LABEL" x="-5.0" y="-5.0">bbs13</text>
-            <g class="sld-voltage-indicator sld-powered" id="idbbs13_VOLTAGE_INDICATOR" transform="translate(150.0,-5.0)">
-                <rect class="sld-powered" height="10" rx="1" ry="1" width="20"/>
-                <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
-                <text class="sld-label" x="0.0" y="-5.0">Top</text>
-            </g>
         </g>
-        <g class="sld-busbar-section" id="idbbs23" transform="translate(202.5,277.0)">
-            <line x1="0" x2="175.0" y1="0" y2="0"/>
+        <g class="sld-busbar-section" id="idbbs23" transform="translate(152.5,277.0)">
+            <line x1="0" x2="125.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs23_NW_LABEL" x="-5.0" y="-5.0">bbs23</text>
-            <g class="sld-voltage-indicator sld-unpowered" id="idbbs23_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
-                <rect class="sld-powered" height="10" rx="1" ry="1" width="20"/>
-                <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
-                <text class="sld-label" x="0.0" y="15.0">Bottom</text>
-            </g>
         </g>
         <g class="cell idEXTERN_32_0" id="idEXTERN_32_0">
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_3" transform="translate(111.0,218.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_3" transform="translate(61.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadA" transform="translate(111.0,138.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadA" transform="translate(61.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load sld-top-feeder" id="idloadA" transform="translate(107.0,75.5)">
+            <g class="sld-load sld-top-feeder" id="idloadA" transform="translate(57.0,75.5)">
                 <rect height="9" width="16"/>
                 <line x1="0" x2="16" y1="0" y2="9"/>
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadA_N_LABEL" x="-5.0" y="-5.0">loadA</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_d1_95_INTERNAL_95_vl1_95_3">
-                <polyline points="115.0,252.0,115.0,222.0"/>
+                <polyline points="65.0,252.0,65.0,222.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_3_95_fA">
-                <polyline points="115.0,222.0,115.0,192.0"/>
+                <polyline points="65.0,222.0,65.0,192.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_d2_95_INTERNAL_95_vl1_95_3">
-                <polyline points="115.0,277.0,115.0,222.0"/>
+                <polyline points="65.0,277.0,65.0,222.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_fA_95_INTERNAL_95_vl1_95_loadA">
-                <polyline points="115.0,172.0,115.0,142.0"/>
+                <polyline points="65.0,172.0,65.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadA_95_loadA">
-                <polyline points="115.0,142.0,115.0,84.5"/>
+                <polyline points="65.0,142.0,65.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadA_ARROW_ACTIVE" transform="translate(110.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadA_ARROW_ACTIVE" transform="translate(60.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadA_ARROW_REACTIVE" transform="translate(110.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadA_ARROW_REACTIVE" transform="translate(60.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd1" transform="translate(111.0,248.0)">
+            <g class="sld-disconnector sld-closed" id="idd1" transform="translate(61.0,248.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idfA" transform="translate(105.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idfA" transform="translate(55.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd2" transform="translate(111.0,273.0)">
+            <g class="sld-disconnector sld-closed" id="idd2" transform="translate(61.0,273.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_2" id="idEXTERN_32_2">
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadB" transform="translate(161.0,138.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadB" transform="translate(111.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load sld-top-feeder" id="idloadB" transform="translate(157.0,75.5)">
+            <g class="sld-load sld-top-feeder" id="idloadB" transform="translate(107.0,75.5)">
                 <rect height="9" width="16"/>
                 <line x1="0" x2="16" y1="0" y2="9"/>
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadB_N_LABEL" x="-5.0" y="-5.0">loadB</text>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_5" transform="translate(161.0,218.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_5" transform="translate(111.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="165.0,222.0,165.0,192.0"/>
+                <polyline points="115.0,222.0,115.0,192.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_fB_95_INTERNAL_95_vl1_95_loadB">
-                <polyline points="165.0,172.0,165.0,142.0"/>
+                <polyline points="115.0,172.0,115.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadB_95_loadB">
-                <polyline points="165.0,142.0,165.0,84.5"/>
+                <polyline points="115.0,142.0,115.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadB_ARROW_ACTIVE" transform="translate(160.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadB_ARROW_ACTIVE" transform="translate(110.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadB_ARROW_REACTIVE" transform="translate(160.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadB_ARROW_REACTIVE" transform="translate(110.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,277.0,165.0,222.0"/>
+                <polyline points="115.0,277.0,115.0,222.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,252.0,165.0,222.0"/>
+                <polyline points="115.0,252.0,115.0,222.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_4_46_1">
-                <polyline points="165.0,222.0,190.0,222.0,190.0,182.0"/>
+                <polyline points="115.0,222.0,140.0,222.0,140.0,182.0"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idfB" transform="translate(155.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idfB" transform="translate(105.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idb1" transform="translate(161.0,273.0)">
+            <g class="sld-disconnector sld-closed" id="idb1" transform="translate(111.0,273.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idb2" transform="translate(161.0,248.0)">
+            <g class="sld-disconnector sld-closed" id="idb2" transform="translate(111.0,248.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="cell idEXTERN_32_3" id="idEXTERN_32_3">
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadC" transform="translate(286.0,138.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadC" transform="translate(236.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_c1" transform="translate(311.0,218.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_c1" transform="translate(261.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_c2" transform="translate(261.0,218.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_c2" transform="translate(211.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load sld-top-feeder" id="idloadC" transform="translate(282.0,75.5)">
+            <g class="sld-load sld-top-feeder" id="idloadC" transform="translate(232.0,75.5)">
                 <rect height="9" width="16"/>
                 <line x1="0" x2="16" y1="0" y2="9"/>
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadC_N_LABEL" x="-5.0" y="-5.0">loadC</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="315.0,172.0,315.0,142.0,290.0,142.0"/>
+                <polyline points="265.0,172.0,265.0,142.0,240.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="265.0,172.0,265.0,142.0,290.0,142.0"/>
+                <polyline points="215.0,172.0,215.0,142.0,240.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
-                <polyline points="290.0,142.0,290.0,84.5"/>
+                <polyline points="240.0,142.0,240.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(285.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(235.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(285.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(235.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_INTERNAL_95_vl1_95_Shunt_32_4_46_2">
-                <polyline points="290.0,142.0,240.0,142.0,240.0,182.0"/>
+                <polyline points="240.0,142.0,190.0,142.0,190.0,182.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c1_95_c1">
-                <polyline points="315.0,222.0,315.0,192.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
-                <polyline points="315.0,273.0,315.0,222.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
                 <polyline points="265.0,222.0,265.0,192.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
-                <polyline points="265.0,248.0,265.0,222.0"/>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
+                <polyline points="265.0,273.0,265.0,222.0"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idc1" transform="translate(305.0,172.0)">
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
+                <polyline points="215.0,222.0,215.0,192.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
+                <polyline points="215.0,248.0,215.0,222.0"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idc1" transform="translate(255.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection" id="idBUSCO_95_c1" transform="translate(311.0,273.0)">
+            <g class="sld-bus-connection" id="idBUSCO_95_c1" transform="translate(261.0,273.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idc2" transform="translate(255.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idc2" transform="translate(205.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection" id="idBUSCO_95_c2" transform="translate(261.0,248.0)">
+            <g class="sld-bus-connection" id="idBUSCO_95_c2" transform="translate(211.0,248.0)">
                 <circle cx="4" cy="4" r="2"/>
             </g>
         </g>
         <g class="cell idSHUNT_32_4" id="idSHUNT_32_4">
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_5" transform="translate(161.0,218.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_5" transform="translate(111.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_Shunt_32_4_46_1" transform="translate(186.0,178.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_Shunt_32_4_46_1" transform="translate(136.0,178.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_Shunt_32_4_46_2" transform="translate(236.0,178.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_Shunt_32_4_46_2" transform="translate(186.0,178.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadC" transform="translate(286.0,138.0)">
+            <g class="sld-node" id="idINTERNAL_95_vl1_95_loadC" transform="translate(236.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="165.0,222.0,165.0,192.0"/>
+                <polyline points="115.0,222.0,115.0,192.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,277.0,165.0,222.0"/>
+                <polyline points="115.0,277.0,115.0,222.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,252.0,165.0,222.0"/>
+                <polyline points="115.0,252.0,115.0,222.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_4_46_1">
-                <polyline points="165.0,222.0,190.0,222.0,190.0,182.0"/>
+                <polyline points="115.0,222.0,140.0,222.0,140.0,182.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_4_46_1">
-                <polyline points="205.0,182.0,190.0,182.0"/>
+                <polyline points="155.0,182.0,140.0,182.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_4_46_2">
-                <polyline points="225.0,182.0,240.0,182.0"/>
+                <polyline points="175.0,182.0,190.0,182.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_INTERNAL_95_vl1_95_Shunt_32_4_46_2">
-                <polyline points="290.0,142.0,240.0,142.0,240.0,182.0"/>
+                <polyline points="240.0,142.0,190.0,142.0,190.0,182.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="315.0,172.0,315.0,142.0,290.0,142.0"/>
+                <polyline points="265.0,172.0,265.0,142.0,240.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="265.0,172.0,265.0,142.0,290.0,142.0"/>
+                <polyline points="215.0,172.0,215.0,142.0,240.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
-                <polyline points="290.0,142.0,290.0,84.5"/>
+                <polyline points="240.0,142.0,240.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(285.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(235.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(285.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(235.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-breaker sld-closed" id="idlink" transform="translate(205.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idlink" transform="translate(155.0,172.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
When addCellForBusInfo parameter of BlockOrganizer is set to true, one cell is adding on previous subsection only at right and left side


**What is the new behavior (if this is a feature change)?**
Replace addCellForBusInfo parameter of BlockOrganizer by a map (bus id / side) 
in order to add cell on previous subsection only at right or left side


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
