### PR TITLE
Remove VoltageLevelGraph::getCells

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockPositionner.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockPositionner.java
@@ -7,7 +7,6 @@
 package com.powsybl.sld.layout;
 
 import com.powsybl.sld.model.cells.BusCell;
-import com.powsybl.sld.model.cells.Cell;
 import com.powsybl.sld.model.cells.InternCell;
 import com.powsybl.sld.model.coordinate.Side;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
@@ -155,9 +154,7 @@ class BlockPositionner {
     }
 
     private void manageInternCellOverlaps(VoltageLevelGraph graph) {
-        List<InternCell> cellsToHandle = graph.getCells().stream()
-                .filter(cell -> cell.getType() == Cell.CellType.INTERN)
-                .map(InternCell.class::cast)
+        List<InternCell> cellsToHandle = graph.getInternCellStream()
                 .filter(internCell -> internCell.checkIsNotShape(InternCell.Shape.FLAT, InternCell.Shape.UNDEFINED, InternCell.Shape.UNHANDLEDPATTERN))
                 .collect(Collectors.toList());
         InternCellsLanes lane = new InternCellsLanes(cellsToHandle);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ImplicitCellDetector.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ImplicitCellDetector.java
@@ -79,7 +79,7 @@ public class ImplicitCellDetector implements CellDetector {
             createExternAndShuntCells(graph, nodes);
         }
 
-        graph.getCells().forEach(Cell::getFullId);
+        graph.getCellStream().forEach(Cell::getFullId);
 
         graph.logCellDetectionStatus();
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionFinder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionFinder.java
@@ -45,9 +45,7 @@ public interface PositionFinder {
     }
 
     default void forceSameOrientationForShuntedCell(VoltageLevelGraph graph) {
-        graph.getCells().stream()
-                .filter(c -> c.getType() == Cell.CellType.SHUNT).map(ShuntCell.class::cast)
-                .forEach(sc -> sc.alignDirections(Side.LEFT));
+        graph.getShuntCellStream().forEach(sc -> sc.alignDirections(Side.LEFT));
     }
 
     default void organizeDirections(VoltageLevelGraph graph, List<Subsection> subsections) {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
@@ -92,15 +92,8 @@ public class PositionVoltageLevelLayout extends AbstractVoltageLevelLayout {
     }
 
     private void calculateCellCoord(VoltageLevelGraph graph, LayoutParameters layoutParam) {
-        graph.getCells().stream()
-                .filter(cell -> cell.getType() == Cell.CellType.EXTERN
-                        || cell.getType() == Cell.CellType.INTERN)
-                .map(BusCell.class::cast)
-                .forEach(cell -> cell.calculateCoord(layoutParam, createLayoutContext(graph, cell, layoutParam)));
-        graph.getCells().stream()
-                .filter(cell -> cell.getType() == Cell.CellType.SHUNT)
-                .map(ShuntCell.class::cast)
-                .forEach(cell -> cell.calculateCoord(layoutParam, null));
+        graph.getBusCellStream().forEach(cell -> cell.calculateCoord(layoutParam, createLayoutContext(graph, cell, layoutParam)));
+        graph.getShuntCellStream().forEach(cell -> cell.calculateCoord(layoutParam, null));
     }
 
     private LayoutContext createLayoutContext(VoltageLevelGraph graph, BusCell cell, LayoutParameters layoutParam) {
@@ -128,15 +121,13 @@ public class PositionVoltageLevelLayout extends AbstractVoltageLevelLayout {
             Map<Direction, Double> maxInternCellHeight = new EnumMap<>(Direction.class);
             // Initialize map with intern cells height
             // in order to keep intern cells visible if there are no extern cells
-            getGraph().getCells().stream()
-                    .filter(cell -> cell.getType() == Cell.CellType.INTERN)
-                    .forEach(cell -> maxInternCellHeight.merge(((BusCell) cell).getDirection(), cell.calculateHeight(layoutParam), Math::max));
+            getGraph().getInternCellStream().forEach(cell ->
+                    maxInternCellHeight.merge(((BusCell) cell).getDirection(), cell.calculateHeight(layoutParam), Math::max));
 
             // when using the adapt cell height to content option, we have to calculate the
             // maximum height of all the extern cells in each direction (top and bottom)
-            getGraph().getCells().stream()
-                .filter(cell -> cell.getType() == Cell.CellType.EXTERN)
-                .forEach(cell -> maxCellHeight.merge(((BusCell) cell).getDirection(), cell.calculateHeight(layoutParam), Math::max));
+            getGraph().getExternCellStream().forEach(cell ->
+                    maxCellHeight.merge(((BusCell) cell).getDirection(), cell.calculateHeight(layoutParam), Math::max));
 
             // if needed, adjusting the maximum calculated cell height to the minimum extern cell height parameter
             EnumSet.allOf(Direction.class).forEach(d -> maxCellHeight.compute(d, (k, v) -> {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Subsection.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/Subsection.java
@@ -103,9 +103,7 @@ public class Subsection {
 
         internCellCoherence(graph, lbsCluster.getLbsList(), subsections);
 
-        graph.getCells().stream()
-                .filter(c -> c.getType() == Cell.CellType.SHUNT)
-                .map(ShuntCell.class::cast).forEach(ShuntCell::alignExternCells);
+        graph.getShuntCellStream().forEach(ShuntCell::alignExternCells);
         if (handleShunts) {
             shuntCellCoherence(graph, subsections);
         }
@@ -129,10 +127,8 @@ public class Subsection {
     private static void identifyVerticalInternCells(VoltageLevelGraph graph, List<Subsection> subsections) {
         Map<InternCell, Subsection> verticalCells = new LinkedHashMap<>();
 
-        graph.getCells().stream()
-                .filter(c -> c.getType() == Cell.CellType.INTERN
-                        && ((InternCell) c).checkIsNotShape(InternCell.Shape.UNILEG, InternCell.Shape.UNDEFINED, InternCell.Shape.UNHANDLEDPATTERN))
-                .map(InternCell.class::cast)
+        graph.getInternCellStream()
+                .filter(c -> c.checkIsNotShape(InternCell.Shape.UNILEG, InternCell.Shape.UNDEFINED, InternCell.Shape.UNHANDLEDPATTERN))
                 .forEach(c ->
                         subsections.stream()
                                 .filter(subsection -> subsection.containsAllBusNodes(c.getBusNodes()))
@@ -214,9 +210,7 @@ public class Subsection {
     }
 
     private static void shuntCellCoherence(VoltageLevelGraph vlGraph, List<Subsection> subsections) {
-        Map<ShuntCell, List<BusNode>> shuntCells2Buses = vlGraph.getCells().stream()
-                .filter(c -> c.getType() == Cell.CellType.SHUNT)
-                .map(ShuntCell.class::cast)
+        Map<ShuntCell, List<BusNode>> shuntCells2Buses = vlGraph.getShuntCellStream()
                 .collect(Collectors.toMap(Function.identity(), ShuntCell::getParentBusNodes, (u, v) -> {
                     throw new IllegalStateException(String.format("Duplicate key %s", u));
                 }, LinkedHashMap::new));

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/PositionByClustering.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/PositionByClustering.java
@@ -152,7 +152,7 @@ public class PositionByClustering implements PositionFinder {
         }
 
         Set<ShuntCell> visitedShuntCells = new HashSet<>();
-        graph.getCells().stream().filter(c -> c.getType() == SHUNT).map(ShuntCell.class::cast).forEach(shuntCell -> {
+        graph.getShuntCellStream().forEach(shuntCell -> {
             // starting from each shunt, find the shunt-connected set of extern cells to set the same direction for all of them
             List<ExternCell> externCells = new ArrayList<>();
             shuntTraversal(shuntCell, visitedShuntCells, externCells);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionfromextension/PositionFromExtension.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionfromextension/PositionFromExtension.java
@@ -74,7 +74,7 @@ public class PositionFromExtension implements PositionFinder {
             cell.setDirection(node.getDirection());
             node.getOrder().ifPresent(cell::setOrder);
         });
-        graph.getCells().stream().filter(cell -> cell.getType().isBusCell()).map(BusCell.class::cast).forEach(bc -> {
+        graph.getBusCellStream().forEach(bc -> {
             bc.getNodes().stream().map(Node::getOrder)
                     .filter(Optional::isPresent)
                     .mapToInt(Optional::get)
@@ -85,9 +85,7 @@ public class PositionFromExtension implements PositionFinder {
             }
         });
 
-        List<ExternCell> problematicCells = graph.getCells().stream()
-                .filter(cell -> cell.getType().equals(EXTERN))
-                .map(ExternCell.class::cast)
+        List<ExternCell> problematicCells = graph.getExternCellStream()
                 .filter(cell -> cell.getOrder().isEmpty()).collect(Collectors.toList());
         if (!problematicCells.isEmpty()) {
             LOGGER.warn("Unable to build the layout only with Extension\nproblematic cells :");

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/Cell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/Cell.java
@@ -24,10 +24,6 @@ import java.util.*;
 public interface Cell {
     enum CellType {
         INTERN, EXTERN, SHUNT;
-
-        public boolean isBusCell() {
-            return this == INTERN || this == EXTERN;
-        }
     }
 
     List<Node> getNodes();

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/VoltageLevelGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/VoltageLevelGraph.java
@@ -10,9 +10,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.sld.layout.LayoutParameters;
 import com.powsybl.sld.library.ComponentTypeName;
-import com.powsybl.sld.model.cells.BusCell;
-import com.powsybl.sld.model.cells.Cell;
-import com.powsybl.sld.model.cells.ExternCell;
+import com.powsybl.sld.model.cells.*;
 import com.powsybl.sld.model.coordinate.Direction;
 import com.powsybl.sld.model.coordinate.Orientation;
 import com.powsybl.sld.model.coordinate.Point;
@@ -548,8 +546,24 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
         return new LinkedHashSet<>(edges);
     }
 
-    public Set<Cell> getCells() {
-        return new TreeSet<>(cells);
+    public Stream<Cell> getCellStream() {
+        return cells.stream();
+    }
+
+    public Stream<BusCell> getBusCellStream() {
+        return cells.stream().filter(BusCell.class::isInstance).map(BusCell.class::cast);
+    }
+
+    public Stream<InternCell> getInternCellStream() {
+        return cells.stream().filter(InternCell.class::isInstance).map(InternCell.class::cast);
+    }
+
+    public Stream<ExternCell> getExternCellStream() {
+        return cells.stream().filter(ExternCell.class::isInstance).map(ExternCell.class::cast);
+    }
+
+    public Stream<ShuntCell> getShuntCellStream() {
+        return cells.stream().filter(ShuntCell.class::isInstance).map(ShuntCell.class::cast);
     }
 
     @Override

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -242,10 +242,9 @@ public class DefaultSVGWriter implements SVGWriter {
         Set<Edge> remainingEdgesToDraw = graph.getEdgeSet();
 
         drawBuses(prefixId, root, graph, metadata, initProvider, styleProvider, remainingNodesToDraw);
-        for (Cell cell : graph.getCells()) {
-            drawCell(prefixId, root, graph, cell, metadata, initProvider, styleProvider,
-                remainingEdgesToDraw, remainingNodesToDraw);
-        }
+        graph.getCellStream().forEach(cell ->
+                drawCell(prefixId, root, graph, cell, metadata, initProvider, styleProvider,
+                        remainingEdgesToDraw, remainingNodesToDraw));
 
         drawEdges(prefixId, root, graph, metadata, initProvider, styleProvider, remainingEdgesToDraw);
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7CellDetectionIssue.java
@@ -57,6 +57,6 @@ public class TestCase7CellDetectionIssue extends AbstractTestCaseIidm {
         new ImplicitCellDetector().detectCells(g);
 
         // assert cells
-        assertEquals(1, g.getCells().size());
+        assertEquals(1, g.getCellStream().count());
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialBlock.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialBlock.java
@@ -20,6 +20,8 @@ import com.powsybl.sld.model.cells.Cell;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static com.powsybl.sld.model.coordinate.Coord.Dimension.*;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
 import static com.powsybl.sld.model.nodes.Node.NodeType.*;
@@ -55,8 +57,10 @@ public class TestSerialBlock extends AbstractTestCaseIidm {
         // build blocks
         new BlockOrganizer().organize(g);
 
-        assertEquals(1, g.getCells().size());
-        Cell cell = g.getCells().iterator().next();
+        assertEquals(1, g.getCellStream().count());
+        Optional<Cell> oCell = g.getCellStream().findFirst();
+        assertTrue(oCell.isPresent());
+        Cell cell = oCell.get();
         assertEquals(Block.Type.SERIAL, cell.getRootBlock().getType());
         SerialBlock sb = (SerialBlock) cell.getRootBlock();
         assertTrue(sb.isEmbeddingNodeType(BUS));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialParallelBlock.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialParallelBlock.java
@@ -22,6 +22,8 @@ import com.powsybl.sld.model.cells.Cell;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static com.powsybl.sld.model.coordinate.Coord.Dimension.*;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
 import static com.powsybl.sld.model.nodes.Node.NodeType.*;
@@ -57,8 +59,10 @@ public class TestSerialParallelBlock extends AbstractTestCaseIidm {
         new ImplicitCellDetector().detectCells(g);
         new BlockOrganizer().organize(g);
 
-        assertEquals(1, g.getCells().size());
-        Cell cell = g.getCells().iterator().next();
+        assertEquals(1, g.getCellStream().count());
+        Optional<Cell> oCell = g.getCellStream().findFirst();
+        assertTrue(oCell.isPresent());
+        Cell cell = oCell.get();
         assertEquals(Block.Type.SERIAL, cell.getRootBlock().getType());
         SerialBlock sb = (SerialBlock) cell.getRootBlock();
         assertTrue(sb.isEmbeddingNodeType(BUS));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase7CellDetectionIssue.java
@@ -41,6 +41,6 @@ public class TestCase7CellDetectionIssue extends AbstractTestCaseRaw {
     public void test() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl");
         new ImplicitCellDetector().detectCells(g);
-        assertEquals(1, g.getCells().size());
+        assertEquals(1, g.getCellStream().count());
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUnhandledPatternInternCell.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestUnhandledPatternInternCell.java
@@ -7,6 +7,7 @@
 package com.powsybl.sld.raw;
 
 import com.powsybl.sld.builders.VoltageLevelRawBuilder;
+import com.powsybl.sld.model.cells.Cell;
 import com.powsybl.sld.model.cells.InternCell;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import com.powsybl.sld.model.nodes.BusNode;
@@ -15,7 +16,10 @@ import com.powsybl.sld.model.nodes.SwitchNode;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
@@ -50,6 +54,9 @@ public class TestUnhandledPatternInternCell extends AbstractTestCaseRaw {
     public void test() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl");
         voltageLevelGraphLayout(g);
-        assertEquals(InternCell.Shape.UNHANDLEDPATTERN, ((InternCell) g.getCells().iterator().next()).getShape());
+        Optional<Cell> firstCell = g.getCellStream().findFirst();
+        assertTrue(firstCell.isPresent());
+        assertTrue(firstCell.get() instanceof InternCell);
+        assertEquals(InternCell.Shape.UNHANDLEDPATTERN, ((InternCell) firstCell.get()).getShape());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** 
Feature / refactor



**What is the current behavior?** 
`VoltageLevelGraph::getCells` is called when one wants:
- a stream of BusCell 
- or a stream of ShuntCell
- or a stream of intern cells
- or a stream of extern cells

Each time a new TreeSet is created copying the existing TreeSet and then the same filtering is writing again and again.



**What is the new behavior (if this is a feature change)?**
`VoltageLevelGraph::getCellStream` is deleted and the following methods introduced:
- `VoltageLevelGraph::getCellStream`
- `VoltageLevelGraph::getShuntCellStream`
- `VoltageLevelGraph::getBusCellStream`
- `VoltageLevelGraph::getExternCellStream`
- `VoltageLevelGraph::getInternCellStream`


**Does this PR introduce a breaking change or deprecate an API?** 
No, internal API