### PR TITLE
Use sets in graph traversal

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/GraphTraversal.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/GraphTraversal.java
@@ -8,8 +8,9 @@ package com.powsybl.sld.layout;
 
 import com.powsybl.sld.model.Node;
 
-import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -33,8 +34,8 @@ public final class GraphTraversal {
     static boolean run(Node node,
                        Predicate<Node> extremityCriteria,
                        Predicate<Node> unsuccessfulCriteria,
-                       List<Node> nodesResult,
-                       List<Node> outsideNodes) {
+                       Set<Node> nodesResult,
+                       Set<Node> outsideNodes) {
 
         if (outsideNodes.contains(node)) {
             return false;
@@ -58,10 +59,10 @@ public final class GraphTraversal {
         return true;
     }
 
-    static List<Node> run(Node node,
+    static Set<Node> run(Node node,
                           Predicate<Node> extremityCriteria,
-                          List<Node> outsideNodes) {
-        List<Node> nodesResult = new ArrayList<>();
+                          Set<Node> outsideNodes) {
+        Set<Node> nodesResult = new LinkedHashSet<>();
         run(node, extremityCriteria, n -> false, nodesResult, outsideNodes);
         return nodesResult;
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Subsection.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Subsection.java
@@ -12,6 +12,7 @@ import com.powsybl.sld.model.coordinate.Side;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.powsybl.sld.model.coordinate.Side.LEFT;
 import static com.powsybl.sld.model.coordinate.Side.RIGHT;
@@ -289,14 +290,14 @@ public class Subsection {
                         .map(FeederNode.class::cast).collect(Collectors.toList());
                 if (feeders.size() > 1) {
                     FictitiousNode shNode = sc.getSideShuntNode(side);
-                    List<Node> outsideNodes = new ArrayList<>();
+                    Set<Node> outsideNodes = new HashSet<>();
                     outsideNodes.add(shNode);
                     List<FeederNode> shuntSideFeederNodes = shNode.getAdjacentNodes().stream().flatMap(node -> {
-                        List<Node> gtResult = new ArrayList<>();
+                        Set<Node> gtResult = new LinkedHashSet<>();
                         if (GraphTraversal.run(node, node1 -> node1.getType() == Node.NodeType.FEEDER, node1 -> node1.getType() == Node.NodeType.BUS, gtResult, outsideNodes)) {
                             return gtResult.stream().filter(n -> n.getType() == Node.NodeType.FEEDER).map(FeederNode.class::cast);
                         } else {
-                            return new ArrayList<FeederNode>().stream();
+                            return Stream.empty();
                         }
                     }).collect(Collectors.toList());
                     feeders.removeAll(shuntSideFeederNodes);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/TopologyCalculation.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/TopologyCalculation.java
@@ -6,11 +6,12 @@
  */
 package com.powsybl.sld.layout;
 
-import com.powsybl.sld.model.VoltageLevelGraph;
 import com.powsybl.sld.model.Node;
 import com.powsybl.sld.model.SwitchNode;
+import com.powsybl.sld.model.VoltageLevelGraph;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,11 +34,11 @@ public final class TopologyCalculation {
     public static List<TopologicallyConnectedNodesSet> run(VoltageLevelGraph graph) {
         List<TopologicallyConnectedNodesSet> topologicallyConnectedNodesSets = new ArrayList<>();
         List<Node> nodesToVisit = graph.getNodes();
-        List<Node> visitedNodes = new ArrayList<>();
+        Set<Node> visitedNodes = new HashSet<>();
         Node node = identifyNonOpenNode(nodesToVisit);
         while (node != null) {
             List<SwitchNode> openSwitches = new ArrayList<>();
-            List<Node> connectedNodes = GraphTraversal
+            Set<Node> connectedNodes = GraphTraversal
                     .run(node, n -> extremityCriteria(n, openSwitches), visitedNodes);
             Set<SwitchNode> borderSwitchNodes = openSwitches.stream()
                     .filter(n -> isBorderSwitchNode(n, connectedNodes))
@@ -64,7 +65,7 @@ public final class TopologyCalculation {
         return remainingNodes.stream().filter(n -> !isOpenSwitchNode(n)).findFirst().orElse(null);
     }
 
-    private static boolean isBorderSwitchNode(SwitchNode switchNode, List<Node> connectedNodes) {
+    private static boolean isBorderSwitchNode(SwitchNode switchNode, Set<Node> connectedNodes) {
         return !connectedNodes.containsAll(switchNode.getAdjacentNodes());
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBusCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractBusCell.java
@@ -11,6 +11,7 @@ import com.powsybl.sld.layout.LayoutParameters;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -29,7 +30,7 @@ public abstract class AbstractBusCell extends AbstractCell implements BusCell {
 
     private Direction direction = Direction.UNDEFINED;
 
-    protected AbstractBusCell(int cellIndex, CellType type, List<Node> nodes) {
+    protected AbstractBusCell(int cellIndex, CellType type, Collection<Node> nodes) {
         super(cellIndex, type, nodes);
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/AbstractCell.java
@@ -11,6 +11,7 @@ import com.powsybl.sld.layout.LayoutParameters;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -29,7 +30,7 @@ public abstract class AbstractCell implements Cell {
 
     private Block rootBlock;
 
-    AbstractCell(int cellNumber, CellType type, List<Node> nodes) {
+    AbstractCell(int cellNumber, CellType type, Collection<Node> nodes) {
         this.type = Objects.requireNonNull(type);
         number = cellNumber;
         setNodes(nodes);
@@ -47,7 +48,7 @@ public abstract class AbstractCell implements Cell {
         nodes.removeAll(nodeToRemove);
     }
 
-    private void setNodes(List<Node> nodes) {
+    private void setNodes(Collection<Node> nodes) {
         this.nodes.addAll(nodes);
         // the cell of the node of a SHUNT node (which belongs to a SHUNT and an EXTERN cells)
         // is the cell of the EXTERN cell

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/ExternCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/ExternCell.java
@@ -10,12 +10,14 @@ import com.powsybl.sld.model.coordinate.Position;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
+import java.util.Collection;
 
-import static com.powsybl.sld.model.Cell.CellType.*;
-import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
-import static com.powsybl.sld.model.coordinate.Side.*;
-import static com.powsybl.sld.model.Node.NodeType.*;
+import static com.powsybl.sld.model.Cell.CellType.EXTERN;
+import static com.powsybl.sld.model.Node.NodeType.FEEDER;
+import static com.powsybl.sld.model.coordinate.Position.Dimension.H;
+import static com.powsybl.sld.model.coordinate.Position.Dimension.V;
+import static com.powsybl.sld.model.coordinate.Side.LEFT;
+import static com.powsybl.sld.model.coordinate.Side.RIGHT;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
@@ -27,7 +29,7 @@ public class ExternCell extends AbstractBusCell {
 
     private ShuntCell shuntCell = null;
 
-    public ExternCell(int cellNumber, List<Node> nodes) {
+    public ExternCell(int cellNumber, Collection<Node> nodes) {
         super(cellNumber, EXTERN, nodes);
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/InternCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/InternCell.java
@@ -58,7 +58,7 @@ public class InternCell extends AbstractBusCell {
     private Block body;
     private boolean exceptionIfPatternNotHandled;
 
-    public InternCell(int cellNumber, List<Node> nodes, boolean exceptionIfPatternNotHandled) {
+    public InternCell(int cellNumber, Collection<Node> nodes, boolean exceptionIfPatternNotHandled) {
         super(cellNumber, CellType.INTERN, nodes);
         legs = new EnumMap<>(Side.class);
         setDirection(Direction.UNDEFINED);

--- a/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.svg
@@ -140,16 +140,6 @@
                 <path class="sld-sw-open" d="M8,0 0,8"/>
                 <text class="sld-label" id="d2_default" text-anchor="middle" x="0.0" y="-5.0">d2</text>
             </g>
-            <g class="sld-breaker sld-closed" id="idbB" transform="translate(130.0,88.0)">
-                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
-                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
-                <text class="sld-label" id="bB_default" text-anchor="middle" x="0.0" y="-5.0">bB</text>
-            </g>
-            <g class="sld-breaker sld-closed" id="idbC" transform="translate(130.0,128.0)">
-                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
-                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
-                <text class="sld-label" id="bC_default" text-anchor="middle" x="0.0" y="-5.0">bC</text>
-            </g>
         </g>
     </g>
 </svg>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
Graph traversal uses
- one list for traversed nodes, hence creating duplicated nodes in some cases
- one list for visited nodes, hence affecting performance for large substations / voltage levels


**What is the new behavior (if this is a feature change)?**
Graph traversal uses
- one set for traversed nodes
- one set for visited nodes


**Does this PR introduce a breaking change or deprecate an API?** 
No, the GraphTraversal methods signature is changed but it is an internal API

