### PR TITLE
Make load-break-switch looks like breaker (blue & white)

### DIFF
--- a/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.css
+++ b/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.css
@@ -4,7 +4,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.css
+++ b/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.css
@@ -4,13 +4,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -37,7 +37,7 @@ public abstract class AbstractTestCase {
 
     protected boolean debugJsonFiles = false;
     protected boolean debugSvgFiles = false;
-    protected boolean overrideTestReferences = true;
+    protected boolean overrideTestReferences = false;
 
     protected final ResourcesComponentLibrary componentLibrary = getResourcesComponentLibrary();
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/AbstractTestCase.java
@@ -37,7 +37,7 @@ public abstract class AbstractTestCase {
 
     protected boolean debugJsonFiles = false;
     protected boolean debugSvgFiles = false;
-    protected boolean overrideTestReferences = false;
+    protected boolean overrideTestReferences = true;
 
     protected final ResourcesComponentLibrary componentLibrary = getResourcesComponentLibrary();
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseLoadBreakSwitch.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseLoadBreakSwitch.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.iidm;
+
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.SwitchKind;
+import com.powsybl.iidm.network.TopologyKind;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
+import com.powsybl.sld.iidm.extensions.ConnectablePosition;
+import com.powsybl.sld.model.graphs.VoltageLevelGraph;
+import com.powsybl.sld.util.TopologicalStyleProvider;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Thomas Adam <tadam at silicom.fr>
+ */
+public class TestCaseLoadBreakSwitch extends AbstractTestCaseIidm {
+
+    @Before
+    public void setUp() {
+        network = Network.create("testCaseLoadBreakSwitch", "test");
+        graphBuilder = new NetworkGraphBuilder(network);
+        substation = createSubstation(network, "s", "s", Country.FR);
+        vl = createVoltageLevel(substation, "vl", "vl", TopologyKind.NODE_BREAKER, 380, 10);
+        createBusBarSection(vl, "bbs", "bbs", 0, 1, 1);
+        createBusBarSection(vl, "bbs2", "bbs2", 1, 2, 2);
+        createGenerator(vl, "G", "G", "G", 0, ConnectablePosition.Direction.TOP, 2, 50, 100, false, 100, 400);
+        createLoad(vl, "l", "l", "l", 0, ConnectablePosition.Direction.BOTTOM, 3, 10, 10);
+        createSwitch(vl, "d", "d", SwitchKind.LOAD_BREAK_SWITCH, false, false, false, 0, 2);
+        createSwitch(vl, "b", "b", SwitchKind.LOAD_BREAK_SWITCH, false, true, false, 1, 3);
+        createSwitch(vl, "b1", "b1", SwitchKind.LOAD_BREAK_SWITCH, false, true, false, 0, 1);
+
+        createTwoWindingsTransformer(substation, "T11", "T11", 250, 100, 52, 12, 65, 90,
+                4, 6, vl.getId(), vl.getId(),
+                "T11", null, ConnectablePosition.Direction.TOP,
+                "T11", null, ConnectablePosition.Direction.BOTTOM);
+        createSwitch(vl, "b2", "b2", SwitchKind.LOAD_BREAK_SWITCH, false, true, false, 0, 4);
+        createSwitch(vl, "b3", "b3", SwitchKind.LOAD_BREAK_SWITCH, false, true, false, 1, 5);
+        createSwitch(vl, "b4", "b4", SwitchKind.LOAD_BREAK_SWITCH, false, true, false, 5, 6);
+        createSwitch(vl, "b5", "b5", SwitchKind.LOAD_BREAK_SWITCH, false, true, false, 5, 3);
+    }
+
+    @Test
+    public void test() {
+        // build graph
+        VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
+
+        // Run layout
+        voltageLevelGraphLayout(g);
+
+        // write Json and compare to reference
+        assertEquals(toString("/TestCaseLoadBreakSwitch.svg"), toSVG(g, "/TestCaseLoadBreakSwitch.svg", getDefaultDiagramLabelProvider(), new TopologicalStyleProvider(network)));
+    }
+}

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
@@ -32,13 +32,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
@@ -32,7 +32,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase1.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase1.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase1.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase1.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHFirst.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHFirst.svg
@@ -96,7 +96,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHFirst.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHFirst.svg
@@ -96,13 +96,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHLast.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHLast.svg
@@ -96,7 +96,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHLast.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHLast.svg
@@ -96,13 +96,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHMiddle.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHMiddle.svg
@@ -96,7 +96,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHMiddle.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHMiddle.svg
@@ -96,13 +96,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHNone.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHNone.svg
@@ -96,7 +96,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHNone.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHNone.svg
@@ -96,13 +96,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -32,13 +32,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -32,7 +32,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -96,7 +96,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -96,13 +96,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase14UpToNFeederInfos.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase14UpToNFeederInfos.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase14UpToNFeederInfos.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase14UpToNFeederInfos.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
@@ -96,7 +96,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
@@ -96,13 +96,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCaseFictitiousBus.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseFictitiousBus.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCaseFictitiousBus.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseFictitiousBus.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCaseFictitiousBusTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseFictitiousBusTopological.svg
@@ -96,7 +96,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCaseFictitiousBusTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseFictitiousBusTopological.svg
@@ -96,13 +96,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
@@ -217,12 +217,12 @@
             <g class="sld-arrow-p sld-in" id="idG_ARROW_ACTIVE" transform="translate(260.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-arrow-q sld-in" id="idG_ARROW_REACTIVE" transform="translate(260.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_d" transform="translate(261.0,356.0)">
                 <circle cx="4" cy="4" r="2"/>
@@ -257,12 +257,12 @@
             <g class="sld-arrow-p sld-in" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(160.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-arrow-q sld-in" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(160.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_b2" transform="translate(161.0,356.0)">
                 <circle cx="4" cy="4" r="2"/>
@@ -294,12 +294,12 @@
             <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(310.0,635.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
-                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-arrow-p sld-in" id="idl_ARROW_ACTIVE" transform="translate(310.0,615.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
-                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_INTERNAL_95_vl_95_Shunt_32_4_46_1">
                 <polyline points="315.0,603.0,290.0,603.0,290.0,556.0"/>
@@ -358,12 +358,12 @@
             <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(310.0,635.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
-                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-arrow-p sld-in" id="idl_ARROW_ACTIVE" transform="translate(310.0,615.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
-                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-load-break-switch sld-open sld-disconnected" id="idb5" transform="translate(260.0,551.0)">
                 <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0" transform="rotate(90.0,5.0,5.0)"/>
@@ -407,12 +407,12 @@
             <g class="sld-arrow-q sld-in" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(210.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
-                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-arrow-p sld-in" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(210.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
-                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-load-break-switch sld-open sld-disconnected" id="idb3" transform="translate(210.0,457.0)">
                 <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0"/>

--- a/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
@@ -96,7 +96,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
@@ -98,7 +98,8 @@
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
 .sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
-.sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
+.sld-bus-connection {fill: var(--sld-vl-color, black)}
+.sld-cell-shape-flat .sld-bus-connection {visibility: hidden}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
@@ -159,7 +160,7 @@
             <line x1="0" x2="275.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
         </g>
-        <g class="cell idINTERN_32_0" id="idINTERN_32_0">
+        <g class="sld-intern-cell sld-cell-shape-vertical" id="idINTERN_32_0">
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl_95_b1" transform="translate(111.0,316.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
@@ -167,7 +168,7 @@
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_BUSCO_95_b1_95_INTERNAL_95_vl_95_b1">
-                <polyline points="115.0,356.0,115.0,320.0"/>
+                <polyline points="115.0,360.0,115.0,320.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_INTERNAL_95_vl_95_b1_95_b1">
                 <polyline points="115.0,320.0,95.0,320.0"/>
@@ -176,20 +177,20 @@
                 <polyline points="65.0,320.0,85.0,320.0"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_BUSCO_95_b1_95_INTERNAL_95_vl_95_b1">
-                <polyline points="65.0,381.0,65.0,320.0"/>
+                <polyline points="65.0,385.0,65.0,320.0"/>
             </g>
             <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_b1" transform="translate(111.0,356.0)">
-                <circle cx="4" cy="4" r="2"/>
+                <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-load-break-switch sld-open sld-disconnected" id="idb1" transform="translate(85.0,315.0)">
                 <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0" transform="rotate(90.0,5.0,5.0)"/>
                 <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0" transform="rotate(90.0,5.0,5.0)"/>
             </g>
             <g class="sld-bus-connection sld-fictitious sld-disconnected" id="idBUSCO_95_b1" transform="translate(61.0,381.0)">
-                <circle cx="4" cy="4" r="2"/>
+                <circle cx="4" cy="4" r="4"/>
             </g>
         </g>
-        <g class="cell idEXTERN_32_1" id="idEXTERN_32_1">
+        <g class="sld-extern-cell" id="idEXTERN_32_1">
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl_95_d" transform="translate(261.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
@@ -203,7 +204,7 @@
                 <text class="sld-label" id="G_N_LABEL" x="-5.0" y="-5.0">G</text>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_BUSCO_95_d_95_INTERNAL_95_vl_95_d">
-                <polyline points="265.0,356.0,265.0,330.0"/>
+                <polyline points="265.0,360.0,265.0,330.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_INTERNAL_95_vl_95_d_95_d">
                 <polyline points="265.0,330.0,265.0,241.0"/>
@@ -225,14 +226,14 @@
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_d" transform="translate(261.0,356.0)">
-                <circle cx="4" cy="4" r="2"/>
+                <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-load-break-switch sld-closed sld-vl300to500-0" id="idd" transform="translate(260.0,231.0)">
                 <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0"/>
                 <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0"/>
             </g>
         </g>
-        <g class="cell idEXTERN_32_2" id="idEXTERN_32_2">
+        <g class="sld-extern-cell" id="idEXTERN_32_2">
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl_95_b2" transform="translate(161.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
@@ -243,7 +244,7 @@
                 <text class="sld-label" id="T11_ONE_N_LABEL" x="-5.0" y="-5.0">T11</text>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_BUSCO_95_b2_95_INTERNAL_95_vl_95_b2">
-                <polyline points="165.0,356.0,165.0,330.0"/>
+                <polyline points="165.0,360.0,165.0,330.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_INTERNAL_95_vl_95_b2_95_b2">
                 <polyline points="165.0,330.0,165.0,241.0"/>
@@ -265,14 +266,14 @@
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_b2" transform="translate(161.0,356.0)">
-                <circle cx="4" cy="4" r="2"/>
+                <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-load-break-switch sld-open sld-disconnected" id="idb2" transform="translate(160.0,231.0)">
                 <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0"/>
                 <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0"/>
             </g>
         </g>
-        <g class="cell idEXTERN_32_3" id="idEXTERN_32_3">
+        <g class="sld-extern-cell" id="idEXTERN_32_3">
             <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_l" transform="translate(311.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
@@ -308,17 +309,17 @@
                 <polyline points="315.0,415.0,315.0,504.0"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_BUSCO_95_b_95_INTERNAL_95_vl_95_b">
-                <polyline points="315.0,389.0,315.0,415.0"/>
+                <polyline points="315.0,385.0,315.0,415.0"/>
             </g>
             <g class="sld-load-break-switch sld-open sld-disconnected" id="idb" transform="translate(310.0,504.0)">
                 <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0"/>
                 <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0"/>
             </g>
             <g class="sld-bus-connection sld-fictitious sld-disconnected" id="idBUSCO_95_b" transform="translate(311.0,381.0)">
-                <circle cx="4" cy="4" r="2"/>
+                <circle cx="4" cy="4" r="4"/>
             </g>
         </g>
-        <g class="cell idSHUNT_32_4" id="idSHUNT_32_4">
+        <g class="sld-shunt-cell" id="idSHUNT_32_4">
             <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_5" transform="translate(211.0,505.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
@@ -370,7 +371,7 @@
                 <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0" transform="rotate(90.0,5.0,5.0)"/>
             </g>
         </g>
-        <g class="cell idEXTERN_32_5" id="idEXTERN_32_5">
+        <g class="sld-extern-cell" id="idEXTERN_32_5">
             <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_5" transform="translate(211.0,505.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
@@ -396,7 +397,7 @@
                 <polyline points="215.0,415.0,215.0,457.0"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_BUSCO_95_b3_95_INTERNAL_95_vl_95_b3">
-                <polyline points="215.0,389.0,215.0,415.0"/>
+                <polyline points="215.0,385.0,215.0,415.0"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_b4_95_INTERNAL_95_vl_95_T11_95_TWO">
                 <polyline points="215.0,561.0,215.0,603.0"/>
@@ -419,7 +420,7 @@
                 <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0"/>
             </g>
             <g class="sld-bus-connection sld-fictitious sld-disconnected" id="idBUSCO_95_b3" transform="translate(211.0,381.0)">
-                <circle cx="4" cy="4" r="2"/>
+                <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-load-break-switch sld-open sld-disconnected" id="idb4" transform="translate(210.0,551.0)">
                 <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0"/>

--- a/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
@@ -1,0 +1,440 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg height="745.0" viewBox="0 0 380.0 745.0" width="380.0" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+/* ----------------------------------------------------------------------- */
+/* File: tautologies.css ------------------------------------------------- */
+.sld-out .sld-arrow-in {visibility: hidden}
+.sld-in .sld-arrow-out {visibility: hidden}
+.sld-closed .sld-sw-open {visibility: hidden}
+.sld-open .sld-sw-closed {visibility: hidden}
+.sld-hidden-node {visibility: hidden}
+.sld-top-feeder .sld-label {dominant-baseline: auto}
+.sld-bottom-feeder .sld-label {dominant-baseline: hanging}
+.sld-arrow-p .sld-label {dominant-baseline: middle}
+.sld-arrow-q .sld-label {dominant-baseline: middle}
+/* ----------------------------------------------------------------------- */
+/* File: topologicalBaseVoltages.css ------------------------------------- */
+.sld-disconnected {--sld-vl-color: #808080}
+.sld-vl300to500-0 {--sld-vl-color: #FF0000}
+.sld-vl300to500-1 {--sld-vl-color: #7F6C00}
+.sld-vl300to500-2 {--sld-vl-color: #F6B2FF}
+.sld-vl300to500-3 {--sld-vl-color: #996700}
+.sld-vl300to500-4 {--sld-vl-color: #FF85EB}
+.sld-vl300to500-5 {--sld-vl-color: #B25B00}
+.sld-vl300to500-6 {--sld-vl-color: #FF59B5}
+.sld-vl300to500-7 {--sld-vl-color: #CC4400}
+.sld-vl300to500-8 {--sld-vl-color: #FF2C67}
+.sld-vl300to500-9 {--sld-vl-color: #E52600}
+.sld-vl180to300-0 {--sld-vl-color: #218B21}
+.sld-vl180to300-1 {--sld-vl-color: #0D4940}
+.sld-vl180to300-2 {--sld-vl-color: #DFDAB9}
+.sld-vl180to300-3 {--sld-vl-color: #105640}
+.sld-vl180to300-4 {--sld-vl-color: #C2CB92}
+.sld-vl180to300-5 {--sld-vl-color: #14643C}
+.sld-vl180to300-6 {--sld-vl-color: #95B66B}
+.sld-vl180to300-7 {--sld-vl-color: #187036}
+.sld-vl180to300-8 {--sld-vl-color: #5FA046}
+.sld-vl180to300-9 {--sld-vl-color: #1C7E2D}
+.sld-vl120to180-0 {--sld-vl-color: #00AFAE}
+.sld-vl120to180-1 {--sld-vl-color: #000D58}
+.sld-vl120to180-2 {--sld-vl-color: #B8E7B2}
+.sld-vl120to180-3 {--sld-vl-color: #002169}
+.sld-vl120to180-4 {--sld-vl-color: #85D993}
+.sld-vl120to180-5 {--sld-vl-color: #003C7B}
+.sld-vl120to180-6 {--sld-vl-color: #59CB8B}
+.sld-vl120to180-7 {--sld-vl-color: #005C8C}
+.sld-vl120to180-8 {--sld-vl-color: #2CBD94}
+.sld-vl120to180-9 {--sld-vl-color: #00839E}
+.sld-vl70to120-0 {--sld-vl-color: #CC5500}
+.sld-vl70to120-1 {--sld-vl-color: #4A6600}
+.sld-vl70to120-2 {--sld-vl-color: #EFB2DD}
+.sld-vl70to120-3 {--sld-vl-color: #6E7A00}
+.sld-vl70to120-4 {--sld-vl-color: #E685AE}
+.sld-vl70to120-5 {--sld-vl-color: #8E8400}
+.sld-vl70to120-6 {--sld-vl-color: #DD596B}
+.sld-vl70to120-7 {--sld-vl-color: #A37B00}
+.sld-vl70to120-8 {--sld-vl-color: #D4432C}
+.sld-vl70to120-9 {--sld-vl-color: #B76B00}
+.sld-vl50to70-0 {--sld-vl-color: #A020EF}
+.sld-vl50to70-1 {--sld-vl-color: #7F0848}
+.sld-vl50to70-2 {--sld-vl-color: #B7DBFE}
+.sld-vl50to70-3 {--sld-vl-color: #960C6D}
+.sld-vl50to70-4 {--sld-vl-color: #8DA6FE}
+.sld-vl50to70-5 {--sld-vl-color: #AD109A}
+.sld-vl50to70-6 {--sld-vl-color: #6F66FB}
+.sld-vl50to70-7 {--sld-vl-color: #BC14C4}
+.sld-vl50to70-8 {--sld-vl-color: #7F42F6}
+.sld-vl50to70-9 {--sld-vl-color: #B11AD9}
+.sld-vl30to50-0 {--sld-vl-color: #FF8290}
+.sld-vl30to50-1 {--sld-vl-color: #7F6F41}
+.sld-vl30to50-2 {--sld-vl-color: #F6D9FF}
+.sld-vl30to50-3 {--sld-vl-color: #99784E}
+.sld-vl30to50-4 {--sld-vl-color: #FFC3FB}
+.sld-vl30to50-5 {--sld-vl-color: #B27D5B}
+.sld-vl30to50-6 {--sld-vl-color: #FFADE3}
+.sld-vl30to50-7 {--sld-vl-color: #CC7E68}
+.sld-vl30to50-8 {--sld-vl-color: #FF97BF}
+.sld-vl30to50-9 {--sld-vl-color: #E57B75}
+.sld-vl0to30-0 {--sld-vl-color: #AAAE27}
+.sld-vl0to30-1 {--sld-vl-color: #195B0F}
+.sld-vl0to30-2 {--sld-vl-color: #EABABE}
+.sld-vl0to30-3 {--sld-vl-color: #2D6C13}
+.sld-vl0to30-4 {--sld-vl-color: #DDA193}
+.sld-vl0to30-5 {--sld-vl-color: #477D17}
+.sld-vl0to30-6 {--sld-vl-color: #CE9A6E}
+.sld-vl0to30-7 {--sld-vl-color: #648D1C}
+.sld-vl0to30-8 {--sld-vl-color: #BEA04A}
+.sld-vl0to30-9 {--sld-vl-color: #869D22}
+/* ----------------------------------------------------------------------- */
+/* File : highlightLineStates.css ---------------------------------------- */
+.sld-feeder-disconnected {stroke: black}
+.sld-feeder-connected-disconnected {stroke-dasharray: 3,3}
+.sld-feeder-disconnected-connected {stroke: black; stroke-dasharray: 3,3}
+/* ----------------------------------------------------------------------- */
+/* File : components.css ------------------------------------------------- */
+/* Stroke black */
+.sld-disconnector {stroke-width: 3; stroke: black; fill: none}
+/* Stroke blue */
+.sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
+/* Stroke --sld-vl-color with fallback black */
+.sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
+.sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
+/* Stroke --sld-vl-color with fallback red */
+.sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
+/* Stroke --sld-vl-color with fallback blue */
+.sld-load {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-three-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-winding {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-capacitor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-inductor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst-arrow {stroke: black; fill: none}
+.sld-svc {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-vsc {stroke: var(--sld-vl-color, blue); font-size: 7.43px; fill: none}
+/* Stroke none & fill: --sld-vl-color */
+.sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
+/* Stroke none & fill: black */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
+.sld-node {stroke: none; fill: black}
+.sld-flash {stroke: none; fill: black}
+.sld-lock {stroke: none; fill: black}
+/* Specific */
+.sld-grid {stroke: #003700; stroke-dasharray: 1,10}
+.sld-arrow-p {fill:black}
+.sld-arrow-q {fill:blue}
+.sld-frame {fill: var(--sld-background-color, transparent)}
+/* Stroke maroon for fictitious switch */
+.sld-breaker.sld-fictitious {stroke: maroon}
+.sld-disconnector.sld-fictitious {stroke: maroon}
+.sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
+
+]]></style>
+    <rect class="sld-frame" height="100%" width="100%"/>
+    <g>
+        <g class="sld-grid" id="GRID_vl">
+            <line x1="40.0" x2="40.0" y1="80.0" y2="665.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="665.0"/>
+            <line x1="140.0" x2="140.0" y1="80.0" y2="665.0"/>
+            <line x1="190.0" x2="190.0" y1="80.0" y2="665.0"/>
+            <line x1="240.0" x2="240.0" y1="80.0" y2="665.0"/>
+            <line x1="290.0" x2="290.0" y1="80.0" y2="665.0"/>
+            <line x1="340.0" x2="340.0" y1="80.0" y2="665.0"/>
+            <line x1="40.0" x2="340.0" y1="330.0" y2="330.0"/>
+            <line x1="40.0" x2="340.0" y1="320.0" y2="320.0"/>
+            <line x1="40.0" x2="340.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="340.0" y1="415.0" y2="415.0"/>
+            <line x1="40.0" x2="340.0" y1="425.0" y2="425.0"/>
+            <line x1="40.0" x2="340.0" y1="603.0" y2="603.0"/>
+        </g>
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs" transform="translate(52.5,360.0)">
+            <line x1="0" x2="275.0" y1="0" y2="0"/>
+            <text class="sld-label" id="bbs_NW_LABEL" x="-5.0" y="-5.0">bbs</text>
+        </g>
+        <g class="sld-busbar-section sld-disconnected" id="idbbs2" transform="translate(52.5,385.0)">
+            <line x1="0" x2="275.0" y1="0" y2="0"/>
+            <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
+        </g>
+        <g class="cell idINTERN_32_0" id="idINTERN_32_0">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl_95_b1" transform="translate(111.0,316.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_b1" transform="translate(61.0,316.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_BUSCO_95_b1_95_INTERNAL_95_vl_95_b1">
+                <polyline points="115.0,356.0,115.0,320.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_INTERNAL_95_vl_95_b1_95_b1">
+                <polyline points="115.0,320.0,95.0,320.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_b1_95_b1">
+                <polyline points="65.0,320.0,85.0,320.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_BUSCO_95_b1_95_INTERNAL_95_vl_95_b1">
+                <polyline points="65.0,381.0,65.0,320.0"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_b1" transform="translate(111.0,356.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb1" transform="translate(85.0,315.0)">
+                <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0" transform="rotate(90.0,5.0,5.0)"/>
+                <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0" transform="rotate(90.0,5.0,5.0)"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious sld-disconnected" id="idBUSCO_95_b1" transform="translate(61.0,381.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_1" id="idEXTERN_32_1">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl_95_d" transform="translate(261.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl_95_G" transform="translate(261.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-generator sld-top-feeder sld-vl300to500-0" id="idG" transform="translate(259.0,74.0)">
+                <circle cx="6" cy="6" r="6"/>
+                <path d="M6,6 A 6 40 0 0 0 2,6"/>
+                <path d="M6,6 A 6 40 0 0 0 10,6"/>
+                <text class="sld-label" id="G_N_LABEL" x="-5.0" y="-5.0">G</text>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_BUSCO_95_d_95_INTERNAL_95_vl_95_d">
+                <polyline points="265.0,356.0,265.0,330.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_INTERNAL_95_vl_95_d_95_d">
+                <polyline points="265.0,330.0,265.0,241.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_d_95_INTERNAL_95_vl_95_G">
+                <polyline points="265.0,231.0,265.0,142.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_INTERNAL_95_vl_95_G_95_G">
+                <polyline points="265.0,142.0,265.0,86.0"/>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idG_ARROW_ACTIVE" transform="translate(260.0,101.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idG_ARROW_REACTIVE" transform="translate(260.0,121.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+            </g>
+            <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_d" transform="translate(261.0,356.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+            <g class="sld-load-break-switch sld-closed sld-vl300to500-0" id="idd" transform="translate(260.0,231.0)">
+                <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0"/>
+                <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0"/>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_2" id="idEXTERN_32_2">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl_95_b2" transform="translate(161.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_T11_95_ONE" transform="translate(161.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-top-feeder sld-disconnected" id="idT11_95_ONE" transform="translate(165.0,80.0)">
+                <text class="sld-label" id="T11_ONE_N_LABEL" x="-5.0" y="-5.0">T11</text>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_BUSCO_95_b2_95_INTERNAL_95_vl_95_b2">
+                <polyline points="165.0,356.0,165.0,330.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_INTERNAL_95_vl_95_b2_95_b2">
+                <polyline points="165.0,330.0,165.0,241.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_b2_95_INTERNAL_95_vl_95_T11_95_ONE">
+                <polyline points="165.0,231.0,165.0,142.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected sld-feeder-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_T11_95_ONE_95_T11_95_ONE">
+                <polyline points="165.0,142.0,165.0,80.0"/>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(160.0,95.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(160.0,115.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+            </g>
+            <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_b2" transform="translate(161.0,356.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb2" transform="translate(160.0,231.0)">
+                <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0"/>
+                <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0"/>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_3" id="idEXTERN_32_3">
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_l" transform="translate(311.0,599.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_b" transform="translate(311.0,411.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-load sld-bottom-feeder sld-disconnected" id="idl" transform="translate(307.0,660.5)">
+                <rect height="9" width="16"/>
+                <line x1="0" x2="16" y1="0" y2="9"/>
+                <line x1="16" x2="0" y1="0" y2="9"/>
+                <text class="sld-label" id="l_S_LABEL" x="-5.0" y="14.0">l</text>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_b_95_INTERNAL_95_vl_95_l">
+                <polyline points="315.0,514.0,315.0,603.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_l">
+                <polyline points="315.0,603.0,315.0,660.5"/>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(310.0,635.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idl_ARROW_ACTIVE" transform="translate(310.0,615.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_INTERNAL_95_vl_95_Shunt_32_4_46_1">
+                <polyline points="315.0,603.0,290.0,603.0,290.0,556.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_b_95_b">
+                <polyline points="315.0,415.0,315.0,504.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_BUSCO_95_b_95_INTERNAL_95_vl_95_b">
+                <polyline points="315.0,389.0,315.0,415.0"/>
+            </g>
+            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb" transform="translate(310.0,504.0)">
+                <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0"/>
+                <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious sld-disconnected" id="idBUSCO_95_b" transform="translate(311.0,381.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+        </g>
+        <g class="cell idSHUNT_32_4" id="idSHUNT_32_4">
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_5" transform="translate(211.0,505.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_Shunt_32_4_46_2" transform="translate(236.0,552.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_Shunt_32_4_46_1" transform="translate(286.0,552.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_l" transform="translate(311.0,599.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_b3_95_INTERNAL_95_vl_95_5">
+                <polyline points="215.0,467.0,215.0,509.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_5_95_b4">
+                <polyline points="215.0,509.0,215.0,551.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_5_95_INTERNAL_95_vl_95_Shunt_32_4_46_2">
+                <polyline points="215.0,509.0,240.0,509.0,240.0,556.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_b5_95_INTERNAL_95_vl_95_Shunt_32_4_46_2">
+                <polyline points="260.0,556.0,240.0,556.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_b5_95_INTERNAL_95_vl_95_Shunt_32_4_46_1">
+                <polyline points="270.0,556.0,290.0,556.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_INTERNAL_95_vl_95_Shunt_32_4_46_1">
+                <polyline points="315.0,603.0,290.0,603.0,290.0,556.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_b_95_INTERNAL_95_vl_95_l">
+                <polyline points="315.0,514.0,315.0,603.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_l">
+                <polyline points="315.0,603.0,315.0,660.5"/>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(310.0,635.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idl_ARROW_ACTIVE" transform="translate(310.0,615.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+            </g>
+            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb5" transform="translate(260.0,551.0)">
+                <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0" transform="rotate(90.0,5.0,5.0)"/>
+                <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0" transform="rotate(90.0,5.0,5.0)"/>
+            </g>
+        </g>
+        <g class="cell idEXTERN_32_5" id="idEXTERN_32_5">
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_5" transform="translate(211.0,505.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_b3" transform="translate(211.0,411.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_T11_95_TWO" transform="translate(211.0,599.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-bottom-feeder sld-disconnected" id="idT11_95_TWO" transform="translate(215.0,665.0)">
+                <text class="sld-label" id="T11_TWO_S_LABEL" x="-5.0" y="5.0">T11</text>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_b3_95_INTERNAL_95_vl_95_5">
+                <polyline points="215.0,467.0,215.0,509.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_5_95_b4">
+                <polyline points="215.0,509.0,215.0,551.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_5_95_INTERNAL_95_vl_95_Shunt_32_4_46_2">
+                <polyline points="215.0,509.0,240.0,509.0,240.0,556.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_b3_95_b3">
+                <polyline points="215.0,415.0,215.0,457.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_BUSCO_95_b3_95_INTERNAL_95_vl_95_b3">
+                <polyline points="215.0,389.0,215.0,415.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_b4_95_INTERNAL_95_vl_95_T11_95_TWO">
+                <polyline points="215.0,561.0,215.0,603.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected sld-feeder-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_T11_95_TWO_95_T11_95_TWO">
+                <polyline points="215.0,603.0,215.0,665.0"/>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(210.0,640.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(210.0,620.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">NaN</text>
+            </g>
+            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb3" transform="translate(210.0,457.0)">
+                <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0"/>
+                <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious sld-disconnected" id="idBUSCO_95_b3" transform="translate(211.0,381.0)">
+                <circle cx="4" cy="4" r="2"/>
+            </g>
+            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb4" transform="translate(210.0,551.0)">
+                <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0"/>
+                <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0"/>
+            </g>
+        </g>
+        <g class="sld-wire sld-disconnected sld-feeder-disconnected" id="idEDGE_95_T11_95_ONE">
+            <polyline points="165.0,80.0,165.0,20.0,20.0,20.0,20.0,364.5"/>
+        </g>
+        <g class="sld-wire sld-disconnected sld-feeder-disconnected" id="idEDGE_95_T11_95_TWO">
+            <polyline points="215.0,665.0,215.0,725.0,20.0,725.0,20.0,380.5"/>
+        </g>
+        <g class="sld-two-wt sld-fictitious" id="idT11" transform="translate(15.0,365.0)">
+            <circle class="sld-disconnected sld-winding" cx="5" cy="10" r="5" transform="rotate(180.0,5.0,7.5)"/>
+            <circle class="sld-disconnected sld-winding" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
+        </g>
+    </g>
+</svg>

--- a/single-line-diagram-core/src/test/resources/TestFeederOnBus.svg
+++ b/single-line-diagram-core/src/test/resources/TestFeederOnBus.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestFeederOnBus.svg
+++ b/single-line-diagram-core/src/test/resources/TestFeederOnBus.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestFeederOnBusDisconnector.svg
+++ b/single-line-diagram-core/src/test/resources/TestFeederOnBusDisconnector.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestFeederOnBusDisconnector.svg
+++ b/single-line-diagram-core/src/test/resources/TestFeederOnBusDisconnector.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestSldClassSubstation.svg
+++ b/single-line-diagram-core/src/test/resources/TestSldClassSubstation.svg
@@ -96,7 +96,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestSldClassSubstation.svg
+++ b/single-line-diagram-core/src/test/resources/TestSldClassSubstation.svg
@@ -96,13 +96,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/TestSldClassVl.svg
+++ b/single-line-diagram-core/src/test/resources/TestSldClassVl.svg
@@ -96,7 +96,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/TestSldClassVl.svg
+++ b/single-line-diagram-core/src/test/resources/TestSldClassVl.svg
@@ -96,13 +96,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
+++ b/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
@@ -96,7 +96,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
+++ b/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
@@ -96,13 +96,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/feederInfoTest.svg
+++ b/single-line-diagram-core/src/test/resources/feederInfoTest.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/feederInfoTest.svg
+++ b/single-line-diagram-core/src/test/resources/feederInfoTest.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/label_on_all_nodes.svg
+++ b/single-line-diagram-core/src/test/resources/label_on_all_nodes.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/label_on_all_nodes.svg
+++ b/single-line-diagram-core/src/test/resources/label_on_all_nodes.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_substation.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_substation.svg
@@ -32,13 +32,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_substation.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_substation.svg
@@ -32,7 +32,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl2.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl2.svg
@@ -32,13 +32,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl2.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl2.svg
@@ -32,7 +32,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl3.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl3.svg
@@ -32,13 +32,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl3.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl3.svg
@@ -32,7 +32,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/substation.svg
+++ b/single-line-diagram-core/src/test/resources/substation.svg
@@ -32,13 +32,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/substation.svg
+++ b/single-line-diagram-core/src/test/resources/substation.svg
@@ -32,7 +32,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
+++ b/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
+++ b/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
+++ b/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
+++ b/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/substation_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/substation_optimized.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/substation_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/substation_optimized.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/topological_style_substation.svg
+++ b/single-line-diagram-core/src/test/resources/topological_style_substation.svg
@@ -96,7 +96,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/topological_style_substation.svg
+++ b/single-line-diagram-core/src/test/resources/topological_style_substation.svg
@@ -96,13 +96,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/vl1.svg
+++ b/single-line-diagram-core/src/test/resources/vl1.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/vl1.svg
+++ b/single-line-diagram-core/src/test/resources/vl1.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/vl1_multiline_tooltip.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_multiline_tooltip.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/vl1_multiline_tooltip.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_multiline_tooltip.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/vl1_tooltip.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_tooltip.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/vl1_tooltip.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_tooltip.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/vl2.svg
+++ b/single-line-diagram-core/src/test/resources/vl2.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/vl2.svg
+++ b/single-line-diagram-core/src/test/resources/vl2.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/vl3.svg
+++ b/single-line-diagram-core/src/test/resources/vl3.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/vl3.svg
+++ b/single-line-diagram-core/src/test/resources/vl3.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/vl3_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_optimized.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/vl3_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_optimized.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/with_frame_background.svg
+++ b/single-line-diagram-core/src/test/resources/with_frame_background.svg
@@ -35,7 +35,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}

--- a/single-line-diagram-core/src/test/resources/with_frame_background.svg
+++ b/single-line-diagram-core/src/test/resources/with_frame_background.svg
@@ -35,13 +35,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/zone.svg
+++ b/single-line-diagram-core/src/test/resources/zone.svg
@@ -18,13 +18,13 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: none}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
 /* Stroke --sld-vl-color with fallback red */
 .sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
 /* Stroke --sld-vl-color with fallback blue */
-.sld-load-break-switch {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-load {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
 .sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}

--- a/single-line-diagram-core/src/test/resources/zone.svg
+++ b/single-line-diagram-core/src/test/resources/zone.svg
@@ -18,7 +18,7 @@
 .sld-disconnector {stroke-width: 3; stroke: black; fill: none}
 /* Stroke blue */
 .sld-breaker {stroke-width: 2; stroke: blue; fill:white}
-.sld-load-break-switch {stroke: blue; fill: none}
+.sld-load-break-switch {stroke: blue; fill: white}
 /* Stroke --sld-vl-color with fallback black */
 .sld-bus-connection {stroke: var(--sld-vl-color, black); stroke-width: 4; fill: none}
 .sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
load-break-switch is colored with voltage color if Nominal or Topological style provider is used


**What is the new behavior (if this is a feature change)?**
load-break-switch is always colored with blue & white as breaker


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
