### PR TITLE
Raw builder classes can be extended

### DIFF
--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/LayoutToCgmesExtensionsConverter.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/main/java/com/powsybl/sld/cgmes/layout/LayoutToCgmesExtensionsConverter.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.cgmes.layout;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.cgmes.dl.conversion.CgmesDLUtils;
 import com.powsybl.sld.cgmes.dl.iidm.extensions.*;
 import com.powsybl.sld.layout.*;

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/AbstractCgmesVoltageLevelLayoutTest.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/AbstractCgmesVoltageLevelLayoutTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 
 import com.powsybl.iidm.network.VoltageLevel;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import com.powsybl.sld.model.Node;

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/BusTopologyTest.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/BusTopologyTest.java
@@ -37,7 +37,7 @@ import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
 import com.powsybl.iidm.network.VoltageLevel;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.cgmes.dl.iidm.extensions.CouplingDeviceDiagramData;
 import com.powsybl.sld.cgmes.dl.iidm.extensions.DiagramPoint;
 import com.powsybl.sld.cgmes.dl.iidm.extensions.DiagramTerminal;

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/CgmesZoneLayoutTest.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/CgmesZoneLayoutTest.java
@@ -8,7 +8,7 @@ package com.powsybl.sld.cgmes.layout;
 
 import com.powsybl.iidm.network.Branch.Side;
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.cgmes.dl.iidm.extensions.*;
 import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.model.*;

--- a/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/DoubleBusbarSectionTest.java
+++ b/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/DoubleBusbarSectionTest.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.cgmes.layout;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.cgmes.dl.iidm.extensions.*;
 import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.model.BusNode;

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/RawGraphBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/RawGraphBuilder.java
@@ -10,247 +10,44 @@ import com.powsybl.sld.model.*;
 
 import java.util.*;
 
