### PR TITLE
Add debug-sld folder into .powsybl to write debug files

### DIFF
--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -21,6 +21,8 @@ import org.apache.commons.io.output.NullWriter;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -34,7 +36,7 @@ public abstract class AbstractTestCase {
     private static final Pattern SVG_FIX_PATTERN = Pattern.compile(">\\s*(<\\!\\[CDATA\\[.*?]]>)\\s*</", Pattern.DOTALL);
 
     protected boolean debugJsonFiles = false;
-    protected boolean debugSvgFiles = false;
+    protected boolean debugSvgFiles = true;
     protected boolean overrideTestReferences = false;
 
     protected final ResourcesComponentLibrary componentLibrary = getResourcesComponentLibrary();
@@ -91,14 +93,19 @@ public abstract class AbstractTestCase {
     }
 
     protected void writeToFileInDebugDir(String filename, StringWriter content) {
-        File debugFolder = new File(System.getProperty("user.home"), ".powsybl/debug-sld");
-        if (debugFolder.exists() || debugFolder.mkdir()) {
-            File file = new File(debugFolder, filename);
-            try (OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {
-                fw.write(content.toString());
+        Path debugFolder = Path.of(System.getProperty("user.home"), ".powsybl", "debug-sld");
+        if (!Files.exists(debugFolder)) {
+            try {
+                Files.createDirectories(debugFolder);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+        }
+        Path debugFile = Path.of(debugFolder.toString(), filename);
+        try (BufferedWriter bw = Files.newBufferedWriter(debugFile, StandardCharsets.UTF_8)) {
+            bw.write(content.toString());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -103,7 +103,7 @@ public abstract class AbstractTestCase {
         }
         Path debugFile = Path.of(debugFolder.toString(), filename);
         try (BufferedWriter bw = Files.newBufferedWriter(debugFile, StandardCharsets.UTF_8)) {
-            bw.write(content.toString());
+            bw.write(normalizeLineSeparator(content.toString()));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -115,7 +115,7 @@ public abstract class AbstractTestCase {
             return;
         }
         try (BufferedWriter bw = Files.newBufferedWriter(testReference, StandardCharsets.UTF_8)) {
-            bw.write(fixSvg(content.toString()));
+            bw.write(normalizeLineSeparator(fixSvg(content.toString())));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -91,7 +91,7 @@ public abstract class AbstractTestCase {
     }
 
     protected void writeToFileInDebugDir(String filename, StringWriter content) {
-        File debugFolder = new File(System.getProperty("user.home"), ".powsybl/debug");
+        File debugFolder = new File(System.getProperty("user.home"), ".powsybl/debug-sld");
         if (debugFolder.exists() || debugFolder.mkdir()) {
             File file = new File(debugFolder, filename);
             try (OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -94,16 +94,12 @@ public abstract class AbstractTestCase {
 
     protected void writeToFileInDebugDir(String filename, StringWriter content) {
         Path debugFolder = Path.of(System.getProperty("user.home"), ".powsybl", "debug-sld");
-        if (!Files.exists(debugFolder)) {
-            try {
-                Files.createDirectories(debugFolder);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+        try {
+            Files.createDirectories(debugFolder);
+            Path debugFile = debugFolder.resolve(filename.startsWith("/") ? filename.substring(1) : filename);
+            try (BufferedWriter bw = Files.newBufferedWriter(debugFile, StandardCharsets.UTF_8)) {
+                bw.write(normalizeLineSeparator(content.toString()));
             }
-        }
-        Path debugFile = Path.of(debugFolder.toString(), filename);
-        try (BufferedWriter bw = Files.newBufferedWriter(debugFile, StandardCharsets.UTF_8)) {
-            bw.write(normalizeLineSeparator(content.toString()));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -91,7 +91,7 @@ public abstract class AbstractTestCase {
     }
 
     protected void writeToFileInDebugDir(String filename, StringWriter content) {
-        File debugFolder = new File(System.getProperty("user.home"), ".powsybl");
+        File debugFolder = new File(System.getProperty("user.home"), ".powsybl/debug");
         if (debugFolder.exists() || debugFolder.mkdir()) {
             File file = new File(debugFolder, filename);
             try (OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -36,7 +36,7 @@ public abstract class AbstractTestCase {
     private static final Pattern SVG_FIX_PATTERN = Pattern.compile(">\\s*(<\\!\\[CDATA\\[.*?]]>)\\s*</", Pattern.DOTALL);
 
     protected boolean debugJsonFiles = false;
-    protected boolean debugSvgFiles = true;
+    protected boolean debugSvgFiles = false;
     protected boolean overrideTestReferences = false;
 
     protected final ResourcesComponentLibrary componentLibrary = getResourcesComponentLibrary();
@@ -110,12 +110,12 @@ public abstract class AbstractTestCase {
     }
 
     protected void overrideTestReference(String filename, StringWriter content) {
-        File testReference = new File("src/test/resources", filename);
-        if (!testReference.exists()) {
+        Path testReference = Path.of("src", "test", "resources", filename);
+        if (!Files.exists(testReference)) {
             return;
         }
-        try (OutputStreamWriter fw = new OutputStreamWriter(new FileOutputStream(testReference), StandardCharsets.UTF_8)) {
-            fw.write(fixSvg(content.toString()));
+        try (BufferedWriter bw = Files.newBufferedWriter(testReference, StandardCharsets.UTF_8)) {
+            bw.write(fixSvg(content.toString()));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Signed-off-by: Thomas ADAM <tadam@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Debug files are written at user home .powsybl folder


**What is the new behavior (if this is a feature change)?**
Debug files are written at user home .powsybl/debug-sld folder



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
