### PR TITLE
Add fictitious style on busbar-section

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/NodeFactory.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/NodeFactory.java
@@ -31,6 +31,7 @@ public final class NodeFactory {
 
     public static BusNode createFictitiousBusNode(VoltageLevelGraph graph, String id) {
         BusNode bn = new BusNode(id, null, true);
+        bn.setBusBarIndexSectionIndex(1, 1);
         graph.addNode(bn);
         return bn;
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/BusNode.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/nodes/BusNode.java
@@ -36,7 +36,7 @@ public class BusNode extends Node {
 
     public void calculateCoord(LayoutParameters layoutParameters, double firstBusY) {
         double elementaryWidth = layoutParameters.getCellWidth() / 2;
-        double busPadding = layoutParameters.getBusPadding();
+        double busPadding = isFictitious() ? elementaryWidth : layoutParameters.getBusPadding();
         setCoordinates(position.get(H) * elementaryWidth + busPadding,
             firstBusY + position.get(V) * layoutParameters.getVerticalSpaceBus());
         setPxWidth(position.getSpan(H) * elementaryWidth - 2 * busPadding);

--- a/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.css
+++ b/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.css
@@ -39,4 +39,4 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
-.sld-busbar-section.sld-fictitious {stroke-width: 1}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}

--- a/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.css
+++ b/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.css
@@ -39,3 +39,4 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke-width: 1}

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseFictitiousBus.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseFictitiousBus.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
+import com.powsybl.sld.util.TopologicalStyleProvider;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,25 +45,25 @@ public class TestCaseFictitiousBus extends AbstractTestCaseIidm {
         substation = null;
         vl = network.newVoltageLevel()
                 .setId("vl")
-                .setNominalV(300)
+                .setNominalV(50)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
 
         vl1 = network.newVoltageLevel()
                 .setId("vl1")
-                .setNominalV(120)
+                .setNominalV(10)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
 
         vl2 = network.newVoltageLevel()
                 .setId("vl2")
-                .setNominalV(130)
+                .setNominalV(30)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
 
         vl3 = network.newVoltageLevel()
                 .setId("vl3")
-                .setNominalV(50)
+                .setNominalV(10)
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
 
@@ -88,7 +89,7 @@ public class TestCaseFictitiousBus extends AbstractTestCaseIidm {
     }
 
     @Test
-    public void test() {
+    public void testBasic() {
         // build graph
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
 
@@ -98,5 +99,18 @@ public class TestCaseFictitiousBus extends AbstractTestCaseIidm {
         // write Json and compare to reference
         assertEquals(toString("/TestCaseFictitiousBus.svg"),
                 toSVG(g, "/TestCaseFictitiousBus.svg", getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider()));
+    }
+
+    @Test
+    public void testTopological() {
+        // build graph
+        VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
+
+        // Run layout
+        voltageLevelGraphLayout(g);
+
+        // write Json and compare to reference
+        assertEquals(toString("/TestCaseFictitiousBusTopological.svg"),
+                toSVG(g, "/TestCaseFictitiousBusTopological.svg", getDefaultDiagramLabelProvider(), new TopologicalStyleProvider(network)));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseFictitiousBus.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseFictitiousBus.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.iidm;
+
+import com.powsybl.iidm.network.*;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
+import com.powsybl.sld.iidm.extensions.ConnectablePosition;
+import com.powsybl.sld.model.graphs.VoltageLevelGraph;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * <pre>
+ *     vl1  vl2
+ *     |    |
+ * L1  |    |  L2
+ *     |    |
+ *     --*---  Fictitious busbar section
+ *       |
+ *   L3  |
+ *       |
+ *       vl3
+ *
+ * </pre>
+ *
+ * @author Thomas Adam <tadam at silicom.fr>
+ */
+public class TestCaseFictitiousBus extends AbstractTestCaseIidm {
+
+    private VoltageLevel vl1;
+    private VoltageLevel vl2;
+    private VoltageLevel vl3;
+
+    @Before
+    public void setUp() {
+        network = Network.create("testCase1", "test");
+        graphBuilder = new NetworkGraphBuilder(network);
+        substation = null;
+        vl = network.newVoltageLevel()
+                .setId("vl")
+                .setNominalV(300)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+
+        vl1 = network.newVoltageLevel()
+                .setId("vl1")
+                .setNominalV(120)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+
+        vl2 = network.newVoltageLevel()
+                .setId("vl2")
+                .setNominalV(130)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+
+        vl3 = network.newVoltageLevel()
+                .setId("vl3")
+                .setNominalV(50)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+
+        createInternalConnection(vl, 1, 0);
+        createInternalConnection(vl, 2, 0);
+        createInternalConnection(vl, 3, 0);
+
+        createLine(network, "L1", "L1", 1.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+                1, 10, vl.getId(), vl1.getId(),
+                "L1", 0, ConnectablePosition.Direction.TOP,
+                "L1", 1, ConnectablePosition.Direction.TOP);
+
+        createLine(network, "L2", "L2", 1.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+                2, 20, vl.getId(), vl2.getId(),
+                "L2", 1, ConnectablePosition.Direction.BOTTOM,
+                "L2", 0, ConnectablePosition.Direction.TOP);
+
+        createLine(network, "L3", "L3", 1.0, 1.0, 1.0, 0.0, 0.0, 0.0,
+                3, 30, vl.getId(), vl3.getId(),
+                "L3", 2, ConnectablePosition.Direction.TOP,
+                "L3", 0, ConnectablePosition.Direction.TOP);
+
+    }
+
+    @Test
+    public void test() {
+        // build graph
+        VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
+
+        // Run layout
+        voltageLevelGraphLayout(g);
+
+        // write Json and compare to reference
+        assertEquals(toString("/TestCaseFictitiousBus.svg"),
+                toSVG(g, "/TestCaseFictitiousBus.svg", getDefaultDiagramLabelProvider(), getDefaultDiagramStyleProvider()));
+    }
+}

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
@@ -67,6 +67,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestCase1.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase1.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHFirst.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHFirst.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHLast.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHLast.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHMiddle.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHMiddle.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHNone.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHNone.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -67,6 +67,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -131,6 +131,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestCase14UpToNFeederInfos.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase14UpToNFeederInfos.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 .sld-voltage-indicator .sld-label {dominant-baseline: middle}

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
@@ -131,6 +131,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 .sld-voltage-indicator .sld-label {dominant-baseline: middle}

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 .sld-voltage-indicator .sld-label {dominant-baseline: middle}

--- a/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestCaseFictitiousBus.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseFictitiousBus.svg
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg height="720.0" viewBox="0 0 230.0 720.0" width="230.0" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+/* ----------------------------------------------------------------------- */
+/* File: tautologies.css ------------------------------------------------- */
+.sld-out .sld-arrow-in {visibility: hidden}
+.sld-in .sld-arrow-out {visibility: hidden}
+.sld-closed .sld-sw-open {visibility: hidden}
+.sld-open .sld-sw-closed {visibility: hidden}
+.sld-hidden-node {visibility: hidden}
+.sld-top-feeder .sld-label {dominant-baseline: auto}
+.sld-bottom-feeder .sld-label {dominant-baseline: hanging}
+.sld-arrow-p .sld-label {dominant-baseline: middle}
+.sld-arrow-q .sld-label {dominant-baseline: middle}
+/* ----------------------------------------------------------------------- */
+/* File : components.css ------------------------------------------------- */
+/* Stroke black */
+.sld-disconnector {stroke-width: 3; stroke: black; fill: none}
+/* Stroke blue */
+.sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+/* Stroke --sld-vl-color with fallback black */
+.sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
+.sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
+/* Stroke --sld-vl-color with fallback red */
+.sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
+/* Stroke --sld-vl-color with fallback blue */
+.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-load {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-three-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-winding {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-capacitor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-inductor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst-arrow {stroke: black; fill: none}
+.sld-svc {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-vsc {stroke: var(--sld-vl-color, blue); font-size: 7.43px; fill: none}
+/* Stroke none & fill: --sld-vl-color */
+.sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
+/* Stroke none & fill: black */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
+.sld-node {stroke: none; fill: black}
+.sld-flash {stroke: none; fill: black}
+.sld-lock {stroke: none; fill: black}
+/* Specific */
+.sld-grid {stroke: #003700; stroke-dasharray: 1,10}
+.sld-arrow-p {fill:black}
+.sld-arrow-q {fill:blue}
+.sld-frame {fill: var(--sld-background-color, transparent)}
+/* Stroke maroon for fictitious switch */
+.sld-breaker.sld-fictitious {stroke: maroon}
+.sld-disconnector.sld-fictitious {stroke: maroon}
+.sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
+
+]]></style>
+    <rect class="sld-frame" height="100%" width="100%"/>
+    <g>
+        <g class="sld-grid" id="GRID_vl">
+            <line x1="40.0" x2="40.0" y1="80.0" y2="640.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="640.0"/>
+            <line x1="140.0" x2="140.0" y1="80.0" y2="640.0"/>
+            <line x1="190.0" x2="190.0" y1="80.0" y2="640.0"/>
+            <line x1="40.0" x2="190.0" y1="330.0" y2="330.0"/>
+            <line x1="40.0" x2="190.0" y1="320.0" y2="320.0"/>
+            <line x1="40.0" x2="190.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="190.0" y1="390.0" y2="390.0"/>
+            <line x1="40.0" x2="190.0" y1="400.0" y2="400.0"/>
+            <line x1="40.0" x2="190.0" y1="578.0" y2="578.0"/>
+        </g>
+        <g class="sld-busbar-section sld-fictitious" id="idINTERNAL_95_vl_95_0FictitiousBus" transform="translate(65.0,360.0)">
+            <line x1="0" x2="100.0" y1="0" y2="0"/>
+        </g>
+        <g class="cell idEXTERN_32_0" id="idEXTERN_32_0">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L1_95_ONE_95_1" transform="translate(61.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L1_95_ONE_95_2" transform="translate(61.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-top-feeder" id="idL1_95_ONE" transform="translate(65.0,80.0)">
+                <text class="sld-label" id="L1_ONE_N_LABEL" x="-5.0" y="-5.0">L1</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_L1_95_ONE_95_INTERNAL_95_vl_95_L1_95_ONE_95_1">
+                <polyline points="65.0,356.0,65.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_1_95_INTERNAL_95_vl_95_L1_95_ONE_95_2">
+                <polyline points="65.0,330.0,65.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_2_95_L1_95_ONE">
+                <polyline points="65.0,142.0,65.0,80.0"/>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idL1_95_ONE_ARROW_ACTIVE" transform="translate(60.0,95.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idL1_95_ONE_ARROW_REACTIVE" transform="translate(60.0,115.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_L1_95_ONE" transform="translate(61.0,356.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_1" id="idEXTERN_32_1">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L2_95_ONE_95_1" transform="translate(111.0,386.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L2_95_ONE_95_2" transform="translate(111.0,574.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-bottom-feeder" id="idL2_95_ONE" transform="translate(115.0,640.0)">
+                <text class="sld-label" id="L2_ONE_S_LABEL" x="-5.0" y="5.0">L2</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_L2_95_ONE_95_INTERNAL_95_vl_95_L2_95_ONE_95_1">
+                <polyline points="115.0,364.0,115.0,390.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_1_95_INTERNAL_95_vl_95_L2_95_ONE_95_2">
+                <polyline points="115.0,390.0,115.0,578.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_2_95_L2_95_ONE">
+                <polyline points="115.0,578.0,115.0,640.0"/>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idL2_95_ONE_ARROW_REACTIVE" transform="translate(110.0,615.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idL2_95_ONE_ARROW_ACTIVE" transform="translate(110.0,595.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_L2_95_ONE" transform="translate(111.0,356.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_2" id="idEXTERN_32_2">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L3_95_ONE_95_1" transform="translate(161.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L3_95_ONE_95_2" transform="translate(161.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-top-feeder" id="idL3_95_ONE" transform="translate(165.0,80.0)">
+                <text class="sld-label" id="L3_ONE_N_LABEL" x="-5.0" y="-5.0">L3</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_L3_95_ONE_95_INTERNAL_95_vl_95_L3_95_ONE_95_1">
+                <polyline points="165.0,356.0,165.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_1_95_INTERNAL_95_vl_95_L3_95_ONE_95_2">
+                <polyline points="165.0,330.0,165.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_2_95_L3_95_ONE">
+                <polyline points="165.0,142.0,165.0,80.0"/>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idL3_95_ONE_ARROW_ACTIVE" transform="translate(160.0,95.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idL3_95_ONE_ARROW_REACTIVE" transform="translate(160.0,115.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_L3_95_ONE" transform="translate(161.0,356.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/single-line-diagram-core/src/test/resources/TestCaseFictitiousBusTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseFictitiousBusTopological.svg
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg height="720.0" viewBox="0 0 230.0 720.0" width="230.0" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+/* ----------------------------------------------------------------------- */
+/* File: tautologies.css ------------------------------------------------- */
+.sld-out .sld-arrow-in {visibility: hidden}
+.sld-in .sld-arrow-out {visibility: hidden}
+.sld-closed .sld-sw-open {visibility: hidden}
+.sld-open .sld-sw-closed {visibility: hidden}
+.sld-hidden-node {visibility: hidden}
+.sld-top-feeder .sld-label {dominant-baseline: auto}
+.sld-bottom-feeder .sld-label {dominant-baseline: hanging}
+.sld-arrow-p .sld-label {dominant-baseline: middle}
+.sld-arrow-q .sld-label {dominant-baseline: middle}
+/* ----------------------------------------------------------------------- */
+/* File: topologicalBaseVoltages.css ------------------------------------- */
+.sld-disconnected {--sld-vl-color: #808080}
+.sld-vl300to500-0 {--sld-vl-color: #FF0000}
+.sld-vl300to500-1 {--sld-vl-color: #7F6C00}
+.sld-vl300to500-2 {--sld-vl-color: #F6B2FF}
+.sld-vl300to500-3 {--sld-vl-color: #996700}
+.sld-vl300to500-4 {--sld-vl-color: #FF85EB}
+.sld-vl300to500-5 {--sld-vl-color: #B25B00}
+.sld-vl300to500-6 {--sld-vl-color: #FF59B5}
+.sld-vl300to500-7 {--sld-vl-color: #CC4400}
+.sld-vl300to500-8 {--sld-vl-color: #FF2C67}
+.sld-vl300to500-9 {--sld-vl-color: #E52600}
+.sld-vl180to300-0 {--sld-vl-color: #218B21}
+.sld-vl180to300-1 {--sld-vl-color: #0D4940}
+.sld-vl180to300-2 {--sld-vl-color: #DFDAB9}
+.sld-vl180to300-3 {--sld-vl-color: #105640}
+.sld-vl180to300-4 {--sld-vl-color: #C2CB92}
+.sld-vl180to300-5 {--sld-vl-color: #14643C}
+.sld-vl180to300-6 {--sld-vl-color: #95B66B}
+.sld-vl180to300-7 {--sld-vl-color: #187036}
+.sld-vl180to300-8 {--sld-vl-color: #5FA046}
+.sld-vl180to300-9 {--sld-vl-color: #1C7E2D}
+.sld-vl120to180-0 {--sld-vl-color: #00AFAE}
+.sld-vl120to180-1 {--sld-vl-color: #000D58}
+.sld-vl120to180-2 {--sld-vl-color: #B8E7B2}
+.sld-vl120to180-3 {--sld-vl-color: #002169}
+.sld-vl120to180-4 {--sld-vl-color: #85D993}
+.sld-vl120to180-5 {--sld-vl-color: #003C7B}
+.sld-vl120to180-6 {--sld-vl-color: #59CB8B}
+.sld-vl120to180-7 {--sld-vl-color: #005C8C}
+.sld-vl120to180-8 {--sld-vl-color: #2CBD94}
+.sld-vl120to180-9 {--sld-vl-color: #00839E}
+.sld-vl70to120-0 {--sld-vl-color: #CC5500}
+.sld-vl70to120-1 {--sld-vl-color: #4A6600}
+.sld-vl70to120-2 {--sld-vl-color: #EFB2DD}
+.sld-vl70to120-3 {--sld-vl-color: #6E7A00}
+.sld-vl70to120-4 {--sld-vl-color: #E685AE}
+.sld-vl70to120-5 {--sld-vl-color: #8E8400}
+.sld-vl70to120-6 {--sld-vl-color: #DD596B}
+.sld-vl70to120-7 {--sld-vl-color: #A37B00}
+.sld-vl70to120-8 {--sld-vl-color: #D4432C}
+.sld-vl70to120-9 {--sld-vl-color: #B76B00}
+.sld-vl50to70-0 {--sld-vl-color: #A020EF}
+.sld-vl50to70-1 {--sld-vl-color: #7F0848}
+.sld-vl50to70-2 {--sld-vl-color: #B7DBFE}
+.sld-vl50to70-3 {--sld-vl-color: #960C6D}
+.sld-vl50to70-4 {--sld-vl-color: #8DA6FE}
+.sld-vl50to70-5 {--sld-vl-color: #AD109A}
+.sld-vl50to70-6 {--sld-vl-color: #6F66FB}
+.sld-vl50to70-7 {--sld-vl-color: #BC14C4}
+.sld-vl50to70-8 {--sld-vl-color: #7F42F6}
+.sld-vl50to70-9 {--sld-vl-color: #B11AD9}
+.sld-vl30to50-0 {--sld-vl-color: #FF8290}
+.sld-vl30to50-1 {--sld-vl-color: #7F6F41}
+.sld-vl30to50-2 {--sld-vl-color: #F6D9FF}
+.sld-vl30to50-3 {--sld-vl-color: #99784E}
+.sld-vl30to50-4 {--sld-vl-color: #FFC3FB}
+.sld-vl30to50-5 {--sld-vl-color: #B27D5B}
+.sld-vl30to50-6 {--sld-vl-color: #FFADE3}
+.sld-vl30to50-7 {--sld-vl-color: #CC7E68}
+.sld-vl30to50-8 {--sld-vl-color: #FF97BF}
+.sld-vl30to50-9 {--sld-vl-color: #E57B75}
+.sld-vl0to30-0 {--sld-vl-color: #AAAE27}
+.sld-vl0to30-1 {--sld-vl-color: #195B0F}
+.sld-vl0to30-2 {--sld-vl-color: #EABABE}
+.sld-vl0to30-3 {--sld-vl-color: #2D6C13}
+.sld-vl0to30-4 {--sld-vl-color: #DDA193}
+.sld-vl0to30-5 {--sld-vl-color: #477D17}
+.sld-vl0to30-6 {--sld-vl-color: #CE9A6E}
+.sld-vl0to30-7 {--sld-vl-color: #648D1C}
+.sld-vl0to30-8 {--sld-vl-color: #BEA04A}
+.sld-vl0to30-9 {--sld-vl-color: #869D22}
+/* ----------------------------------------------------------------------- */
+/* File : highlightLineStates.css ---------------------------------------- */
+.sld-feeder-disconnected {stroke: black}
+.sld-feeder-connected-disconnected {stroke-dasharray: 3,3}
+.sld-feeder-disconnected-connected {stroke: black; stroke-dasharray: 3,3}
+/* ----------------------------------------------------------------------- */
+/* File : components.css ------------------------------------------------- */
+/* Stroke black */
+.sld-disconnector {stroke-width: 3; stroke: black; fill: none}
+/* Stroke blue */
+.sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+/* Stroke --sld-vl-color with fallback black */
+.sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
+.sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
+/* Stroke --sld-vl-color with fallback red */
+.sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
+/* Stroke --sld-vl-color with fallback blue */
+.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-load {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-three-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-winding {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-capacitor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-inductor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst-arrow {stroke: black; fill: none}
+.sld-svc {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-vsc {stroke: var(--sld-vl-color, blue); font-size: 7.43px; fill: none}
+/* Stroke none & fill: --sld-vl-color */
+.sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
+/* Stroke none & fill: black */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
+.sld-node {stroke: none; fill: black}
+.sld-flash {stroke: none; fill: black}
+.sld-lock {stroke: none; fill: black}
+/* Specific */
+.sld-grid {stroke: #003700; stroke-dasharray: 1,10}
+.sld-arrow-p {fill:black}
+.sld-arrow-q {fill:blue}
+.sld-frame {fill: var(--sld-background-color, transparent)}
+/* Stroke maroon for fictitious switch */
+.sld-breaker.sld-fictitious {stroke: maroon}
+.sld-disconnector.sld-fictitious {stroke: maroon}
+.sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
+
+]]></style>
+    <rect class="sld-frame" height="100%" width="100%"/>
+    <g>
+        <g class="sld-grid" id="GRID_vl">
+            <line x1="40.0" x2="40.0" y1="80.0" y2="640.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="640.0"/>
+            <line x1="140.0" x2="140.0" y1="80.0" y2="640.0"/>
+            <line x1="190.0" x2="190.0" y1="80.0" y2="640.0"/>
+            <line x1="40.0" x2="190.0" y1="330.0" y2="330.0"/>
+            <line x1="40.0" x2="190.0" y1="320.0" y2="320.0"/>
+            <line x1="40.0" x2="190.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="190.0" y1="390.0" y2="390.0"/>
+            <line x1="40.0" x2="190.0" y1="400.0" y2="400.0"/>
+            <line x1="40.0" x2="190.0" y1="578.0" y2="578.0"/>
+        </g>
+        <g class="sld-busbar-section sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_0FictitiousBus" transform="translate(65.0,360.0)">
+            <line x1="0" x2="100.0" y1="0" y2="0"/>
+        </g>
+        <g class="cell idEXTERN_32_0" id="idEXTERN_32_0">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L1_95_ONE_95_1" transform="translate(61.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L1_95_ONE_95_2" transform="translate(61.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-top-feeder sld-vl50to70-0" id="idL1_95_ONE" transform="translate(65.0,80.0)">
+                <text class="sld-label" id="L1_ONE_N_LABEL" x="-5.0" y="-5.0">L1</text>
+            </g>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_BUSCO_95_L1_95_ONE_95_INTERNAL_95_vl_95_L1_95_ONE_95_1">
+                <polyline points="65.0,356.0,65.0,330.0"/>
+            </g>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_1_95_INTERNAL_95_vl_95_L1_95_ONE_95_2">
+                <polyline points="65.0,330.0,65.0,142.0"/>
+            </g>
+            <g class="sld-wire sld-vl50to70-0 sld-feeder-connected-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_2_95_L1_95_ONE">
+                <polyline points="65.0,142.0,65.0,80.0"/>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idL1_95_ONE_ARROW_ACTIVE" transform="translate(60.0,95.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idL1_95_ONE_ARROW_REACTIVE" transform="translate(60.0,115.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-bus-connection sld-fictitious sld-vl50to70-0" id="idBUSCO_95_L1_95_ONE" transform="translate(61.0,356.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_1" id="idEXTERN_32_1">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L2_95_ONE_95_1" transform="translate(111.0,386.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L2_95_ONE_95_2" transform="translate(111.0,574.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-bottom-feeder sld-vl50to70-0" id="idL2_95_ONE" transform="translate(115.0,640.0)">
+                <text class="sld-label" id="L2_ONE_S_LABEL" x="-5.0" y="5.0">L2</text>
+            </g>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_BUSCO_95_L2_95_ONE_95_INTERNAL_95_vl_95_L2_95_ONE_95_1">
+                <polyline points="115.0,364.0,115.0,390.0"/>
+            </g>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_1_95_INTERNAL_95_vl_95_L2_95_ONE_95_2">
+                <polyline points="115.0,390.0,115.0,578.0"/>
+            </g>
+            <g class="sld-wire sld-vl50to70-0 sld-feeder-connected-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_2_95_L2_95_ONE">
+                <polyline points="115.0,578.0,115.0,640.0"/>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idL2_95_ONE_ARROW_REACTIVE" transform="translate(110.0,615.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idL2_95_ONE_ARROW_ACTIVE" transform="translate(110.0,595.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-bus-connection sld-fictitious sld-vl50to70-0" id="idBUSCO_95_L2_95_ONE" transform="translate(111.0,356.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_2" id="idEXTERN_32_2">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L3_95_ONE_95_1" transform="translate(161.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L3_95_ONE_95_2" transform="translate(161.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-top-feeder sld-vl50to70-0" id="idL3_95_ONE" transform="translate(165.0,80.0)">
+                <text class="sld-label" id="L3_ONE_N_LABEL" x="-5.0" y="-5.0">L3</text>
+            </g>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_BUSCO_95_L3_95_ONE_95_INTERNAL_95_vl_95_L3_95_ONE_95_1">
+                <polyline points="165.0,356.0,165.0,330.0"/>
+            </g>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_1_95_INTERNAL_95_vl_95_L3_95_ONE_95_2">
+                <polyline points="165.0,330.0,165.0,142.0"/>
+            </g>
+            <g class="sld-wire sld-vl50to70-0 sld-feeder-connected-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_2_95_L3_95_ONE">
+                <polyline points="165.0,142.0,165.0,80.0"/>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idL3_95_ONE_ARROW_ACTIVE" transform="translate(160.0,95.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idL3_95_ONE_ARROW_REACTIVE" transform="translate(160.0,115.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">0</text>
+            </g>
+            <g class="sld-bus-connection sld-fictitious sld-vl50to70-0" id="idBUSCO_95_L3_95_ONE" transform="translate(161.0,356.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/single-line-diagram-core/src/test/resources/TestFeederOnBus.svg
+++ b/single-line-diagram-core/src/test/resources/TestFeederOnBus.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestFeederOnBusDisconnector.svg
+++ b/single-line-diagram-core/src/test/resources/TestFeederOnBusDisconnector.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestSldClassSubstation.svg
+++ b/single-line-diagram-core/src/test/resources/TestSldClassSubstation.svg
@@ -131,6 +131,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/TestSldClassVl.svg
+++ b/single-line-diagram-core/src/test/resources/TestSldClassVl.svg
@@ -131,6 +131,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
+++ b/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
@@ -131,6 +131,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/feederInfoTest.svg
+++ b/single-line-diagram-core/src/test/resources/feederInfoTest.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/label_on_all_nodes.svg
+++ b/single-line-diagram-core/src/test/resources/label_on_all_nodes.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_substation.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_substation.svg
@@ -67,6 +67,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl2.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl2.svg
@@ -67,6 +67,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl3.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl3.svg
@@ -67,6 +67,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/substation.svg
+++ b/single-line-diagram-core/src/test/resources/substation.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
+++ b/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
+++ b/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/substation_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/substation_optimized.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <defs>

--- a/single-line-diagram-core/src/test/resources/topological_style_substation.svg
+++ b/single-line-diagram-core/src/test/resources/topological_style_substation.svg
@@ -131,6 +131,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/vl1.svg
+++ b/single-line-diagram-core/src/test/resources/vl1.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/vl1_multiline_tooltip.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_multiline_tooltip.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <defs>

--- a/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <defs>

--- a/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/vl1_tooltip.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_tooltip.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/vl2.svg
+++ b/single-line-diagram-core/src/test/resources/vl2.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <defs>

--- a/single-line-diagram-core/src/test/resources/vl3.svg
+++ b/single-line-diagram-core/src/test/resources/vl3.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/vl3_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_optimized.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <defs>

--- a/single-line-diagram-core/src/test/resources/with_frame_background.svg
+++ b/single-line-diagram-core/src/test/resources/with_frame_background.svg
@@ -70,6 +70,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>

--- a/single-line-diagram-core/src/test/resources/zone.svg
+++ b/single-line-diagram-core/src/test/resources/zone.svg
@@ -53,6 +53,7 @@
 .sld-breaker.sld-fictitious {stroke: maroon}
 .sld-disconnector.sld-fictitious {stroke: maroon}
 .sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
 
 ]]></style>
     <rect class="sld-frame" height="100%" width="100%"/>


### PR DESCRIPTION
Signed-off-by: Thomas ADAM <tadam@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When a line is connected to an other one, a fictitious busbar section is displayed


**What is the new behavior (if this is a feature change)?**
When a line is connected to an other one, a line is displayed in place of fictitious busbar


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