-import static com.powsybl.sld.model.FeederWithSideNode.Side.*;
-
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 
 public class RawGraphBuilder implements GraphBuilder {
 
-    private final Map<String, VoltageLevelBuilder> vlBuilders = new TreeMap<>();
-    private final Map<String, SubstationBuilder> ssBuilders = new TreeMap<>();
+    private final Map<String, VoltageLevelRawBuilder> vlBuilders = new TreeMap<>();
+    private final Map<String, SubstationRawBuilder> ssBuilders = new TreeMap<>();
 
-    public VoltageLevelBuilder createVoltageLevelBuilder(VoltageLevelInfos voltageLevelInfos, boolean forVoltageLevelDiagram) {
-        VoltageLevelBuilder vlBuilder = new VoltageLevelBuilder(voltageLevelInfos, forVoltageLevelDiagram);
+    public VoltageLevelRawBuilder createVoltageLevelBuilder(VoltageLevelInfos voltageLevelInfos, boolean forVoltageLevelDiagram) {
+        VoltageLevelRawBuilder vlBuilder = new VoltageLevelRawBuilder(voltageLevelInfos, forVoltageLevelDiagram, this::getVoltageLevelInfosFromId);
         vlBuilders.put(voltageLevelInfos.getId(), vlBuilder);
         return vlBuilder;
     }
 
-    public VoltageLevelBuilder createVoltageLevelBuilder(String vlId, double vlNominalV, boolean forVoltageLevelDiagram) {
+    public VoltageLevelRawBuilder createVoltageLevelBuilder(String vlId, double vlNominalV, boolean forVoltageLevelDiagram) {
         return createVoltageLevelBuilder(new VoltageLevelInfos(vlId, vlId, vlNominalV), forVoltageLevelDiagram);
     }
 
-    public VoltageLevelBuilder createVoltageLevelBuilder(VoltageLevelInfos voltageLevelInfos) {
+    public VoltageLevelRawBuilder createVoltageLevelBuilder(VoltageLevelInfos voltageLevelInfos) {
         return createVoltageLevelBuilder(voltageLevelInfos, true);
     }
 
-    public VoltageLevelBuilder createVoltageLevelBuilder(String vlId, double vlNominalV) {
+    public VoltageLevelRawBuilder createVoltageLevelBuilder(String vlId, double vlNominalV) {
         return createVoltageLevelBuilder(new VoltageLevelInfos(vlId, vlId, vlNominalV));
     }
 
     public VoltageLevelInfos getVoltageLevelInfosFromId(String id) {
         if (vlBuilders.containsKey(id)) {
-            return vlBuilders.get(id).voltageLevelInfos;
+            return vlBuilders.get(id).getVoltageLevelInfos();
         }
         return new VoltageLevelInfos("OTHER", "OTHER", 0);
     }
 
-    public class VoltageLevelBuilder {
-
-        private VoltageLevelInfos voltageLevelInfos;
-        private final VoltageLevelGraph voltageLevelGraph;
-
-        private SubstationBuilder substationBuilder;
-
-        public VoltageLevelBuilder(VoltageLevelInfos voltageLevelInfos, boolean forVoltageLevelDiagram) {
-            this.voltageLevelInfos = voltageLevelInfos;
-            voltageLevelGraph = VoltageLevelGraph.create(voltageLevelInfos, forVoltageLevelDiagram);
-        }
-
-        public VoltageLevelGraph getGraph() {
-            return voltageLevelGraph;
-        }
-
-        public SubstationBuilder getSubstationBuilder() {
-            return substationBuilder;
-        }
-
-        public void setSubstationBuilder(SubstationBuilder substationBuilder) {
-            this.substationBuilder = substationBuilder;
-        }
-
-        public BusNode createBusBarSection(String id, int busbarIndex, int sectionIndex) {
-            BusNode busNode = BusNode.create(voltageLevelGraph, id, id);
-            voltageLevelGraph.addNode(busNode);
-            busNode.setBusBarIndexSectionIndex(busbarIndex, sectionIndex);
-            return busNode;
-        }
-
-        public BusNode createBusBarSection(String id) {
-            BusNode busNode = BusNode.create(voltageLevelGraph, id, id);
-            voltageLevelGraph.addNode(busNode);
-            return busNode;
-        }
-
-        public SwitchNode createSwitchNode(SwitchNode.SwitchKind sk, String id, boolean fictitious, boolean open) {
-            SwitchNode sw = new SwitchNode(id, id, sk.name(), fictitious, voltageLevelGraph, sk, open);
-            voltageLevelGraph.addNode(sw);
-            return sw;
-        }
-
-        public SwitchNode createSwitchNode(SwitchNode.SwitchKind sk, String id, boolean fictitious, boolean open, Integer order, BusCell.Direction direction) {
-            SwitchNode sw = new SwitchNode(id, id, sk.name(), fictitious, voltageLevelGraph, sk, open);
-            voltageLevelGraph.addNode(sw);
-            if (direction != null || order != null) {
-                addExtension(sw, order, direction);
-            }
-            return sw;
-        }
-
-        public void connectNode(Node node1, Node node2) {
-            voltageLevelGraph.addEdge(node1, node2);
-        }
-
-        public FictitiousNode createFictitiousNode(int id) {
-            InternalNode fictitiousNode = new InternalNode(id, voltageLevelGraph);
-            voltageLevelGraph.addNode(fictitiousNode);
-            return fictitiousNode;
-        }
-
-        public FictitiousNode createFictitiousNode(String id) {
-            InternalNode fictitiousNode = new InternalNode(id, voltageLevelGraph);
-            voltageLevelGraph.addNode(fictitiousNode);
-            return fictitiousNode;
-        }
-
-        public void addExtension(Node fn, Integer order, BusCell.Direction direction) {
-            if (order != null) {
-                fn.setOrder(order);
-            }
-            fn.setDirection(direction == null ? BusCell.Direction.UNDEFINED : direction);
-        }
-
-        private void commonFeederSetting(FeederNode node, String id, int order, BusCell.Direction direction) {
-            node.setLabel(id);
-            voltageLevelGraph.addNode(node);
-            if (direction != null) {
-                addExtension(node, order, direction);
-            }
-        }
-
-        public FeederNode createLoad(String id) {
-            return createLoad(id, 0, null);
-        }
-
-        public FeederNode createLoad(String id, int order, BusCell.Direction direction) {
-            FeederInjectionNode fn = FeederInjectionNode.createLoad(voltageLevelGraph, id, id);
-            commonFeederSetting(fn, id, order, direction);
-            return fn;
-        }
-
-        public FeederNode createGenerator(String id) {
-            return createGenerator(id, 0, null);
-        }
-
-        public FeederNode createGenerator(String id, int order, BusCell.Direction direction) {
-            FeederInjectionNode fn = FeederInjectionNode.createGenerator(voltageLevelGraph, id, id);
-            commonFeederSetting(fn, id, order, direction);
-            return fn;
-        }
-
-        public FeederLineNode createFeederLineNode(String id, String otherVlId, FeederWithSideNode.Side side, int order, BusCell.Direction direction) {
-            FeederLineNode fln = FeederLineNode.create(voltageLevelGraph, id + "_" + side, id, id, side, getVoltageLevelInfosFromId(otherVlId));
-            commonFeederSetting(fln, id, order, direction);
-            return fln;
-        }
-
-        public Feeder2WTNode createFeeder2WTNode(String id, String otherVlId, FeederWithSideNode.Side side,
-                                                 int order, BusCell.Direction direction) {
-            Feeder2WTNode f2WTe = Feeder2WTNode.create(voltageLevelGraph, id + "_" + side, id, id, side, getVoltageLevelInfosFromId(otherVlId));
-            commonFeederSetting(f2WTe, id, order, direction);
-            return f2WTe;
-        }
-
-        public Feeder2WTLegNode createFeeder2wtLegNode(String id, FeederWithSideNode.Side side,
-                                                       int order, BusCell.Direction direction) {
-            Feeder2WTLegNode f2WTe = Feeder2WTLegNode.create(voltageLevelGraph, id + "_" + side, id, id, side);
-            commonFeederSetting(f2WTe, id, order, direction);
-            return f2WTe;
-        }
-
-        public Feeder3WTLegNode createFeeder3wtLegNode(String id, FeederWithSideNode.Side side, int order, BusCell.Direction direction) {
-            Feeder3WTLegNode f3WTe = Feeder3WTLegNode.createForSubstationDiagram(voltageLevelGraph, id + "_" + side, id, id, side);
-            commonFeederSetting(f3WTe, id + side.getIntValue(), order, direction);
-            return f3WTe;
-        }
-    }
-
-    public SubstationBuilder createSubstationBuilder(String id) {
-        SubstationBuilder ssb = new SubstationBuilder(id);
+    public SubstationRawBuilder createSubstationBuilder(String id) {
+        SubstationRawBuilder ssb = new SubstationRawBuilder(id);
         ssBuilders.put(id, ssb);
         return ssb;
-    }
-
-    public class SubstationBuilder {
-
-        SubstationGraph substationGraph;
-        List<VoltageLevelBuilder> voltageLevelBuilders = new ArrayList<>();
-
-        public SubstationBuilder(String id) {
-            substationGraph = SubstationGraph.create(id);
-        }
-
-        public SubstationGraph getGraph() {
-            return substationGraph;
-        }
-
-        public void addVlBuilder(VoltageLevelBuilder vlBuilder) {
-            voltageLevelBuilders.add(vlBuilder);
-            vlBuilder.setSubstationBuilder(this);
-        }
-
-        public Map<VoltageLevelBuilder, FeederLineNode> createLine(String id, VoltageLevelBuilder vl1, VoltageLevelBuilder vl2, int order1, int order2,
-                                                                   BusCell.Direction direction1, BusCell.Direction direction2) {
-            Map<VoltageLevelBuilder, FeederLineNode> feederLineNodes = new HashMap<>();
-            FeederLineNode feederLineNode1 = vl1.createFeederLineNode(id, vl2.voltageLevelInfos.getId(), ONE, order1, direction1);
-            FeederLineNode feederLineNode2 = vl2.createFeederLineNode(id, vl1.voltageLevelInfos.getId(), TWO, order2, direction2);
-            feederLineNodes.put(vl1, feederLineNode1);
-            feederLineNodes.put(vl2, feederLineNode2);
-            substationGraph.addLineEdge(id, feederLineNode1, feederLineNode2);
-            return feederLineNodes;
-        }
-
-        public Map<VoltageLevelBuilder, FeederLineNode> createLine(String id, VoltageLevelBuilder vl1, VoltageLevelBuilder vl2) {
-            return createLine(id, vl1, vl2, 0, 0, null, null);
-        }
-
-        public Map<VoltageLevelBuilder, Feeder2WTLegNode> createFeeder2WT(String id, VoltageLevelBuilder vl1, VoltageLevelBuilder vl2, int order1, int order2,
-                                                                          BusCell.Direction direction1, BusCell.Direction direction2) {
-            Map<VoltageLevelBuilder, Feeder2WTLegNode> f2WTNodes = new HashMap<>();
-            Feeder2WTLegNode feeder2WtNode1 = vl1.createFeeder2wtLegNode(id, ONE, order1, direction1);
-            Feeder2WTLegNode feeder2WTNode2 = vl2.createFeeder2wtLegNode(id, TWO, order2, direction2);
-            f2WTNodes.put(vl1, feeder2WtNode1);
-            f2WTNodes.put(vl2, feeder2WTNode2);
-            substationGraph.addMultiTermNode(Middle2WTNode.create(id, id, substationGraph, feeder2WtNode1, feeder2WTNode2, vl1.voltageLevelInfos, vl2.voltageLevelInfos, false));
-            return f2WTNodes;
-        }
-
-        public Map<VoltageLevelBuilder, Feeder2WTLegNode> createFeeder2WT(String id, VoltageLevelBuilder vl1, VoltageLevelBuilder vl2) {
-            return createFeeder2WT(id, vl1, vl2, 0, 0, null, null);
-        }
-
-        public Map<VoltageLevelBuilder, Feeder3WTLegNode> createFeeder3WT(String id, VoltageLevelBuilder vl1, VoltageLevelBuilder vl2, VoltageLevelBuilder vl3,
-                                                                          int order1, int order2, int order3,
-                                                                          BusCell.Direction direction1, BusCell.Direction direction2, BusCell.Direction direction3) {
-            Map<VoltageLevelBuilder, Feeder3WTLegNode> f3WTNodes = new HashMap<>();
-            Feeder3WTLegNode feeder3WTNode1 = vl1.createFeeder3wtLegNode(id, ONE, order1, direction1);
-            Feeder3WTLegNode feeder3WTNode2 = vl2.createFeeder3wtLegNode(id, TWO, order2, direction2);
-            Feeder3WTLegNode feeder3WTNode3 = vl3.createFeeder3wtLegNode(id, THREE, order3, direction3);
-            f3WTNodes.put(vl1, feeder3WTNode1);
-            f3WTNodes.put(vl2, feeder3WTNode2);
-            f3WTNodes.put(vl3, feeder3WTNode3);
-
-            // creation of the middle node and the edges linking the transformer leg nodes to this middle node
-            substationGraph.addMultiTermNode(Middle3WTNode.create(id, id, substationGraph, feeder3WTNode1, feeder3WTNode2, feeder3WTNode3,
-                    vl1.voltageLevelInfos, vl2.voltageLevelInfos, vl3.voltageLevelInfos, false));
-
-            return f3WTNodes;
-        }
-
-        public Map<VoltageLevelBuilder, Feeder3WTLegNode> createFeeder3WT(String id, VoltageLevelBuilder vl1, VoltageLevelBuilder vl2, VoltageLevelBuilder vl3) {
-            return createFeeder3WT(id, vl1, vl2, vl3, 0, 0, 0, null, null, null);
-        }
     }
 
     public VoltageLevelGraph buildVoltageLevelGraph(String id,
@@ -259,10 +56,10 @@ public class RawGraphBuilder implements GraphBuilder {
     }
 
     public SubstationGraph buildSubstationGraph(String id) {
-        SubstationBuilder sGraphBuilder = ssBuilders.get(id);
+        SubstationRawBuilder sGraphBuilder = ssBuilders.get(id);
         SubstationGraph ssGraph = sGraphBuilder.getGraph();
         sGraphBuilder.voltageLevelBuilders.stream()
-            .map(VoltageLevelBuilder::getGraph)
+            .map(VoltageLevelRawBuilder::getGraph)
             .sorted(Comparator.comparingDouble(vlGraph -> -vlGraph.getVoltageLevelInfos().getNominalVoltage()))
             .forEach(ssGraph::addVoltageLevel);
         return ssGraph;

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagram.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/SingleLineDiagram.java
@@ -9,6 +9,7 @@ package com.powsybl.sld;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.layout.*;
 import com.powsybl.sld.library.ComponentLibrary;
 import com.powsybl.sld.library.ConvergenceComponentLibrary;

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/SubstationRawBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/SubstationRawBuilder.java
@@ -1,0 +1,81 @@
+package com.powsybl.sld;
+
+import com.powsybl.sld.model.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.powsybl.sld.model.FeederWithSideNode.Side.*;
+
+public class SubstationRawBuilder {
+
+    SubstationGraph substationGraph;
+    List<VoltageLevelRawBuilder> voltageLevelBuilders = new ArrayList<>();
+
+    public SubstationRawBuilder(String id) {
+        substationGraph = SubstationGraph.create(id);
+    }
+
+    public SubstationGraph getGraph() {
+        return substationGraph;
+    }
+
+    public void addVlBuilder(VoltageLevelRawBuilder vlBuilder) {
+        voltageLevelBuilders.add(vlBuilder);
+        vlBuilder.setSubstationBuilder(this);
+    }
+
+    public Map<VoltageLevelRawBuilder, FeederLineNode> createLine(String id, VoltageLevelRawBuilder vl1, VoltageLevelRawBuilder vl2, int order1, int order2,
+                                                                  BusCell.Direction direction1, BusCell.Direction direction2) {
+        Map<VoltageLevelRawBuilder, FeederLineNode> feederLineNodes = new HashMap<>();
+        FeederLineNode feederLineNode1 = vl1.createFeederLineNode(id, vl2.getVoltageLevelInfos().getId(), ONE, order1, direction1);
+        FeederLineNode feederLineNode2 = vl2.createFeederLineNode(id, vl1.getVoltageLevelInfos().getId(), TWO, order2, direction2);
+        feederLineNodes.put(vl1, feederLineNode1);
+        feederLineNodes.put(vl2, feederLineNode2);
+        substationGraph.addLineEdge(id, feederLineNode1, feederLineNode2);
+        return feederLineNodes;
+    }
+
+    public Map<VoltageLevelRawBuilder, FeederLineNode> createLine(String id, VoltageLevelRawBuilder vl1, VoltageLevelRawBuilder vl2) {
+        return createLine(id, vl1, vl2, 0, 0, null, null);
+    }
+
+    public Map<VoltageLevelRawBuilder, Feeder2WTLegNode> createFeeder2WT(String id, VoltageLevelRawBuilder vl1, VoltageLevelRawBuilder vl2, int order1, int order2,
+                                                                         BusCell.Direction direction1, BusCell.Direction direction2) {
+        Map<VoltageLevelRawBuilder, Feeder2WTLegNode> f2WTNodes = new HashMap<>();
+        Feeder2WTLegNode feeder2WtNode1 = vl1.createFeeder2wtLegNode(id, ONE, order1, direction1);
+        Feeder2WTLegNode feeder2WTNode2 = vl2.createFeeder2wtLegNode(id, TWO, order2, direction2);
+        f2WTNodes.put(vl1, feeder2WtNode1);
+        f2WTNodes.put(vl2, feeder2WTNode2);
+        substationGraph.addMultiTermNode(Middle2WTNode.create(id, id, substationGraph, feeder2WtNode1, feeder2WTNode2, vl1.getVoltageLevelInfos(), vl2.getVoltageLevelInfos(), false));
+        return f2WTNodes;
+    }
+
+    public Map<VoltageLevelRawBuilder, Feeder2WTLegNode> createFeeder2WT(String id, VoltageLevelRawBuilder vl1, VoltageLevelRawBuilder vl2) {
+        return createFeeder2WT(id, vl1, vl2, 0, 0, null, null);
+    }
+
+    public Map<VoltageLevelRawBuilder, Feeder3WTLegNode> createFeeder3WT(String id, VoltageLevelRawBuilder vl1, VoltageLevelRawBuilder vl2, VoltageLevelRawBuilder vl3,
+                                                                         int order1, int order2, int order3,
+                                                                         BusCell.Direction direction1, BusCell.Direction direction2, BusCell.Direction direction3) {
+        Map<VoltageLevelRawBuilder, Feeder3WTLegNode> f3WTNodes = new HashMap<>();
+        Feeder3WTLegNode feeder3WTNode1 = vl1.createFeeder3wtLegNode(id, ONE, order1, direction1);
+        Feeder3WTLegNode feeder3WTNode2 = vl2.createFeeder3wtLegNode(id, TWO, order2, direction2);
+        Feeder3WTLegNode feeder3WTNode3 = vl3.createFeeder3wtLegNode(id, THREE, order3, direction3);
+        f3WTNodes.put(vl1, feeder3WTNode1);
+        f3WTNodes.put(vl2, feeder3WTNode2);
+        f3WTNodes.put(vl3, feeder3WTNode3);
+
+        // creation of the middle node and the edges linking the transformer leg nodes to this middle node
+        substationGraph.addMultiTermNode(Middle3WTNode.create(id, id, substationGraph, feeder3WTNode1, feeder3WTNode2, feeder3WTNode3,
+                vl1.getVoltageLevelInfos(), vl2.getVoltageLevelInfos(), vl3.getVoltageLevelInfos(), false));
+
+        return f3WTNodes;
+    }
+
+    public Map<VoltageLevelRawBuilder, Feeder3WTLegNode> createFeeder3WT(String id, VoltageLevelRawBuilder vl1, VoltageLevelRawBuilder vl2, VoltageLevelRawBuilder vl3) {
+        return createFeeder3WT(id, vl1, vl2, vl3, 0, 0, 0, null, null, null);
+    }
+}

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/VoltageLevelRawBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/VoltageLevelRawBuilder.java
@@ -1,0 +1,141 @@
+package com.powsybl.sld;
+
+import com.powsybl.sld.model.*;
+
+import java.util.function.Function;
+
+public class VoltageLevelRawBuilder {
+
+    private final VoltageLevelInfos voltageLevelInfos;
+    private final VoltageLevelGraph voltageLevelGraph;
+    private final Function<String, VoltageLevelInfos> getVoltageLevelInfosFromId;
+
+    private SubstationRawBuilder substationBuilder;
+
+    public VoltageLevelRawBuilder(VoltageLevelInfos voltageLevelInfos, boolean forVoltageLevelDiagram, Function<String, VoltageLevelInfos> getVoltageLevelInfosFromId) {
+        this.voltageLevelInfos = voltageLevelInfos;
+        this.voltageLevelGraph = VoltageLevelGraph.create(voltageLevelInfos, forVoltageLevelDiagram);
+        this.getVoltageLevelInfosFromId = getVoltageLevelInfosFromId;
+    }
+
+    public VoltageLevelGraph getGraph() {
+        return voltageLevelGraph;
+    }
+
+    public SubstationRawBuilder getSubstationBuilder() {
+        return substationBuilder;
+    }
+
+    public void setSubstationBuilder(SubstationRawBuilder substationBuilder) {
+        this.substationBuilder = substationBuilder;
+    }
+
+    public BusNode createBusBarSection(String id, int busbarIndex, int sectionIndex) {
+        BusNode busNode = BusNode.create(voltageLevelGraph, id, id);
+        voltageLevelGraph.addNode(busNode);
+        busNode.setBusBarIndexSectionIndex(busbarIndex, sectionIndex);
+        return busNode;
+    }
+
+    public BusNode createBusBarSection(String id) {
+        BusNode busNode = BusNode.create(voltageLevelGraph, id, id);
+        voltageLevelGraph.addNode(busNode);
+        return busNode;
+    }
+
+    public SwitchNode createSwitchNode(SwitchNode.SwitchKind sk, String id, boolean fictitious, boolean open) {
+        SwitchNode sw = new SwitchNode(id, id, sk.name(), fictitious, voltageLevelGraph, sk, open);
+        voltageLevelGraph.addNode(sw);
+        return sw;
+    }
+
+    public SwitchNode createSwitchNode(SwitchNode.SwitchKind sk, String id, boolean fictitious, boolean open, Integer order, BusCell.Direction direction) {
+        SwitchNode sw = new SwitchNode(id, id, sk.name(), fictitious, voltageLevelGraph, sk, open);
+        voltageLevelGraph.addNode(sw);
+        if (direction != null || order != null) {
+            addExtension(sw, order, direction);
+        }
+        return sw;
+    }
+
+    public void connectNode(Node node1, Node node2) {
+        voltageLevelGraph.addEdge(node1, node2);
+    }
+
+    public FictitiousNode createFictitiousNode(int id) {
+        InternalNode fictitiousNode = new InternalNode(id, voltageLevelGraph);
+        voltageLevelGraph.addNode(fictitiousNode);
+        return fictitiousNode;
+    }
+
+    public FictitiousNode createFictitiousNode(String id) {
+        InternalNode fictitiousNode = new InternalNode(id, voltageLevelGraph);
+        voltageLevelGraph.addNode(fictitiousNode);
+        return fictitiousNode;
+    }
+
+    public void addExtension(Node fn, Integer order, BusCell.Direction direction) {
+        if (order != null) {
+            fn.setOrder(order);
+        }
+        fn.setDirection(direction == null ? BusCell.Direction.UNDEFINED : direction);
+    }
+
+    private void commonFeederSetting(FeederNode node, String id, int order, BusCell.Direction direction) {
+        node.setLabel(id);
+        voltageLevelGraph.addNode(node);
+        if (direction != null) {
+            addExtension(node, order, direction);
+        }
+    }
+
+    public FeederNode createLoad(String id) {
+        return createLoad(id, 0, null);
+    }
+
+    public FeederNode createLoad(String id, int order, BusCell.Direction direction) {
+        FeederInjectionNode fn = FeederInjectionNode.createLoad(voltageLevelGraph, id, id);
+        commonFeederSetting(fn, id, order, direction);
+        return fn;
+    }
+
+    public FeederNode createGenerator(String id) {
+        return createGenerator(id, 0, null);
+    }
+
+    public FeederNode createGenerator(String id, int order, BusCell.Direction direction) {
+        FeederInjectionNode fn = FeederInjectionNode.createGenerator(voltageLevelGraph, id, id);
+        commonFeederSetting(fn, id, order, direction);
+        return fn;
+    }
+
+    public FeederLineNode createFeederLineNode(String id, String otherVlId, FeederWithSideNode.Side side, int order, BusCell.Direction direction) {
+        FeederLineNode fln = FeederLineNode.create(voltageLevelGraph, id + "_" + side, id, id, side, getVoltageLevelInfosFromId.apply(otherVlId));
+        commonFeederSetting(fln, id, order, direction);
+        return fln;
+    }
+
+    public Feeder2WTNode createFeeder2WTNode(String id, String otherVlId, FeederWithSideNode.Side side,
+                                             int order, BusCell.Direction direction) {
+        Feeder2WTNode f2WTe = Feeder2WTNode.create(voltageLevelGraph, id + "_" + side, id, id, side, getVoltageLevelInfosFromId.apply(otherVlId));
+        commonFeederSetting(f2WTe, id, order, direction);
+        return f2WTe;
+    }
+
+    public Feeder2WTLegNode createFeeder2wtLegNode(String id, FeederWithSideNode.Side side,
+                                                   int order, BusCell.Direction direction) {
+        Feeder2WTLegNode f2WTe = Feeder2WTLegNode.create(voltageLevelGraph, id + "_" + side, id, id, side);
+        commonFeederSetting(f2WTe, id, order, direction);
+        return f2WTe;
+    }
+
+    public Feeder3WTLegNode createFeeder3wtLegNode(String id, FeederWithSideNode.Side side, int order, BusCell.Direction direction) {
+        Feeder3WTLegNode f3WTe = Feeder3WTLegNode.createForSubstationDiagram(voltageLevelGraph, id + "_" + side, id, id, side);
+        commonFeederSetting(f3WTe, id + side.getIntValue(), order, direction);
+        return f3WTe;
+    }
+
+    public VoltageLevelInfos getVoltageLevelInfos() {
+        return voltageLevelInfos;
+    }
+}

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/GraphBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/GraphBuilder.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.sld;
+package com.powsybl.sld.builders;
 
 import java.util.List;
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/NetworkGraphBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/NetworkGraphBuilder.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.sld;
+package com.powsybl.sld.builders;
 
 import com.google.common.collect.ImmutableMap;
 import com.powsybl.commons.PowsyblException;

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/RawGraphBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/RawGraphBuilder.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.sld;
+package com.powsybl.sld.builders;
 
 import com.powsybl.sld.model.*;
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/SubstationRawBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/SubstationRawBuilder.java
@@ -1,4 +1,4 @@
-package com.powsybl.sld;
+package com.powsybl.sld.builders;
 
 import com.powsybl.sld.model.*;
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/VoltageLevelRawBuilder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/builders/VoltageLevelRawBuilder.java
@@ -1,4 +1,4 @@
-package com.powsybl.sld;
+package com.powsybl.sld.builders;
 
 import com.powsybl.sld.model.*;
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/AbstractTestCaseIidm.java
@@ -9,7 +9,7 @@ package com.powsybl.sld.iidm;
 import com.powsybl.commons.extensions.Extendable;
 import com.powsybl.iidm.network.*;
 import com.powsybl.sld.AbstractTestCase;
-import com.powsybl.sld.GraphBuilder;
+import com.powsybl.sld.builders.GraphBuilder;
 import com.powsybl.sld.iidm.extensions.BusbarSectionPositionAdder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.iidm.extensions.ConnectablePositionAdder;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import org.junit.Before;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11SubstationGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase11SubstationGraph.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.*;
 import com.powsybl.sld.model.SubstationGraph;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase12GraphWith3WT.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase12GraphWith3WT.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.*;
 import com.powsybl.sld.library.ComponentLibrary;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase13ZoneGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase13ZoneGraph.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.iidm;
 
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.model.ZoneGraph;
 import com.powsybl.sld.model.ZoneGraphTest;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase14UpToNFeederInfos.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase14UpToNFeederInfos.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.model.BusCell;
 import com.powsybl.sld.model.FeederNode;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.BlockOrganizer;
 import com.powsybl.sld.layout.ImplicitCellDetector;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1BusBreaker.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1BusBreaker.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import org.junit.Before;
 import org.junit.Test;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1inverted.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase1inverted.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import org.junit.Before;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase2StackedCell.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase2StackedCell.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import org.junit.Before;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase3Coupling.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase3Coupling.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import org.junit.Before;
 import org.junit.Test;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase4NotParallelel.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase4NotParallelel.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import org.junit.Before;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntHorizontal.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntHorizontal.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import org.junit.Before;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntVertical.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase5ShuntVertical.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import org.junit.Before;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase6CouplingNonFlatHorizontal.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase6CouplingNonFlatHorizontal.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import org.junit.Before;
 import org.junit.Test;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase6InternalConnection.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase6InternalConnection.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import org.junit.Before;
 import org.junit.Test;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7CellDetectionIssue.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.ImplicitCellDetector;
 import com.powsybl.sld.model.VoltageLevelGraph;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseConsecutiveShunts.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseConsecutiveShunts.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.iidm.import_.Importers;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.model.Node;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import com.powsybl.sld.svg.DefaultDiagramLabelProvider;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseGraphAdaptCellHeightToContent.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseGraphAdaptCellHeightToContent.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.BlockOrganizer;
 import com.powsybl.sld.layout.ImplicitCellDetector;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestInternalBranchesBusBreaker.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestInternalBranchesBusBreaker.java
@@ -9,7 +9,7 @@ package com.powsybl.sld.iidm;
 import com.powsybl.commons.config.BaseVoltagesConfig;
 import com.powsybl.commons.config.ModuleConfigRepository;
 import com.powsybl.commons.config.PlatformConfig;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
 import com.powsybl.sld.layout.VerticalSubstationLayoutFactory;
 import com.powsybl.sld.model.SubstationGraph;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestInternalBranchesNodeBreaker.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestInternalBranchesNodeBreaker.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.iidm;
 
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
 import com.powsybl.sld.layout.VerticalSubstationLayoutFactory;
 import com.powsybl.sld.model.SubstationGraph;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestNodeDecoratorsBusBreaker.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestNodeDecoratorsBusBreaker.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.iidm;
 
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.model.VoltageLevelGraph;
 import org.junit.Before;
 import org.junit.Test;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestNodeDecoratorsNodeBreaker.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestNodeDecoratorsNodeBreaker.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.iidm.network.Network;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.library.ComponentSize;
 import com.powsybl.sld.model.Node;
 import com.powsybl.sld.model.SubstationGraph;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialBlock.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialBlock.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.BlockOrganizer;
 import com.powsybl.sld.layout.ImplicitCellDetector;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialParallelBlock.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialParallelBlock.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.BlockOrganizer;
 import com.powsybl.sld.layout.ImplicitCellDetector;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSingleLineDiagramClass.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSingleLineDiagramClass.java
@@ -10,7 +10,7 @@ import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.SingleLineDiagram;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import org.apache.commons.io.output.NullWriter;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestTopologyCalculation.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestTopologyCalculation.java
@@ -10,7 +10,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.*;
 import com.powsybl.sld.model.Node;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnicityNodeIdWithMutipleNetwork.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestUnicityNodeIdWithMutipleNetwork.java
@@ -7,8 +7,8 @@
 package com.powsybl.sld.iidm;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.GraphBuilder;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.GraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.model.VoltageLevelGraph;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/model/AddNodeGraphTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/model/AddNodeGraphTest.java
@@ -8,7 +8,7 @@ package com.powsybl.sld.model;
 
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.AbstractTestCaseIidm;
 import com.powsybl.sld.library.ComponentTypeName;
 import org.junit.Before;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/model/ZoneGraphTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/model/ZoneGraphTest.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.model;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import org.joda.time.DateTime;
 import org.junit.Test;
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/AbstractTestCaseRaw.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/AbstractTestCaseRaw.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.raw;
 
 import com.powsybl.sld.AbstractTestCase;
-import com.powsybl.sld.RawGraphBuilder;
+import com.powsybl.sld.builders.RawGraphBuilder;
 import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.model.FeederNode;
 import com.powsybl.sld.model.Graph;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/AbstractTestCaseRaw.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/AbstractTestCaseRaw.java
@@ -6,17 +6,22 @@
  */
 package com.powsybl.sld.raw;
 
-import static com.powsybl.sld.library.ComponentTypeName.ARROW_ACTIVE;
-import static com.powsybl.sld.library.ComponentTypeName.ARROW_REACTIVE;
-
 import com.powsybl.sld.AbstractTestCase;
 import com.powsybl.sld.RawGraphBuilder;
 import com.powsybl.sld.layout.LayoutParameters;
-import com.powsybl.sld.model.*;
-import com.powsybl.sld.svg.*;
+import com.powsybl.sld.model.FeederNode;
+import com.powsybl.sld.model.Graph;
+import com.powsybl.sld.model.Node;
+import com.powsybl.sld.svg.BasicStyleProvider;
+import com.powsybl.sld.svg.DiagramLabelProvider;
+import com.powsybl.sld.svg.FeederInfo;
+import com.powsybl.sld.svg.LabelPosition;
 
 import java.util.*;
 import java.util.stream.Stream;
+
+import static com.powsybl.sld.library.ComponentTypeName.ARROW_ACTIVE;
+import static com.powsybl.sld.library.ComponentTypeName.ARROW_REACTIVE;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase1.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase1.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import com.powsybl.sld.svg.BasicStyleProvider;
 import org.junit.Before;
@@ -30,7 +31,7 @@ public class TestCase1 extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs = vlBuilder.createBusBarSection("bbs", 1, 1);
         FeederNode load = vlBuilder.createLoad("l", 0, BusCell.Direction.TOP);
         SwitchNode d = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "d", false, false);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase1.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase1.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import com.powsybl.sld.svg.BasicStyleProvider;
 import org.junit.Before;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase11SubstationGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase11SubstationGraph.java
@@ -6,8 +6,8 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.SubstationRawBuilder;
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.SubstationRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
 import com.powsybl.sld.layout.VerticalSubstationLayoutFactory;
 import com.powsybl.sld.model.*;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase11SubstationGraph.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase11SubstationGraph.java
@@ -6,7 +6,8 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.RawGraphBuilder;
+import com.powsybl.sld.SubstationRawBuilder;
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
 import com.powsybl.sld.layout.VerticalSubstationLayoutFactory;
 import com.powsybl.sld.model.*;
@@ -24,8 +25,8 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        RawGraphBuilder.SubstationBuilder ssb1 = rawGraphBuilder.createSubstationBuilder("subst");
-        RawGraphBuilder.VoltageLevelBuilder vlb1 = rawGraphBuilder.createVoltageLevelBuilder("vl1", 380, false);
+        SubstationRawBuilder ssb1 = rawGraphBuilder.createSubstationBuilder("subst");
+        VoltageLevelRawBuilder vlb1 = rawGraphBuilder.createVoltageLevelBuilder("vl1", 380, false);
         ssb1.addVlBuilder(vlb1);
 
         BusNode bbs1 = vlb1.createBusBarSection("bbs1", 1, 1);
@@ -77,7 +78,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
         vlb1.connectNode(dgen2, bgen2);
         vlb1.connectNode(gen2, bgen2);
 
-        RawGraphBuilder.VoltageLevelBuilder vlb2 = rawGraphBuilder.createVoltageLevelBuilder("vl2", 225, false);
+        VoltageLevelRawBuilder vlb2 = rawGraphBuilder.createVoltageLevelBuilder("vl2", 225, false);
         ssb1.addVlBuilder(vlb2);
 
         BusNode bbs5 = vlb2.createBusBarSection("bbs5", 1, 1);
@@ -106,7 +107,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
         vlb2.connectNode(bgen4, dgen4);
 
         // third voltage level
-        RawGraphBuilder.VoltageLevelBuilder vlb3 = rawGraphBuilder.createVoltageLevelBuilder("vl3", 225, false);
+        VoltageLevelRawBuilder vlb3 = rawGraphBuilder.createVoltageLevelBuilder("vl3", 225, false);
         ssb1.addVlBuilder(vlb3);
 
         BusNode bbs7 = vlb3.createBusBarSection("bbs7", 1, 1);
@@ -123,7 +124,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
         //
         */
 
-        Map<RawGraphBuilder.VoltageLevelBuilder, Feeder2WTLegNode> feeder2WTs1 = ssb1.createFeeder2WT("trf1", vlb1, vlb2,
+        Map<VoltageLevelRawBuilder, Feeder2WTLegNode> feeder2WTs1 = ssb1.createFeeder2WT("trf1", vlb1, vlb2,
                 1, 1, BusCell.Direction.TOP, BusCell.Direction.TOP);
         SwitchNode dtrf11 = vlb1.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "dtrf11", false, false);
         SwitchNode btrf11 = vlb1.createSwitchNode(SwitchNode.SwitchKind.BREAKER, "btrf11", false, false);
@@ -137,7 +138,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
         vlb2.connectNode(dtrf21, btrf21);
         vlb2.connectNode(btrf21, feeder2WTs1.get(vlb2));
 
-        Map<RawGraphBuilder.VoltageLevelBuilder, Feeder2WTLegNode> feeder2WTs2 = ssb1.createFeeder2WT("trf2", vlb1, vlb2,
+        Map<VoltageLevelRawBuilder, Feeder2WTLegNode> feeder2WTs2 = ssb1.createFeeder2WT("trf2", vlb1, vlb2,
                 11, 7, BusCell.Direction.TOP, BusCell.Direction.BOTTOM);
         SwitchNode dtrf12 = vlb1.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "dtrf12", false, false);
         SwitchNode btrf12 = vlb1.createSwitchNode(SwitchNode.SwitchKind.BREAKER, "btrf12", false, false);
@@ -151,7 +152,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
         vlb2.connectNode(dtrf22, btrf22);
         vlb2.connectNode(btrf22, feeder2WTs2.get(vlb2));
 
-        Map<RawGraphBuilder.VoltageLevelBuilder, Feeder2WTLegNode> feeder2WTs3 = ssb1.createFeeder2WT("trf3", vlb1, vlb2,
+        Map<VoltageLevelRawBuilder, Feeder2WTLegNode> feeder2WTs3 = ssb1.createFeeder2WT("trf3", vlb1, vlb2,
                 3, 8, BusCell.Direction.BOTTOM, BusCell.Direction.BOTTOM);
 
         SwitchNode dtrf13 = vlb1.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "dtrf13", false, false);
@@ -166,7 +167,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
         vlb2.connectNode(dtrf23, btrf23);
         vlb2.connectNode(btrf23, feeder2WTs3.get(vlb2));
 
-        Map<RawGraphBuilder.VoltageLevelBuilder, Feeder2WTLegNode> feeder2WTs4 = ssb1.createFeeder2WT("trf4", vlb1, vlb2,
+        Map<VoltageLevelRawBuilder, Feeder2WTLegNode> feeder2WTs4 = ssb1.createFeeder2WT("trf4", vlb1, vlb2,
                 10, 3, BusCell.Direction.BOTTOM, BusCell.Direction.TOP);
 
         SwitchNode dtrf14 = vlb1.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "dtrf14", false, false);
@@ -181,7 +182,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
         vlb2.connectNode(dtrf24, btrf24);
         vlb2.connectNode(btrf24, feeder2WTs4.get(vlb2));
 
-        Map<RawGraphBuilder.VoltageLevelBuilder, Feeder2WTLegNode> feeder2WTs5 = ssb1.createFeeder2WT("trf5", vlb1, vlb3,
+        Map<VoltageLevelRawBuilder, Feeder2WTLegNode> feeder2WTs5 = ssb1.createFeeder2WT("trf5", vlb1, vlb3,
                 4, 1, BusCell.Direction.TOP, BusCell.Direction.BOTTOM);
 
         SwitchNode dtrf15 = vlb1.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "dtrf15", false, false);
@@ -200,7 +201,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
         //
        */
 
-        Map<RawGraphBuilder.VoltageLevelBuilder, Feeder3WTLegNode> feeder3WTs6 = ssb1.createFeeder3WT("trf6", vlb1, vlb2, vlb3,
+        Map<VoltageLevelRawBuilder, Feeder3WTLegNode> feeder3WTs6 = ssb1.createFeeder3WT("trf6", vlb1, vlb2, vlb3,
                 5, 5, 2, BusCell.Direction.TOP, BusCell.Direction.TOP, BusCell.Direction.TOP);
 
         SwitchNode dtrf16 = vlb1.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "dtrf16", false, false);
@@ -221,7 +222,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
         vlb3.connectNode(dtrf36, btrf36);
         vlb3.connectNode(btrf36, feeder3WTs6.get(vlb3));
 
-        Map<RawGraphBuilder.VoltageLevelBuilder, Feeder3WTLegNode> feeder3WTs7 = ssb1.createFeeder3WT("trf7", vlb1, vlb2, vlb3,
+        Map<VoltageLevelRawBuilder, Feeder3WTLegNode> feeder3WTs7 = ssb1.createFeeder3WT("trf7", vlb1, vlb2, vlb3,
                 6, 4, 3, BusCell.Direction.BOTTOM, BusCell.Direction.TOP, BusCell.Direction.BOTTOM);
 
         SwitchNode dtrf17 = vlb1.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "dtrf17", false, false);
@@ -242,7 +243,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
         vlb3.connectNode(dtrf37, btrf37);
         vlb3.connectNode(btrf37, feeder3WTs7.get(vlb3));
 
-        Map<RawGraphBuilder.VoltageLevelBuilder, Feeder3WTLegNode> feeder3WTs8 = ssb1.createFeeder3WT("trf8", vlb1, vlb2, vlb3,
+        Map<VoltageLevelRawBuilder, Feeder3WTLegNode> feeder3WTs8 = ssb1.createFeeder3WT("trf8", vlb1, vlb2, vlb3,
                 9, 6, 4, BusCell.Direction.TOP, BusCell.Direction.BOTTOM, BusCell.Direction.TOP);
 
         SwitchNode dtrf18 = vlb1.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "dtrf18", false, false);
@@ -267,8 +268,8 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
         //
        */
 
-        RawGraphBuilder.SubstationBuilder ssb2 = rawGraphBuilder.createSubstationBuilder("subst2");
-        RawGraphBuilder.VoltageLevelBuilder vlsubst2 = rawGraphBuilder.createVoltageLevelBuilder("vlSubst2", 380, false);
+        SubstationRawBuilder ssb2 = rawGraphBuilder.createSubstationBuilder("subst2");
+        VoltageLevelRawBuilder vlsubst2 = rawGraphBuilder.createVoltageLevelBuilder("vlSubst2", 380, false);
         ssb2.addVlBuilder(vlsubst2);
 
         BusNode bbs12 = vlsubst2.createBusBarSection("bbs1_2", 1, 1);
@@ -278,7 +279,7 @@ public class TestCase11SubstationGraph extends AbstractTestCaseRaw {
 
         SwitchNode dline212 = vlsubst2.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "dline21_2", false, false);
         SwitchNode bline212 = vlsubst2.createSwitchNode(SwitchNode.SwitchKind.BREAKER, "bline21_2", false, false);
-        Map<RawGraphBuilder.VoltageLevelBuilder, FeederLineNode> line1 =
+        Map<VoltageLevelRawBuilder, FeederLineNode> line1 =
                 ssb2.createLine("line1", vlb1, vlsubst2, 7, 1, BusCell.Direction.TOP, BusCell.Direction.TOP);
         vlb1.connectNode(bbs1, dline112);
         vlb1.connectNode(dline112, bline112);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase2.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase2.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.BlockOrganizer;
 import com.powsybl.sld.layout.ImplicitCellDetector;
 import com.powsybl.sld.layout.PositionVoltageLevelLayout;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase2.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase2.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.BlockOrganizer;
 import com.powsybl.sld.layout.ImplicitCellDetector;
 import com.powsybl.sld.layout.PositionVoltageLevelLayout;
@@ -39,7 +40,7 @@ public class TestCase2 extends AbstractTestCaseRaw {
     }
 
     private void buildVl(String id) {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder(id, 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder(id, 380);
         BusNode bbs1 = vlBuilder.createBusBarSection("bbs1", 1, 1);
         BusNode bbs2 = vlBuilder.createBusBarSection("bbs2", 2, 1);
         SwitchNode d1 = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "d1", false, false);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase3.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase3.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.SwitchNode;
 import com.powsybl.sld.model.VoltageLevelGraph;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase3.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase3.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.SwitchNode;
 import com.powsybl.sld.model.VoltageLevelGraph;
@@ -31,7 +32,7 @@ public class TestCase3 extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs1 = vlBuilder.createBusBarSection("bbs1", 1, 1);
         BusNode bbs2 = vlBuilder.createBusBarSection("bbs2", 2, 1);
         SwitchNode d1 = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "d1", false, false);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase4.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase4.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
 import org.junit.Test;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase4.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase4.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,7 +39,7 @@ public class TestCase4 extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs11 = vlBuilder.createBusBarSection("bbs1.1", 1, 1);
         BusNode bbs12 = vlBuilder.createBusBarSection("bbs1.2", 1, 2);
         SwitchNode ss1 = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "ss1", false, false);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5H.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5H.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +32,7 @@ public class TestCase5H extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs = vlBuilder.createBusBarSection("bbs", 1, 1);
         FeederNode la = vlBuilder.createLoad("la", 10, BusCell.Direction.TOP);
         SwitchNode ba = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.BREAKER, "ba", false, false);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5H.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5H.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
 import org.junit.Test;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5V.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5V.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
 import org.junit.Test;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5V.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase5V.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +32,7 @@ public class TestCase5V extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs = vlBuilder.createBusBarSection("bbs", 1, 1);
         FeederNode la = vlBuilder.createLoad("la", 20, BusCell.Direction.TOP);
         SwitchNode ba = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.BREAKER, "ba", false, false);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase6.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase6.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.SwitchNode;
 import com.powsybl.sld.model.VoltageLevelGraph;
@@ -31,7 +32,7 @@ public class TestCase6 extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
 
         BusNode bbs11 = vlBuilder.createBusBarSection("bbs1.1", 1, 1);
         BusNode bbs12 = vlBuilder.createBusBarSection("bbs1.2", 1, 2);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase6.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase6.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.SwitchNode;
 import com.powsybl.sld.model.VoltageLevelGraph;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase7CellDetectionIssue.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.ImplicitCellDetector;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
@@ -26,7 +27,7 @@ public class TestCase7CellDetectionIssue extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs = vlBuilder.createBusBarSection("bbs", 1, 1);
         FeederNode load = vlBuilder.createLoad("l", 0, BusCell.Direction.TOP);
         vlBuilder.connectNode(bbs, load);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase7CellDetectionIssue.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.ImplicitCellDetector;
 import com.powsybl.sld.model.*;
 import org.junit.Before;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseComplexCoupling.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseComplexCoupling.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.FictitiousNode;
 import com.powsybl.sld.model.SwitchNode;
@@ -24,7 +25,7 @@ public class TestCaseComplexCoupling extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs1 = vlBuilder.createBusBarSection("bbs1", 1, 1);
         BusNode bbs2 = vlBuilder.createBusBarSection("bbs2", 2, 1);
         SwitchNode d1 = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "d1", false, false);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseComplexCoupling.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseComplexCoupling.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.FictitiousNode;
 import com.powsybl.sld.model.SwitchNode;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseShuntArrangement.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseShuntArrangement.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.BlockOrganizer;
 import com.powsybl.sld.layout.ImplicitCellDetector;
 import com.powsybl.sld.layout.PositionVoltageLevelLayout;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseShuntArrangement.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseShuntArrangement.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.BlockOrganizer;
 import com.powsybl.sld.layout.ImplicitCellDetector;
 import com.powsybl.sld.layout.PositionVoltageLevelLayout;
@@ -25,7 +26,7 @@ public class TestCaseShuntArrangement extends AbstractTestCaseRaw {
     @Before
     public void setUp() {
         int i = 0;
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs1 = vlBuilder.createBusBarSection("bbs1", 1, 1);
         BusNode bbs21 = vlBuilder.createBusBarSection("bbs21", 2, 1);
         BusNode bbs22 = vlBuilder.createBusBarSection("bbs22", 2, 2);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestIncompleteFeederIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestIncompleteFeederIssue.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.RawGraphBuilder;
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.FictitiousNode;
 import com.powsybl.sld.model.SwitchNode;
@@ -42,7 +42,7 @@ public class TestIncompleteFeederIssue extends AbstractTestCaseRaw {
 
     @Test
     public void test() {
-        RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs = vlBuilder.createBusBarSection("bbs", 1, 1);
         SwitchNode d1 = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "d1", false, false);
         FictitiousNode fict1 = vlBuilder.createFictitiousNode("fict1");

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestIncompleteFeederIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestIncompleteFeederIssue.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.FictitiousNode;
 import com.powsybl.sld.model.SwitchNode;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInsertFictitiousNodesAtFeeder.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInsertFictitiousNodesAtFeeder.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.RawGraphBuilder;
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import com.powsybl.sld.svg.BasicStyleProvider;
 import org.junit.Before;
@@ -41,7 +41,7 @@ public class TestInsertFictitiousNodesAtFeeder extends AbstractTestCaseRaw {
 
     @Test
     public void testFeederOnBus() {
-        RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 400);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 400);
         BusNode bbs = vlBuilder.createBusBarSection("bbs", 1, 1);
         FeederLineNode feederLineNode = vlBuilder.createFeederLineNode("line", "otherVl", FeederWithSideNode.Side.ONE, 0, null);
         vlBuilder.connectNode(bbs, feederLineNode);
@@ -53,7 +53,7 @@ public class TestInsertFictitiousNodesAtFeeder extends AbstractTestCaseRaw {
 
     @Test
     public void testFeederOnBusDisconnector() {
-        RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 400);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 400);
         BusNode bbs = vlBuilder.createBusBarSection("bbs", 1, 1);
         SwitchNode busDisconnector = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "busDisconnector", false, false);
         FeederLineNode feederLineNode = vlBuilder.createFeederLineNode("line", "otherVl", FeederWithSideNode.Side.ONE, 0, BusCell.Direction.BOTTOM);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInsertFictitiousNodesAtFeeder.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInsertFictitiousNodesAtFeeder.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import com.powsybl.sld.svg.BasicStyleProvider;
 import org.junit.Before;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellExplicitPosition.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellExplicitPosition.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import com.powsybl.sld.model.BusCell.Direction;
 import org.junit.Before;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellExplicitPosition.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellExplicitPosition.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import com.powsybl.sld.model.BusCell.Direction;
 import org.junit.Before;
@@ -20,7 +21,7 @@ public class TestInternCellExplicitPosition extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl",
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl",
                 380);
         BusNode bbs1 = vlBuilder.createBusBarSection("bbs1", 1, 1);
         FeederNode load1 = vlBuilder.createLoad("l1", 3, BusCell.Direction.TOP);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellShapes.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellShapes.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.FictitiousNode;
 import com.powsybl.sld.model.SwitchNode;
@@ -22,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 public class TestInternCellShapes extends AbstractTestCaseRaw {
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs11 = vlBuilder.createBusBarSection("bbs11", 1, 1);
         BusNode bbs21 = vlBuilder.createBusBarSection("bbs21", 2, 1);
         BusNode bbs12 = vlBuilder.createBusBarSection("bbs12", 1, 2);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellShapes.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestInternCellShapes.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.FictitiousNode;
 import com.powsybl.sld.model.SwitchNode;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestLanesWithUnileg.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestLanesWithUnileg.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.FictitiousNode;
 import com.powsybl.sld.model.SwitchNode;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestLanesWithUnileg.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestLanesWithUnileg.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.FictitiousNode;
 import com.powsybl.sld.model.SwitchNode;
@@ -22,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 public class TestLanesWithUnileg extends AbstractTestCaseRaw {
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs11 = vlBuilder.createBusBarSection("bbs11", 1, 1);
         BusNode bbs12 = vlBuilder.createBusBarSection("bbs12", 1, 2);
         BusNode bbs13 = vlBuilder.createBusBarSection("bbs13", 1, 3);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestOrderConsistency.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestOrderConsistency.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.BlockOrganizer;
 import com.powsybl.sld.layout.ImplicitCellDetector;
 import com.powsybl.sld.layout.PositionVoltageLevelLayout;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestOrderConsistency.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestOrderConsistency.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.RawGraphBuilder;
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.BlockOrganizer;
 import com.powsybl.sld.layout.ImplicitCellDetector;
 import com.powsybl.sld.layout.PositionVoltageLevelLayout;
@@ -31,7 +31,7 @@ public class TestOrderConsistency extends AbstractTestCaseRaw {
     }
 
     private void createCommons(String vlId, boolean middleLeft) {
-        RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder(vlId, 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder(vlId, 380);
         BusNode bbs11 = vlBuilder.createBusBarSection("bbs11", 1, 1);
         BusNode bbs12 = vlBuilder.createBusBarSection("bbs12", 1, 2);
         BusNode bbs21 = vlBuilder.createBusBarSection("bbs21", 2, 1);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOnBus.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOnBus.java
@@ -6,7 +6,11 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.model.*;
+import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.model.BusNode;
+import com.powsybl.sld.model.FeederNode;
+import com.powsybl.sld.model.SwitchNode;
+import com.powsybl.sld.model.VoltageLevelGraph;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,7 +23,7 @@ public class TestParallelFeedersOnBus extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs = vlBuilder.createBusBarSection("bbs", 1, 1);
         FeederNode load1 = vlBuilder.createLoad("l1");
         SwitchNode b = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.BREAKER, "b", false, false);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOnBus.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOnBus.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.BusNode;
 import com.powsybl.sld.model.FeederNode;
 import com.powsybl.sld.model.SwitchNode;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOrders.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOrders.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,7 +20,7 @@ public class TestParallelFeedersOrders extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs = vlBuilder.createBusBarSection("bbs", 1, 1);
         SwitchNode b = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.BREAKER, "b", false, false);
         SwitchNode d = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "d", false, false);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOrders.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestParallelFeedersOrders.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
 import org.junit.Test;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestSerialBlocksInternCells.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestSerialBlocksInternCells.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.BlockOrganizer;
 import com.powsybl.sld.layout.ImplicitCellDetector;
 import com.powsybl.sld.layout.PositionVoltageLevelLayout;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestSerialBlocksInternCells.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestSerialBlocksInternCells.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.BlockOrganizer;
 import com.powsybl.sld.layout.ImplicitCellDetector;
 import com.powsybl.sld.layout.PositionVoltageLevelLayout;
@@ -22,7 +23,7 @@ public class TestSerialBlocksInternCells extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs11 = vlBuilder.createBusBarSection("bbs11", 1, 1);
         BusNode bbs12 = vlBuilder.createBusBarSection("bbs12", 1, 2);
         BusNode bbs21 = vlBuilder.createBusBarSection("bbs21", 2, 1);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUndefinedBlockExternCell.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUndefinedBlockExternCell.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +30,7 @@ public class TestUndefinedBlockExternCell extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs = vlBuilder.createBusBarSection("bbs", 1, 1);
         SwitchNode d = vlBuilder.createSwitchNode(SwitchNode.SwitchKind.DISCONNECTOR, "d", false, false);
         FictitiousNode f0 = vlBuilder.createFictitiousNode("f0");

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUndefinedBlockExternCell.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUndefinedBlockExternCell.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
 import org.junit.Test;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUnhandledPatternInternCell.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUnhandledPatternInternCell.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
+import com.powsybl.sld.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,7 +20,7 @@ public class TestUnhandledPatternInternCell extends AbstractTestCaseRaw {
 
     @Before
     public void setUp() {
-        com.powsybl.sld.RawGraphBuilder.VoltageLevelBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
+        VoltageLevelRawBuilder vlBuilder = rawGraphBuilder.createVoltageLevelBuilder("vl", 380);
         BusNode bbs1 = vlBuilder.createBusBarSection("bbs1", 1, 1);
         BusNode bbs2 = vlBuilder.createBusBarSection("bbs2", 1, 2);
         BusNode bbs3 = vlBuilder.createBusBarSection("bbs3", 1, 3);

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUnhandledPatternInternCell.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUnhandledPatternInternCell.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.sld.raw;
 
-import com.powsybl.sld.VoltageLevelRawBuilder;
+import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.model.*;
 import org.junit.Before;
 import org.junit.Test;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/FeederInfoProviderTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/FeederInfoProviderTest.java
@@ -8,7 +8,7 @@ package com.powsybl.sld.svg;
 
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.StaticVarCompensator.RegulationMode;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.AbstractTestCaseIidm;
 import com.powsybl.sld.iidm.extensions.BusbarSectionPositionAdder;
 import com.powsybl.sld.layout.SmartVoltageLevelLayoutFactory;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/util/NominalVoltageStyleTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/util/NominalVoltageStyleTest.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.util;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.AbstractTestCaseIidm;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.model.*;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/util/TopologicalStyleTest.java
@@ -7,7 +7,7 @@
 package com.powsybl.sld.util;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.sld.NetworkGraphBuilder;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.AbstractTestCaseIidm;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.model.Edge;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Feature



**What is the current behavior?**
`RawGraphBuilder.VoltageLevelBuilder` and `RawGraphBuilder.SubstationBuilder` cannot be extended for custom use



**What is the new behavior (if this is a feature change)?**
`VoltageLevelRawBuilder` and `SubstationRawBuilder` can be extended for custom use. They are in a separate package builders, where the other builders have also been moved to.



**Does this PR introduce a breaking change or deprecate an API?** yes
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
