### PR TITLE
use voltageLevel.getBusView() instead of network.getBusView() to improve performance

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/util/AbstractBaseVoltageDiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/util/AbstractBaseVoltageDiagramStyleProvider.java
@@ -210,7 +210,7 @@ public abstract class AbstractBaseVoltageDiagramStyleProvider extends BasicStyle
 
     @Override
     public List<String> getBusStyles(String busId, VoltageLevelGraph graph) {
-        Bus bus = network.getBusView().getBus(busId);
+        Bus bus = network.getVoltageLevel(graph.getVoltageLevelInfos().getId()).getBusView().getBus(busId);
         if (bus != null) {
             for (Terminal t : bus.getConnectedTerminals()) {
                 for (FeederNode feederNode : graph.getFeederNodes()) {


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Perf improvement


**What is the current behavior?** *(You can also link to an open issue here)*
network.getBusView.getBus() computes the topology of the whole network


**What is the new behavior (if this is a feature change)?**
voltageLevel.getBusView.getBus() computes the topology of the voltage level



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
