### PR TITLE
Choose which components are on busbars

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockOrganizer.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockOrganizer.java
@@ -6,12 +6,17 @@
  */
 package com.powsybl.sld.layout;
 
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.sld.model.blocks.FeederPrimaryBlock;
 import com.powsybl.sld.model.blocks.LegPrimaryBlock;
+import com.powsybl.sld.model.cells.BusCell;
 import com.powsybl.sld.model.cells.Cell;
 import com.powsybl.sld.model.cells.ExternCell;
 import com.powsybl.sld.model.cells.InternCell;
 import com.powsybl.sld.model.coordinate.Side;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
+import com.powsybl.sld.model.nodes.BusConnection;
+import com.powsybl.sld.model.nodes.Node;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +27,7 @@ import java.util.Objects;
 import static com.powsybl.sld.model.blocks.Block.Extremity.END;
 import static com.powsybl.sld.model.blocks.Block.Extremity.START;
 import static com.powsybl.sld.model.cells.Cell.CellType.INTERN;
+import static com.powsybl.sld.model.nodes.Node.NodeType.*;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
@@ -53,10 +59,11 @@ public class BlockOrganizer {
     /**
      * Organize cells into blocks and call the layout resolvers
      */
-    public void organize(VoltageLevelGraph graph) {
+    public void organize(VoltageLevelGraph graph, LayoutParameters layoutParameters) {
         LOGGER.info("Organizing graph cells into blocks");
         graph.getBusCellStream().forEach(cell -> {
             CellBlockDecomposer.determineComplexCell(graph, cell, exceptionIfPatternNotHandled);
+            checkBlocks(cell, layoutParameters);
             if (cell.getType() == INTERN) {
                 ((InternCell) cell).organizeBlocks();
             }
@@ -75,6 +82,31 @@ public class BlockOrganizer {
         graph.getCellStream().forEach(Cell::blockSizing);
 
         new BlockPositionner().determineBlockPositions(graph, subsections, busInfoMap);
+    }
+
+    private void checkBlocks(BusCell cell, LayoutParameters layoutParameters) {
+        cell.getLegPrimaryBlocks().forEach(lpb -> checkLegPrimaryBlockConsistency(lpb, layoutParameters.getComponentsOnBusbars()));
+        cell.getFeederPrimaryBlocks().forEach(this::checkFeederPrimaryBlockConsistency);
+    }
+
+    private void checkLegPrimaryBlockConsistency(LegPrimaryBlock legPrimaryBlock, List<String> componentsOnBus) {
+        List<Node> nodes = legPrimaryBlock.getNodes();
+        boolean consistent = nodes.size() == 3
+                && nodes.get(0).getType() == Node.NodeType.BUS
+                && nodes.get(1) instanceof BusConnection || componentsOnBus.contains(nodes.get(1).getComponentType())
+                && (nodes.get(2).getType() == Node.NodeType.FICTITIOUS || nodes.get(2).getType() == Node.NodeType.SHUNT);
+        if (!consistent) {
+            throw new PowsyblException("LegPrimaryBlock not consistent");
+        }
+    }
+
+    private void checkFeederPrimaryBlockConsistency(FeederPrimaryBlock lpb) {
+        List<Node> nodes = lpb.getNodes();
+        boolean consistent = nodes.size() == 2 && nodes.get(1).getType() == FEEDER
+                && (nodes.get(0).getType() == FICTITIOUS || nodes.get(0).getType() == SHUNT);
+        if (!consistent) {
+            throw new PowsyblException("FeederPrimaryBlock not consistent");
+        }
     }
 
     /**

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockOrganizer.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockOrganizer.java
@@ -6,23 +6,22 @@
  */
 package com.powsybl.sld.layout;
 
-import com.powsybl.sld.layout.positionbyclustering.PositionByClustering;
-import com.powsybl.sld.layout.positionfromextension.PositionFromExtension;
 import com.powsybl.sld.model.blocks.LegPrimaryBlock;
-import com.powsybl.sld.model.cells.*;
+import com.powsybl.sld.model.cells.Cell;
+import com.powsybl.sld.model.cells.ExternCell;
+import com.powsybl.sld.model.cells.InternCell;
 import com.powsybl.sld.model.coordinate.Side;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 import static com.powsybl.sld.model.blocks.Block.Extremity.END;
 import static com.powsybl.sld.model.blocks.Block.Extremity.START;
-import static com.powsybl.sld.model.cells.Cell.CellType.*;
+import static com.powsybl.sld.model.cells.Cell.CellType.INTERN;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
@@ -42,30 +41,6 @@ public class BlockOrganizer {
     private final boolean exceptionIfPatternNotHandled;
 
     private final Map<String, Side> busInfoMap;
-
-    public BlockOrganizer() {
-        this(new PositionFromExtension(), true);
-    }
-
-    public BlockOrganizer(boolean stack) {
-        this(new PositionByClustering(), stack);
-    }
-
-    public BlockOrganizer(PositionFinder positionFinder) {
-        this(positionFinder, true);
-    }
-
-    public BlockOrganizer(PositionFinder positionFinder, boolean stack) {
-        this(positionFinder, stack, false);
-    }
-
-    public BlockOrganizer(PositionFinder positionFinder, boolean stack, boolean exceptionIfPatternNotHandled) {
-        this(positionFinder, stack, exceptionIfPatternNotHandled, false, Collections.emptyMap());
-    }
-
-    public BlockOrganizer(PositionFinder positionFinder, boolean stack, boolean exceptionIfPatternNotHandled, boolean handleShunt) {
-        this(positionFinder, stack, exceptionIfPatternNotHandled, handleShunt, Collections.emptyMap());
-    }
 
     public BlockOrganizer(PositionFinder positionFinder, boolean stack, boolean exceptionIfPatternNotHandled, boolean handleShunt, Map<String, Side> busInfoMap) {
         this.positionFinder = Objects.requireNonNull(positionFinder);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CellBlockDecomposer.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/CellBlockDecomposer.java
@@ -62,11 +62,8 @@ final class CellBlockDecomposer {
     }
 
     private static void mergeBlocks(VoltageLevelGraph vlGraph, BusCell busCell, List<Block> blocks, boolean exceptionIfPatternNotHandled) {
-        // Search all blocks connected to a busbar inside the primary blocks list
-        List<LegPrimaryBlock> primaryLegBlocks = blocks.stream()
-                .filter(b -> b instanceof LegPrimaryBlock)
-                .map(LegPrimaryBlock.class::cast)
-                .collect(Collectors.toList());
+        List<LegPrimaryBlock> legPrimaryBlocks = blocks.stream().filter(LegPrimaryBlock.class::isInstance).map(LegPrimaryBlock.class::cast).collect(Collectors.toList());
+        List<FeederPrimaryBlock> feederPrimaryBlocks = blocks.stream().filter(FeederPrimaryBlock.class::isInstance).map(FeederPrimaryBlock.class::cast).collect(Collectors.toList());
 
         // Merge blocks to obtain a hierarchy of blocks
         while (blocks.size() != 1) {
@@ -84,7 +81,7 @@ final class CellBlockDecomposer {
                 }
             }
         }
-        busCell.blocksSetting(blocks.get(0), primaryLegBlocks);
+        busCell.blocksSetting(blocks.get(0), legPrimaryBlocks, feederPrimaryBlocks);
     }
 
     /**

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/GraphRefiner.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/GraphRefiner.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.sld.layout;
 
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
@@ -8,11 +14,17 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-public class LayoutGraphAdapter {
+/**
+ * Refines the graph so that it becomes consistent with the diagram layout.
+ * In particular for cell detection: it inserts the {@link BusConnection} nodes and {@link InternalNode} hook nodes needed for it.
+ *
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class GraphRefiner {
     private final boolean removeUnnecessaryFictitiousNodes;
     private final boolean substituteSingularFictitiousByFeederNode;
 
-    public LayoutGraphAdapter(boolean removeUnnecessaryFictitiousNodes, boolean substituteSingularFictitiousByFeederNode) {
+    public GraphRefiner(boolean removeUnnecessaryFictitiousNodes, boolean substituteSingularFictitiousByFeederNode) {
         this.removeUnnecessaryFictitiousNodes = removeUnnecessaryFictitiousNodes;
         this.substituteSingularFictitiousByFeederNode = substituteSingularFictitiousByFeederNode;
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ImplicitCellDetector.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ImplicitCellDetector.java
@@ -27,20 +27,15 @@ import java.util.stream.Collectors;
 public class ImplicitCellDetector implements CellDetector {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ImplicitCellDetector.class);
-    private boolean removeUnnecessaryFictitiousNodes;
-    private boolean substituteSingularFictitiousByFeederNode;
-    private boolean exceptionIfPatternNotHandled;
+    private final boolean removeUnnecessaryFictitiousNodes;
+    private final boolean substituteSingularFictitiousByFeederNode;
+    private final boolean exceptionIfPatternNotHandled;
 
     public ImplicitCellDetector(boolean removeUnnecessaryFictitiousNodes, boolean substituteSingularFictitiousByFeederNode, boolean exceptionIfPatternNotHandled) {
         this.removeUnnecessaryFictitiousNodes = removeUnnecessaryFictitiousNodes;
         this.substituteSingularFictitiousByFeederNode = substituteSingularFictitiousByFeederNode;
         this.exceptionIfPatternNotHandled = exceptionIfPatternNotHandled;
     }
-
-    public ImplicitCellDetector() {
-        this(true, true, false);
-    }
-
 
     /**
      * internCell detection : an internal cell is composed of nodes connecting BUSes without connecting Feeder.

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ImplicitCellDetector.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ImplicitCellDetector.java
@@ -27,13 +27,9 @@ import java.util.stream.Collectors;
 public class ImplicitCellDetector implements CellDetector {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ImplicitCellDetector.class);
-    private final boolean removeUnnecessaryFictitiousNodes;
-    private final boolean substituteSingularFictitiousByFeederNode;
     private final boolean exceptionIfPatternNotHandled;
 
-    public ImplicitCellDetector(boolean removeUnnecessaryFictitiousNodes, boolean substituteSingularFictitiousByFeederNode, boolean exceptionIfPatternNotHandled) {
-        this.removeUnnecessaryFictitiousNodes = removeUnnecessaryFictitiousNodes;
-        this.substituteSingularFictitiousByFeederNode = substituteSingularFictitiousByFeederNode;
+    public ImplicitCellDetector(boolean exceptionIfPatternNotHandled) {
         this.exceptionIfPatternNotHandled = exceptionIfPatternNotHandled;
     }
 
@@ -51,8 +47,6 @@ public class ImplicitCellDetector implements CellDetector {
      */
     @Override
     public void detectCells(VoltageLevelGraph graph) {
-        cleaning(graph);
-
         LOGGER.info("Detecting cells...");
 
         List<Node> allocatedNodes = new ArrayList<>();
@@ -90,22 +84,6 @@ public class ImplicitCellDetector implements CellDetector {
             // if a shunt cell is detected two or more EXTERN cells and one or more SHUNT cells are created
             detectAndTypeShunt(graph, nodes, shuntCells);
         }
-    }
-
-    private void cleaning(VoltageLevelGraph graph) {
-        graph.substituteFictitiousNodesMirroringBusNodes();
-        if (removeUnnecessaryFictitiousNodes) {
-            graph.removeUnnecessaryFictitiousNodes();
-        }
-        if (substituteSingularFictitiousByFeederNode) {
-            graph.substituteSingularFictitiousByFeederNode();
-        }
-        graph.insertFictitiousNodesAtFeeders();
-        graph.extendNodeConnectedToBus(node -> node instanceof SwitchNode && ((SwitchNode) node).getKind() != SwitchNode.SwitchKind.DISCONNECTOR);
-        graph.extendNodeConnectedToBus(Middle3WTNode.class::isInstance);
-        graph.extendSwitchBetweenBuses();
-        graph.extendFirstOutsideNode();
-        graph.extendBusConnectedToBus();
     }
 
     /**

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ImplicitCellDetector.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/ImplicitCellDetector.java
@@ -255,9 +255,9 @@ public class ImplicitCellDetector implements CellDetector {
 
     private ShuntCell createShuntCell(VoltageLevelGraph vlGraph, List<Node> shuntNodes) {
         int cellNumber = vlGraph.getNextCellNumber();
-        InternalNode iNode1 = vlGraph.insertInternalNode(shuntNodes.get(0), shuntNodes.get(1),
+        InternalNode iNode1 = vlGraph.insertHookNodesAtBuses(shuntNodes.get(0), shuntNodes.get(1),
                 "Shunt " + cellNumber + ".1");
-        InternalNode iNode2 = vlGraph.insertInternalNode(shuntNodes.get(shuntNodes.size() - 1),
+        InternalNode iNode2 = vlGraph.insertHookNodesAtBuses(shuntNodes.get(shuntNodes.size() - 1),
                 shuntNodes.get(shuntNodes.size() - 2), "Shunt " + cellNumber + ".2");
         shuntNodes.add(1, iNode1);
         shuntNodes.add(shuntNodes.size() - 1, iNode2);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutGraphAdapter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutGraphAdapter.java
@@ -1,0 +1,31 @@
+package com.powsybl.sld.layout;
+
+import com.powsybl.sld.model.graphs.VoltageLevelGraph;
+import com.powsybl.sld.model.nodes.Middle3WTNode;
+import com.powsybl.sld.model.nodes.SwitchNode;
+
+public class LayoutGraphAdapter {
+    private final boolean removeUnnecessaryFictitiousNodes;
+    private final boolean substituteSingularFictitiousByFeederNode;
+
+    public LayoutGraphAdapter(boolean removeUnnecessaryFictitiousNodes, boolean substituteSingularFictitiousByFeederNode) {
+        this.removeUnnecessaryFictitiousNodes = removeUnnecessaryFictitiousNodes;
+        this.substituteSingularFictitiousByFeederNode = substituteSingularFictitiousByFeederNode;
+    }
+
+    void run(VoltageLevelGraph graph) {
+        graph.substituteFictitiousNodesMirroringBusNodes();
+        if (removeUnnecessaryFictitiousNodes) {
+            graph.removeUnnecessaryFictitiousNodes();
+        }
+        if (substituteSingularFictitiousByFeederNode) {
+            graph.substituteSingularFictitiousByFeederNode();
+        }
+        graph.insertFictitiousNodesAtFeeders();
+        graph.extendNodeConnectedToBus(node -> node instanceof SwitchNode && ((SwitchNode) node).getKind() != SwitchNode.SwitchKind.DISCONNECTOR);
+        graph.extendNodeConnectedToBus(Middle3WTNode.class::isInstance);
+        graph.extendSwitchBetweenBuses();
+        graph.extendFirstOutsideNode();
+        graph.extendBusConnectedToBus();
+    }
+}

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -10,7 +10,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.powsybl.sld.library.ComponentSize;
+import com.powsybl.sld.library.ComponentTypeName;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -88,6 +91,9 @@ public class LayoutParameters {
 
     private int feederInfoPrecision = 0;
 
+    /** Components which are displayed on busbars */
+    private List<String> componentsOnBusbars = List.of(ComponentTypeName.DISCONNECTOR);
+
     @JsonIgnore
     private Map<String, ComponentSize> componentsSize;
 
@@ -131,7 +137,8 @@ public class LayoutParameters {
                             @JsonProperty("feederInfosIntraMargin") double feederInfosIntraMargin,
                             @JsonProperty("busInfoMargin") double busInfoMargin,
                             @JsonProperty("busbarsAlignment") Alignment busbarsAlignment,
-                            @JsonProperty("feederInfoPrecision") int feederInfoPrecision) {
+                            @JsonProperty("feederInfoPrecision") int feederInfoPrecision,
+                            @JsonProperty("componentsOnBusbars") List<String> componentsOnBusbars) {
         this.diagramPadding = diagramPadding;
         this.voltageLevelPadding = voltageLevelPadding;
         this.verticalSpaceBus = verticalSpaceBus;
@@ -168,6 +175,7 @@ public class LayoutParameters {
         this.busInfoMargin = busInfoMargin;
         this.busbarsAlignment = busbarsAlignment;
         this.feederInfoPrecision = feederInfoPrecision;
+        this.componentsOnBusbars = new ArrayList<>(componentsOnBusbars);
     }
 
     public LayoutParameters(LayoutParameters other) {
@@ -545,6 +553,15 @@ public class LayoutParameters {
 
     public LayoutParameters setFeederInfoPrecision(int feederInfoPrecision) {
         this.feederInfoPrecision = feederInfoPrecision;
+        return this;
+    }
+
+    public List<String> getComponentsOnBusbars() {
+        return componentsOnBusbars;
+    }
+
+    public LayoutParameters setComponentsOnBusbars(List<String> componentsOnBusbars) {
+        this.componentsOnBusbars = componentsOnBusbars;
         return this;
     }
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -217,6 +217,7 @@ public class LayoutParameters {
         busInfoMargin = other.busInfoMargin;
         busbarsAlignment = other.busbarsAlignment;
         feederInfoPrecision = other.feederInfoPrecision;
+        componentsOnBusbars = new ArrayList<>(other.componentsOnBusbars);
     }
 
     public double getVerticalSpaceBus() {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
@@ -41,14 +41,18 @@ public class PositionVoltageLevelLayout extends AbstractVoltageLevelLayout {
     }
 
     /**
-     * Calculate real coordinate of busNode and blocks connected to busbar
+     * Layout the nodes:
+     * - detect the cells (intern / extern / shunt)
+     * - organize the cells into blocks
+     * - calculate real coordinate of busNode and blocks connected to busbar
      */
     @Override
     public void run(LayoutParameters layoutParam) {
+        LOGGER.info("Running voltage level layout");
+
         cellDetector.detectCells(getGraph());
         blockOrganizer.organize(getGraph());
 
-        LOGGER.info("Running voltage level layout");
         calculateMaxCellHeight(layoutParam);
         calculateBusNodeCoord(getGraph(), layoutParam);
         calculateCellCoord(getGraph(), layoutParam);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
@@ -33,15 +33,18 @@ public class PositionVoltageLevelLayout extends AbstractVoltageLevelLayout {
     private static final Logger LOGGER = LoggerFactory.getLogger(PositionVoltageLevelLayout.class);
     private final CellDetector cellDetector;
     private final BlockOrganizer blockOrganizer;
+    private final LayoutGraphAdapter graphAdapter;
 
-    public PositionVoltageLevelLayout(VoltageLevelGraph graph, CellDetector cellDetector, BlockOrganizer blockOrganizer) {
+    public PositionVoltageLevelLayout(VoltageLevelGraph graph, LayoutGraphAdapter layoutGraphAdapter, CellDetector cellDetector, BlockOrganizer blockOrganizer) {
         super(graph);
+        this.graphAdapter = layoutGraphAdapter;
         this.cellDetector = cellDetector;
         this.blockOrganizer = blockOrganizer;
     }
 
     /**
      * Layout the nodes:
+     * - adapt the graph to have the expected patterns
      * - detect the cells (intern / extern / shunt)
      * - organize the cells into blocks
      * - calculate real coordinate of busNode and blocks connected to busbar
@@ -50,6 +53,7 @@ public class PositionVoltageLevelLayout extends AbstractVoltageLevelLayout {
     public void run(LayoutParameters layoutParam) {
         LOGGER.info("Running voltage level layout");
 
+        graphAdapter.run(getGraph());
         cellDetector.detectCells(getGraph());
         blockOrganizer.organize(getGraph());
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
@@ -53,7 +53,7 @@ public class PositionVoltageLevelLayout extends AbstractVoltageLevelLayout {
     public void run(LayoutParameters layoutParam) {
         LOGGER.info("Running voltage level layout");
 
-        graphAdapter.run(getGraph());
+        graphAdapter.run(getGraph(), layoutParam);
         cellDetector.detectCells(getGraph());
         blockOrganizer.organize(getGraph());
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
@@ -31,9 +31,13 @@ import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
 public class PositionVoltageLevelLayout extends AbstractVoltageLevelLayout {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PositionVoltageLevelLayout.class);
+    private final CellDetector cellDetector;
+    private final BlockOrganizer blockOrganizer;
 
-    public PositionVoltageLevelLayout(VoltageLevelGraph graph) {
+    public PositionVoltageLevelLayout(VoltageLevelGraph graph, CellDetector cellDetector, BlockOrganizer blockOrganizer) {
         super(graph);
+        this.cellDetector = cellDetector;
+        this.blockOrganizer = blockOrganizer;
     }
 
     /**
@@ -41,6 +45,9 @@ public class PositionVoltageLevelLayout extends AbstractVoltageLevelLayout {
      */
     @Override
     public void run(LayoutParameters layoutParam) {
+        cellDetector.detectCells(getGraph());
+        blockOrganizer.organize(getGraph());
+
         LOGGER.info("Running voltage level layout");
         calculateMaxCellHeight(layoutParam);
         calculateBusNodeCoord(getGraph(), layoutParam);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
@@ -33,11 +33,11 @@ public class PositionVoltageLevelLayout extends AbstractVoltageLevelLayout {
     private static final Logger LOGGER = LoggerFactory.getLogger(PositionVoltageLevelLayout.class);
     private final CellDetector cellDetector;
     private final BlockOrganizer blockOrganizer;
-    private final LayoutGraphAdapter graphAdapter;
+    private final GraphRefiner graphAdapter;
 
-    public PositionVoltageLevelLayout(VoltageLevelGraph graph, LayoutGraphAdapter layoutGraphAdapter, CellDetector cellDetector, BlockOrganizer blockOrganizer) {
+    public PositionVoltageLevelLayout(VoltageLevelGraph graph, GraphRefiner graphRefiner, CellDetector cellDetector, BlockOrganizer blockOrganizer) {
         super(graph);
-        this.graphAdapter = layoutGraphAdapter;
+        this.graphAdapter = graphRefiner;
         this.cellDetector = cellDetector;
         this.blockOrganizer = blockOrganizer;
     }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayout.java
@@ -55,7 +55,7 @@ public class PositionVoltageLevelLayout extends AbstractVoltageLevelLayout {
 
         graphAdapter.run(getGraph(), layoutParam);
         cellDetector.detectCells(getGraph());
-        blockOrganizer.organize(getGraph());
+        blockOrganizer.organize(getGraph(), layoutParam);
 
         calculateMaxCellHeight(layoutParam);
         calculateBusNodeCoord(getGraph(), layoutParam);

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactory.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactory.java
@@ -100,12 +100,11 @@ public class PositionVoltageLevelLayoutFactory implements VoltageLevelLayoutFact
     @Override
     public Layout create(VoltageLevelGraph graph) {
         // detect cells
-        new ImplicitCellDetector(removeUnnecessaryFictitiousNodes, substituteSingularFictitiousByFeederNode, exceptionIfPatternNotHandled)
-                .detectCells(graph);
+        ImplicitCellDetector cellDetector = new ImplicitCellDetector(removeUnnecessaryFictitiousNodes, substituteSingularFictitiousByFeederNode, exceptionIfPatternNotHandled);
 
         // build blocks from cells
-        new BlockOrganizer(positionFinder, feederStacked, exceptionIfPatternNotHandled, handleShunts, busInfoMap).organize(graph);
+        BlockOrganizer blockOrganizer = new BlockOrganizer(positionFinder, feederStacked, exceptionIfPatternNotHandled, handleShunts, busInfoMap);
 
-        return new PositionVoltageLevelLayout(graph);
+        return new PositionVoltageLevelLayout(graph, cellDetector, blockOrganizer);
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactory.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactory.java
@@ -99,12 +99,15 @@ public class PositionVoltageLevelLayoutFactory implements VoltageLevelLayoutFact
 
     @Override
     public Layout create(VoltageLevelGraph graph) {
-        // detect cells
-        ImplicitCellDetector cellDetector = new ImplicitCellDetector(removeUnnecessaryFictitiousNodes, substituteSingularFictitiousByFeederNode, exceptionIfPatternNotHandled);
+        // For adapting the graph to the diagram layout
+        LayoutGraphAdapter layoutGraphAdapter = new LayoutGraphAdapter(removeUnnecessaryFictitiousNodes, substituteSingularFictitiousByFeederNode);
 
-        // build blocks from cells
+        // For cell detection
+        ImplicitCellDetector cellDetector = new ImplicitCellDetector(exceptionIfPatternNotHandled);
+
+        // For building blocks from cells
         BlockOrganizer blockOrganizer = new BlockOrganizer(positionFinder, feederStacked, exceptionIfPatternNotHandled, handleShunts, busInfoMap);
 
-        return new PositionVoltageLevelLayout(graph, cellDetector, blockOrganizer);
+        return new PositionVoltageLevelLayout(graph, layoutGraphAdapter, cellDetector, blockOrganizer);
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactory.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionVoltageLevelLayoutFactory.java
@@ -100,7 +100,7 @@ public class PositionVoltageLevelLayoutFactory implements VoltageLevelLayoutFact
     @Override
     public Layout create(VoltageLevelGraph graph) {
         // For adapting the graph to the diagram layout
-        LayoutGraphAdapter layoutGraphAdapter = new LayoutGraphAdapter(removeUnnecessaryFictitiousNodes, substituteSingularFictitiousByFeederNode);
+        GraphRefiner graphRefiner = new GraphRefiner(removeUnnecessaryFictitiousNodes, substituteSingularFictitiousByFeederNode);
 
         // For cell detection
         ImplicitCellDetector cellDetector = new ImplicitCellDetector(exceptionIfPatternNotHandled);
@@ -108,6 +108,6 @@ public class PositionVoltageLevelLayoutFactory implements VoltageLevelLayoutFact
         // For building blocks from cells
         BlockOrganizer blockOrganizer = new BlockOrganizer(positionFinder, feederStacked, exceptionIfPatternNotHandled, handleShunts, busInfoMap);
 
-        return new PositionVoltageLevelLayout(graph, layoutGraphAdapter, cellDetector, blockOrganizer);
+        return new PositionVoltageLevelLayout(graph, graphRefiner, cellDetector, blockOrganizer);
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/TopologicallyConnectedNodesSet.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/TopologicallyConnectedNodesSet.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 /**
  * Represents a connected set of nodes if considering the borderNodes as disconnected:
- * for any couple of nodes in <code>nodess</code> there is at least one path connecting them together WITHOUT passing
+ * for any couple of nodes in <code>nodes</code> there is at least one path connecting them together WITHOUT passing
  * through any nodes of <code>borderNodes</code>.
  * The <code>nodes</code> holds the connected set of nodes.
  * The <code>borderNodes</code> holds the nodes that are at the border of this set, that is for which 1 adjacent node

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/FeederPrimaryBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/FeederPrimaryBlock.java
@@ -29,14 +29,6 @@ public class FeederPrimaryBlock extends AbstractPrimaryBlock {
         if (getExtremityNode(START).getType() == FEEDER) {
             super.reverseBlock();
         }
-        if (!checkConsistency()) {
-            throw new PowsyblException("FeederPrimaryBlock not consistent");
-        }
-    }
-
-    private boolean checkConsistency() {
-        return nodes.size() == 2 && nodes.get(1).getType() == FEEDER
-            && (nodes.get(0).getType() == FICTITIOUS || nodes.get(0).getType() == SHUNT);
     }
 
     public FeederNode getFeederNode() {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/FeederPrimaryBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/FeederPrimaryBlock.java
@@ -7,17 +7,16 @@
 
 package com.powsybl.sld.model.blocks;
 
-import com.powsybl.commons.PowsyblException;
 import com.powsybl.sld.model.nodes.FeederNode;
 import com.powsybl.sld.model.nodes.Node;
 
 import java.util.List;
 
-import static com.powsybl.sld.model.nodes.Node.NodeType.*;
 import static com.powsybl.sld.model.blocks.Block.Extremity.START;
 import static com.powsybl.sld.model.blocks.Block.Type.FEEDERPRIMARY;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.H;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.V;
+import static com.powsybl.sld.model.nodes.Node.NodeType.FEEDER;
 
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/LegPrimaryBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/LegPrimaryBlock.java
@@ -11,16 +11,18 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.sld.model.nodes.BusConnection;
 import com.powsybl.sld.model.nodes.BusNode;
 import com.powsybl.sld.model.nodes.Node;
-import com.powsybl.sld.model.nodes.SwitchNode;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.powsybl.sld.model.blocks.Block.Extremity.*;
-import static com.powsybl.sld.model.blocks.Block.Type.*;
-import static com.powsybl.sld.model.nodes.Node.NodeType.*;
-import static com.powsybl.sld.model.coordinate.Position.Dimension.*;
+import static com.powsybl.sld.model.blocks.Block.Extremity.END;
+import static com.powsybl.sld.model.blocks.Block.Extremity.START;
+import static com.powsybl.sld.model.blocks.Block.Type.LEGPRIMARY;
+import static com.powsybl.sld.model.coordinate.Position.Dimension.H;
+import static com.powsybl.sld.model.coordinate.Position.Dimension.V;
+import static com.powsybl.sld.model.nodes.Node.NodeType.BUS;
+import static com.powsybl.sld.model.nodes.Node.NodeType.FICTITIOUS;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
@@ -36,21 +38,6 @@ public class LegPrimaryBlock extends AbstractPrimaryBlock implements LegBlock {
         if (getExtremityNode(END).getType() == BUS) {
             super.reverseBlock();
         }
-        if (!checkConsistency()) {
-            throw new PowsyblException("LegPrimaryBlock not consistent");
-        }
-    }
-
-    private boolean checkConsistency() {
-        return nodes.size() == 3
-                && nodes.get(0).getType() == BUS
-                && checkMiddleNode(nodes.get(1))
-                && (nodes.get(2).getType() == FICTITIOUS || nodes.get(2).getType() == Node.NodeType.SHUNT);
-    }
-
-    private boolean checkMiddleNode(Node node) {
-        return node instanceof BusConnection
-            || (node instanceof SwitchNode && ((SwitchNode) node).getKind() == SwitchNode.SwitchKind.DISCONNECTOR);
     }
 
     public BusNode getBusNode() {

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/LegPrimaryBlock.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/blocks/LegPrimaryBlock.java
@@ -7,8 +7,6 @@
 
 package com.powsybl.sld.model.blocks;
 
-import com.powsybl.commons.PowsyblException;
-import com.powsybl.sld.model.nodes.BusConnection;
 import com.powsybl.sld.model.nodes.BusNode;
 import com.powsybl.sld.model.nodes.Node;
 
@@ -22,7 +20,6 @@ import static com.powsybl.sld.model.blocks.Block.Type.LEGPRIMARY;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.H;
 import static com.powsybl.sld.model.coordinate.Position.Dimension.V;
 import static com.powsybl.sld.model.nodes.Node.NodeType.BUS;
-import static com.powsybl.sld.model.nodes.Node.NodeType.FICTITIOUS;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/AbstractBusCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/AbstractBusCell.java
@@ -8,16 +8,14 @@ package com.powsybl.sld.model.cells;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.powsybl.sld.model.blocks.Block;
+import com.powsybl.sld.model.blocks.FeederPrimaryBlock;
 import com.powsybl.sld.model.blocks.LegPrimaryBlock;
 import com.powsybl.sld.model.coordinate.Direction;
 import com.powsybl.sld.model.nodes.BusNode;
 import com.powsybl.sld.model.nodes.Node;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -28,7 +26,8 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractBusCell extends AbstractCell implements BusCell {
 
-    private List<LegPrimaryBlock> legPrimaryBlocks = new ArrayList<>();
+    private final List<LegPrimaryBlock> legPrimaryBlocks = new ArrayList<>();
+    private final List<FeederPrimaryBlock> feederPrimaryBlocks = new ArrayList<>();
 
     private Integer order = null;
 
@@ -39,9 +38,10 @@ public abstract class AbstractBusCell extends AbstractCell implements BusCell {
     }
 
     @Override
-    public void blocksSetting(Block rootBlock, List<LegPrimaryBlock> primaryBlocksConnectedToBus) {
+    public void blocksSetting(Block rootBlock, List<LegPrimaryBlock> primaryBlocksConnectedToBus, List<FeederPrimaryBlock> feederPrimaryBlocks) {
         setRootBlock(rootBlock);
-        this.legPrimaryBlocks = new ArrayList<>(primaryBlocksConnectedToBus);
+        this.legPrimaryBlocks.addAll(primaryBlocksConnectedToBus);
+        this.feederPrimaryBlocks.addAll(feederPrimaryBlocks);
     }
 
     @Override
@@ -54,7 +54,12 @@ public abstract class AbstractBusCell extends AbstractCell implements BusCell {
 
     @Override
     public List<LegPrimaryBlock> getLegPrimaryBlocks() {
-        return new ArrayList<>(legPrimaryBlocks);
+        return Collections.unmodifiableList(legPrimaryBlocks);
+    }
+
+    @Override
+    public List<FeederPrimaryBlock> getFeederPrimaryBlocks() {
+        return Collections.unmodifiableList(feederPrimaryBlocks);
     }
 
     @Override

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/BusCell.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/cells/BusCell.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.model.cells;
 import com.powsybl.sld.model.blocks.Block;
+import com.powsybl.sld.model.blocks.FeederPrimaryBlock;
 import com.powsybl.sld.model.blocks.LegPrimaryBlock;
 import com.powsybl.sld.model.coordinate.Direction;
 import com.powsybl.sld.model.nodes.BusNode;
@@ -21,9 +22,11 @@ public interface BusCell extends Cell {
 
     List<BusNode> getBusNodes();
 
-    void blocksSetting(Block rootBlock, List<LegPrimaryBlock> primaryBlocksConnectedToBus);
+    void blocksSetting(Block rootBlock, List<LegPrimaryBlock> primaryBlocksConnectedToBus, List<FeederPrimaryBlock> feederPrimaryBlocks);
 
     List<LegPrimaryBlock> getLegPrimaryBlocks();
+
+    List<FeederPrimaryBlock> getFeederPrimaryBlocks();
 
     int newHPosition(int hPosition);
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/VoltageLevelGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/VoltageLevelGraph.java
@@ -8,7 +8,6 @@ package com.powsybl.sld.model.graphs;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.powsybl.commons.PowsyblException;
-import com.powsybl.sld.library.ComponentTypeName;
 import com.powsybl.sld.model.cells.*;
 import com.powsybl.sld.model.coordinate.Direction;
 import com.powsybl.sld.model.coordinate.Orientation;
@@ -293,175 +292,104 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
                 .map(BusCell.class::cast);
     }
 
+    public void insertBusConnections(Predicate<Node> nodesOnBus) {
+        getNodeBuses().forEach(busNode -> insertBusConnections(busNode, nodesOnBus));
+    }
+
+    private void insertBusConnections(BusNode busNode, Predicate<Node> nodesOnBus) {
+        busNode.getAdjacentNodes().stream()
+                .filter(node -> !nodesOnBus.test(node))
+                .forEach(node -> insertBusConnection(busNode, node));
+    }
+
+    private void insertBusConnection(BusNode busNode, Node nodeConnectedToBusNode) {
+        // Create bus connection
+        BusConnection fNodeToBus = NodeFactory.createBusConnection(this, nodeConnectedToBusNode.getId());
+
+        // Update edges
+        removeEdge(busNode, nodeConnectedToBusNode);
+        addEdge(busNode, fNodeToBus);
+        addEdge(fNodeToBus, nodeConnectedToBusNode);
+    }
+
+    public void insertHookNodesAtBuses() {
+        getNodeBuses().forEach(this::insertHookNodesAtBuses);
+    }
+
+    private void insertHookNodesAtBuses(BusNode busNode) {
+        busNode.getAdjacentNodes()
+                .forEach(nodeOnBus -> nodeOnBus.getAdjacentNodes().stream()
+                        .filter(n -> n.getType() != NodeType.BUS)
+                        .filter(n -> n.getType() == NodeType.FEEDER || n.getType() == NodeType.SWITCH || n instanceof Middle3WTNode)
+                        .forEach(n -> insertBusHookNode(nodeOnBus, n)));
+    }
+
+    private void insertBusHookNode(Node nodeOnBus, Node node) {
+        // Create hook node
+        InternalNode fStackNode = NodeFactory.createInternalNode(this, node.getId());
+
+        // Update edges
+        if (node.getType() == NodeType.FEEDER) {
+            for (Node neighbor : node.getAdjacentNodes()) {
+                addEdge(neighbor, fStackNode);
+                removeEdge(neighbor, node);
+            }
+            addEdge(fStackNode, node);
+        } else {
+            removeEdge(nodeOnBus, node);
+            addEdge(nodeOnBus, fStackNode);
+            addEdge(fStackNode, node);
+        }
+    }
+
     /**
      * Insert fictitious node(s) before feeders in order for the feeder to be properly displayed:
      * feeders need at least one inserted fictitious node to have enough space to display the feeder arrows.
-     * Some special cases:
-     *  - feeders connected directly to a bus need 3 additional nodes (1 BusConnection, 2 InternalNode) to obey the Leg/Body/Feeder structure
-     *  - feeders connected to a bus through a disconnector need 2 additional InternalNode to obey the Leg/Body/Feeder structure
-     *  - 3WT do not need any fictitious node inserted here as they already have the fictitious Middle3WTNode
      */
-    public void insertFictitiousNodesAtFeeders() {
-        List<Node> nodesToAdd = new ArrayList<>();
+    public void insertHookNodesAtFeeders() {
+        // Each feeder node needs a fictitious node to have enough place for the feeder infos (arrows)
+        // Feeder3WTLegNode linked to Middle3WTNode do not need any fictitious node inserted, because of the fictitious Middle3WTNode
         List<Node> feederNodes = nodesByType.computeIfAbsent(Node.NodeType.FEEDER, nodeType -> new ArrayList<>());
-        for (Node feederNode : feederNodes) {
-            List<Node> adjacentNodes = feederNode.getAdjacentNodes();
-            if (isConnectedToBus(feederNode)) {
-                // Feeders linked directly to a bus need 3 fictitious nodes to be properly displayed:
-                //  - 1 bus connection
-                //  - 2 internal nodes to have LegPrimaryBlock + BodyPrimaryBlock + FeederPrimaryBlock
-                addTripleNode(feederNode, nodesToAdd);
-            } else if (isConnectedToBusDisconnector(feederNode)) {
-                // Feeders linked directly to a bus disconnector need 2 internal nodes to be properly displayed, in order
-                // to have LegPrimaryBlock + BodyPrimaryBlock + FeederPrimaryBlock
-                insertTwoInternalNodes(feederNode, nodesToAdd);
-            } else if (!isFeeder3WT(feederNode)) {
-                // Three-winding transformers do not need to be extended in voltage level diagrams, as the Middle3WTNode is already itself an internal node
-                // Create a new fictitious node
-                InternalNode nf = NodeFactory.createInternalNode(this, feederNode.getId());
-                // Create all new edges and remove old ones
-                for (Node neighbor : adjacentNodes) {
-                    addEdge(neighbor, nf);
-                    removeEdge(neighbor, feederNode);
-                }
-                addEdge(nf, feederNode);
-            }
+        feederNodes.stream()
+                .filter(feederNode -> !(feederNode instanceof Feeder3WTLegNode) || !(feederNode.getAdjacentNodes().get(0) instanceof Middle3WTNode))
+                .forEach(this::insertFeederHookNode);
+    }
+
+    private void insertFeederHookNode(Node feederNode) {
+        // Create a new hook node
+        InternalNode nf = NodeFactory.createInternalNode(this, feederNode.getId());
+
+        // Create all new edges and remove old ones
+        for (Node neighbor : feederNode.getAdjacentNodes()) {
+            addEdge(neighbor, nf);
+            removeEdge(neighbor, feederNode);
         }
+        addEdge(nf, feederNode);
     }
 
-    private boolean isConnectedToBus(Node node) {
-        return node.getAdjacentNodes().stream().anyMatch(BusNode.class::isInstance);
+    public void extendBusesConnectedToBuses() {
+        getNodeBuses().forEach(n1 ->
+                n1.getAdjacentNodes().stream()
+                        .filter(n2 -> n2.getType() == Node.NodeType.BUS)
+                        .forEach(n2 -> extendBusConnectedToBus(n1, n2)));
     }
 
-    private boolean isConnectedToBusDisconnector(Node node) {
-        return node.getAdjacentNodes().stream()
-                .filter(SwitchNode.class::isInstance)
-                .map(SwitchNode.class::cast)
-                .filter(sn -> sn.getKind() == SwitchNode.SwitchKind.DISCONNECTOR)
-                .anyMatch(sn -> sn.getAdjacentNodes().stream().anyMatch(n -> n.getType() == Node.NodeType.BUS));
+    private void extendBusConnectedToBus(BusNode n1, Node n2) {
+        removeEdge(n1, n2);
+        String busToBusId = n1.getId() + "-" + n2.getId();
+        InternalNode internalNode1 = NodeFactory.createInternalNode(this, busToBusId + "_1");
+        InternalNode internalNode2 = NodeFactory.createInternalNode(this, busToBusId + "_2");
+        addEdge(n1, internalNode1);
+        addEdge(internalNode1, internalNode2);
+        addEdge(n2, internalNode2);
     }
 
-    private boolean isFeeder3WT(Node feederNode) {
-        List<Node> adjacentNodes = feederNode.getAdjacentNodes();
-        return adjacentNodes.size() == 1 && adjacentNodes.get(0).getComponentType().equals(ComponentTypeName.THREE_WINDINGS_TRANSFORMER);
-    }
-
-    private void addTripleNode(Node feederNode, List<Node> nodesToAdd) {
-        // Create nodes
-        BusConnection fNodeToBus = NodeFactory.createBusConnection(this, feederNode.getId());
-        InternalNode fNodeToSw1 = NodeFactory.createInternalNode(this, feederNode.getId() + "_1");
-        InternalNode fNodeToSw2 = NodeFactory.createInternalNode(this, feederNode.getId() + "_2");
-
-        // Nodes will be added afterwards
-        nodesToAdd.add(fNodeToBus);
-        nodesToAdd.add(fNodeToSw1);
-        nodesToAdd.add(fNodeToSw2);
-
-        // Add edges right away
-        for (Node adjacentNode : feederNode.getAdjacentNodes()) {
-            if (adjacentNode instanceof BusNode) {
-                addEdge(adjacentNode, fNodeToBus);
-            } else {
-                addEdge(adjacentNode, fNodeToSw1);
-            }
-            removeEdge(adjacentNode, feederNode);
-        }
-        addEdge(fNodeToBus, fNodeToSw1);
-        addEdge(fNodeToSw1, fNodeToSw2);
-        addEdge(fNodeToSw2, feederNode);
-    }
-
-    private void insertTwoInternalNodes(Node feederNode, List<Node> nodesToAdd) {
-        // Create nodes
-        InternalNode fNodeToSw1 = NodeFactory.createInternalNode(this, feederNode.getId() + "_1");
-        InternalNode fNodeToSw2 = NodeFactory.createInternalNode(this, feederNode.getId() + "_2");
-
-        // Nodes will be added afterwards
-        nodesToAdd.add(fNodeToSw1);
-        nodesToAdd.add(fNodeToSw2);
-
-        // Add edges right away
-        for (Node adjacentNodes : feederNode.getAdjacentNodes()) {
-            addEdge(adjacentNodes, fNodeToSw1);
-            removeEdge(adjacentNodes, feederNode);
-        }
-        addEdge(fNodeToSw1, fNodeToSw2);
-        addEdge(fNodeToSw2, feederNode);
-    }
-
-    //add a fictitious node between 2 switches or between a switch and a feeder
-    //when one switch is connected to a bus
-    public void extendFirstOutsideNode() {
-        getNodeBuses().stream()
-                .flatMap(node -> node.getAdjacentNodes().stream())
-                .filter(node -> node.getType() == Node.NodeType.SWITCH)
-                .forEach(nodeSwitch ->
-                        nodeSwitch.getAdjacentNodes().stream()
-                                .filter(node -> node.getType() == Node.NodeType.SWITCH ||
-                                        node.getType() == Node.NodeType.FEEDER)
-                                .forEach(node -> {
-                                    removeEdge(node, nodeSwitch);
-                                    InternalNode newNode = NodeFactory.createInternalNode(this, nodeSwitch.getId());
-                                    addEdge(node, newNode);
-                                    addEdge(nodeSwitch, newNode);
-                                }));
-    }
-
-    public void extendNodeConnectedToBus(Predicate<Node> condition) {
-        getNodeBuses().forEach(nodeBus ->
-                nodeBus.getAdjacentNodes().stream()
-                        .filter(condition)
-                        .forEach(nodeSwitch -> addDoubleNode(nodeBus, nodeSwitch, "")));
-    }
-
-    public void extendSwitchBetweenBuses() {
-        getNodeBuses().forEach(nodeBus -> nodeBus.getAdjacentNodes().stream()
-                .filter(SwitchNode.class::isInstance)
-                .filter(n -> n.getAdjacentNodes().stream().allMatch(BusNode.class::isInstance))
-                .forEach(n -> extendSwitchBetweenBuses((SwitchNode) n)));
-    }
-
-    public void extendSwitchBetweenBuses(SwitchNode nodeSwitch) {
-        List<Node> copyAdj = nodeSwitch.getAdjacentNodes();
-        addDoubleNode((BusNode) copyAdj.get(0), nodeSwitch, "_0");
-        addDoubleNode((BusNode) copyAdj.get(1), nodeSwitch, "_1");
-    }
-
-    public void extendBusConnectedToBus() {
-        for (BusNode n1 : getNodeBuses()) {
-            n1.getAdjacentNodes().stream()
-                    .filter(n2 -> n2.getType() == Node.NodeType.BUS)
-                    .forEach(n2 -> {
-                        removeEdge(n1, n2);
-                        String busToBusId = n1.getId() + "-" + n2.getId();
-                        BusConnection fSwToBus1 = NodeFactory.createBusConnection(this, busToBusId + "_1");
-                        InternalNode internalNode1 = NodeFactory.createInternalNode(this, busToBusId + "_1");
-                        InternalNode internalNode2 = NodeFactory.createInternalNode(this, busToBusId + "_2");
-                        BusConnection fSwToBus2 = NodeFactory.createBusConnection(this, busToBusId + "_2");
-                        addEdge(n1, fSwToBus1);
-                        addEdge(fSwToBus1, internalNode1);
-                        addEdge(internalNode1, internalNode2);
-                        addEdge(internalNode2, fSwToBus2);
-                        addEdge(n2, fSwToBus2);
-                    });
-        }
-    }
-
-    public InternalNode insertInternalNode(Node node1, Node node2, String id) {
+    public InternalNode insertHookNodesAtBuses(Node node1, Node node2, String id) {
         removeEdge(node1, node2);
         InternalNode iNode = NodeFactory.createInternalNode(this, id);
         addEdge(node1, iNode);
         addEdge(node2, iNode);
         return iNode;
-    }
-
-    private void addDoubleNode(BusNode busNode, Node node, String suffix) {
-        removeEdge(busNode, node);
-        BusConnection fNodeToBus = NodeFactory.createBusConnection(this, node.getId() + suffix);
-        InternalNode fNodeToSw = NodeFactory.createInternalNode(this, node.getId() + suffix);
-        addEdge(busNode, fNodeToBus);
-        addEdge(fNodeToBus, fNodeToSw);
-        addEdge(fNodeToSw, node);
     }
 
     /**

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/CreateNetworksUtil.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/CreateNetworksUtil.java
@@ -405,4 +405,42 @@ public final class CreateNetworksUtil {
         view.newBreaker().setId("bt").setNode1(0).setNode2(3).add();
         return network;
     }
+
+    public static Network createNetworkWithFiveBusesFourLoads() {
+        Network network = createNetworkWithTwoParallelLoads();
+        VoltageLevel vl = network.getVoltageLevel("vl1");
+
+        createBusBarSection(vl, "bbs1", "bbs1", 0, 1, 1);
+        createBusBarSection(vl, "bbs21", "bbs21", 1, 2, 1);
+        createBusBarSection(vl, "bbs22", "bbs22", 2, 2, 2);
+        createSwitch(vl, "bA", "bA", SwitchKind.BREAKER, false, false, false, 3, 4);
+        createLoad(vl, "loadA", "loadA", "loadA", null, ConnectablePosition.Direction.TOP, 4, 10, 10);
+        createSwitch(vl, "dA1", "dA1", SwitchKind.DISCONNECTOR, false, false, false, 0, 3);
+        createSwitch(vl, "dA2", "dA2", SwitchKind.DISCONNECTOR, false, false, false, 1, 3);
+
+        createSwitch(vl, "bB", "bB", SwitchKind.BREAKER, false, false, false, 5, 6);
+        createLoad(vl, "loadB", "loadB", "loadB", null, ConnectablePosition.Direction.TOP, 6, 10, 10);
+        createSwitch(vl, "dB1", "dB1", SwitchKind.DISCONNECTOR, false, false, false, 2, 5);
+        createSwitch(vl, "dB2", "dB2", SwitchKind.DISCONNECTOR, false, false, false, 0, 5);
+
+        createSwitch(vl, "link", "link", SwitchKind.BREAKER, false, false, false, 5, 9);
+
+        return network;
+    }
+
+    public static Network createNetworkWithTwoParallelLoads() {
+        Network network = Network.create("TestSingleLineDiagramClass", "test");
+        Substation substation = createSubstation(network, "s", "s", Country.FR);
+        VoltageLevel vl = createVoltageLevel(substation, "vl1", "vl1", TopologyKind.NODE_BREAKER, 380, 10);
+        createBusBarSection(vl, "bbs13", "bbs13", 7, 1, 3);
+        createBusBarSection(vl, "bbs23", "bbs23", 8, 2, 3);
+        createLoad(vl, "loadC", "loadC", "loadC", null, ConnectablePosition.Direction.TOP, 9, 10, 10);
+        createSwitch(vl, "bCD1", "bCD1", SwitchKind.BREAKER, false, false, false, 8, 9);
+        createSwitch(vl, "bCD2", "bCD2", SwitchKind.BREAKER, false, false, false, 7, 9);
+        createSwitch(vl, "bCD3", "bCD3", SwitchKind.BREAKER, false, false, false, 7, 9);
+        createSwitch(vl, "bD1", "bD1", SwitchKind.BREAKER, false, false, false, 20, 9);
+        createLoad(vl, "loadD", "loadD", "loadD", null, ConnectablePosition.Direction.TOP, 20, 10, 10);
+        return network;
+    }
+
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/CreateNetworksUtil.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/CreateNetworksUtil.java
@@ -9,6 +9,7 @@ package com.powsybl.sld.iidm;
 import com.powsybl.iidm.network.*;
 import com.powsybl.sld.iidm.extensions.BranchStatus;
 import com.powsybl.sld.iidm.extensions.BranchStatusAdder;
+import com.powsybl.sld.iidm.extensions.BusbarSectionPositionAdder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 
 import static com.powsybl.sld.iidm.AbstractTestCaseIidm.*;
@@ -16,7 +17,7 @@ import static com.powsybl.sld.iidm.AbstractTestCaseIidm.*;
 /**
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
-final class CreateNetworksUtil {
+public final class CreateNetworksUtil {
 
     private CreateNetworksUtil() {
     }
@@ -338,6 +339,70 @@ final class CreateNetworksUtil {
                 .add()
                 .add();
 
+        return network;
+    }
+
+    public static Network createNetworkWithSvcVscScDl() {
+        Network network = Network.create("testCase1", "test");
+        Substation substation = network.newSubstation().setId("s").setCountry(Country.FR).add();
+        VoltageLevel vl = substation.newVoltageLevel().setId("vl").setTopologyKind(TopologyKind.NODE_BREAKER).setNominalV(380).add();
+        VoltageLevel.NodeBreakerView view = vl.getNodeBreakerView();
+        BusbarSection bbs = view.newBusbarSection().setId("bbs").setNode(0).add();
+        bbs.newExtension(BusbarSectionPositionAdder.class).withBusbarIndex(1).withSectionIndex(1);
+        BusbarSection bbs2 = view.newBusbarSection().setId("bbs2").setNode(3).add();
+        bbs2.newExtension(BusbarSectionPositionAdder.class).withBusbarIndex(2).withSectionIndex(2);
+        StaticVarCompensator svc = vl.newStaticVarCompensator()
+                .setId("svc")
+                .setName("svc")
+                .setNode(2)
+                .setBmin(0.0002)
+                .setBmax(0.0008)
+                .setRegulationMode(StaticVarCompensator.RegulationMode.VOLTAGE)
+                .setVoltageSetPoint(390)
+                .add();
+        svc.getTerminal()
+                .setP(100.0)
+                .setQ(50.0);
+        VscConverterStation vsc = vl.newVscConverterStation()
+                .setId("vsc")
+                .setName("Converter1")
+                .setNode(1)
+                .setLossFactor(0.011f)
+                .setVoltageSetpoint(405.0)
+                .setVoltageRegulatorOn(true)
+                .add();
+        vsc.getTerminal()
+                .setP(100.0)
+                .setQ(50.0);
+        ShuntCompensator c1 = vl.newShuntCompensator()
+                .setId("C1")
+                .setName("Filter 1")
+                .setNode(4)
+                .setSectionCount(1)
+                .newLinearModel()
+                .setBPerSection(1e-5)
+                .setMaximumSectionCount(1)
+                .add()
+                .add();
+        DanglingLine dl1 = vl.newDanglingLine()
+                .setId("dl1")
+                .setName("Dangling line 1")
+                .setNode(5)
+                .setP0(1)
+                .setQ0(1)
+                .setR(0)
+                .setX(0)
+                .setB(0)
+                .setG(0)
+                .add();
+        dl1.getTerminal()
+                .setP(100.0)
+                .setQ(50.0);
+        view.newDisconnector().setId("d").setNode1(0).setNode2(1).add();
+        view.newBreaker().setId("b").setNode1(1).setNode2(2).add();
+        view.newBreaker().setId("b2").setNode1(3).setNode2(4).add();
+        view.newBreaker().setId("b3").setNode1(3).setNode2(5).add();
+        view.newBreaker().setId("bt").setNode1(0).setNode2(3).add();
         return network;
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
@@ -12,10 +12,7 @@ import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
-import com.powsybl.sld.layout.BlockOrganizer;
-import com.powsybl.sld.layout.ImplicitCellDetector;
-import com.powsybl.sld.layout.PositionVoltageLevelLayout;
-import com.powsybl.sld.layout.positionfromextension.PositionFromExtension;
+import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
 import com.powsybl.sld.library.ResourcesComponentLibrary;
 import com.powsybl.sld.model.coordinate.Side;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
@@ -170,8 +167,12 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
 
         // Run layout
-        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension(), true, true, true, labelProvider.getBusInfoSides(g));
-        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
+        new PositionVoltageLevelLayoutFactory()
+                .setBusInfoMap(labelProvider.getBusInfoSides(g))
+                .setExceptionIfPatternNotHandled(true)
+                .setHandleShunts(true)
+                .create(g)
+                .run(layoutParameters);
 
         // write SVG and compare to reference
         assertEquals(toString(filename), toSVG(g, filename, labelProvider, styleProvider));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
@@ -6,12 +6,7 @@
  */
 package com.powsybl.sld.iidm;
 
-import com.powsybl.iidm.network.Country;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.SwitchKind;
-import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.sld.builders.NetworkGraphBuilder;
-import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
 import com.powsybl.sld.library.ResourcesComponentLibrary;
 import com.powsybl.sld.model.coordinate.Side;
@@ -58,31 +53,8 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
 
     @Before
     public void setUp() throws IOException {
-        int order = 0;
-        network = Network.create("TestSingleLineDiagramClass", "test");
+        network = CreateNetworksUtil.createNetworkWithFiveBusesFourLoads();
         graphBuilder = new NetworkGraphBuilder(network);
-        substation = createSubstation(network, "s", "s", Country.FR);
-        vl = createVoltageLevel(substation, "vl1", "vl1", TopologyKind.NODE_BREAKER, 380, 10);
-        createBusBarSection(vl, "bbs1", "bbs1", 0, 1, 1);
-        createBusBarSection(vl, "bbs21", "bbs21", 1, 2, 1);
-        createBusBarSection(vl, "bbs22", "bbs22", 2, 2, 2);
-        createSwitch(vl, "fA", "fA", SwitchKind.BREAKER, false, false, false, 3, 4);
-        createLoad(vl, "loadA", "loadA", "loadA", order++, ConnectablePosition.Direction.TOP, 4, 10, 10);
-        createSwitch(vl, "d1", "d1", SwitchKind.DISCONNECTOR, false, false, false, 0, 3);
-        createSwitch(vl, "d2", "d2", SwitchKind.DISCONNECTOR, false, false, false, 1, 3);
-
-        createSwitch(vl, "fB", "fB", SwitchKind.BREAKER, false, false, false, 5, 6);
-        createLoad(vl, "loadB", "loadB", "loadB", order++, ConnectablePosition.Direction.TOP, 6, 10, 10);
-        createSwitch(vl, "b1", "b1", SwitchKind.DISCONNECTOR, false, false, false, 2, 5);
-        createSwitch(vl, "b2", "b2", SwitchKind.DISCONNECTOR, false, false, false, 0, 5);
-
-        createBusBarSection(vl, "bbs13", "bbs13", 7, 1, 3);
-        createBusBarSection(vl, "bbs23", "bbs23", 8, 2, 3);
-        createLoad(vl, "loadC", "loadC", "loadC", order++, ConnectablePosition.Direction.TOP, 9, 10, 10);
-        createSwitch(vl, "c1", "c1", SwitchKind.BREAKER, false, false, false, 8, 9);
-        createSwitch(vl, "c2", "c2", SwitchKind.BREAKER, false, false, false, 7, 9);
-
-        createSwitch(vl, "link", "link", SwitchKind.BREAKER, false, false, false, 5, 9);
 
         withFullBusInfoProvider = new DefaultDiagramLabelProvider(network, componentLibrary, layoutParameters) {
             @Override
@@ -164,7 +136,7 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
                 .setBusInfoMargin(5);
 
         // build graph
-        VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
+        VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph("vl1");
 
         // Run layout
         new PositionVoltageLevelLayoutFactory()

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase15GraphWithVoltageIndicator.java
@@ -170,9 +170,8 @@ public class TestCase15GraphWithVoltageIndicator extends AbstractTestCaseIidm {
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
 
         // Run layout
-        new ImplicitCellDetector().detectCells(g);
-        new BlockOrganizer(new PositionFromExtension(), true, true, true, labelProvider.getBusInfoSides(g)).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension(), true, true, true, labelProvider.getBusInfoSides(g));
+        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
 
         // write SVG and compare to reference
         assertEquals(toString(filename), toSVG(g, filename, labelProvider, styleProvider));

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7CellDetectionIssue.java
@@ -54,7 +54,7 @@ public class TestCase7CellDetectionIssue extends AbstractTestCaseIidm {
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
 
         // detect cells
-        new ImplicitCellDetector().detectCells(g);
+        new ImplicitCellDetector(true, true, false).detectCells(g);
 
         // assert cells
         assertEquals(1, g.getCellStream().count());

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCase7CellDetectionIssue.java
@@ -54,7 +54,7 @@ public class TestCase7CellDetectionIssue extends AbstractTestCaseIidm {
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
 
         // detect cells
-        new ImplicitCellDetector(true, true, false).detectCells(g);
+        new ImplicitCellDetector(false).detectCells(g);
 
         // assert cells
         assertEquals(1, g.getCellStream().count());

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseGraphAdaptCellHeightToContent.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseGraphAdaptCellHeightToContent.java
@@ -12,11 +12,7 @@ import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
-import com.powsybl.sld.layout.BlockOrganizer;
-import com.powsybl.sld.layout.CellDetector;
-import com.powsybl.sld.layout.ImplicitCellDetector;
-import com.powsybl.sld.layout.PositionVoltageLevelLayout;
-import com.powsybl.sld.layout.positionfromextension.PositionFromExtension;
+import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import org.junit.Before;
 import org.junit.Test;
@@ -90,9 +86,12 @@ public class TestCaseGraphAdaptCellHeightToContent extends AbstractTestCaseIidm 
         layoutParameters.setAdaptCellHeightToContent(false);
 
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
-        CellDetector cellDetector = new ImplicitCellDetector(false, true, false);
-        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension(), false);
-        new PositionVoltageLevelLayout(g, cellDetector, blockOrganizer).run(layoutParameters);
+
+        new PositionVoltageLevelLayoutFactory()
+                .setFeederStacked(false)
+                .setRemoveUnnecessaryFictitiousNodes(false)
+                .create(g)
+                .run(layoutParameters);
 
         assertEquals(toString("/TestCaseGraphExternCellHeightFixed.json"), toJson(g, "/TestCaseGraphExternCellHeightFixed.json"));
     }
@@ -103,9 +102,11 @@ public class TestCaseGraphAdaptCellHeightToContent extends AbstractTestCaseIidm 
         layoutParameters.setAdaptCellHeightToContent(true);
 
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
-        CellDetector cellDetector = new ImplicitCellDetector(false, true, false);
-        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension(), true);
-        new PositionVoltageLevelLayout(g, cellDetector, blockOrganizer).run(layoutParameters);
+
+        new PositionVoltageLevelLayoutFactory()
+                .setRemoveUnnecessaryFictitiousNodes(false)
+                .create(g)
+                .run(layoutParameters);
 
         assertEquals(toString("/TestCaseGraphAdaptCellHeightToContent.json"), toJson(g, "/TestCaseGraphAdaptCellHeightToContent.json"));
     }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseGraphAdaptCellHeightToContent.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseGraphAdaptCellHeightToContent.java
@@ -13,9 +13,10 @@ import com.powsybl.iidm.network.TopologyKind;
 import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.layout.BlockOrganizer;
+import com.powsybl.sld.layout.CellDetector;
 import com.powsybl.sld.layout.ImplicitCellDetector;
-import com.powsybl.sld.layout.positionfromextension.PositionFromExtension;
 import com.powsybl.sld.layout.PositionVoltageLevelLayout;
+import com.powsybl.sld.layout.positionfromextension.PositionFromExtension;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import org.junit.Before;
 import org.junit.Test;
@@ -89,9 +90,9 @@ public class TestCaseGraphAdaptCellHeightToContent extends AbstractTestCaseIidm 
         layoutParameters.setAdaptCellHeightToContent(false);
 
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
-        new ImplicitCellDetector(false, true, false).detectCells(g);
-        new BlockOrganizer(new PositionFromExtension(), false).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        CellDetector cellDetector = new ImplicitCellDetector(false, true, false);
+        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension(), false);
+        new PositionVoltageLevelLayout(g, cellDetector, blockOrganizer).run(layoutParameters);
 
         assertEquals(toString("/TestCaseGraphExternCellHeightFixed.json"), toJson(g, "/TestCaseGraphExternCellHeightFixed.json"));
     }
@@ -102,9 +103,9 @@ public class TestCaseGraphAdaptCellHeightToContent extends AbstractTestCaseIidm 
         layoutParameters.setAdaptCellHeightToContent(true);
 
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
-        new ImplicitCellDetector(false, true, false).detectCells(g);
-        new BlockOrganizer(new PositionFromExtension(), true).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        CellDetector cellDetector = new ImplicitCellDetector(false, true, false);
+        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension(), true);
+        new PositionVoltageLevelLayout(g, cellDetector, blockOrganizer).run(layoutParameters);
 
         assertEquals(toString("/TestCaseGraphAdaptCellHeightToContent.json"), toJson(g, "/TestCaseGraphAdaptCellHeightToContent.json"));
     }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestDoubleForkNode.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestDoubleForkNode.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.iidm;
+
+import com.powsybl.sld.builders.NetworkGraphBuilder;
+import com.powsybl.sld.model.graphs.VoltageLevelGraph;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class TestDoubleForkNode extends AbstractTestCaseIidm {
+
+    @Before
+    public void setUp() throws IOException {
+        network = CreateNetworksUtil.createNetworkWithTwoParallelLoads();
+        graphBuilder = new NetworkGraphBuilder(network);
+    }
+
+    @Test
+    public void test() {
+        // build graph
+        VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph("vl1");
+
+        // Run layout
+        voltageLevelGraphLayout(g);
+
+        // write SVG and compare to reference
+        assertEquals(toString("/testDoubleForkNode.json"), toJson(g, "/testDoubleForkNode.json"));
+    }
+}

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialBlock.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialBlock.java
@@ -67,8 +67,8 @@ public class TestSerialBlock extends AbstractTestCaseIidm {
         assertTrue(sb.getSubBlocks().get(2).isEmbeddingNodeType(FEEDER));
 
         assertEquals("bbs", sb.getSubBlocks().get(0).getStartingNode().getId());
-        assertEquals("INTERNAL_vl_da", sb.getSubBlocks().get(0).getEndingNode().getId());
-        assertEquals("INTERNAL_vl_da", sb.getSubBlocks().get(1).getStartingNode().getId());
+        assertEquals("INTERNAL_vl_ba", sb.getSubBlocks().get(0).getEndingNode().getId());
+        assertEquals("INTERNAL_vl_ba", sb.getSubBlocks().get(1).getStartingNode().getId());
         assertEquals("INTERNAL_vl_la", sb.getSubBlocks().get(1).getEndingNode().getId());
         assertEquals("INTERNAL_vl_la", sb.getSubBlocks().get(2).getStartingNode().getId());
         assertEquals("la", sb.getSubBlocks().get(2).getEndingNode().getId());
@@ -120,11 +120,11 @@ public class TestSerialBlock extends AbstractTestCaseIidm {
         sb.reverseBlock();
 
         // LegPrimaryBlock is NOT reversed (bus is always the starting node)
-        assertEquals("INTERNAL_vl_da", sb.getSubBlocks().get(1).getEndingNode().getId());
+        assertEquals("INTERNAL_vl_ba", sb.getSubBlocks().get(1).getEndingNode().getId());
         assertEquals("bbs", sb.getSubBlocks().get(2).getStartingNode().getId());
 
         // BodyPrimaryBlock is reversed
-        assertEquals("INTERNAL_vl_da", sb.getSubBlocks().get(1).getEndingNode().getId());
+        assertEquals("INTERNAL_vl_ba", sb.getSubBlocks().get(1).getEndingNode().getId());
         assertEquals("INTERNAL_vl_la", sb.getSubBlocks().get(1).getStartingNode().getId());
 
         // FeederPrimaryBlock is NOT reversed (feeder is always the ending node)

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialBlock.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialBlock.java
@@ -9,10 +9,7 @@ package com.powsybl.sld.iidm;
 import com.powsybl.iidm.network.*;
 import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
-import com.powsybl.sld.layout.BlockOrganizer;
-import com.powsybl.sld.layout.CalculateCoordBlockVisitor;
-import com.powsybl.sld.layout.ImplicitCellDetector;
-import com.powsybl.sld.layout.LayoutContext;
+import com.powsybl.sld.layout.*;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import com.powsybl.sld.model.blocks.Block;
 import com.powsybl.sld.model.blocks.SerialBlock;
@@ -53,11 +50,8 @@ public class TestSerialBlock extends AbstractTestCaseIidm {
         // build graph
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
 
-        // detect cells
-        new ImplicitCellDetector().detectCells(g);
-
-        // build blocks
-        new BlockOrganizer().organize(g);
+        // layout
+        new PositionVoltageLevelLayoutFactory().create(g).run(layoutParameters);
 
         assertEquals(1, g.getCellStream().count());
         Optional<Cell> oCell = g.getCellStream().findFirst();

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialParallelBlock.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialParallelBlock.java
@@ -9,10 +9,7 @@ package com.powsybl.sld.iidm;
 import com.powsybl.iidm.network.*;
 import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
-import com.powsybl.sld.layout.BlockOrganizer;
-import com.powsybl.sld.layout.CalculateCoordBlockVisitor;
-import com.powsybl.sld.layout.ImplicitCellDetector;
-import com.powsybl.sld.layout.LayoutContext;
+import com.powsybl.sld.layout.*;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import com.powsybl.sld.model.blocks.Block;
 import com.powsybl.sld.model.blocks.BodyParallelBlock;
@@ -58,8 +55,7 @@ public class TestSerialParallelBlock extends AbstractTestCaseIidm {
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
 
         // detect cells
-        new ImplicitCellDetector().detectCells(g);
-        new BlockOrganizer().organize(g);
+        new PositionVoltageLevelLayoutFactory().create(g).run(layoutParameters);
 
         assertEquals(1, g.getCellStream().count());
         Optional<Cell> oCell = g.getCellStream().findFirst();

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialParallelBlock.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestSerialParallelBlock.java
@@ -130,8 +130,8 @@ public class TestSerialParallelBlock extends AbstractTestCaseIidm {
 
         sb.reverseBlock();
 
-        assertEquals("INTERNAL_vl_da", sb.getEndingNode().getId());
-        assertEquals("INTERNAL_vl_da", subSB.getEndingNode().getId());
+        assertEquals("INTERNAL_vl_ba", sb.getEndingNode().getId());
+        assertEquals("INTERNAL_vl_ba", subSB.getEndingNode().getId());
         assertEquals("INTERNAL_vl_2", subPB.getSubBlocks().get(1).getEndingNode().getId());
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/ComponentsOnBusTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/ComponentsOnBusTest.java
@@ -6,27 +6,18 @@
  */
 package com.powsybl.sld.layout;
 
-import com.powsybl.iidm.network.Network;
 import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.AbstractTestCaseIidm;
 import com.powsybl.sld.iidm.CreateNetworksUtil;
-import com.powsybl.sld.layout.SmartVoltageLevelLayoutFactory;
-import com.powsybl.sld.library.ComponentLibrary;
 import com.powsybl.sld.library.ComponentTypeName;
-import com.powsybl.sld.library.ConvergenceComponentLibrary;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
-import com.powsybl.sld.model.nodes.FeederNode;
-import com.powsybl.sld.svg.DefaultDiagramLabelProvider;
-import com.powsybl.sld.svg.FeederInfo;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
 
-import static com.powsybl.sld.library.ComponentTypeName.ARROW_ACTIVE;
-import static com.powsybl.sld.library.ComponentTypeName.ARROW_REACTIVE;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/ComponentsOnBusTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/ComponentsOnBusTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.layout;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
+import com.powsybl.sld.iidm.AbstractTestCaseIidm;
+import com.powsybl.sld.iidm.CreateNetworksUtil;
+import com.powsybl.sld.layout.SmartVoltageLevelLayoutFactory;
+import com.powsybl.sld.library.ComponentLibrary;
+import com.powsybl.sld.library.ComponentTypeName;
+import com.powsybl.sld.library.ConvergenceComponentLibrary;
+import com.powsybl.sld.model.graphs.VoltageLevelGraph;
+import com.powsybl.sld.model.nodes.FeederNode;
+import com.powsybl.sld.svg.DefaultDiagramLabelProvider;
+import com.powsybl.sld.svg.FeederInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.powsybl.sld.library.ComponentTypeName.ARROW_ACTIVE;
+import static com.powsybl.sld.library.ComponentTypeName.ARROW_REACTIVE;
+import static org.junit.Assert.*;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class ComponentsOnBusTest extends AbstractTestCaseIidm {
+
+    @Before
+    public void setUp() {
+        network = CreateNetworksUtil.createNetworkWithSvcVscScDl();
+        graphBuilder = new NetworkGraphBuilder(network);
+        vl = network.getVoltageLevel("vl");
+    }
+
+    @Test
+    public void testNoComponentsOnBuses() {
+        layoutParameters.setComponentsOnBusbars(Collections.emptyList());
+        VoltageLevelGraph vlg = graphBuilder.buildVoltageLevelGraph(vl.getId());
+        voltageLevelGraphLayout(vlg);
+        assertEquals(toString("/noComponentsOnBus.svg"), toSVG(vlg, "/noComponentsOnBus.svg"));
+    }
+
+    @Test
+    public void testSwitchesOnBuses() {
+        layoutParameters.setComponentsOnBusbars(List.of(ComponentTypeName.BREAKER, ComponentTypeName.DISCONNECTOR));
+        VoltageLevelGraph vlg = graphBuilder.buildVoltageLevelGraph(vl.getId());
+        voltageLevelGraphLayout(vlg);
+        assertEquals(toString("/switchesOnBus.svg"), toSVG(vlg, "/switchesOnBus.svg"));
+    }
+}

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/layout/LayoutParametersTest.java
@@ -8,6 +8,8 @@ package com.powsybl.sld.layout;
 
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -55,7 +57,8 @@ public class LayoutParametersTest {
                 .setFeederInfosIntraMargin(21)
                 .setBusInfoMargin(22)
                 .setBusbarsAlignment(LayoutParameters.Alignment.LAST)
-                .setFeederInfoPrecision(12);
+                .setFeederInfoPrecision(12)
+                .setComponentsOnBusbars(List.of("COMPONENT_ON_BUS"));
 
         LayoutParameters layoutParameters2 = new LayoutParameters(layoutParameters);
 
@@ -101,5 +104,6 @@ public class LayoutParametersTest {
         assertEquals(layoutParameters.getBusInfoMargin(), layoutParameters2.getBusInfoMargin(), 0);
         assertEquals(layoutParameters.getBusbarsAlignment(), layoutParameters2.getBusbarsAlignment());
         assertEquals(layoutParameters.getFeederInfoPrecision(), layoutParameters2.getFeederInfoPrecision());
+        assertEquals(layoutParameters.getComponentsOnBusbars(), layoutParameters2.getComponentsOnBusbars());
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase2.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase2.java
@@ -7,18 +7,17 @@
 package com.powsybl.sld.raw;
 
 import com.powsybl.sld.builders.VoltageLevelRawBuilder;
-import com.powsybl.sld.layout.BlockOrganizer;
-import com.powsybl.sld.layout.ImplicitCellDetector;
-import com.powsybl.sld.layout.PositionVoltageLevelLayout;
-import com.powsybl.sld.layout.positionfromextension.PositionFromExtension;
-import com.powsybl.sld.model.graphs.*;
-import com.powsybl.sld.model.nodes.*;
-
+import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
+import com.powsybl.sld.model.graphs.VoltageLevelGraph;
+import com.powsybl.sld.model.nodes.BusNode;
+import com.powsybl.sld.model.nodes.FeederNode;
+import com.powsybl.sld.model.nodes.FictitiousNode;
+import com.powsybl.sld.model.nodes.SwitchNode;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import static com.powsybl.sld.model.coordinate.Direction.TOP;
+import static org.junit.Assert.assertEquals;
 
 /**
  * <pre>
@@ -69,8 +68,10 @@ public class TestCase2 extends AbstractTestCaseRaw {
     @Test
     public void testUnstacked() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vlUnstack");
-        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension(), false);
-        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
+        new PositionVoltageLevelLayoutFactory()
+                .setFeederStacked(false)
+                .create(g)
+                .run(layoutParameters);
         assertEquals(toString("/TestCase2UnStackedCell.json"), toJson(g, "/TestCase2UnStackedCell.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase2.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase2.java
@@ -69,9 +69,8 @@ public class TestCase2 extends AbstractTestCaseRaw {
     @Test
     public void testUnstacked() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vlUnstack");
-        new ImplicitCellDetector().detectCells(g);
-        new BlockOrganizer(new PositionFromExtension(), false).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension(), false);
+        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
         assertEquals(toString("/TestCase2UnStackedCell.json"), toJson(g, "/TestCase2UnStackedCell.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase7CellDetectionIssue.java
@@ -40,7 +40,7 @@ public class TestCase7CellDetectionIssue extends AbstractTestCaseRaw {
     @Test
     public void test() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl");
-        new ImplicitCellDetector().detectCells(g);
+        new ImplicitCellDetector(true, true, false).detectCells(g);
         assertEquals(1, g.getCellStream().count());
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase7CellDetectionIssue.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCase7CellDetectionIssue.java
@@ -40,7 +40,7 @@ public class TestCase7CellDetectionIssue extends AbstractTestCaseRaw {
     @Test
     public void test() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl");
-        new ImplicitCellDetector(true, true, false).detectCells(g);
+        new ImplicitCellDetector(false).detectCells(g);
         assertEquals(1, g.getCellStream().count());
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseShuntArrangement.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseShuntArrangement.java
@@ -173,18 +173,16 @@ public class TestCaseShuntArrangement extends AbstractTestCaseRaw {
     @Test
     public void test1() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl");
-        new ImplicitCellDetector().detectCells(g);
-        new BlockOrganizer(new PositionFromExtension(), true, true, false).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension(), true, true, false);
+        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
         assertEquals(toString("/TestCaseShuntArrangementNo.json"), toJson(g, "/TestCaseShuntArrangementNo.json"));
     }
 
     @Test
     public void test2() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl");
-        new ImplicitCellDetector().detectCells(g);
-        new BlockOrganizer(new PositionFromExtension(), true, true, true).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension(), true, true, true);
+        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
         assertEquals(toString("/TestCaseShuntArrangementYes.json"), toJson(g, "/TestCaseShuntArrangementYes.json"));
     }
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseShuntArrangement.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestCaseShuntArrangement.java
@@ -7,16 +7,12 @@
 package com.powsybl.sld.raw;
 
 import com.powsybl.sld.builders.VoltageLevelRawBuilder;
-import com.powsybl.sld.layout.BlockOrganizer;
-import com.powsybl.sld.layout.ImplicitCellDetector;
-import com.powsybl.sld.layout.PositionVoltageLevelLayout;
-import com.powsybl.sld.layout.positionfromextension.PositionFromExtension;
+import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import com.powsybl.sld.model.nodes.BusNode;
 import com.powsybl.sld.model.nodes.FeederNode;
 import com.powsybl.sld.model.nodes.FictitiousNode;
 import com.powsybl.sld.model.nodes.SwitchNode;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -173,16 +169,21 @@ public class TestCaseShuntArrangement extends AbstractTestCaseRaw {
     @Test
     public void test1() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl");
-        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension(), true, true, false);
-        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
+        new PositionVoltageLevelLayoutFactory()
+                .setExceptionIfPatternNotHandled(true)
+                .create(g)
+                .run(layoutParameters);
         assertEquals(toString("/TestCaseShuntArrangementNo.json"), toJson(g, "/TestCaseShuntArrangementNo.json"));
     }
 
     @Test
     public void test2() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl");
-        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension(), true, true, true);
-        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
+        new PositionVoltageLevelLayoutFactory()
+                .setExceptionIfPatternNotHandled(true)
+                .setHandleShunts(true)
+                .create(g)
+                .run(layoutParameters);
         assertEquals(toString("/TestCaseShuntArrangementYes.json"), toJson(g, "/TestCaseShuntArrangementYes.json"));
     }
 

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestOrderConsistency.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestOrderConsistency.java
@@ -17,12 +17,11 @@ import com.powsybl.sld.model.nodes.BusNode;
 import com.powsybl.sld.model.nodes.FeederNode;
 import com.powsybl.sld.model.nodes.FictitiousNode;
 import com.powsybl.sld.model.nodes.SwitchNode;
-
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import static com.powsybl.sld.model.coordinate.Direction.TOP;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
@@ -94,36 +93,32 @@ public class TestOrderConsistency extends AbstractTestCaseRaw {
     @Test
     public void testClustMiddleLeft() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl1");
-        new ImplicitCellDetector().detectCells(g);
-        new BlockOrganizer(new PositionByClustering()).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionByClustering());
+        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
         assertEquals(toString("/orderConsistencyClust1.json"), toJson(g, "/orderConsistencyClust1.json"));
     }
 
     @Test
     public void testClustNoMiddleLeft() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl2");
-        new ImplicitCellDetector().detectCells(g);
-        new BlockOrganizer(new PositionByClustering()).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionByClustering());
+        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
         assertEquals(toString("/orderConsistencyClust2.json"), toJson(g, "/orderConsistencyClust2.json"));
     }
 
     @Test
     public void testExtMiddleLeft() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl1");
-        new ImplicitCellDetector().detectCells(g);
-        new BlockOrganizer(new PositionFromExtension()).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension());
+        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
         assertEquals(toString("/orderConsistencyExt1.json"), toJson(g, "/orderConsistencyExt1.json"));
     }
 
     @Test
     public void testExtNoMiddleLeft() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl2");
-        new ImplicitCellDetector().detectCells(g);
-        new BlockOrganizer(new PositionFromExtension()).organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension());
+        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
         assertEquals(toString("/orderConsistencyExt2.json"), toJson(g, "/orderConsistencyExt2.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestOrderConsistency.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestOrderConsistency.java
@@ -7,11 +7,8 @@
 package com.powsybl.sld.raw;
 
 import com.powsybl.sld.builders.VoltageLevelRawBuilder;
-import com.powsybl.sld.layout.BlockOrganizer;
-import com.powsybl.sld.layout.ImplicitCellDetector;
-import com.powsybl.sld.layout.PositionVoltageLevelLayout;
+import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
 import com.powsybl.sld.layout.positionbyclustering.PositionByClustering;
-import com.powsybl.sld.layout.positionfromextension.PositionFromExtension;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import com.powsybl.sld.model.nodes.BusNode;
 import com.powsybl.sld.model.nodes.FeederNode;
@@ -93,32 +90,28 @@ public class TestOrderConsistency extends AbstractTestCaseRaw {
     @Test
     public void testClustMiddleLeft() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl1");
-        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionByClustering());
-        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
+        new PositionVoltageLevelLayoutFactory(new PositionByClustering()).create(g).run(layoutParameters);
         assertEquals(toString("/orderConsistencyClust1.json"), toJson(g, "/orderConsistencyClust1.json"));
     }
 
     @Test
     public void testClustNoMiddleLeft() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl2");
-        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionByClustering());
-        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
+        new PositionVoltageLevelLayoutFactory(new PositionByClustering()).create(g).run(layoutParameters);
         assertEquals(toString("/orderConsistencyClust2.json"), toJson(g, "/orderConsistencyClust2.json"));
     }
 
     @Test
     public void testExtMiddleLeft() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl1");
-        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension());
-        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
+        new PositionVoltageLevelLayoutFactory().create(g).run(layoutParameters);
         assertEquals(toString("/orderConsistencyExt1.json"), toJson(g, "/orderConsistencyExt1.json"));
     }
 
     @Test
     public void testExtNoMiddleLeft() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl2");
-        BlockOrganizer blockOrganizer = new BlockOrganizer(new PositionFromExtension());
-        new PositionVoltageLevelLayout(g, new ImplicitCellDetector(), blockOrganizer).run(layoutParameters);
+        new PositionVoltageLevelLayoutFactory().create(g).run(layoutParameters);
         assertEquals(toString("/orderConsistencyExt2.json"), toJson(g, "/orderConsistencyExt2.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestSerialBlocksInternCells.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestSerialBlocksInternCells.java
@@ -8,6 +8,7 @@ package com.powsybl.sld.raw;
 
 import com.powsybl.sld.builders.VoltageLevelRawBuilder;
 import com.powsybl.sld.layout.BlockOrganizer;
+import com.powsybl.sld.layout.CellDetector;
 import com.powsybl.sld.layout.ImplicitCellDetector;
 import com.powsybl.sld.layout.PositionVoltageLevelLayout;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
@@ -62,9 +63,8 @@ public class TestSerialBlocksInternCells extends AbstractTestCaseRaw {
     @Test
     public void test() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl");
-        new ImplicitCellDetector(false, true, false).detectCells(g);
-        new BlockOrganizer().organize(g);
-        new PositionVoltageLevelLayout(g).run(layoutParameters);
+        CellDetector cellDetector = new ImplicitCellDetector(false, true, false);
+        new PositionVoltageLevelLayout(g, cellDetector, new BlockOrganizer()).run(layoutParameters);
         assertEquals(toString("/testSerialBlocksInternCells.json"), toJson(g, "/testSerialBlocksInternCells.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestSerialBlocksInternCells.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/raw/TestSerialBlocksInternCells.java
@@ -7,13 +7,11 @@
 package com.powsybl.sld.raw;
 
 import com.powsybl.sld.builders.VoltageLevelRawBuilder;
-import com.powsybl.sld.layout.BlockOrganizer;
-import com.powsybl.sld.layout.CellDetector;
-import com.powsybl.sld.layout.ImplicitCellDetector;
-import com.powsybl.sld.layout.PositionVoltageLevelLayout;
+import com.powsybl.sld.layout.PositionVoltageLevelLayoutFactory;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
-import com.powsybl.sld.model.nodes.*;
-
+import com.powsybl.sld.model.nodes.BusNode;
+import com.powsybl.sld.model.nodes.FictitiousNode;
+import com.powsybl.sld.model.nodes.SwitchNode;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -63,8 +61,10 @@ public class TestSerialBlocksInternCells extends AbstractTestCaseRaw {
     @Test
     public void test() {
         VoltageLevelGraph g = rawGraphBuilder.buildVoltageLevelGraph("vl");
-        CellDetector cellDetector = new ImplicitCellDetector(false, true, false);
-        new PositionVoltageLevelLayout(g, cellDetector, new BlockOrganizer()).run(layoutParameters);
+        new PositionVoltageLevelLayoutFactory()
+                .setRemoveUnnecessaryFictitiousNodes(false)
+                .create(g)
+                .run(layoutParameters);
         assertEquals(toString("/testSerialBlocksInternCells.json"), toJson(g, "/testSerialBlocksInternCells.json"));
     }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/FeederInfoProviderTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/FeederInfoProviderTest.java
@@ -6,22 +6,17 @@
  */
 package com.powsybl.sld.svg;
 
-import com.powsybl.iidm.network.*;
-import com.powsybl.iidm.network.StaticVarCompensator.RegulationMode;
+import com.powsybl.iidm.network.Network;
 import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.AbstractTestCaseIidm;
 import com.powsybl.sld.iidm.CreateNetworksUtil;
-import com.powsybl.sld.iidm.extensions.BusbarSectionPositionAdder;
-import com.powsybl.sld.layout.SmartVoltageLevelLayoutFactory;
 import com.powsybl.sld.library.ComponentLibrary;
 import com.powsybl.sld.library.ConvergenceComponentLibrary;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import com.powsybl.sld.model.nodes.FeederNode;
-
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 
 import static com.powsybl.sld.library.ComponentTypeName.ARROW_ACTIVE;

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/FeederInfoProviderTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/svg/FeederInfoProviderTest.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.StaticVarCompensator.RegulationMode;
 import com.powsybl.sld.builders.NetworkGraphBuilder;
 import com.powsybl.sld.iidm.AbstractTestCaseIidm;
+import com.powsybl.sld.iidm.CreateNetworksUtil;
 import com.powsybl.sld.iidm.extensions.BusbarSectionPositionAdder;
 import com.powsybl.sld.layout.SmartVoltageLevelLayoutFactory;
 import com.powsybl.sld.library.ComponentLibrary;
@@ -20,6 +21,7 @@ import com.powsybl.sld.model.nodes.FeederNode;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.powsybl.sld.library.ComponentTypeName.ARROW_ACTIVE;
@@ -34,67 +36,9 @@ public class FeederInfoProviderTest extends AbstractTestCaseIidm {
 
     @Before
     public void setUp() {
-        layoutParameters.setFeederInfoSymmetry(true);
-        network = Network.create("testCase1", "test");
+        network = CreateNetworksUtil.createNetworkWithSvcVscScDl();
         graphBuilder = new NetworkGraphBuilder(network);
-        substation = network.newSubstation().setId("s").setCountry(Country.FR).add();
-        vl = substation.newVoltageLevel().setId("vl").setTopologyKind(TopologyKind.NODE_BREAKER).setNominalV(380).add();
-        VoltageLevel.NodeBreakerView view = vl.getNodeBreakerView();
-        BusbarSection bbs = view.newBusbarSection().setId("bbs").setNode(0).add();
-        bbs.newExtension(BusbarSectionPositionAdder.class).withBusbarIndex(1).withSectionIndex(1);
-        BusbarSection bbs2 = view.newBusbarSection().setId("bbs2").setNode(3).add();
-        bbs2.newExtension(BusbarSectionPositionAdder.class).withBusbarIndex(2).withSectionIndex(2);
-        StaticVarCompensator svc = vl.newStaticVarCompensator()
-            .setId("svc")
-            .setName("svc")
-            .setNode(2)
-            .setBmin(0.0002)
-            .setBmax(0.0008)
-            .setRegulationMode(RegulationMode.VOLTAGE)
-            .setVoltageSetPoint(390)
-            .add();
-        svc.getTerminal()
-                .setP(100.0)
-                .setQ(50.0);
-        VscConverterStation vsc = vl.newVscConverterStation()
-            .setId("vsc")
-            .setName("Converter1")
-            .setNode(1)
-            .setLossFactor(0.011f)
-            .setVoltageSetpoint(405.0)
-            .setVoltageRegulatorOn(true)
-            .add();
-        vsc.getTerminal()
-                .setP(100.0)
-                .setQ(50.0);
-        ShuntCompensator c1 = vl.newShuntCompensator()
-            .setId("C1")
-            .setName("Filter 1")
-            .setNode(4)
-            .setSectionCount(1)
-            .newLinearModel()
-                .setBPerSection(1e-5)
-                .setMaximumSectionCount(1)
-            .add()
-            .add();
-        DanglingLine dl1 = vl.newDanglingLine()
-                .setId("dl1")
-                .setName("Dangling line 1")
-                .setNode(5)
-                .setP0(1)
-                .setQ0(1)
-                .setR(0)
-                .setX(0)
-                .setB(0)
-                .setG(0)
-                .add();
-        dl1.getTerminal()
-                .setP(100.0)
-                .setQ(50.0);
-        view.newDisconnector().setId("d").setNode1(0).setNode2(1).add();
-        view.newBreaker().setId("b").setNode1(1).setNode2(2).add();
-        view.newBreaker().setId("b2").setNode1(3).setNode2(4).add();
-        view.newBreaker().setId("b3").setNode1(3).setNode2(5).add();
+        vl = network.getVoltageLevel("vl");
     }
 
     @Test
@@ -102,7 +46,7 @@ public class FeederInfoProviderTest extends AbstractTestCaseIidm {
         ComponentLibrary componentLibrary = new ConvergenceComponentLibrary();
         layoutParameters.setFeederInfoSymmetry(true);
         VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
-        new SmartVoltageLevelLayoutFactory(network).create(g).run(layoutParameters); // to have cell orientations (bottom / up)
+        voltageLevelGraphLayout(g); // to have cell orientations (bottom / up)
         assertEquals(toString("/feederInfoTest.svg"), toSVG(g, "/feederInfoTest.svg"));
 
         Network network2 = Network.create("testCase2", "test2");

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
@@ -135,10 +135,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_LD1_95_1" transform="translate(161.0,326.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_LD1" transform="translate(161.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_LD1_95_2" transform="translate(161.0,138.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_LD1" transform="translate(161.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-load sld-top-feeder sld-vl300to500" id="idLD1" transform="translate(157.0,75.5)">
@@ -147,13 +147,13 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="LD1_N_LABEL" x="-5.0" y="-5.0">LD1</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_LD1_95_INTERNAL_95_VL1_95_LD1_95_1">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_LD1_95_INTERNAL_95_VL1_95_LD1">
                 <polyline points="165.0,360.0,165.0,330.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_LD1_95_1_95_INTERNAL_95_VL1_95_LD1_95_2">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_LD1_95_INTERNAL_95_VL1_95_LD1">
                 <polyline points="165.0,330.0,165.0,142.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_LD1_95_2_95_LD1">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_LD1_95_LD1">
                 <polyline points="165.0,142.0,165.0,84.5"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idLD1_ARROW_ACTIVE" transform="translate(160.0,99.5)">
@@ -171,22 +171,22 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L11_95_ONE_95_1" transform="translate(211.0,411.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L11_95_ONE" transform="translate(211.0,411.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L11_95_ONE_95_2" transform="translate(211.0,599.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L11_95_ONE" transform="translate(211.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder sld-vl300to500" id="idL11_95_ONE" transform="translate(215.0,665.0)">
                 <text class="sld-label" id="L11_ONE_S_LABEL" x="-5.0" y="5.0">L11</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_L11_95_ONE_95_INTERNAL_95_VL1_95_L11_95_ONE_95_1">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_L11_95_ONE_95_INTERNAL_95_VL1_95_L11_95_ONE">
                 <polyline points="215.0,360.0,215.0,415.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_2">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_INTERNAL_95_VL1_95_L11_95_ONE">
                 <polyline points="215.0,415.0,215.0,603.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_2_95_L11_95_ONE">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_L11_95_ONE">
                 <polyline points="215.0,603.0,215.0,665.0"/>
             </g>
             <g class="sld-arrow-q sld-in" id="idL11_95_ONE_ARROW_REACTIVE" transform="translate(210.0,640.0)">
@@ -204,22 +204,22 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_T11_95_ONE_95_1" transform="translate(261.0,326.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_T11_95_ONE" transform="translate(261.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_T11_95_ONE_95_2" transform="translate(261.0,138.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_T11_95_ONE" transform="translate(261.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder sld-vl300to500" id="idT11_95_ONE" transform="translate(265.0,80.0)">
                 <text class="sld-label" id="T11_ONE_N_LABEL" x="-5.0" y="-5.0">T11</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_T11_95_ONE_95_INTERNAL_95_VL1_95_T11_95_ONE_95_1">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_T11_95_ONE_95_INTERNAL_95_VL1_95_T11_95_ONE">
                 <polyline points="265.0,360.0,265.0,330.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_2">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_INTERNAL_95_VL1_95_T11_95_ONE">
                 <polyline points="265.0,330.0,265.0,142.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_2_95_T11_95_ONE">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_T11_95_ONE">
                 <polyline points="265.0,142.0,265.0,80.0"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(260.0,95.0)">
@@ -237,22 +237,22 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L12_95_ONE_95_1" transform="translate(311.0,411.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L12_95_ONE" transform="translate(311.0,411.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L12_95_ONE_95_2" transform="translate(311.0,599.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L12_95_ONE" transform="translate(311.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder sld-vl300to500" id="idL12_95_ONE" transform="translate(315.0,665.0)">
                 <text class="sld-label" id="L12_ONE_S_LABEL" x="-5.0" y="5.0">L12</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_L12_95_ONE_95_INTERNAL_95_VL1_95_L12_95_ONE_95_1">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_L12_95_ONE_95_INTERNAL_95_VL1_95_L12_95_ONE">
                 <polyline points="315.0,360.0,315.0,415.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_2">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_INTERNAL_95_VL1_95_L12_95_ONE">
                 <polyline points="315.0,415.0,315.0,603.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_2_95_L12_95_ONE">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_L12_95_ONE">
                 <polyline points="315.0,603.0,315.0,665.0"/>
             </g>
             <g class="sld-arrow-q sld-in" id="idL12_95_ONE_ARROW_REACTIVE" transform="translate(310.0,640.0)">
@@ -321,10 +321,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_G_95_1" transform="translate(461.0,326.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_G" transform="translate(461.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_G_95_2" transform="translate(461.0,138.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_G" transform="translate(461.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-generator sld-top-feeder sld-vl300to500" id="idG" transform="translate(459.0,74.0)">
@@ -333,13 +333,13 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="G_N_LABEL" x="-5.0" y="-5.0">G</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_G_95_INTERNAL_95_VL1_95_G_95_1">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_G_95_INTERNAL_95_VL1_95_G">
                 <polyline points="465.0,385.0,465.0,330.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_1_95_INTERNAL_95_VL1_95_G_95_2">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_INTERNAL_95_VL1_95_G">
                 <polyline points="465.0,330.0,465.0,142.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_2_95_G">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_G">
                 <polyline points="465.0,142.0,465.0,86.0"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idG_ARROW_ACTIVE" transform="translate(460.0,101.0)">
@@ -357,22 +357,22 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L11_95_TWO_95_1" transform="translate(511.0,411.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L11_95_TWO" transform="translate(511.0,411.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L11_95_TWO_95_2" transform="translate(511.0,599.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L11_95_TWO" transform="translate(511.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder sld-vl300to500" id="idL11_95_TWO" transform="translate(515.0,665.0)">
                 <text class="sld-label" id="L11_TWO_S_LABEL" x="-5.0" y="5.0">L11</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_L11_95_TWO_95_INTERNAL_95_VL1_95_L11_95_TWO_95_1">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_L11_95_TWO_95_INTERNAL_95_VL1_95_L11_95_TWO">
                 <polyline points="515.0,385.0,515.0,415.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_2">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_INTERNAL_95_VL1_95_L11_95_TWO">
                 <polyline points="515.0,415.0,515.0,603.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_2_95_L11_95_TWO">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_L11_95_TWO">
                 <polyline points="515.0,603.0,515.0,665.0"/>
             </g>
             <g class="sld-arrow-q sld-in" id="idL11_95_TWO_ARROW_REACTIVE" transform="translate(510.0,640.0)">
@@ -390,22 +390,22 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_T11_95_TWO_95_1" transform="translate(561.0,326.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_T11_95_TWO" transform="translate(561.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_T11_95_TWO_95_2" transform="translate(561.0,138.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_T11_95_TWO" transform="translate(561.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder sld-vl300to500" id="idT11_95_TWO" transform="translate(565.0,80.0)">
                 <text class="sld-label" id="T11_TWO_N_LABEL" x="-5.0" y="-5.0">T11</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_T11_95_TWO_95_INTERNAL_95_VL1_95_T11_95_TWO_95_1">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_T11_95_TWO_95_INTERNAL_95_VL1_95_T11_95_TWO">
                 <polyline points="565.0,385.0,565.0,330.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_2">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_INTERNAL_95_VL1_95_T11_95_TWO">
                 <polyline points="565.0,330.0,565.0,142.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_2_95_T11_95_TWO">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_T11_95_TWO">
                 <polyline points="565.0,142.0,565.0,80.0"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(560.0,95.0)">
@@ -423,10 +423,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_T12_95_ONE_95_1" transform="translate(611.0,411.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_T12_95_ONE" transform="translate(611.0,411.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_T12_95_ONE_95_2" transform="translate(611.0,599.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_T12_95_ONE" transform="translate(611.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-two-wt sld-bottom-feeder" id="idT12_95_ONE" transform="translate(610.0,657.5)">
@@ -434,13 +434,13 @@
                 <circle class="sld-vl300to500 sld-winding" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
                 <text class="sld-label" id="T12_ONE_S_LABEL" x="-5.0" y="20.0">T12</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_T12_95_ONE_95_INTERNAL_95_VL1_95_T12_95_ONE_95_1">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_BUSCO_95_T12_95_ONE_95_INTERNAL_95_VL1_95_T12_95_ONE">
                 <polyline points="615.0,385.0,615.0,415.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_2">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_INTERNAL_95_VL1_95_T12_95_ONE">
                 <polyline points="615.0,415.0,615.0,603.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_2_95_T12_95_ONE">
+            <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_T12_95_ONE">
                 <polyline points="615.0,603.0,615.0,657.0"/>
             </g>
             <g class="sld-arrow-q sld-in" id="idT12_95_ONE_ARROW_REACTIVE" transform="translate(610.0,632.0)">

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreakerH.json
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreakerH.json
@@ -191,7 +191,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_G_1",
+      "id" : "INTERNAL_VL1_G",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -200,7 +200,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_G_2",
+      "id" : "INTERNAL_VL1_G",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -209,7 +209,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_L11_ONE_1",
+      "id" : "INTERNAL_VL1_L11_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -218,7 +218,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_L11_ONE_2",
+      "id" : "INTERNAL_VL1_L11_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -227,7 +227,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_L11_TWO_1",
+      "id" : "INTERNAL_VL1_L11_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -235,7 +235,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_L11_TWO_2",
+      "id" : "INTERNAL_VL1_L11_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -243,7 +243,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_L12_ONE_1",
+      "id" : "INTERNAL_VL1_L12_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -252,7 +252,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_L12_ONE_2",
+      "id" : "INTERNAL_VL1_L12_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -261,7 +261,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_LD1_1",
+      "id" : "INTERNAL_VL1_LD1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -269,7 +269,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_LD1_2",
+      "id" : "INTERNAL_VL1_LD1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -277,7 +277,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T11_ONE_1",
+      "id" : "INTERNAL_VL1_T11_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -285,7 +285,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T11_ONE_2",
+      "id" : "INTERNAL_VL1_T11_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -293,7 +293,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T11_TWO_1",
+      "id" : "INTERNAL_VL1_T11_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -302,7 +302,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T11_TWO_2",
+      "id" : "INTERNAL_VL1_T11_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -311,7 +311,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T12_ONE_1",
+      "id" : "INTERNAL_VL1_T12_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -319,7 +319,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T12_ONE_2",
+      "id" : "INTERNAL_VL1_T12_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -327,7 +327,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T3_12_ONE_1",
+      "id" : "INTERNAL_VL1_T3_12_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -335,7 +335,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T3_12_ONE_2",
+      "id" : "INTERNAL_VL1_T3_12_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -343,7 +343,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T3_12_TWO_1",
+      "id" : "INTERNAL_VL1_T3_12_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -352,7 +352,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T3_12_TWO_2",
+      "id" : "INTERNAL_VL1_T3_12_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -662,7 +662,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B11", "BUSCO_LD1", "INTERNAL_VL1_LD1_1" ]
+          "nodes" : [ "B11", "BUSCO_LD1", "INTERNAL_VL1_LD1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -683,7 +683,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_LD1_1", "INTERNAL_VL1_LD1_2" ]
+          "nodes" : [ "INTERNAL_VL1_LD1", "INTERNAL_VL1_LD1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -704,7 +704,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_LD1_2", "LD1" ]
+          "nodes" : [ "INTERNAL_VL1_LD1", "LD1" ]
         } ]
       }
     }, {
@@ -752,7 +752,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B11", "BUSCO_L11_ONE", "INTERNAL_VL1_L11_ONE_1" ]
+          "nodes" : [ "B11", "BUSCO_L11_ONE", "INTERNAL_VL1_L11_ONE" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -773,7 +773,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_L11_ONE_1", "INTERNAL_VL1_L11_ONE_2" ]
+          "nodes" : [ "INTERNAL_VL1_L11_ONE", "INTERNAL_VL1_L11_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -794,7 +794,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_L11_ONE_2", "L11_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_L11_ONE", "L11_ONE" ]
         } ]
       }
     }, {
@@ -842,7 +842,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B11", "BUSCO_T11_ONE", "INTERNAL_VL1_T11_ONE_1" ]
+          "nodes" : [ "B11", "BUSCO_T11_ONE", "INTERNAL_VL1_T11_ONE" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -863,7 +863,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_T11_ONE_1", "INTERNAL_VL1_T11_ONE_2" ]
+          "nodes" : [ "INTERNAL_VL1_T11_ONE", "INTERNAL_VL1_T11_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -884,7 +884,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_T11_ONE_2", "T11_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_T11_ONE", "T11_ONE" ]
         } ]
       }
     }, {
@@ -932,7 +932,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B11", "BUSCO_L12_ONE", "INTERNAL_VL1_L12_ONE_1" ]
+          "nodes" : [ "B11", "BUSCO_L12_ONE", "INTERNAL_VL1_L12_ONE" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -953,7 +953,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_L12_ONE_1", "INTERNAL_VL1_L12_ONE_2" ]
+          "nodes" : [ "INTERNAL_VL1_L12_ONE", "INTERNAL_VL1_L12_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -974,7 +974,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_L12_ONE_2", "L12_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_L12_ONE", "L12_ONE" ]
         } ]
       }
     }, {
@@ -1022,7 +1022,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B11", "BUSCO_T3_12_ONE", "INTERNAL_VL1_T3_12_ONE_1" ]
+          "nodes" : [ "B11", "BUSCO_T3_12_ONE", "INTERNAL_VL1_T3_12_ONE" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1043,7 +1043,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_T3_12_ONE_1", "INTERNAL_VL1_T3_12_ONE_2" ]
+          "nodes" : [ "INTERNAL_VL1_T3_12_ONE", "INTERNAL_VL1_T3_12_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1064,7 +1064,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_T3_12_ONE_2", "T3_12_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_T3_12_ONE", "T3_12_ONE" ]
         } ]
       }
     }, {
@@ -1112,7 +1112,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B12", "BUSCO_G", "INTERNAL_VL1_G_1" ]
+          "nodes" : [ "B12", "BUSCO_G", "INTERNAL_VL1_G" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1133,7 +1133,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_G_1", "INTERNAL_VL1_G_2" ]
+          "nodes" : [ "INTERNAL_VL1_G", "INTERNAL_VL1_G" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1154,7 +1154,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_G_2", "G" ]
+          "nodes" : [ "INTERNAL_VL1_G", "G" ]
         } ]
       }
     }, {
@@ -1202,7 +1202,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B12", "BUSCO_L11_TWO", "INTERNAL_VL1_L11_TWO_1" ]
+          "nodes" : [ "B12", "BUSCO_L11_TWO", "INTERNAL_VL1_L11_TWO" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1223,7 +1223,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_L11_TWO_1", "INTERNAL_VL1_L11_TWO_2" ]
+          "nodes" : [ "INTERNAL_VL1_L11_TWO", "INTERNAL_VL1_L11_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1244,7 +1244,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_L11_TWO_2", "L11_TWO" ]
+          "nodes" : [ "INTERNAL_VL1_L11_TWO", "L11_TWO" ]
         } ]
       }
     }, {
@@ -1292,7 +1292,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B12", "BUSCO_T11_TWO", "INTERNAL_VL1_T11_TWO_1" ]
+          "nodes" : [ "B12", "BUSCO_T11_TWO", "INTERNAL_VL1_T11_TWO" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1313,7 +1313,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_T11_TWO_1", "INTERNAL_VL1_T11_TWO_2" ]
+          "nodes" : [ "INTERNAL_VL1_T11_TWO", "INTERNAL_VL1_T11_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1334,7 +1334,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_T11_TWO_2", "T11_TWO" ]
+          "nodes" : [ "INTERNAL_VL1_T11_TWO", "T11_TWO" ]
         } ]
       }
     }, {
@@ -1382,7 +1382,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B12", "BUSCO_T12_ONE", "INTERNAL_VL1_T12_ONE_1" ]
+          "nodes" : [ "B12", "BUSCO_T12_ONE", "INTERNAL_VL1_T12_ONE" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1403,7 +1403,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_T12_ONE_1", "INTERNAL_VL1_T12_ONE_2" ]
+          "nodes" : [ "INTERNAL_VL1_T12_ONE", "INTERNAL_VL1_T12_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1424,7 +1424,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_T12_ONE_2", "T12_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_T12_ONE", "T12_ONE" ]
         } ]
       }
     }, {
@@ -1472,7 +1472,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B12", "BUSCO_T3_12_TWO", "INTERNAL_VL1_T3_12_TWO_1" ]
+          "nodes" : [ "B12", "BUSCO_T3_12_TWO", "INTERNAL_VL1_T3_12_TWO" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1493,7 +1493,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_T3_12_TWO_1", "INTERNAL_VL1_T3_12_TWO_2" ]
+          "nodes" : [ "INTERNAL_VL1_T3_12_TWO", "INTERNAL_VL1_T3_12_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1514,7 +1514,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_T3_12_TWO_2", "T3_12_TWO" ]
+          "nodes" : [ "INTERNAL_VL1_T3_12_TWO", "T3_12_TWO" ]
         } ]
       }
     } ],
@@ -1522,140 +1522,140 @@
       "node1" : "B11",
       "node2" : "BUSCO_LD1"
     }, {
-      "node1" : "BUSCO_LD1",
-      "node2" : "INTERNAL_VL1_LD1_1"
-    }, {
-      "node1" : "INTERNAL_VL1_LD1_1",
-      "node2" : "INTERNAL_VL1_LD1_2"
-    }, {
-      "node1" : "INTERNAL_VL1_LD1_2",
-      "node2" : "LD1"
-    }, {
       "node1" : "B11",
       "node2" : "BUSCO_L11_ONE"
-    }, {
-      "node1" : "BUSCO_L11_ONE",
-      "node2" : "INTERNAL_VL1_L11_ONE_1"
-    }, {
-      "node1" : "INTERNAL_VL1_L11_ONE_1",
-      "node2" : "INTERNAL_VL1_L11_ONE_2"
-    }, {
-      "node1" : "INTERNAL_VL1_L11_ONE_2",
-      "node2" : "L11_ONE"
     }, {
       "node1" : "B11",
       "node2" : "BUSCO_T11_ONE"
     }, {
-      "node1" : "BUSCO_T11_ONE",
-      "node2" : "INTERNAL_VL1_T11_ONE_1"
-    }, {
-      "node1" : "INTERNAL_VL1_T11_ONE_1",
-      "node2" : "INTERNAL_VL1_T11_ONE_2"
-    }, {
-      "node1" : "INTERNAL_VL1_T11_ONE_2",
-      "node2" : "T11_ONE"
-    }, {
       "node1" : "B11",
       "node2" : "BUSCO_L12_ONE"
-    }, {
-      "node1" : "BUSCO_L12_ONE",
-      "node2" : "INTERNAL_VL1_L12_ONE_1"
-    }, {
-      "node1" : "INTERNAL_VL1_L12_ONE_1",
-      "node2" : "INTERNAL_VL1_L12_ONE_2"
-    }, {
-      "node1" : "INTERNAL_VL1_L12_ONE_2",
-      "node2" : "L12_ONE"
     }, {
       "node1" : "B11",
       "node2" : "BUSCO_T3_12_ONE"
     }, {
-      "node1" : "BUSCO_T3_12_ONE",
-      "node2" : "INTERNAL_VL1_T3_12_ONE_1"
-    }, {
-      "node1" : "INTERNAL_VL1_T3_12_ONE_1",
-      "node2" : "INTERNAL_VL1_T3_12_ONE_2"
-    }, {
-      "node1" : "INTERNAL_VL1_T3_12_ONE_2",
-      "node2" : "T3_12_ONE"
+      "node1" : "B11",
+      "node2" : "BUSCO_BR1"
     }, {
       "node1" : "B12",
       "node2" : "BUSCO_G"
     }, {
-      "node1" : "BUSCO_G",
-      "node2" : "INTERNAL_VL1_G_1"
-    }, {
-      "node1" : "INTERNAL_VL1_G_1",
-      "node2" : "INTERNAL_VL1_G_2"
-    }, {
-      "node1" : "INTERNAL_VL1_G_2",
-      "node2" : "G"
-    }, {
       "node1" : "B12",
       "node2" : "BUSCO_L11_TWO"
-    }, {
-      "node1" : "BUSCO_L11_TWO",
-      "node2" : "INTERNAL_VL1_L11_TWO_1"
-    }, {
-      "node1" : "INTERNAL_VL1_L11_TWO_1",
-      "node2" : "INTERNAL_VL1_L11_TWO_2"
-    }, {
-      "node1" : "INTERNAL_VL1_L11_TWO_2",
-      "node2" : "L11_TWO"
     }, {
       "node1" : "B12",
       "node2" : "BUSCO_T11_TWO"
     }, {
-      "node1" : "BUSCO_T11_TWO",
-      "node2" : "INTERNAL_VL1_T11_TWO_1"
-    }, {
-      "node1" : "INTERNAL_VL1_T11_TWO_1",
-      "node2" : "INTERNAL_VL1_T11_TWO_2"
-    }, {
-      "node1" : "INTERNAL_VL1_T11_TWO_2",
-      "node2" : "T11_TWO"
-    }, {
       "node1" : "B12",
       "node2" : "BUSCO_T12_ONE"
-    }, {
-      "node1" : "BUSCO_T12_ONE",
-      "node2" : "INTERNAL_VL1_T12_ONE_1"
-    }, {
-      "node1" : "INTERNAL_VL1_T12_ONE_1",
-      "node2" : "INTERNAL_VL1_T12_ONE_2"
-    }, {
-      "node1" : "INTERNAL_VL1_T12_ONE_2",
-      "node2" : "T12_ONE"
     }, {
       "node1" : "B12",
       "node2" : "BUSCO_T3_12_TWO"
     }, {
-      "node1" : "BUSCO_T3_12_TWO",
-      "node2" : "INTERNAL_VL1_T3_12_TWO_1"
-    }, {
-      "node1" : "INTERNAL_VL1_T3_12_TWO_1",
-      "node2" : "INTERNAL_VL1_T3_12_TWO_2"
-    }, {
-      "node1" : "INTERNAL_VL1_T3_12_TWO_2",
-      "node2" : "T3_12_TWO"
-    }, {
-      "node1" : "B11",
-      "node2" : "BUSCO_BR1"
-    }, {
-      "node1" : "BUSCO_BR1",
-      "node2" : "INTERNAL_VL1_BR1"
-    }, {
-      "node1" : "INTERNAL_VL1_BR1",
-      "node2" : "BR1"
-    }, {
       "node1" : "B12",
       "node2" : "BUSCO_BR1"
     }, {
+      "node1" : "BUSCO_LD1",
+      "node2" : "INTERNAL_VL1_LD1"
+    }, {
+      "node1" : "BUSCO_L11_ONE",
+      "node2" : "INTERNAL_VL1_L11_ONE"
+    }, {
+      "node1" : "BUSCO_T11_ONE",
+      "node2" : "INTERNAL_VL1_T11_ONE"
+    }, {
+      "node1" : "BUSCO_L12_ONE",
+      "node2" : "INTERNAL_VL1_L12_ONE"
+    }, {
+      "node1" : "BUSCO_T3_12_ONE",
+      "node2" : "INTERNAL_VL1_T3_12_ONE"
+    }, {
       "node1" : "BUSCO_BR1",
       "node2" : "INTERNAL_VL1_BR1"
     }, {
       "node1" : "INTERNAL_VL1_BR1",
       "node2" : "BR1"
+    }, {
+      "node1" : "BUSCO_G",
+      "node2" : "INTERNAL_VL1_G"
+    }, {
+      "node1" : "BUSCO_L11_TWO",
+      "node2" : "INTERNAL_VL1_L11_TWO"
+    }, {
+      "node1" : "BUSCO_T11_TWO",
+      "node2" : "INTERNAL_VL1_T11_TWO"
+    }, {
+      "node1" : "BUSCO_T12_ONE",
+      "node2" : "INTERNAL_VL1_T12_ONE"
+    }, {
+      "node1" : "BUSCO_T3_12_TWO",
+      "node2" : "INTERNAL_VL1_T3_12_TWO"
+    }, {
+      "node1" : "BUSCO_BR1",
+      "node2" : "INTERNAL_VL1_BR1"
+    }, {
+      "node1" : "INTERNAL_VL1_BR1",
+      "node2" : "BR1"
+    }, {
+      "node1" : "INTERNAL_VL1_LD1",
+      "node2" : "INTERNAL_VL1_LD1"
+    }, {
+      "node1" : "INTERNAL_VL1_LD1",
+      "node2" : "LD1"
+    }, {
+      "node1" : "INTERNAL_VL1_L11_ONE",
+      "node2" : "INTERNAL_VL1_L11_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_L11_ONE",
+      "node2" : "L11_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_T11_ONE",
+      "node2" : "INTERNAL_VL1_T11_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_T11_ONE",
+      "node2" : "T11_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_L12_ONE",
+      "node2" : "INTERNAL_VL1_L12_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_L12_ONE",
+      "node2" : "L12_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_T3_12_ONE",
+      "node2" : "INTERNAL_VL1_T3_12_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_T3_12_ONE",
+      "node2" : "T3_12_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_G",
+      "node2" : "INTERNAL_VL1_G"
+    }, {
+      "node1" : "INTERNAL_VL1_G",
+      "node2" : "G"
+    }, {
+      "node1" : "INTERNAL_VL1_L11_TWO",
+      "node2" : "INTERNAL_VL1_L11_TWO"
+    }, {
+      "node1" : "INTERNAL_VL1_L11_TWO",
+      "node2" : "L11_TWO"
+    }, {
+      "node1" : "INTERNAL_VL1_T11_TWO",
+      "node2" : "INTERNAL_VL1_T11_TWO"
+    }, {
+      "node1" : "INTERNAL_VL1_T11_TWO",
+      "node2" : "T11_TWO"
+    }, {
+      "node1" : "INTERNAL_VL1_T12_ONE",
+      "node2" : "INTERNAL_VL1_T12_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_T12_ONE",
+      "node2" : "T12_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_T3_12_TWO",
+      "node2" : "INTERNAL_VL1_T3_12_TWO"
+    }, {
+      "node1" : "INTERNAL_VL1_T3_12_TWO",
+      "node2" : "T3_12_TWO"
     } ],
     "multitermNodes" : [ {
       "type" : "FICTITIOUS",
@@ -1765,7 +1765,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_L12_TWO_1",
+      "id" : "INTERNAL_VL2_L12_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -1774,7 +1774,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_L12_TWO_2",
+      "id" : "INTERNAL_VL2_L12_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -1783,7 +1783,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_LD2_1",
+      "id" : "INTERNAL_VL2_LD2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -1791,7 +1791,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_LD2_2",
+      "id" : "INTERNAL_VL2_LD2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -1799,7 +1799,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_T12_TWO_1",
+      "id" : "INTERNAL_VL2_T12_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -1807,7 +1807,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_T12_TWO_2",
+      "id" : "INTERNAL_VL2_T12_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -1815,7 +1815,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_T3_12_THREE_1",
+      "id" : "INTERNAL_VL2_T3_12_THREE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -1824,7 +1824,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_T3_12_THREE_2",
+      "id" : "INTERNAL_VL2_T3_12_THREE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -1949,7 +1949,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B21", "BUSCO_LD2", "INTERNAL_VL2_LD2_1" ]
+          "nodes" : [ "B21", "BUSCO_LD2", "INTERNAL_VL2_LD2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1970,7 +1970,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_LD2_1", "INTERNAL_VL2_LD2_2" ]
+          "nodes" : [ "INTERNAL_VL2_LD2", "INTERNAL_VL2_LD2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1991,7 +1991,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL2_LD2_2", "LD2" ]
+          "nodes" : [ "INTERNAL_VL2_LD2", "LD2" ]
         } ]
       }
     }, {
@@ -2039,7 +2039,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B21", "BUSCO_L12_TWO", "INTERNAL_VL2_L12_TWO_1" ]
+          "nodes" : [ "B21", "BUSCO_L12_TWO", "INTERNAL_VL2_L12_TWO" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2060,7 +2060,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_L12_TWO_1", "INTERNAL_VL2_L12_TWO_2" ]
+          "nodes" : [ "INTERNAL_VL2_L12_TWO", "INTERNAL_VL2_L12_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2081,7 +2081,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL2_L12_TWO_2", "L12_TWO" ]
+          "nodes" : [ "INTERNAL_VL2_L12_TWO", "L12_TWO" ]
         } ]
       }
     }, {
@@ -2129,7 +2129,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B21", "BUSCO_T12_TWO", "INTERNAL_VL2_T12_TWO_1" ]
+          "nodes" : [ "B21", "BUSCO_T12_TWO", "INTERNAL_VL2_T12_TWO" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2150,7 +2150,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_T12_TWO_1", "INTERNAL_VL2_T12_TWO_2" ]
+          "nodes" : [ "INTERNAL_VL2_T12_TWO", "INTERNAL_VL2_T12_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2171,7 +2171,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL2_T12_TWO_2", "T12_TWO" ]
+          "nodes" : [ "INTERNAL_VL2_T12_TWO", "T12_TWO" ]
         } ]
       }
     }, {
@@ -2219,7 +2219,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B21", "BUSCO_T3_12_THREE", "INTERNAL_VL2_T3_12_THREE_1" ]
+          "nodes" : [ "B21", "BUSCO_T3_12_THREE", "INTERNAL_VL2_T3_12_THREE" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2240,7 +2240,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_T3_12_THREE_1", "INTERNAL_VL2_T3_12_THREE_2" ]
+          "nodes" : [ "INTERNAL_VL2_T3_12_THREE", "INTERNAL_VL2_T3_12_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2261,7 +2261,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL2_T3_12_THREE_2", "T3_12_THREE" ]
+          "nodes" : [ "INTERNAL_VL2_T3_12_THREE", "T3_12_THREE" ]
         } ]
       }
     } ],
@@ -2269,49 +2269,49 @@
       "node1" : "B21",
       "node2" : "BUSCO_LD2"
     }, {
-      "node1" : "BUSCO_LD2",
-      "node2" : "INTERNAL_VL2_LD2_1"
-    }, {
-      "node1" : "INTERNAL_VL2_LD2_1",
-      "node2" : "INTERNAL_VL2_LD2_2"
-    }, {
-      "node1" : "INTERNAL_VL2_LD2_2",
-      "node2" : "LD2"
-    }, {
       "node1" : "B21",
       "node2" : "BUSCO_L12_TWO"
-    }, {
-      "node1" : "BUSCO_L12_TWO",
-      "node2" : "INTERNAL_VL2_L12_TWO_1"
-    }, {
-      "node1" : "INTERNAL_VL2_L12_TWO_1",
-      "node2" : "INTERNAL_VL2_L12_TWO_2"
-    }, {
-      "node1" : "INTERNAL_VL2_L12_TWO_2",
-      "node2" : "L12_TWO"
     }, {
       "node1" : "B21",
       "node2" : "BUSCO_T12_TWO"
     }, {
-      "node1" : "BUSCO_T12_TWO",
-      "node2" : "INTERNAL_VL2_T12_TWO_1"
-    }, {
-      "node1" : "INTERNAL_VL2_T12_TWO_1",
-      "node2" : "INTERNAL_VL2_T12_TWO_2"
-    }, {
-      "node1" : "INTERNAL_VL2_T12_TWO_2",
-      "node2" : "T12_TWO"
-    }, {
       "node1" : "B21",
       "node2" : "BUSCO_T3_12_THREE"
     }, {
+      "node1" : "BUSCO_LD2",
+      "node2" : "INTERNAL_VL2_LD2"
+    }, {
+      "node1" : "BUSCO_L12_TWO",
+      "node2" : "INTERNAL_VL2_L12_TWO"
+    }, {
+      "node1" : "BUSCO_T12_TWO",
+      "node2" : "INTERNAL_VL2_T12_TWO"
+    }, {
       "node1" : "BUSCO_T3_12_THREE",
-      "node2" : "INTERNAL_VL2_T3_12_THREE_1"
+      "node2" : "INTERNAL_VL2_T3_12_THREE"
     }, {
-      "node1" : "INTERNAL_VL2_T3_12_THREE_1",
-      "node2" : "INTERNAL_VL2_T3_12_THREE_2"
+      "node1" : "INTERNAL_VL2_LD2",
+      "node2" : "INTERNAL_VL2_LD2"
     }, {
-      "node1" : "INTERNAL_VL2_T3_12_THREE_2",
+      "node1" : "INTERNAL_VL2_LD2",
+      "node2" : "LD2"
+    }, {
+      "node1" : "INTERNAL_VL2_L12_TWO",
+      "node2" : "INTERNAL_VL2_L12_TWO"
+    }, {
+      "node1" : "INTERNAL_VL2_L12_TWO",
+      "node2" : "L12_TWO"
+    }, {
+      "node1" : "INTERNAL_VL2_T12_TWO",
+      "node2" : "INTERNAL_VL2_T12_TWO"
+    }, {
+      "node1" : "INTERNAL_VL2_T12_TWO",
+      "node2" : "T12_TWO"
+    }, {
+      "node1" : "INTERNAL_VL2_T3_12_THREE",
+      "node2" : "INTERNAL_VL2_T3_12_THREE"
+    }, {
+      "node1" : "INTERNAL_VL2_T3_12_THREE",
       "node2" : "T3_12_THREE"
     } ],
     "multitermNodes" : [ ],

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreakerV.json
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreakerV.json
@@ -191,7 +191,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_G_1",
+      "id" : "INTERNAL_VL1_G",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -200,7 +200,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_G_2",
+      "id" : "INTERNAL_VL1_G",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -209,7 +209,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_L11_ONE_1",
+      "id" : "INTERNAL_VL1_L11_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -218,7 +218,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_L11_ONE_2",
+      "id" : "INTERNAL_VL1_L11_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -227,7 +227,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_L11_TWO_1",
+      "id" : "INTERNAL_VL1_L11_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -235,7 +235,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_L11_TWO_2",
+      "id" : "INTERNAL_VL1_L11_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -243,7 +243,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_L12_ONE_1",
+      "id" : "INTERNAL_VL1_L12_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -252,7 +252,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_L12_ONE_2",
+      "id" : "INTERNAL_VL1_L12_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -261,7 +261,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_LD1_1",
+      "id" : "INTERNAL_VL1_LD1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -269,7 +269,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_LD1_2",
+      "id" : "INTERNAL_VL1_LD1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -277,7 +277,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T11_ONE_1",
+      "id" : "INTERNAL_VL1_T11_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -285,7 +285,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T11_ONE_2",
+      "id" : "INTERNAL_VL1_T11_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -293,7 +293,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T11_TWO_1",
+      "id" : "INTERNAL_VL1_T11_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -302,7 +302,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T11_TWO_2",
+      "id" : "INTERNAL_VL1_T11_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -311,7 +311,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T12_ONE_1",
+      "id" : "INTERNAL_VL1_T12_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -319,7 +319,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T12_ONE_2",
+      "id" : "INTERNAL_VL1_T12_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -327,7 +327,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T3_12_ONE_1",
+      "id" : "INTERNAL_VL1_T3_12_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -335,7 +335,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T3_12_ONE_2",
+      "id" : "INTERNAL_VL1_T3_12_ONE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -343,7 +343,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T3_12_TWO_1",
+      "id" : "INTERNAL_VL1_T3_12_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -352,7 +352,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_T3_12_TWO_2",
+      "id" : "INTERNAL_VL1_T3_12_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -662,7 +662,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B11", "BUSCO_LD1", "INTERNAL_VL1_LD1_1" ]
+          "nodes" : [ "B11", "BUSCO_LD1", "INTERNAL_VL1_LD1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -683,7 +683,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_LD1_1", "INTERNAL_VL1_LD1_2" ]
+          "nodes" : [ "INTERNAL_VL1_LD1", "INTERNAL_VL1_LD1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -704,7 +704,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_LD1_2", "LD1" ]
+          "nodes" : [ "INTERNAL_VL1_LD1", "LD1" ]
         } ]
       }
     }, {
@@ -752,7 +752,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B11", "BUSCO_L11_ONE", "INTERNAL_VL1_L11_ONE_1" ]
+          "nodes" : [ "B11", "BUSCO_L11_ONE", "INTERNAL_VL1_L11_ONE" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -773,7 +773,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_L11_ONE_1", "INTERNAL_VL1_L11_ONE_2" ]
+          "nodes" : [ "INTERNAL_VL1_L11_ONE", "INTERNAL_VL1_L11_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -794,7 +794,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_L11_ONE_2", "L11_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_L11_ONE", "L11_ONE" ]
         } ]
       }
     }, {
@@ -842,7 +842,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B11", "BUSCO_T11_ONE", "INTERNAL_VL1_T11_ONE_1" ]
+          "nodes" : [ "B11", "BUSCO_T11_ONE", "INTERNAL_VL1_T11_ONE" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -863,7 +863,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_T11_ONE_1", "INTERNAL_VL1_T11_ONE_2" ]
+          "nodes" : [ "INTERNAL_VL1_T11_ONE", "INTERNAL_VL1_T11_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -884,7 +884,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_T11_ONE_2", "T11_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_T11_ONE", "T11_ONE" ]
         } ]
       }
     }, {
@@ -932,7 +932,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B11", "BUSCO_L12_ONE", "INTERNAL_VL1_L12_ONE_1" ]
+          "nodes" : [ "B11", "BUSCO_L12_ONE", "INTERNAL_VL1_L12_ONE" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -953,7 +953,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_L12_ONE_1", "INTERNAL_VL1_L12_ONE_2" ]
+          "nodes" : [ "INTERNAL_VL1_L12_ONE", "INTERNAL_VL1_L12_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -974,7 +974,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_L12_ONE_2", "L12_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_L12_ONE", "L12_ONE" ]
         } ]
       }
     }, {
@@ -1022,7 +1022,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B11", "BUSCO_T3_12_ONE", "INTERNAL_VL1_T3_12_ONE_1" ]
+          "nodes" : [ "B11", "BUSCO_T3_12_ONE", "INTERNAL_VL1_T3_12_ONE" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1043,7 +1043,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_T3_12_ONE_1", "INTERNAL_VL1_T3_12_ONE_2" ]
+          "nodes" : [ "INTERNAL_VL1_T3_12_ONE", "INTERNAL_VL1_T3_12_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1064,7 +1064,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_T3_12_ONE_2", "T3_12_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_T3_12_ONE", "T3_12_ONE" ]
         } ]
       }
     }, {
@@ -1112,7 +1112,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B12", "BUSCO_G", "INTERNAL_VL1_G_1" ]
+          "nodes" : [ "B12", "BUSCO_G", "INTERNAL_VL1_G" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1133,7 +1133,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_G_1", "INTERNAL_VL1_G_2" ]
+          "nodes" : [ "INTERNAL_VL1_G", "INTERNAL_VL1_G" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1154,7 +1154,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_G_2", "G" ]
+          "nodes" : [ "INTERNAL_VL1_G", "G" ]
         } ]
       }
     }, {
@@ -1202,7 +1202,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B12", "BUSCO_L11_TWO", "INTERNAL_VL1_L11_TWO_1" ]
+          "nodes" : [ "B12", "BUSCO_L11_TWO", "INTERNAL_VL1_L11_TWO" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1223,7 +1223,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_L11_TWO_1", "INTERNAL_VL1_L11_TWO_2" ]
+          "nodes" : [ "INTERNAL_VL1_L11_TWO", "INTERNAL_VL1_L11_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1244,7 +1244,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_L11_TWO_2", "L11_TWO" ]
+          "nodes" : [ "INTERNAL_VL1_L11_TWO", "L11_TWO" ]
         } ]
       }
     }, {
@@ -1292,7 +1292,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B12", "BUSCO_T11_TWO", "INTERNAL_VL1_T11_TWO_1" ]
+          "nodes" : [ "B12", "BUSCO_T11_TWO", "INTERNAL_VL1_T11_TWO" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1313,7 +1313,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_T11_TWO_1", "INTERNAL_VL1_T11_TWO_2" ]
+          "nodes" : [ "INTERNAL_VL1_T11_TWO", "INTERNAL_VL1_T11_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1334,7 +1334,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_T11_TWO_2", "T11_TWO" ]
+          "nodes" : [ "INTERNAL_VL1_T11_TWO", "T11_TWO" ]
         } ]
       }
     }, {
@@ -1382,7 +1382,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B12", "BUSCO_T12_ONE", "INTERNAL_VL1_T12_ONE_1" ]
+          "nodes" : [ "B12", "BUSCO_T12_ONE", "INTERNAL_VL1_T12_ONE" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1403,7 +1403,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_T12_ONE_1", "INTERNAL_VL1_T12_ONE_2" ]
+          "nodes" : [ "INTERNAL_VL1_T12_ONE", "INTERNAL_VL1_T12_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1424,7 +1424,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_T12_ONE_2", "T12_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_T12_ONE", "T12_ONE" ]
         } ]
       }
     }, {
@@ -1472,7 +1472,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B12", "BUSCO_T3_12_TWO", "INTERNAL_VL1_T3_12_TWO_1" ]
+          "nodes" : [ "B12", "BUSCO_T3_12_TWO", "INTERNAL_VL1_T3_12_TWO" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1493,7 +1493,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_T3_12_TWO_1", "INTERNAL_VL1_T3_12_TWO_2" ]
+          "nodes" : [ "INTERNAL_VL1_T3_12_TWO", "INTERNAL_VL1_T3_12_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1514,7 +1514,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL1_T3_12_TWO_2", "T3_12_TWO" ]
+          "nodes" : [ "INTERNAL_VL1_T3_12_TWO", "T3_12_TWO" ]
         } ]
       }
     } ],
@@ -1522,140 +1522,140 @@
       "node1" : "B11",
       "node2" : "BUSCO_LD1"
     }, {
-      "node1" : "BUSCO_LD1",
-      "node2" : "INTERNAL_VL1_LD1_1"
-    }, {
-      "node1" : "INTERNAL_VL1_LD1_1",
-      "node2" : "INTERNAL_VL1_LD1_2"
-    }, {
-      "node1" : "INTERNAL_VL1_LD1_2",
-      "node2" : "LD1"
-    }, {
       "node1" : "B11",
       "node2" : "BUSCO_L11_ONE"
-    }, {
-      "node1" : "BUSCO_L11_ONE",
-      "node2" : "INTERNAL_VL1_L11_ONE_1"
-    }, {
-      "node1" : "INTERNAL_VL1_L11_ONE_1",
-      "node2" : "INTERNAL_VL1_L11_ONE_2"
-    }, {
-      "node1" : "INTERNAL_VL1_L11_ONE_2",
-      "node2" : "L11_ONE"
     }, {
       "node1" : "B11",
       "node2" : "BUSCO_T11_ONE"
     }, {
-      "node1" : "BUSCO_T11_ONE",
-      "node2" : "INTERNAL_VL1_T11_ONE_1"
-    }, {
-      "node1" : "INTERNAL_VL1_T11_ONE_1",
-      "node2" : "INTERNAL_VL1_T11_ONE_2"
-    }, {
-      "node1" : "INTERNAL_VL1_T11_ONE_2",
-      "node2" : "T11_ONE"
-    }, {
       "node1" : "B11",
       "node2" : "BUSCO_L12_ONE"
-    }, {
-      "node1" : "BUSCO_L12_ONE",
-      "node2" : "INTERNAL_VL1_L12_ONE_1"
-    }, {
-      "node1" : "INTERNAL_VL1_L12_ONE_1",
-      "node2" : "INTERNAL_VL1_L12_ONE_2"
-    }, {
-      "node1" : "INTERNAL_VL1_L12_ONE_2",
-      "node2" : "L12_ONE"
     }, {
       "node1" : "B11",
       "node2" : "BUSCO_T3_12_ONE"
     }, {
-      "node1" : "BUSCO_T3_12_ONE",
-      "node2" : "INTERNAL_VL1_T3_12_ONE_1"
-    }, {
-      "node1" : "INTERNAL_VL1_T3_12_ONE_1",
-      "node2" : "INTERNAL_VL1_T3_12_ONE_2"
-    }, {
-      "node1" : "INTERNAL_VL1_T3_12_ONE_2",
-      "node2" : "T3_12_ONE"
+      "node1" : "B11",
+      "node2" : "BUSCO_BR1"
     }, {
       "node1" : "B12",
       "node2" : "BUSCO_G"
     }, {
-      "node1" : "BUSCO_G",
-      "node2" : "INTERNAL_VL1_G_1"
-    }, {
-      "node1" : "INTERNAL_VL1_G_1",
-      "node2" : "INTERNAL_VL1_G_2"
-    }, {
-      "node1" : "INTERNAL_VL1_G_2",
-      "node2" : "G"
-    }, {
       "node1" : "B12",
       "node2" : "BUSCO_L11_TWO"
-    }, {
-      "node1" : "BUSCO_L11_TWO",
-      "node2" : "INTERNAL_VL1_L11_TWO_1"
-    }, {
-      "node1" : "INTERNAL_VL1_L11_TWO_1",
-      "node2" : "INTERNAL_VL1_L11_TWO_2"
-    }, {
-      "node1" : "INTERNAL_VL1_L11_TWO_2",
-      "node2" : "L11_TWO"
     }, {
       "node1" : "B12",
       "node2" : "BUSCO_T11_TWO"
     }, {
-      "node1" : "BUSCO_T11_TWO",
-      "node2" : "INTERNAL_VL1_T11_TWO_1"
-    }, {
-      "node1" : "INTERNAL_VL1_T11_TWO_1",
-      "node2" : "INTERNAL_VL1_T11_TWO_2"
-    }, {
-      "node1" : "INTERNAL_VL1_T11_TWO_2",
-      "node2" : "T11_TWO"
-    }, {
       "node1" : "B12",
       "node2" : "BUSCO_T12_ONE"
-    }, {
-      "node1" : "BUSCO_T12_ONE",
-      "node2" : "INTERNAL_VL1_T12_ONE_1"
-    }, {
-      "node1" : "INTERNAL_VL1_T12_ONE_1",
-      "node2" : "INTERNAL_VL1_T12_ONE_2"
-    }, {
-      "node1" : "INTERNAL_VL1_T12_ONE_2",
-      "node2" : "T12_ONE"
     }, {
       "node1" : "B12",
       "node2" : "BUSCO_T3_12_TWO"
     }, {
-      "node1" : "BUSCO_T3_12_TWO",
-      "node2" : "INTERNAL_VL1_T3_12_TWO_1"
-    }, {
-      "node1" : "INTERNAL_VL1_T3_12_TWO_1",
-      "node2" : "INTERNAL_VL1_T3_12_TWO_2"
-    }, {
-      "node1" : "INTERNAL_VL1_T3_12_TWO_2",
-      "node2" : "T3_12_TWO"
-    }, {
-      "node1" : "B11",
-      "node2" : "BUSCO_BR1"
-    }, {
-      "node1" : "BUSCO_BR1",
-      "node2" : "INTERNAL_VL1_BR1"
-    }, {
-      "node1" : "INTERNAL_VL1_BR1",
-      "node2" : "BR1"
-    }, {
       "node1" : "B12",
       "node2" : "BUSCO_BR1"
     }, {
+      "node1" : "BUSCO_LD1",
+      "node2" : "INTERNAL_VL1_LD1"
+    }, {
+      "node1" : "BUSCO_L11_ONE",
+      "node2" : "INTERNAL_VL1_L11_ONE"
+    }, {
+      "node1" : "BUSCO_T11_ONE",
+      "node2" : "INTERNAL_VL1_T11_ONE"
+    }, {
+      "node1" : "BUSCO_L12_ONE",
+      "node2" : "INTERNAL_VL1_L12_ONE"
+    }, {
+      "node1" : "BUSCO_T3_12_ONE",
+      "node2" : "INTERNAL_VL1_T3_12_ONE"
+    }, {
       "node1" : "BUSCO_BR1",
       "node2" : "INTERNAL_VL1_BR1"
     }, {
       "node1" : "INTERNAL_VL1_BR1",
       "node2" : "BR1"
+    }, {
+      "node1" : "BUSCO_G",
+      "node2" : "INTERNAL_VL1_G"
+    }, {
+      "node1" : "BUSCO_L11_TWO",
+      "node2" : "INTERNAL_VL1_L11_TWO"
+    }, {
+      "node1" : "BUSCO_T11_TWO",
+      "node2" : "INTERNAL_VL1_T11_TWO"
+    }, {
+      "node1" : "BUSCO_T12_ONE",
+      "node2" : "INTERNAL_VL1_T12_ONE"
+    }, {
+      "node1" : "BUSCO_T3_12_TWO",
+      "node2" : "INTERNAL_VL1_T3_12_TWO"
+    }, {
+      "node1" : "BUSCO_BR1",
+      "node2" : "INTERNAL_VL1_BR1"
+    }, {
+      "node1" : "INTERNAL_VL1_BR1",
+      "node2" : "BR1"
+    }, {
+      "node1" : "INTERNAL_VL1_LD1",
+      "node2" : "INTERNAL_VL1_LD1"
+    }, {
+      "node1" : "INTERNAL_VL1_LD1",
+      "node2" : "LD1"
+    }, {
+      "node1" : "INTERNAL_VL1_L11_ONE",
+      "node2" : "INTERNAL_VL1_L11_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_L11_ONE",
+      "node2" : "L11_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_T11_ONE",
+      "node2" : "INTERNAL_VL1_T11_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_T11_ONE",
+      "node2" : "T11_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_L12_ONE",
+      "node2" : "INTERNAL_VL1_L12_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_L12_ONE",
+      "node2" : "L12_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_T3_12_ONE",
+      "node2" : "INTERNAL_VL1_T3_12_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_T3_12_ONE",
+      "node2" : "T3_12_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_G",
+      "node2" : "INTERNAL_VL1_G"
+    }, {
+      "node1" : "INTERNAL_VL1_G",
+      "node2" : "G"
+    }, {
+      "node1" : "INTERNAL_VL1_L11_TWO",
+      "node2" : "INTERNAL_VL1_L11_TWO"
+    }, {
+      "node1" : "INTERNAL_VL1_L11_TWO",
+      "node2" : "L11_TWO"
+    }, {
+      "node1" : "INTERNAL_VL1_T11_TWO",
+      "node2" : "INTERNAL_VL1_T11_TWO"
+    }, {
+      "node1" : "INTERNAL_VL1_T11_TWO",
+      "node2" : "T11_TWO"
+    }, {
+      "node1" : "INTERNAL_VL1_T12_ONE",
+      "node2" : "INTERNAL_VL1_T12_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_T12_ONE",
+      "node2" : "T12_ONE"
+    }, {
+      "node1" : "INTERNAL_VL1_T3_12_TWO",
+      "node2" : "INTERNAL_VL1_T3_12_TWO"
+    }, {
+      "node1" : "INTERNAL_VL1_T3_12_TWO",
+      "node2" : "T3_12_TWO"
     } ],
     "multitermNodes" : [ {
       "type" : "FICTITIOUS",
@@ -1765,7 +1765,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_L12_TWO_1",
+      "id" : "INTERNAL_VL2_L12_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -1774,7 +1774,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_L12_TWO_2",
+      "id" : "INTERNAL_VL2_L12_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -1783,7 +1783,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_LD2_1",
+      "id" : "INTERNAL_VL2_LD2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -1791,7 +1791,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_LD2_2",
+      "id" : "INTERNAL_VL2_LD2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -1799,7 +1799,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_T12_TWO_1",
+      "id" : "INTERNAL_VL2_T12_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -1807,7 +1807,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_T12_TWO_2",
+      "id" : "INTERNAL_VL2_T12_TWO",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -1815,7 +1815,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_T3_12_THREE_1",
+      "id" : "INTERNAL_VL2_T3_12_THREE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -1824,7 +1824,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_T3_12_THREE_2",
+      "id" : "INTERNAL_VL2_T3_12_THREE",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -1949,7 +1949,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B21", "BUSCO_LD2", "INTERNAL_VL2_LD2_1" ]
+          "nodes" : [ "B21", "BUSCO_LD2", "INTERNAL_VL2_LD2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1970,7 +1970,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_LD2_1", "INTERNAL_VL2_LD2_2" ]
+          "nodes" : [ "INTERNAL_VL2_LD2", "INTERNAL_VL2_LD2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1991,7 +1991,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL2_LD2_2", "LD2" ]
+          "nodes" : [ "INTERNAL_VL2_LD2", "LD2" ]
         } ]
       }
     }, {
@@ -2039,7 +2039,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B21", "BUSCO_L12_TWO", "INTERNAL_VL2_L12_TWO_1" ]
+          "nodes" : [ "B21", "BUSCO_L12_TWO", "INTERNAL_VL2_L12_TWO" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2060,7 +2060,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_L12_TWO_1", "INTERNAL_VL2_L12_TWO_2" ]
+          "nodes" : [ "INTERNAL_VL2_L12_TWO", "INTERNAL_VL2_L12_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2081,7 +2081,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL2_L12_TWO_2", "L12_TWO" ]
+          "nodes" : [ "INTERNAL_VL2_L12_TWO", "L12_TWO" ]
         } ]
       }
     }, {
@@ -2129,7 +2129,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B21", "BUSCO_T12_TWO", "INTERNAL_VL2_T12_TWO_1" ]
+          "nodes" : [ "B21", "BUSCO_T12_TWO", "INTERNAL_VL2_T12_TWO" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2150,7 +2150,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_T12_TWO_1", "INTERNAL_VL2_T12_TWO_2" ]
+          "nodes" : [ "INTERNAL_VL2_T12_TWO", "INTERNAL_VL2_T12_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2171,7 +2171,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL2_T12_TWO_2", "T12_TWO" ]
+          "nodes" : [ "INTERNAL_VL2_T12_TWO", "T12_TWO" ]
         } ]
       }
     }, {
@@ -2219,7 +2219,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "B21", "BUSCO_T3_12_THREE", "INTERNAL_VL2_T3_12_THREE_1" ]
+          "nodes" : [ "B21", "BUSCO_T3_12_THREE", "INTERNAL_VL2_T3_12_THREE" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2240,7 +2240,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_T3_12_THREE_1", "INTERNAL_VL2_T3_12_THREE_2" ]
+          "nodes" : [ "INTERNAL_VL2_T3_12_THREE", "INTERNAL_VL2_T3_12_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2261,7 +2261,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "INTERNAL_VL2_T3_12_THREE_2", "T3_12_THREE" ]
+          "nodes" : [ "INTERNAL_VL2_T3_12_THREE", "T3_12_THREE" ]
         } ]
       }
     } ],
@@ -2269,49 +2269,49 @@
       "node1" : "B21",
       "node2" : "BUSCO_LD2"
     }, {
-      "node1" : "BUSCO_LD2",
-      "node2" : "INTERNAL_VL2_LD2_1"
-    }, {
-      "node1" : "INTERNAL_VL2_LD2_1",
-      "node2" : "INTERNAL_VL2_LD2_2"
-    }, {
-      "node1" : "INTERNAL_VL2_LD2_2",
-      "node2" : "LD2"
-    }, {
       "node1" : "B21",
       "node2" : "BUSCO_L12_TWO"
-    }, {
-      "node1" : "BUSCO_L12_TWO",
-      "node2" : "INTERNAL_VL2_L12_TWO_1"
-    }, {
-      "node1" : "INTERNAL_VL2_L12_TWO_1",
-      "node2" : "INTERNAL_VL2_L12_TWO_2"
-    }, {
-      "node1" : "INTERNAL_VL2_L12_TWO_2",
-      "node2" : "L12_TWO"
     }, {
       "node1" : "B21",
       "node2" : "BUSCO_T12_TWO"
     }, {
-      "node1" : "BUSCO_T12_TWO",
-      "node2" : "INTERNAL_VL2_T12_TWO_1"
-    }, {
-      "node1" : "INTERNAL_VL2_T12_TWO_1",
-      "node2" : "INTERNAL_VL2_T12_TWO_2"
-    }, {
-      "node1" : "INTERNAL_VL2_T12_TWO_2",
-      "node2" : "T12_TWO"
-    }, {
       "node1" : "B21",
       "node2" : "BUSCO_T3_12_THREE"
     }, {
+      "node1" : "BUSCO_LD2",
+      "node2" : "INTERNAL_VL2_LD2"
+    }, {
+      "node1" : "BUSCO_L12_TWO",
+      "node2" : "INTERNAL_VL2_L12_TWO"
+    }, {
+      "node1" : "BUSCO_T12_TWO",
+      "node2" : "INTERNAL_VL2_T12_TWO"
+    }, {
       "node1" : "BUSCO_T3_12_THREE",
-      "node2" : "INTERNAL_VL2_T3_12_THREE_1"
+      "node2" : "INTERNAL_VL2_T3_12_THREE"
     }, {
-      "node1" : "INTERNAL_VL2_T3_12_THREE_1",
-      "node2" : "INTERNAL_VL2_T3_12_THREE_2"
+      "node1" : "INTERNAL_VL2_LD2",
+      "node2" : "INTERNAL_VL2_LD2"
     }, {
-      "node1" : "INTERNAL_VL2_T3_12_THREE_2",
+      "node1" : "INTERNAL_VL2_LD2",
+      "node2" : "LD2"
+    }, {
+      "node1" : "INTERNAL_VL2_L12_TWO",
+      "node2" : "INTERNAL_VL2_L12_TWO"
+    }, {
+      "node1" : "INTERNAL_VL2_L12_TWO",
+      "node2" : "L12_TWO"
+    }, {
+      "node1" : "INTERNAL_VL2_T12_TWO",
+      "node2" : "INTERNAL_VL2_T12_TWO"
+    }, {
+      "node1" : "INTERNAL_VL2_T12_TWO",
+      "node2" : "T12_TWO"
+    }, {
+      "node1" : "INTERNAL_VL2_T3_12_THREE",
+      "node2" : "INTERNAL_VL2_T3_12_THREE"
+    }, {
+      "node1" : "INTERNAL_VL2_T3_12_THREE",
       "node2" : "T3_12_THREE"
     } ],
     "multitermNodes" : [ ],

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
@@ -91,22 +91,22 @@
             <text class="sld-label" id="BBS12_NW_LABEL" x="-5.0" y="-5.0">BBS12</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-vertical" id="idINTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_D10" transform="translate(111.0,346.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR1" transform="translate(111.0,346.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_D20" transform="translate(61.0,346.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR1" transform="translate(61.0,346.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D10_95_INTERNAL_95_VL1_95_D10">
+            <g class="sld-wire" id="_95_VL1_95_D10_95_INTERNAL_95_VL1_95_BR1">
                 <polyline points="115.0,390.0,115.0,350.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR1_95_INTERNAL_95_VL1_95_D10">
-                <polyline points="100.0,350.0,115.0,350.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR1_95_BR1">
+                <polyline points="115.0,350.0,100.0,350.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR1_95_INTERNAL_95_VL1_95_D20">
-                <polyline points="80.0,350.0,65.0,350.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR1_95_BR1">
+                <polyline points="65.0,350.0,80.0,350.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D20_95_INTERNAL_95_VL1_95_D20">
+            <g class="sld-wire" id="_95_VL1_95_D20_95_INTERNAL_95_VL1_95_BR1">
                 <polyline points="65.0,415.0,65.0,350.0"/>
             </g>
             <g class="sld-disconnector sld-closed" id="idD10" transform="translate(111.0,386.0)">
@@ -123,7 +123,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_D11" transform="translate(161.0,356.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR12" transform="translate(161.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_L1" transform="translate(161.0,168.0)">
@@ -135,11 +135,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="L1_N_LABEL" x="-5.0" y="-5.0">L1</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D11_95_INTERNAL_95_VL1_95_D11">
+            <g class="sld-wire" id="_95_VL1_95_D11_95_INTERNAL_95_VL1_95_BR12">
                 <polyline points="165.0,390.0,165.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR12_95_INTERNAL_95_VL1_95_D11">
-                <polyline points="165.0,276.0,165.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR12_95_BR12">
+                <polyline points="165.0,360.0,165.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR12_95_INTERNAL_95_VL1_95_L1">
                 <polyline points="165.0,256.0,165.0,172.0"/>
@@ -167,7 +167,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_D13" transform="translate(211.0,356.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR14" transform="translate(211.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_ONE" transform="translate(211.0,168.0)">
@@ -176,11 +176,11 @@
             <g class="sld-top-feeder" id="idL11_95_ONE" transform="translate(215.0,110.0)">
                 <text class="sld-label" id="L11_ONE_N_LABEL" x="-5.0" y="-5.0">L11</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D13_95_INTERNAL_95_VL1_95_D13">
+            <g class="sld-wire" id="_95_VL1_95_D13_95_INTERNAL_95_VL1_95_BR14">
                 <polyline points="215.0,390.0,215.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR14_95_INTERNAL_95_VL1_95_D13">
-                <polyline points="215.0,276.0,215.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR14_95_BR14">
+                <polyline points="215.0,360.0,215.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR14_95_INTERNAL_95_VL1_95_L11_95_ONE">
                 <polyline points="215.0,256.0,215.0,172.0"/>
@@ -208,7 +208,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_D15" transform="translate(261.0,356.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR16" transform="translate(261.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_L12_95_ONE" transform="translate(261.0,168.0)">
@@ -217,11 +217,11 @@
             <g class="sld-top-feeder" id="idL12_95_ONE" transform="translate(265.0,110.0)">
                 <text class="sld-label" id="L12_ONE_N_LABEL" x="-5.0" y="-5.0">L12</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D15_95_INTERNAL_95_VL1_95_D15">
+            <g class="sld-wire" id="_95_VL1_95_D15_95_INTERNAL_95_VL1_95_BR16">
                 <polyline points="265.0,390.0,265.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR16_95_INTERNAL_95_VL1_95_D15">
-                <polyline points="265.0,276.0,265.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR16_95_BR16">
+                <polyline points="265.0,360.0,265.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR16_95_INTERNAL_95_VL1_95_L12_95_ONE">
                 <polyline points="265.0,256.0,265.0,172.0"/>
@@ -249,7 +249,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_D17" transform="translate(311.0,356.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR18" transform="translate(311.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_ONE" transform="translate(311.0,168.0)">
@@ -258,11 +258,11 @@
             <g class="sld-top-feeder" id="idT11_95_ONE" transform="translate(315.0,110.0)">
                 <text class="sld-label" id="T11_ONE_N_LABEL" x="-5.0" y="-5.0">T11</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D17_95_INTERNAL_95_VL1_95_D17">
+            <g class="sld-wire" id="_95_VL1_95_D17_95_INTERNAL_95_VL1_95_BR18">
                 <polyline points="315.0,390.0,315.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR18_95_INTERNAL_95_VL1_95_D17">
-                <polyline points="315.0,276.0,315.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR18_95_BR18">
+                <polyline points="315.0,360.0,315.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR18_95_INTERNAL_95_VL1_95_T11_95_ONE">
                 <polyline points="315.0,256.0,315.0,172.0"/>
@@ -290,7 +290,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_D19" transform="translate(386.0,356.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR20" transform="translate(386.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder" id="idT3_95_12_95_TWO" transform="translate(365.0,110.0)">
@@ -299,11 +299,11 @@
             <g class="sld-top-feeder" id="idT3_95_12_95_THREE" transform="translate(415.0,110.0)">
                 <text class="sld-label" id="T3_12_THREE_N_LABEL" x="-5.0" y="-5.0">T3_12</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D19_95_INTERNAL_95_VL1_95_D19">
+            <g class="sld-wire" id="_95_VL1_95_D19_95_INTERNAL_95_VL1_95_BR20">
                 <polyline points="390.0,390.0,390.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR20_95_INTERNAL_95_VL1_95_D19">
-                <polyline points="390.0,276.0,390.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR20_95_BR20">
+                <polyline points="390.0,360.0,390.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR20_95_T3_95_12">
                 <polyline points="390.0,256.0,390.0,184.0"/>
@@ -349,7 +349,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_D21" transform="translate(461.0,356.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR22" transform="translate(461.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_G" transform="translate(461.0,168.0)">
@@ -361,11 +361,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="G_N_LABEL" x="-5.0" y="-5.0">G</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D21_95_INTERNAL_95_VL1_95_D21">
+            <g class="sld-wire" id="_95_VL1_95_D21_95_INTERNAL_95_VL1_95_BR22">
                 <polyline points="465.0,415.0,465.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR22_95_INTERNAL_95_VL1_95_D21">
-                <polyline points="465.0,276.0,465.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR22_95_BR22">
+                <polyline points="465.0,360.0,465.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR22_95_INTERNAL_95_VL1_95_G">
                 <polyline points="465.0,256.0,465.0,172.0"/>
@@ -393,7 +393,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_D23" transform="translate(511.0,356.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR24" transform="translate(511.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_TWO" transform="translate(511.0,168.0)">
@@ -402,11 +402,11 @@
             <g class="sld-top-feeder" id="idL11_95_TWO" transform="translate(515.0,110.0)">
                 <text class="sld-label" id="L11_TWO_N_LABEL" x="-5.0" y="-5.0">L11</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D23_95_INTERNAL_95_VL1_95_D23">
+            <g class="sld-wire" id="_95_VL1_95_D23_95_INTERNAL_95_VL1_95_BR24">
                 <polyline points="515.0,415.0,515.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR24_95_INTERNAL_95_VL1_95_D23">
-                <polyline points="515.0,276.0,515.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR24_95_BR24">
+                <polyline points="515.0,360.0,515.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR24_95_INTERNAL_95_VL1_95_L11_95_TWO">
                 <polyline points="515.0,256.0,515.0,172.0"/>
@@ -434,7 +434,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_D25" transform="translate(561.0,356.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR26" transform="translate(561.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_TWO" transform="translate(561.0,168.0)">
@@ -443,11 +443,11 @@
             <g class="sld-top-feeder" id="idT11_95_TWO" transform="translate(565.0,110.0)">
                 <text class="sld-label" id="T11_TWO_N_LABEL" x="-5.0" y="-5.0">T11</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D25_95_INTERNAL_95_VL1_95_D25">
+            <g class="sld-wire" id="_95_VL1_95_D25_95_INTERNAL_95_VL1_95_BR26">
                 <polyline points="565.0,415.0,565.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR26_95_INTERNAL_95_VL1_95_D25">
-                <polyline points="565.0,276.0,565.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR26_95_BR26">
+                <polyline points="565.0,360.0,565.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR26_95_INTERNAL_95_VL1_95_T11_95_TWO">
                 <polyline points="565.0,256.0,565.0,172.0"/>
@@ -475,7 +475,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_D27" transform="translate(611.0,356.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR28" transform="translate(611.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_T12_95_ONE" transform="translate(611.0,168.0)">
@@ -486,11 +486,11 @@
                 <circle class="sld-winding" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="T12_ONE_N_LABEL" x="-5.0" y="-5.0">T12</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D27_95_INTERNAL_95_VL1_95_D27">
+            <g class="sld-wire" id="_95_VL1_95_D27_95_INTERNAL_95_VL1_95_BR28">
                 <polyline points="615.0,415.0,615.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR28_95_INTERNAL_95_VL1_95_D27">
-                <polyline points="615.0,276.0,615.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR28_95_BR28">
+                <polyline points="615.0,360.0,615.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR28_95_INTERNAL_95_VL1_95_T12_95_ONE">
                 <polyline points="615.0,256.0,615.0,172.0"/>
@@ -518,7 +518,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_10">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_D29" transform="translate(686.0,356.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR30" transform="translate(686.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder" id="idT3_95_12_95_ONE" transform="translate(665.0,110.0)">
@@ -527,11 +527,11 @@
             <g class="sld-top-feeder" id="idT3_95_12_95_THREE" transform="translate(715.0,110.0)">
                 <text class="sld-label" id="T3_12_THREE_N_LABEL" x="-5.0" y="-5.0">T3_12</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D29_95_INTERNAL_95_VL1_95_D29">
+            <g class="sld-wire" id="_95_VL1_95_D29_95_INTERNAL_95_VL1_95_BR30">
                 <polyline points="690.0,415.0,690.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR30_95_INTERNAL_95_VL1_95_D29">
-                <polyline points="690.0,276.0,690.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR30_95_BR30">
+                <polyline points="690.0,360.0,690.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR30_95_T3_95_12">
                 <polyline points="690.0,256.0,690.0,184.0"/>

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreakerH.json
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreakerH.json
@@ -315,7 +315,7 @@
       "direction" : "TOP"
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D10",
+      "id" : "INTERNAL_VL1_BR1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -323,47 +323,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D11",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 125.0,
-      "y" : 250.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D13",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 175.0,
-      "y" : 250.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D15",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 225.0,
-      "y" : 250.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D17",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 275.0,
-      "y" : 250.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D19",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 325.0,
-      "y" : 250.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D20",
+      "id" : "INTERNAL_VL1_BR1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -371,7 +331,47 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D21",
+      "id" : "INTERNAL_VL1_BR12",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 125.0,
+      "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_VL1_BR14",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 175.0,
+      "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_VL1_BR16",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 225.0,
+      "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_VL1_BR18",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 275.0,
+      "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_VL1_BR20",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 325.0,
+      "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_VL1_BR22",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -379,7 +379,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D23",
+      "id" : "INTERNAL_VL1_BR24",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -387,7 +387,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D25",
+      "id" : "INTERNAL_VL1_BR26",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -395,7 +395,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D27",
+      "id" : "INTERNAL_VL1_BR28",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -403,7 +403,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D29",
+      "id" : "INTERNAL_VL1_BR30",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -698,7 +698,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS12", "D20", "INTERNAL_VL1_D20" ]
+          "nodes" : [ "BBS12", "D20", "INTERNAL_VL1_BR1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -719,7 +719,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_VL1_D20", "BR1", "INTERNAL_VL1_D10" ]
+          "nodes" : [ "INTERNAL_VL1_BR1", "BR1", "INTERNAL_VL1_BR1" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -740,7 +740,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS11", "D10", "INTERNAL_VL1_D10" ]
+          "nodes" : [ "BBS11", "D10", "INTERNAL_VL1_BR1" ]
         } ]
       }
     }, {
@@ -787,7 +787,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS11", "D11", "INTERNAL_VL1_D11" ]
+          "nodes" : [ "BBS11", "D11", "INTERNAL_VL1_BR12" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -808,7 +808,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D11", "BR12", "INTERNAL_VL1_L1" ]
+          "nodes" : [ "INTERNAL_VL1_BR12", "BR12", "INTERNAL_VL1_L1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -876,7 +876,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS11", "D13", "INTERNAL_VL1_D13" ]
+          "nodes" : [ "BBS11", "D13", "INTERNAL_VL1_BR14" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -897,7 +897,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D13", "BR14", "INTERNAL_VL1_L11_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_BR14", "BR14", "INTERNAL_VL1_L11_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -965,7 +965,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS11", "D15", "INTERNAL_VL1_D15" ]
+          "nodes" : [ "BBS11", "D15", "INTERNAL_VL1_BR16" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -986,7 +986,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D15", "BR16", "INTERNAL_VL1_L12_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_BR16", "BR16", "INTERNAL_VL1_L12_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1054,7 +1054,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS11", "D17", "INTERNAL_VL1_D17" ]
+          "nodes" : [ "BBS11", "D17", "INTERNAL_VL1_BR18" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1075,7 +1075,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D17", "BR18", "INTERNAL_VL1_T11_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_BR18", "BR18", "INTERNAL_VL1_T11_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1143,7 +1143,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS11", "D19", "INTERNAL_VL1_D19" ]
+          "nodes" : [ "BBS11", "D19", "INTERNAL_VL1_BR20" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1164,7 +1164,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D19", "BR20", "INTERNAL_VL1_T3_12_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_BR20", "BR20", "INTERNAL_VL1_T3_12_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1232,7 +1232,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS12", "D21", "INTERNAL_VL1_D21" ]
+          "nodes" : [ "BBS12", "D21", "INTERNAL_VL1_BR22" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1253,7 +1253,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D21", "BR22", "INTERNAL_VL1_G" ]
+          "nodes" : [ "INTERNAL_VL1_BR22", "BR22", "INTERNAL_VL1_G" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1321,7 +1321,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS12", "D23", "INTERNAL_VL1_D23" ]
+          "nodes" : [ "BBS12", "D23", "INTERNAL_VL1_BR24" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1342,7 +1342,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D23", "BR24", "INTERNAL_VL1_L11_TWO" ]
+          "nodes" : [ "INTERNAL_VL1_BR24", "BR24", "INTERNAL_VL1_L11_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1410,7 +1410,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS12", "D25", "INTERNAL_VL1_D25" ]
+          "nodes" : [ "BBS12", "D25", "INTERNAL_VL1_BR26" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1431,7 +1431,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D25", "BR26", "INTERNAL_VL1_T11_TWO" ]
+          "nodes" : [ "INTERNAL_VL1_BR26", "BR26", "INTERNAL_VL1_T11_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1499,7 +1499,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS12", "D27", "INTERNAL_VL1_D27" ]
+          "nodes" : [ "BBS12", "D27", "INTERNAL_VL1_BR28" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1520,7 +1520,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D27", "BR28", "INTERNAL_VL1_T12_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_BR28", "BR28", "INTERNAL_VL1_T12_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1588,7 +1588,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS12", "D29", "INTERNAL_VL1_D29" ]
+          "nodes" : [ "BBS12", "D29", "INTERNAL_VL1_BR30" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1609,7 +1609,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D29", "BR30", "INTERNAL_VL1_T3_12_TWO" ]
+          "nodes" : [ "INTERNAL_VL1_BR30", "BR30", "INTERNAL_VL1_T3_12_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1671,6 +1671,78 @@
       "node1" : "BBS12",
       "node2" : "D29"
     }, {
+      "node1" : "D10",
+      "node2" : "INTERNAL_VL1_BR1"
+    }, {
+      "node1" : "INTERNAL_VL1_BR1",
+      "node2" : "BR1"
+    }, {
+      "node1" : "D11",
+      "node2" : "INTERNAL_VL1_BR12"
+    }, {
+      "node1" : "INTERNAL_VL1_BR12",
+      "node2" : "BR12"
+    }, {
+      "node1" : "D13",
+      "node2" : "INTERNAL_VL1_BR14"
+    }, {
+      "node1" : "INTERNAL_VL1_BR14",
+      "node2" : "BR14"
+    }, {
+      "node1" : "D15",
+      "node2" : "INTERNAL_VL1_BR16"
+    }, {
+      "node1" : "INTERNAL_VL1_BR16",
+      "node2" : "BR16"
+    }, {
+      "node1" : "D17",
+      "node2" : "INTERNAL_VL1_BR18"
+    }, {
+      "node1" : "INTERNAL_VL1_BR18",
+      "node2" : "BR18"
+    }, {
+      "node1" : "D19",
+      "node2" : "INTERNAL_VL1_BR20"
+    }, {
+      "node1" : "INTERNAL_VL1_BR20",
+      "node2" : "BR20"
+    }, {
+      "node1" : "D20",
+      "node2" : "INTERNAL_VL1_BR1"
+    }, {
+      "node1" : "INTERNAL_VL1_BR1",
+      "node2" : "BR1"
+    }, {
+      "node1" : "D21",
+      "node2" : "INTERNAL_VL1_BR22"
+    }, {
+      "node1" : "INTERNAL_VL1_BR22",
+      "node2" : "BR22"
+    }, {
+      "node1" : "D23",
+      "node2" : "INTERNAL_VL1_BR24"
+    }, {
+      "node1" : "INTERNAL_VL1_BR24",
+      "node2" : "BR24"
+    }, {
+      "node1" : "D25",
+      "node2" : "INTERNAL_VL1_BR26"
+    }, {
+      "node1" : "INTERNAL_VL1_BR26",
+      "node2" : "BR26"
+    }, {
+      "node1" : "D27",
+      "node2" : "INTERNAL_VL1_BR28"
+    }, {
+      "node1" : "INTERNAL_VL1_BR28",
+      "node2" : "BR28"
+    }, {
+      "node1" : "D29",
+      "node2" : "INTERNAL_VL1_BR30"
+    }, {
+      "node1" : "INTERNAL_VL1_BR30",
+      "node2" : "BR30"
+    }, {
       "node1" : "BR12",
       "node2" : "INTERNAL_VL1_L1"
     }, {
@@ -1730,78 +1802,6 @@
     }, {
       "node1" : "INTERNAL_VL1_T3_12_TWO",
       "node2" : "T3_12_TWO"
-    }, {
-      "node1" : "BR1",
-      "node2" : "INTERNAL_VL1_D10"
-    }, {
-      "node1" : "D10",
-      "node2" : "INTERNAL_VL1_D10"
-    }, {
-      "node1" : "BR12",
-      "node2" : "INTERNAL_VL1_D11"
-    }, {
-      "node1" : "D11",
-      "node2" : "INTERNAL_VL1_D11"
-    }, {
-      "node1" : "BR14",
-      "node2" : "INTERNAL_VL1_D13"
-    }, {
-      "node1" : "D13",
-      "node2" : "INTERNAL_VL1_D13"
-    }, {
-      "node1" : "BR16",
-      "node2" : "INTERNAL_VL1_D15"
-    }, {
-      "node1" : "D15",
-      "node2" : "INTERNAL_VL1_D15"
-    }, {
-      "node1" : "BR18",
-      "node2" : "INTERNAL_VL1_D17"
-    }, {
-      "node1" : "D17",
-      "node2" : "INTERNAL_VL1_D17"
-    }, {
-      "node1" : "BR20",
-      "node2" : "INTERNAL_VL1_D19"
-    }, {
-      "node1" : "D19",
-      "node2" : "INTERNAL_VL1_D19"
-    }, {
-      "node1" : "BR1",
-      "node2" : "INTERNAL_VL1_D20"
-    }, {
-      "node1" : "D20",
-      "node2" : "INTERNAL_VL1_D20"
-    }, {
-      "node1" : "BR22",
-      "node2" : "INTERNAL_VL1_D21"
-    }, {
-      "node1" : "D21",
-      "node2" : "INTERNAL_VL1_D21"
-    }, {
-      "node1" : "BR24",
-      "node2" : "INTERNAL_VL1_D23"
-    }, {
-      "node1" : "D23",
-      "node2" : "INTERNAL_VL1_D23"
-    }, {
-      "node1" : "BR26",
-      "node2" : "INTERNAL_VL1_D25"
-    }, {
-      "node1" : "D25",
-      "node2" : "INTERNAL_VL1_D25"
-    }, {
-      "node1" : "BR28",
-      "node2" : "INTERNAL_VL1_D27"
-    }, {
-      "node1" : "D27",
-      "node2" : "INTERNAL_VL1_D27"
-    }, {
-      "node1" : "BR30",
-      "node2" : "INTERNAL_VL1_D29"
-    }, {
-      "node1" : "D29",
-      "node2" : "INTERNAL_VL1_D29"
     } ],
     "multitermNodes" : [ {
       "type" : "FICTITIOUS",
@@ -1965,7 +1965,7 @@
       "kind" : "DISCONNECTOR"
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_D31",
+      "id" : "INTERNAL_VL2_BR32",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -1973,7 +1973,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_D33",
+      "id" : "INTERNAL_VL2_BR34",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -1981,7 +1981,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_D35",
+      "id" : "INTERNAL_VL2_BR36",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -1989,7 +1989,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_D37",
+      "id" : "INTERNAL_VL2_BR38",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2142,7 +2142,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS2", "D31", "INTERNAL_VL2_D31" ]
+          "nodes" : [ "BBS2", "D31", "INTERNAL_VL2_BR32" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2163,7 +2163,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_D31", "BR32", "INTERNAL_VL2_L2" ]
+          "nodes" : [ "INTERNAL_VL2_BR32", "BR32", "INTERNAL_VL2_L2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2231,7 +2231,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS2", "D33", "INTERNAL_VL2_D33" ]
+          "nodes" : [ "BBS2", "D33", "INTERNAL_VL2_BR34" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2252,7 +2252,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_D33", "BR34", "INTERNAL_VL2_L12_TWO" ]
+          "nodes" : [ "INTERNAL_VL2_BR34", "BR34", "INTERNAL_VL2_L12_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2320,7 +2320,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS2", "D35", "INTERNAL_VL2_D35" ]
+          "nodes" : [ "BBS2", "D35", "INTERNAL_VL2_BR36" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2341,7 +2341,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_D35", "BR36", "INTERNAL_VL2_T12_TWO" ]
+          "nodes" : [ "INTERNAL_VL2_BR36", "BR36", "INTERNAL_VL2_T12_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2409,7 +2409,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS2", "D37", "INTERNAL_VL2_D37" ]
+          "nodes" : [ "BBS2", "D37", "INTERNAL_VL2_BR38" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2430,7 +2430,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_D37", "BR38", "INTERNAL_VL2_T3_12_THREE" ]
+          "nodes" : [ "INTERNAL_VL2_BR38", "BR38", "INTERNAL_VL2_T3_12_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2468,6 +2468,30 @@
       "node1" : "BBS2",
       "node2" : "D37"
     }, {
+      "node1" : "D31",
+      "node2" : "INTERNAL_VL2_BR32"
+    }, {
+      "node1" : "INTERNAL_VL2_BR32",
+      "node2" : "BR32"
+    }, {
+      "node1" : "D33",
+      "node2" : "INTERNAL_VL2_BR34"
+    }, {
+      "node1" : "INTERNAL_VL2_BR34",
+      "node2" : "BR34"
+    }, {
+      "node1" : "D35",
+      "node2" : "INTERNAL_VL2_BR36"
+    }, {
+      "node1" : "INTERNAL_VL2_BR36",
+      "node2" : "BR36"
+    }, {
+      "node1" : "D37",
+      "node2" : "INTERNAL_VL2_BR38"
+    }, {
+      "node1" : "INTERNAL_VL2_BR38",
+      "node2" : "BR38"
+    }, {
       "node1" : "BR32",
       "node2" : "INTERNAL_VL2_L2"
     }, {
@@ -2491,30 +2515,6 @@
     }, {
       "node1" : "INTERNAL_VL2_T3_12_THREE",
       "node2" : "T3_12_THREE"
-    }, {
-      "node1" : "BR32",
-      "node2" : "INTERNAL_VL2_D31"
-    }, {
-      "node1" : "D31",
-      "node2" : "INTERNAL_VL2_D31"
-    }, {
-      "node1" : "BR34",
-      "node2" : "INTERNAL_VL2_D33"
-    }, {
-      "node1" : "D33",
-      "node2" : "INTERNAL_VL2_D33"
-    }, {
-      "node1" : "BR36",
-      "node2" : "INTERNAL_VL2_D35"
-    }, {
-      "node1" : "D35",
-      "node2" : "INTERNAL_VL2_D35"
-    }, {
-      "node1" : "BR38",
-      "node2" : "INTERNAL_VL2_D37"
-    }, {
-      "node1" : "D37",
-      "node2" : "INTERNAL_VL2_D37"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreakerV.json
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreakerV.json
@@ -315,7 +315,7 @@
       "direction" : "TOP"
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D10",
+      "id" : "INTERNAL_VL1_BR1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -323,47 +323,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D11",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 125.0,
-      "y" : 250.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D13",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 175.0,
-      "y" : 250.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D15",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 225.0,
-      "y" : 250.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D17",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 275.0,
-      "y" : 250.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D19",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 325.0,
-      "y" : 250.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D20",
+      "id" : "INTERNAL_VL1_BR1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -371,7 +331,47 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D21",
+      "id" : "INTERNAL_VL1_BR12",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 125.0,
+      "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_VL1_BR14",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 175.0,
+      "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_VL1_BR16",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 225.0,
+      "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_VL1_BR18",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 275.0,
+      "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_VL1_BR20",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 325.0,
+      "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_VL1_BR22",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -379,7 +379,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D23",
+      "id" : "INTERNAL_VL1_BR24",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
@@ -387,7 +387,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D25",
+      "id" : "INTERNAL_VL1_BR26",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -395,7 +395,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D27",
+      "id" : "INTERNAL_VL1_BR28",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -403,7 +403,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL1_D29",
+      "id" : "INTERNAL_VL1_BR30",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -698,7 +698,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS12", "D20", "INTERNAL_VL1_D20" ]
+          "nodes" : [ "BBS12", "D20", "INTERNAL_VL1_BR1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -719,7 +719,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_VL1_D20", "BR1", "INTERNAL_VL1_D10" ]
+          "nodes" : [ "INTERNAL_VL1_BR1", "BR1", "INTERNAL_VL1_BR1" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -740,7 +740,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS11", "D10", "INTERNAL_VL1_D10" ]
+          "nodes" : [ "BBS11", "D10", "INTERNAL_VL1_BR1" ]
         } ]
       }
     }, {
@@ -787,7 +787,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS11", "D11", "INTERNAL_VL1_D11" ]
+          "nodes" : [ "BBS11", "D11", "INTERNAL_VL1_BR12" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -808,7 +808,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D11", "BR12", "INTERNAL_VL1_L1" ]
+          "nodes" : [ "INTERNAL_VL1_BR12", "BR12", "INTERNAL_VL1_L1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -876,7 +876,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS11", "D13", "INTERNAL_VL1_D13" ]
+          "nodes" : [ "BBS11", "D13", "INTERNAL_VL1_BR14" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -897,7 +897,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D13", "BR14", "INTERNAL_VL1_L11_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_BR14", "BR14", "INTERNAL_VL1_L11_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -965,7 +965,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS11", "D15", "INTERNAL_VL1_D15" ]
+          "nodes" : [ "BBS11", "D15", "INTERNAL_VL1_BR16" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -986,7 +986,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D15", "BR16", "INTERNAL_VL1_L12_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_BR16", "BR16", "INTERNAL_VL1_L12_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1054,7 +1054,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS11", "D17", "INTERNAL_VL1_D17" ]
+          "nodes" : [ "BBS11", "D17", "INTERNAL_VL1_BR18" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1075,7 +1075,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D17", "BR18", "INTERNAL_VL1_T11_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_BR18", "BR18", "INTERNAL_VL1_T11_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1143,7 +1143,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS11", "D19", "INTERNAL_VL1_D19" ]
+          "nodes" : [ "BBS11", "D19", "INTERNAL_VL1_BR20" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1164,7 +1164,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D19", "BR20", "INTERNAL_VL1_T3_12_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_BR20", "BR20", "INTERNAL_VL1_T3_12_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1232,7 +1232,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS12", "D21", "INTERNAL_VL1_D21" ]
+          "nodes" : [ "BBS12", "D21", "INTERNAL_VL1_BR22" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1253,7 +1253,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D21", "BR22", "INTERNAL_VL1_G" ]
+          "nodes" : [ "INTERNAL_VL1_BR22", "BR22", "INTERNAL_VL1_G" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1321,7 +1321,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS12", "D23", "INTERNAL_VL1_D23" ]
+          "nodes" : [ "BBS12", "D23", "INTERNAL_VL1_BR24" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1342,7 +1342,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D23", "BR24", "INTERNAL_VL1_L11_TWO" ]
+          "nodes" : [ "INTERNAL_VL1_BR24", "BR24", "INTERNAL_VL1_L11_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1410,7 +1410,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS12", "D25", "INTERNAL_VL1_D25" ]
+          "nodes" : [ "BBS12", "D25", "INTERNAL_VL1_BR26" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1431,7 +1431,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D25", "BR26", "INTERNAL_VL1_T11_TWO" ]
+          "nodes" : [ "INTERNAL_VL1_BR26", "BR26", "INTERNAL_VL1_T11_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1499,7 +1499,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS12", "D27", "INTERNAL_VL1_D27" ]
+          "nodes" : [ "BBS12", "D27", "INTERNAL_VL1_BR28" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1520,7 +1520,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D27", "BR28", "INTERNAL_VL1_T12_ONE" ]
+          "nodes" : [ "INTERNAL_VL1_BR28", "BR28", "INTERNAL_VL1_T12_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1588,7 +1588,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS12", "D29", "INTERNAL_VL1_D29" ]
+          "nodes" : [ "BBS12", "D29", "INTERNAL_VL1_BR30" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1609,7 +1609,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL1_D29", "BR30", "INTERNAL_VL1_T3_12_TWO" ]
+          "nodes" : [ "INTERNAL_VL1_BR30", "BR30", "INTERNAL_VL1_T3_12_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1671,6 +1671,78 @@
       "node1" : "BBS12",
       "node2" : "D29"
     }, {
+      "node1" : "D10",
+      "node2" : "INTERNAL_VL1_BR1"
+    }, {
+      "node1" : "INTERNAL_VL1_BR1",
+      "node2" : "BR1"
+    }, {
+      "node1" : "D11",
+      "node2" : "INTERNAL_VL1_BR12"
+    }, {
+      "node1" : "INTERNAL_VL1_BR12",
+      "node2" : "BR12"
+    }, {
+      "node1" : "D13",
+      "node2" : "INTERNAL_VL1_BR14"
+    }, {
+      "node1" : "INTERNAL_VL1_BR14",
+      "node2" : "BR14"
+    }, {
+      "node1" : "D15",
+      "node2" : "INTERNAL_VL1_BR16"
+    }, {
+      "node1" : "INTERNAL_VL1_BR16",
+      "node2" : "BR16"
+    }, {
+      "node1" : "D17",
+      "node2" : "INTERNAL_VL1_BR18"
+    }, {
+      "node1" : "INTERNAL_VL1_BR18",
+      "node2" : "BR18"
+    }, {
+      "node1" : "D19",
+      "node2" : "INTERNAL_VL1_BR20"
+    }, {
+      "node1" : "INTERNAL_VL1_BR20",
+      "node2" : "BR20"
+    }, {
+      "node1" : "D20",
+      "node2" : "INTERNAL_VL1_BR1"
+    }, {
+      "node1" : "INTERNAL_VL1_BR1",
+      "node2" : "BR1"
+    }, {
+      "node1" : "D21",
+      "node2" : "INTERNAL_VL1_BR22"
+    }, {
+      "node1" : "INTERNAL_VL1_BR22",
+      "node2" : "BR22"
+    }, {
+      "node1" : "D23",
+      "node2" : "INTERNAL_VL1_BR24"
+    }, {
+      "node1" : "INTERNAL_VL1_BR24",
+      "node2" : "BR24"
+    }, {
+      "node1" : "D25",
+      "node2" : "INTERNAL_VL1_BR26"
+    }, {
+      "node1" : "INTERNAL_VL1_BR26",
+      "node2" : "BR26"
+    }, {
+      "node1" : "D27",
+      "node2" : "INTERNAL_VL1_BR28"
+    }, {
+      "node1" : "INTERNAL_VL1_BR28",
+      "node2" : "BR28"
+    }, {
+      "node1" : "D29",
+      "node2" : "INTERNAL_VL1_BR30"
+    }, {
+      "node1" : "INTERNAL_VL1_BR30",
+      "node2" : "BR30"
+    }, {
       "node1" : "BR12",
       "node2" : "INTERNAL_VL1_L1"
     }, {
@@ -1730,78 +1802,6 @@
     }, {
       "node1" : "INTERNAL_VL1_T3_12_TWO",
       "node2" : "T3_12_TWO"
-    }, {
-      "node1" : "BR1",
-      "node2" : "INTERNAL_VL1_D10"
-    }, {
-      "node1" : "D10",
-      "node2" : "INTERNAL_VL1_D10"
-    }, {
-      "node1" : "BR12",
-      "node2" : "INTERNAL_VL1_D11"
-    }, {
-      "node1" : "D11",
-      "node2" : "INTERNAL_VL1_D11"
-    }, {
-      "node1" : "BR14",
-      "node2" : "INTERNAL_VL1_D13"
-    }, {
-      "node1" : "D13",
-      "node2" : "INTERNAL_VL1_D13"
-    }, {
-      "node1" : "BR16",
-      "node2" : "INTERNAL_VL1_D15"
-    }, {
-      "node1" : "D15",
-      "node2" : "INTERNAL_VL1_D15"
-    }, {
-      "node1" : "BR18",
-      "node2" : "INTERNAL_VL1_D17"
-    }, {
-      "node1" : "D17",
-      "node2" : "INTERNAL_VL1_D17"
-    }, {
-      "node1" : "BR20",
-      "node2" : "INTERNAL_VL1_D19"
-    }, {
-      "node1" : "D19",
-      "node2" : "INTERNAL_VL1_D19"
-    }, {
-      "node1" : "BR1",
-      "node2" : "INTERNAL_VL1_D20"
-    }, {
-      "node1" : "D20",
-      "node2" : "INTERNAL_VL1_D20"
-    }, {
-      "node1" : "BR22",
-      "node2" : "INTERNAL_VL1_D21"
-    }, {
-      "node1" : "D21",
-      "node2" : "INTERNAL_VL1_D21"
-    }, {
-      "node1" : "BR24",
-      "node2" : "INTERNAL_VL1_D23"
-    }, {
-      "node1" : "D23",
-      "node2" : "INTERNAL_VL1_D23"
-    }, {
-      "node1" : "BR26",
-      "node2" : "INTERNAL_VL1_D25"
-    }, {
-      "node1" : "D25",
-      "node2" : "INTERNAL_VL1_D25"
-    }, {
-      "node1" : "BR28",
-      "node2" : "INTERNAL_VL1_D27"
-    }, {
-      "node1" : "D27",
-      "node2" : "INTERNAL_VL1_D27"
-    }, {
-      "node1" : "BR30",
-      "node2" : "INTERNAL_VL1_D29"
-    }, {
-      "node1" : "D29",
-      "node2" : "INTERNAL_VL1_D29"
     } ],
     "multitermNodes" : [ {
       "type" : "FICTITIOUS",
@@ -1965,7 +1965,7 @@
       "kind" : "DISCONNECTOR"
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_D31",
+      "id" : "INTERNAL_VL2_BR32",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -1973,7 +1973,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_D33",
+      "id" : "INTERNAL_VL2_BR34",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -1981,7 +1981,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_D35",
+      "id" : "INTERNAL_VL2_BR36",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -1989,7 +1989,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_VL2_D37",
+      "id" : "INTERNAL_VL2_BR38",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2142,7 +2142,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS2", "D31", "INTERNAL_VL2_D31" ]
+          "nodes" : [ "BBS2", "D31", "INTERNAL_VL2_BR32" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2163,7 +2163,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_D31", "BR32", "INTERNAL_VL2_L2" ]
+          "nodes" : [ "INTERNAL_VL2_BR32", "BR32", "INTERNAL_VL2_L2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2231,7 +2231,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS2", "D33", "INTERNAL_VL2_D33" ]
+          "nodes" : [ "BBS2", "D33", "INTERNAL_VL2_BR34" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2252,7 +2252,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_D33", "BR34", "INTERNAL_VL2_L12_TWO" ]
+          "nodes" : [ "INTERNAL_VL2_BR34", "BR34", "INTERNAL_VL2_L12_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2320,7 +2320,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS2", "D35", "INTERNAL_VL2_D35" ]
+          "nodes" : [ "BBS2", "D35", "INTERNAL_VL2_BR36" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2341,7 +2341,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_D35", "BR36", "INTERNAL_VL2_T12_TWO" ]
+          "nodes" : [ "INTERNAL_VL2_BR36", "BR36", "INTERNAL_VL2_T12_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2409,7 +2409,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "BBS2", "D37", "INTERNAL_VL2_D37" ]
+          "nodes" : [ "BBS2", "D37", "INTERNAL_VL2_BR38" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2430,7 +2430,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_VL2_D37", "BR38", "INTERNAL_VL2_T3_12_THREE" ]
+          "nodes" : [ "INTERNAL_VL2_BR38", "BR38", "INTERNAL_VL2_T3_12_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2468,6 +2468,30 @@
       "node1" : "BBS2",
       "node2" : "D37"
     }, {
+      "node1" : "D31",
+      "node2" : "INTERNAL_VL2_BR32"
+    }, {
+      "node1" : "INTERNAL_VL2_BR32",
+      "node2" : "BR32"
+    }, {
+      "node1" : "D33",
+      "node2" : "INTERNAL_VL2_BR34"
+    }, {
+      "node1" : "INTERNAL_VL2_BR34",
+      "node2" : "BR34"
+    }, {
+      "node1" : "D35",
+      "node2" : "INTERNAL_VL2_BR36"
+    }, {
+      "node1" : "INTERNAL_VL2_BR36",
+      "node2" : "BR36"
+    }, {
+      "node1" : "D37",
+      "node2" : "INTERNAL_VL2_BR38"
+    }, {
+      "node1" : "INTERNAL_VL2_BR38",
+      "node2" : "BR38"
+    }, {
       "node1" : "BR32",
       "node2" : "INTERNAL_VL2_L2"
     }, {
@@ -2491,30 +2515,6 @@
     }, {
       "node1" : "INTERNAL_VL2_T3_12_THREE",
       "node2" : "T3_12_THREE"
-    }, {
-      "node1" : "BR32",
-      "node2" : "INTERNAL_VL2_D31"
-    }, {
-      "node1" : "D31",
-      "node2" : "INTERNAL_VL2_D31"
-    }, {
-      "node1" : "BR34",
-      "node2" : "INTERNAL_VL2_D33"
-    }, {
-      "node1" : "D33",
-      "node2" : "INTERNAL_VL2_D33"
-    }, {
-      "node1" : "BR36",
-      "node2" : "INTERNAL_VL2_D35"
-    }, {
-      "node1" : "D35",
-      "node2" : "INTERNAL_VL2_D35"
-    }, {
-      "node1" : "BR38",
-      "node2" : "INTERNAL_VL2_D37"
-    }, {
-      "node1" : "D37",
-      "node2" : "INTERNAL_VL2_D37"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
@@ -121,10 +121,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_LD1_95_1" transform="translate(161.0,326.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_LD1" transform="translate(161.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_LD1_95_2" transform="translate(161.0,138.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_LD1" transform="translate(161.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-load sld-top-feeder" id="idLD1" transform="translate(157.0,75.5)">
@@ -133,13 +133,13 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="LD1_N_LABEL" x="-5.0" y="-5.0">LD1</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_LD1_95_INTERNAL_95_VL1_95_LD1_95_1">
+            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_LD1_95_INTERNAL_95_VL1_95_LD1">
                 <polyline points="165.0,360.0,165.0,330.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_LD1_95_1_95_INTERNAL_95_VL1_95_LD1_95_2">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_LD1_95_INTERNAL_95_VL1_95_LD1">
                 <polyline points="165.0,330.0,165.0,142.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_LD1_95_2_95_LD1">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_LD1_95_LD1">
                 <polyline points="165.0,142.0,165.0,84.5"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idLD1_ARROW_ACTIVE" transform="translate(160.0,99.5)">
@@ -157,10 +157,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_ONE_95_1" transform="translate(211.0,411.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_ONE" transform="translate(211.0,411.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_ONE_95_2" transform="translate(211.0,599.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_ONE" transform="translate(211.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder" id="idL11_95_ONE" transform="translate(215.0,665.0)">
@@ -169,13 +169,13 @@
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(5.0,-68.0)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_L11_95_ONE_95_INTERNAL_95_VL1_95_L11_95_ONE_95_1">
+            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_L11_95_ONE_95_INTERNAL_95_VL1_95_L11_95_ONE">
                 <polyline points="215.0,360.0,215.0,415.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_2">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_INTERNAL_95_VL1_95_L11_95_ONE">
                 <polyline points="215.0,415.0,215.0,603.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_2_95_L11_95_ONE">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_L11_95_ONE">
                 <polyline points="215.0,603.0,215.0,665.0"/>
             </g>
             <g class="sld-arrow-q sld-in" id="idL11_95_ONE_ARROW_REACTIVE" transform="translate(210.0,640.0)">
@@ -193,10 +193,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_ONE_95_1" transform="translate(261.0,326.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_ONE" transform="translate(261.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_ONE_95_2" transform="translate(261.0,138.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_ONE" transform="translate(261.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder" id="idT11_95_ONE" transform="translate(265.0,80.0)">
@@ -205,13 +205,13 @@
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(5.0,56.0)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_T11_95_ONE_95_INTERNAL_95_VL1_95_T11_95_ONE_95_1">
+            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_T11_95_ONE_95_INTERNAL_95_VL1_95_T11_95_ONE">
                 <polyline points="265.0,360.0,265.0,330.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_2">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_INTERNAL_95_VL1_95_T11_95_ONE">
                 <polyline points="265.0,330.0,265.0,142.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_2_95_T11_95_ONE">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_T11_95_ONE">
                 <polyline points="265.0,142.0,265.0,80.0"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(260.0,95.0)">
@@ -229,10 +229,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L12_95_ONE_95_1" transform="translate(311.0,411.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L12_95_ONE" transform="translate(311.0,411.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L12_95_ONE_95_2" transform="translate(311.0,599.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L12_95_ONE" transform="translate(311.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder" id="idL12_95_ONE" transform="translate(315.0,665.0)">
@@ -241,13 +241,13 @@
                     <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(5.0,-69.5)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_L12_95_ONE_95_INTERNAL_95_VL1_95_L12_95_ONE_95_1">
+            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_L12_95_ONE_95_INTERNAL_95_VL1_95_L12_95_ONE">
                 <polyline points="315.0,360.0,315.0,415.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_2">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_INTERNAL_95_VL1_95_L12_95_ONE">
                 <polyline points="315.0,415.0,315.0,603.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_2_95_L12_95_ONE">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_L12_95_ONE">
                 <polyline points="315.0,603.0,315.0,665.0"/>
             </g>
             <g class="sld-arrow-q sld-in" id="idL12_95_ONE_ARROW_REACTIVE" transform="translate(310.0,640.0)">
@@ -319,10 +319,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_G_95_1" transform="translate(461.0,326.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_G" transform="translate(461.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_G_95_2" transform="translate(461.0,138.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_G" transform="translate(461.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-generator sld-top-feeder" id="idG" transform="translate(459.0,74.0)">
@@ -331,13 +331,13 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="G_N_LABEL" x="-5.0" y="-5.0">G</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_G_95_INTERNAL_95_VL1_95_G_95_1">
+            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_G_95_INTERNAL_95_VL1_95_G">
                 <polyline points="465.0,385.0,465.0,330.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_1_95_INTERNAL_95_VL1_95_G_95_2">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_INTERNAL_95_VL1_95_G">
                 <polyline points="465.0,330.0,465.0,142.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_2_95_G">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_G">
                 <polyline points="465.0,142.0,465.0,86.0"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idG_ARROW_ACTIVE" transform="translate(460.0,101.0)">
@@ -355,10 +355,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_TWO_95_1" transform="translate(511.0,411.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_TWO" transform="translate(511.0,411.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_TWO_95_2" transform="translate(511.0,599.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_TWO" transform="translate(511.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder" id="idL11_95_TWO" transform="translate(515.0,665.0)">
@@ -367,13 +367,13 @@
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(5.0,-68.0)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_L11_95_TWO_95_INTERNAL_95_VL1_95_L11_95_TWO_95_1">
+            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_L11_95_TWO_95_INTERNAL_95_VL1_95_L11_95_TWO">
                 <polyline points="515.0,385.0,515.0,415.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_2">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_INTERNAL_95_VL1_95_L11_95_TWO">
                 <polyline points="515.0,415.0,515.0,603.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_2_95_L11_95_TWO">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_L11_95_TWO">
                 <polyline points="515.0,603.0,515.0,665.0"/>
             </g>
             <g class="sld-arrow-q sld-in" id="idL11_95_TWO_ARROW_REACTIVE" transform="translate(510.0,640.0)">
@@ -391,10 +391,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_TWO_95_1" transform="translate(561.0,326.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_TWO" transform="translate(561.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_TWO_95_2" transform="translate(561.0,138.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_TWO" transform="translate(561.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder" id="idT11_95_TWO" transform="translate(565.0,80.0)">
@@ -403,13 +403,13 @@
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(5.0,56.0)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_T11_95_TWO_95_INTERNAL_95_VL1_95_T11_95_TWO_95_1">
+            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_T11_95_TWO_95_INTERNAL_95_VL1_95_T11_95_TWO">
                 <polyline points="565.0,385.0,565.0,330.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_2">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_INTERNAL_95_VL1_95_T11_95_TWO">
                 <polyline points="565.0,330.0,565.0,142.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_2_95_T11_95_TWO">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_T11_95_TWO">
                 <polyline points="565.0,142.0,565.0,80.0"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(560.0,95.0)">
@@ -427,10 +427,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T12_95_ONE_95_1" transform="translate(611.0,411.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T12_95_ONE" transform="translate(611.0,411.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T12_95_ONE_95_2" transform="translate(611.0,599.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T12_95_ONE" transform="translate(611.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-two-wt sld-bottom-feeder" id="idT12_95_ONE" transform="translate(610.0,657.5)">
@@ -441,13 +441,13 @@
                     <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(10.0,-62.0)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_T12_95_ONE_95_INTERNAL_95_VL1_95_T12_95_ONE_95_1">
+            <g class="sld-wire" id="_95_VL1_95_BUSCO_95_T12_95_ONE_95_INTERNAL_95_VL1_95_T12_95_ONE">
                 <polyline points="615.0,385.0,615.0,415.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_2">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_INTERNAL_95_VL1_95_T12_95_ONE">
                 <polyline points="615.0,415.0,615.0,603.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_2_95_T12_95_ONE">
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_T12_95_ONE">
                 <polyline points="615.0,603.0,615.0,657.0"/>
             </g>
             <g class="sld-arrow-q sld-in" id="idT12_95_ONE_ARROW_REACTIVE" transform="translate(610.0,632.0)">

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
@@ -105,22 +105,22 @@
             <text class="sld-label" id="BBS12_NW_LABEL" x="-5.0" y="-5.0">BBS12</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-vertical" id="idINTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D10" transform="translate(111.0,436.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR1" transform="translate(111.0,436.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D20" transform="translate(61.0,436.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR1" transform="translate(61.0,436.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D10_95_INTERNAL_95_VL1_95_D10">
+            <g class="sld-wire" id="_95_VL1_95_D10_95_INTERNAL_95_VL1_95_BR1">
                 <polyline points="115.0,480.0,115.0,440.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR1_95_INTERNAL_95_VL1_95_D10">
-                <polyline points="100.0,440.0,115.0,440.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR1_95_BR1">
+                <polyline points="115.0,440.0,100.0,440.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR1_95_INTERNAL_95_VL1_95_D20">
-                <polyline points="80.0,440.0,65.0,440.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR1_95_BR1">
+                <polyline points="65.0,440.0,80.0,440.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D20_95_INTERNAL_95_VL1_95_D20">
+            <g class="sld-wire" id="_95_VL1_95_D20_95_INTERNAL_95_VL1_95_BR1">
                 <polyline points="65.0,505.0,65.0,440.0"/>
             </g>
             <g class="sld-disconnector sld-closed" id="idD10" transform="translate(111.0,476.0)">
@@ -137,7 +137,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D11" transform="translate(161.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR12" transform="translate(161.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L1" transform="translate(161.0,258.0)">
@@ -149,11 +149,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="L1_N_LABEL" x="-5.0" y="-5.0">L1</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D11_95_INTERNAL_95_VL1_95_D11">
+            <g class="sld-wire" id="_95_VL1_95_D11_95_INTERNAL_95_VL1_95_BR12">
                 <polyline points="165.0,480.0,165.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR12_95_INTERNAL_95_VL1_95_D11">
-                <polyline points="165.0,366.0,165.0,450.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR12_95_BR12">
+                <polyline points="165.0,450.0,165.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR12_95_INTERNAL_95_VL1_95_L1">
                 <polyline points="165.0,346.0,165.0,262.0"/>
@@ -181,7 +181,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D13" transform="translate(211.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR14" transform="translate(211.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_ONE" transform="translate(211.0,258.0)">
@@ -193,11 +193,11 @@
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(5.0,56.0)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D13_95_INTERNAL_95_VL1_95_D13">
+            <g class="sld-wire" id="_95_VL1_95_D13_95_INTERNAL_95_VL1_95_BR14">
                 <polyline points="215.0,480.0,215.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR14_95_INTERNAL_95_VL1_95_D13">
-                <polyline points="215.0,366.0,215.0,450.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR14_95_BR14">
+                <polyline points="215.0,450.0,215.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR14_95_INTERNAL_95_VL1_95_L11_95_ONE">
                 <polyline points="215.0,346.0,215.0,262.0"/>
@@ -225,7 +225,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D15" transform="translate(261.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR16" transform="translate(261.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L12_95_ONE" transform="translate(261.0,258.0)">
@@ -237,11 +237,11 @@
                     <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(5.0,54.5)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D15_95_INTERNAL_95_VL1_95_D15">
+            <g class="sld-wire" id="_95_VL1_95_D15_95_INTERNAL_95_VL1_95_BR16">
                 <polyline points="265.0,480.0,265.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR16_95_INTERNAL_95_VL1_95_D15">
-                <polyline points="265.0,366.0,265.0,450.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR16_95_BR16">
+                <polyline points="265.0,450.0,265.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR16_95_INTERNAL_95_VL1_95_L12_95_ONE">
                 <polyline points="265.0,346.0,265.0,262.0"/>
@@ -269,7 +269,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D17" transform="translate(311.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR18" transform="translate(311.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_ONE" transform="translate(311.0,258.0)">
@@ -281,11 +281,11 @@
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(5.0,56.0)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D17_95_INTERNAL_95_VL1_95_D17">
+            <g class="sld-wire" id="_95_VL1_95_D17_95_INTERNAL_95_VL1_95_BR18">
                 <polyline points="315.0,480.0,315.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR18_95_INTERNAL_95_VL1_95_D17">
-                <polyline points="315.0,366.0,315.0,450.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR18_95_BR18">
+                <polyline points="315.0,450.0,315.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR18_95_INTERNAL_95_VL1_95_T11_95_ONE">
                 <polyline points="315.0,346.0,315.0,262.0"/>
@@ -313,7 +313,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D19" transform="translate(361.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR20" transform="translate(361.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T3_95_12_95_ONE" transform="translate(361.0,258.0)">
@@ -325,11 +325,11 @@
                     <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(5.0,54.5)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D19_95_INTERNAL_95_VL1_95_D19">
+            <g class="sld-wire" id="_95_VL1_95_D19_95_INTERNAL_95_VL1_95_BR20">
                 <polyline points="365.0,480.0,365.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR20_95_INTERNAL_95_VL1_95_D19">
-                <polyline points="365.0,366.0,365.0,450.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR20_95_BR20">
+                <polyline points="365.0,450.0,365.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR20_95_INTERNAL_95_VL1_95_T3_95_12_95_ONE">
                 <polyline points="365.0,346.0,365.0,262.0"/>
@@ -357,7 +357,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D21" transform="translate(411.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR22" transform="translate(411.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_G" transform="translate(411.0,258.0)">
@@ -369,11 +369,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="G_N_LABEL" x="-5.0" y="-5.0">G</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D21_95_INTERNAL_95_VL1_95_D21">
+            <g class="sld-wire" id="_95_VL1_95_D21_95_INTERNAL_95_VL1_95_BR22">
                 <polyline points="415.0,505.0,415.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR22_95_INTERNAL_95_VL1_95_D21">
-                <polyline points="415.0,366.0,415.0,450.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR22_95_BR22">
+                <polyline points="415.0,450.0,415.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR22_95_INTERNAL_95_VL1_95_G">
                 <polyline points="415.0,346.0,415.0,262.0"/>
@@ -401,7 +401,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D23" transform="translate(461.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR24" transform="translate(461.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_TWO" transform="translate(461.0,258.0)">
@@ -413,11 +413,11 @@
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(5.0,56.0)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D23_95_INTERNAL_95_VL1_95_D23">
+            <g class="sld-wire" id="_95_VL1_95_D23_95_INTERNAL_95_VL1_95_BR24">
                 <polyline points="465.0,505.0,465.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR24_95_INTERNAL_95_VL1_95_D23">
-                <polyline points="465.0,366.0,465.0,450.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR24_95_BR24">
+                <polyline points="465.0,450.0,465.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR24_95_INTERNAL_95_VL1_95_L11_95_TWO">
                 <polyline points="465.0,346.0,465.0,262.0"/>
@@ -445,7 +445,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D25" transform="translate(511.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR26" transform="translate(511.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_TWO" transform="translate(511.0,258.0)">
@@ -457,11 +457,11 @@
                     <path d="M 6,0.168 C 4.36,0.178 2.77,1.63 2.75,4.04 H 2.31 c -0.66,0 -1.19,0.53 -1.19,1.19 v 5.37 c 0,0.6 0.53,1.2 1.19,1.2 h 7.4 c 0.69,0 1.19,-0.6 1.19,-1.2 V 5.23 C 10.9,4.57 10.4,4.04 9.71,4.04 H 9.31 C 9.21,1.6 7.66,0.158 6,0.168 Z M 6,1.41 c 0.97,0 2.02,0.7 2.04,2.63 H 3.99 c 0,-1.89 1.05,-2.63 2.04,-2.63 z m 0,4.38 c 0.58,0 1.04,0.46 1.04,1.02 0,0.41 -0.25,0.72 -0.58,0.88 L 6.91,9.68 H 5 L 5.49,7.69 C 5.17,7.5 5,7.18 5,6.81 5,6.25 5.45,5.79 6,5.79 Z" transform="translate(5.0,56.0)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D25_95_INTERNAL_95_VL1_95_D25">
+            <g class="sld-wire" id="_95_VL1_95_D25_95_INTERNAL_95_VL1_95_BR26">
                 <polyline points="515.0,505.0,515.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR26_95_INTERNAL_95_VL1_95_D25">
-                <polyline points="515.0,366.0,515.0,450.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR26_95_BR26">
+                <polyline points="515.0,450.0,515.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR26_95_INTERNAL_95_VL1_95_T11_95_TWO">
                 <polyline points="515.0,346.0,515.0,262.0"/>
@@ -489,7 +489,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D27" transform="translate(561.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR28" transform="translate(561.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T12_95_ONE" transform="translate(561.0,258.0)">
@@ -501,11 +501,11 @@
                     <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(5.0,54.5)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D27_95_INTERNAL_95_VL1_95_D27">
+            <g class="sld-wire" id="_95_VL1_95_D27_95_INTERNAL_95_VL1_95_BR28">
                 <polyline points="565.0,505.0,565.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR28_95_INTERNAL_95_VL1_95_D27">
-                <polyline points="565.0,366.0,565.0,450.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR28_95_BR28">
+                <polyline points="565.0,450.0,565.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR28_95_INTERNAL_95_VL1_95_T12_95_ONE">
                 <polyline points="565.0,346.0,565.0,262.0"/>
@@ -533,7 +533,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_10">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D29" transform="translate(611.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR30" transform="translate(611.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T3_95_12_95_TWO" transform="translate(611.0,258.0)">
@@ -545,11 +545,11 @@
                     <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(5.0,54.5)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D29_95_INTERNAL_95_VL1_95_D29">
+            <g class="sld-wire" id="_95_VL1_95_D29_95_INTERNAL_95_VL1_95_BR30">
                 <polyline points="615.0,505.0,615.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR30_95_INTERNAL_95_VL1_95_D29">
-                <polyline points="615.0,366.0,615.0,450.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR30_95_BR30">
+                <polyline points="615.0,450.0,615.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR30_95_INTERNAL_95_VL1_95_T3_95_12_95_TWO">
                 <polyline points="615.0,346.0,615.0,262.0"/>
@@ -597,7 +597,7 @@
             <text class="sld-label" id="BBS2_NW_LABEL" x="-5.0" y="-5.0">BBS2</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL2_95_D31" transform="translate(701.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL2_95_BR32" transform="translate(701.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL2_95_L2" transform="translate(701.0,258.0)">
@@ -609,11 +609,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="L2_N_LABEL" x="-5.0" y="-5.0">L2</text>
             </g>
-            <g class="sld-wire" id="_95_VL2_95_D31_95_INTERNAL_95_VL2_95_D31">
+            <g class="sld-wire" id="_95_VL2_95_D31_95_INTERNAL_95_VL2_95_BR32">
                 <polyline points="705.0,480.0,705.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL2_95_BR32_95_INTERNAL_95_VL2_95_D31">
-                <polyline points="705.0,366.0,705.0,450.0"/>
+            <g class="sld-wire" id="_95_VL2_95_INTERNAL_95_VL2_95_BR32_95_BR32">
+                <polyline points="705.0,450.0,705.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL2_95_BR32_95_INTERNAL_95_VL2_95_L2">
                 <polyline points="705.0,346.0,705.0,262.0"/>
@@ -641,7 +641,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL2_95_D33" transform="translate(751.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL2_95_BR34" transform="translate(751.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL2_95_L12_95_TWO" transform="translate(751.0,258.0)">
@@ -653,11 +653,11 @@
                     <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(5.0,54.5)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL2_95_D33_95_INTERNAL_95_VL2_95_D33">
+            <g class="sld-wire" id="_95_VL2_95_D33_95_INTERNAL_95_VL2_95_BR34">
                 <polyline points="755.0,480.0,755.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL2_95_BR34_95_INTERNAL_95_VL2_95_D33">
-                <polyline points="755.0,366.0,755.0,450.0"/>
+            <g class="sld-wire" id="_95_VL2_95_INTERNAL_95_VL2_95_BR34_95_BR34">
+                <polyline points="755.0,450.0,755.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL2_95_BR34_95_INTERNAL_95_VL2_95_L12_95_TWO">
                 <polyline points="755.0,346.0,755.0,262.0"/>
@@ -685,7 +685,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL2_95_D35" transform="translate(801.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL2_95_BR36" transform="translate(801.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL2_95_T12_95_TWO" transform="translate(801.0,258.0)">
@@ -697,11 +697,11 @@
                     <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(5.0,54.5)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL2_95_D35_95_INTERNAL_95_VL2_95_D35">
+            <g class="sld-wire" id="_95_VL2_95_D35_95_INTERNAL_95_VL2_95_BR36">
                 <polyline points="805.0,480.0,805.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL2_95_BR36_95_INTERNAL_95_VL2_95_D35">
-                <polyline points="805.0,366.0,805.0,450.0"/>
+            <g class="sld-wire" id="_95_VL2_95_INTERNAL_95_VL2_95_BR36_95_BR36">
+                <polyline points="805.0,450.0,805.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL2_95_BR36_95_INTERNAL_95_VL2_95_T12_95_TWO">
                 <polyline points="805.0,346.0,805.0,262.0"/>
@@ -729,7 +729,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL2_95_D37" transform="translate(851.0,446.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL2_95_BR38" transform="translate(851.0,446.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL2_95_T3_95_12_95_THREE" transform="translate(851.0,258.0)">
@@ -741,11 +741,11 @@
                     <path d="M 5.5,14.5 8.5,6.36 4.32,5.83 4.2,0.3 1.3,8.47 5.4,8.99 Z" transform="translate(5.0,54.5)"/>
                 </g>
             </g>
-            <g class="sld-wire" id="_95_VL2_95_D37_95_INTERNAL_95_VL2_95_D37">
+            <g class="sld-wire" id="_95_VL2_95_D37_95_INTERNAL_95_VL2_95_BR38">
                 <polyline points="855.0,480.0,855.0,450.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL2_95_BR38_95_INTERNAL_95_VL2_95_D37">
-                <polyline points="855.0,366.0,855.0,450.0"/>
+            <g class="sld-wire" id="_95_VL2_95_INTERNAL_95_VL2_95_BR38_95_BR38">
+                <polyline points="855.0,450.0,855.0,366.0"/>
             </g>
             <g class="sld-wire" id="_95_VL2_95_BR38_95_INTERNAL_95_VL2_95_T3_95_12_95_THREE">
                 <polyline points="855.0,346.0,855.0,262.0"/>

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
@@ -91,22 +91,22 @@
             <text class="sld-label" id="BBS12_NW_LABEL" x="-5.0" y="-5.0">BBS12</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-vertical" id="idINTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D10" transform="translate(111.0,346.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR1" transform="translate(111.0,346.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D20" transform="translate(61.0,346.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR1" transform="translate(61.0,346.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D10_95_INTERNAL_95_VL1_95_D10">
+            <g class="sld-wire" id="_95_VL1_95_D10_95_INTERNAL_95_VL1_95_BR1">
                 <polyline points="115.0,390.0,115.0,350.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR1_95_INTERNAL_95_VL1_95_D10">
-                <polyline points="100.0,350.0,115.0,350.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR1_95_BR1">
+                <polyline points="115.0,350.0,100.0,350.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR1_95_INTERNAL_95_VL1_95_D20">
-                <polyline points="80.0,350.0,65.0,350.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR1_95_BR1">
+                <polyline points="65.0,350.0,80.0,350.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D20_95_INTERNAL_95_VL1_95_D20">
+            <g class="sld-wire" id="_95_VL1_95_D20_95_INTERNAL_95_VL1_95_BR1">
                 <polyline points="65.0,415.0,65.0,350.0"/>
             </g>
             <g class="sld-disconnector sld-closed" id="idD10" transform="translate(111.0,386.0)">
@@ -132,7 +132,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D11" transform="translate(161.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR12" transform="translate(161.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L1" transform="translate(161.0,168.0)">
@@ -144,11 +144,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="L1_N_LABEL" x="-5.0" y="-5.0">L1</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D11_95_INTERNAL_95_VL1_95_D11">
+            <g class="sld-wire" id="_95_VL1_95_D11_95_INTERNAL_95_VL1_95_BR12">
                 <polyline points="165.0,390.0,165.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR12_95_INTERNAL_95_VL1_95_D11">
-                <polyline points="165.0,276.0,165.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR12_95_BR12">
+                <polyline points="165.0,360.0,165.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR12_95_INTERNAL_95_VL1_95_L1">
                 <polyline points="165.0,256.0,165.0,172.0"/>
@@ -182,7 +182,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D13" transform="translate(211.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR14" transform="translate(211.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_ONE" transform="translate(211.0,168.0)">
@@ -191,11 +191,11 @@
             <g class="sld-top-feeder" id="idL11_95_ONE" transform="translate(215.0,110.0)">
                 <text class="sld-label" id="L11_ONE_N_LABEL" x="-5.0" y="-5.0">L11</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D13_95_INTERNAL_95_VL1_95_D13">
+            <g class="sld-wire" id="_95_VL1_95_D13_95_INTERNAL_95_VL1_95_BR14">
                 <polyline points="215.0,390.0,215.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR14_95_INTERNAL_95_VL1_95_D13">
-                <polyline points="215.0,276.0,215.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR14_95_BR14">
+                <polyline points="215.0,360.0,215.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR14_95_INTERNAL_95_VL1_95_L11_95_ONE">
                 <polyline points="215.0,256.0,215.0,172.0"/>
@@ -229,7 +229,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D15" transform="translate(261.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR16" transform="translate(261.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L12_95_ONE" transform="translate(261.0,168.0)">
@@ -238,11 +238,11 @@
             <g class="sld-top-feeder" id="idL12_95_ONE" transform="translate(265.0,110.0)">
                 <text class="sld-label" id="L12_ONE_N_LABEL" x="-5.0" y="-5.0">L12</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D15_95_INTERNAL_95_VL1_95_D15">
+            <g class="sld-wire" id="_95_VL1_95_D15_95_INTERNAL_95_VL1_95_BR16">
                 <polyline points="265.0,390.0,265.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR16_95_INTERNAL_95_VL1_95_D15">
-                <polyline points="265.0,276.0,265.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR16_95_BR16">
+                <polyline points="265.0,360.0,265.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR16_95_INTERNAL_95_VL1_95_L12_95_ONE">
                 <polyline points="265.0,256.0,265.0,172.0"/>
@@ -276,7 +276,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D17" transform="translate(311.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR18" transform="translate(311.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_ONE" transform="translate(311.0,168.0)">
@@ -285,11 +285,11 @@
             <g class="sld-top-feeder" id="idT11_95_ONE" transform="translate(315.0,110.0)">
                 <text class="sld-label" id="T11_ONE_N_LABEL" x="-5.0" y="-5.0">T11</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D17_95_INTERNAL_95_VL1_95_D17">
+            <g class="sld-wire" id="_95_VL1_95_D17_95_INTERNAL_95_VL1_95_BR18">
                 <polyline points="315.0,390.0,315.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR18_95_INTERNAL_95_VL1_95_D17">
-                <polyline points="315.0,276.0,315.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR18_95_BR18">
+                <polyline points="315.0,360.0,315.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR18_95_INTERNAL_95_VL1_95_T11_95_ONE">
                 <polyline points="315.0,256.0,315.0,172.0"/>
@@ -323,7 +323,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D19" transform="translate(386.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR20" transform="translate(386.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder" id="idT3_95_12_95_TWO" transform="translate(365.0,110.0)">
@@ -332,11 +332,11 @@
             <g class="sld-top-feeder" id="idT3_95_12_95_THREE" transform="translate(415.0,110.0)">
                 <text class="sld-label" id="T3_12_THREE_N_LABEL" x="-5.0" y="-5.0">T3_12</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D19_95_INTERNAL_95_VL1_95_D19">
+            <g class="sld-wire" id="_95_VL1_95_D19_95_INTERNAL_95_VL1_95_BR20">
                 <polyline points="390.0,390.0,390.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR20_95_INTERNAL_95_VL1_95_D19">
-                <polyline points="390.0,276.0,390.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR20_95_BR20">
+                <polyline points="390.0,360.0,390.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR20_95_T3_95_12">
                 <polyline points="390.0,256.0,390.0,184.0"/>
@@ -388,7 +388,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D21" transform="translate(461.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR22" transform="translate(461.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_G" transform="translate(461.0,168.0)">
@@ -400,11 +400,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="G_N_LABEL" x="-5.0" y="-5.0">G</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D21_95_INTERNAL_95_VL1_95_D21">
+            <g class="sld-wire" id="_95_VL1_95_D21_95_INTERNAL_95_VL1_95_BR22">
                 <polyline points="465.0,415.0,465.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR22_95_INTERNAL_95_VL1_95_D21">
-                <polyline points="465.0,276.0,465.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR22_95_BR22">
+                <polyline points="465.0,360.0,465.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR22_95_INTERNAL_95_VL1_95_G">
                 <polyline points="465.0,256.0,465.0,172.0"/>
@@ -438,7 +438,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D23" transform="translate(511.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR24" transform="translate(511.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_L11_95_TWO" transform="translate(511.0,168.0)">
@@ -447,11 +447,11 @@
             <g class="sld-top-feeder" id="idL11_95_TWO" transform="translate(515.0,110.0)">
                 <text class="sld-label" id="L11_TWO_N_LABEL" x="-5.0" y="-5.0">L11</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D23_95_INTERNAL_95_VL1_95_D23">
+            <g class="sld-wire" id="_95_VL1_95_D23_95_INTERNAL_95_VL1_95_BR24">
                 <polyline points="515.0,415.0,515.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR24_95_INTERNAL_95_VL1_95_D23">
-                <polyline points="515.0,276.0,515.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR24_95_BR24">
+                <polyline points="515.0,360.0,515.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR24_95_INTERNAL_95_VL1_95_L11_95_TWO">
                 <polyline points="515.0,256.0,515.0,172.0"/>
@@ -485,7 +485,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D25" transform="translate(561.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR26" transform="translate(561.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T11_95_TWO" transform="translate(561.0,168.0)">
@@ -494,11 +494,11 @@
             <g class="sld-top-feeder" id="idT11_95_TWO" transform="translate(565.0,110.0)">
                 <text class="sld-label" id="T11_TWO_N_LABEL" x="-5.0" y="-5.0">T11</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D25_95_INTERNAL_95_VL1_95_D25">
+            <g class="sld-wire" id="_95_VL1_95_D25_95_INTERNAL_95_VL1_95_BR26">
                 <polyline points="565.0,415.0,565.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR26_95_INTERNAL_95_VL1_95_D25">
-                <polyline points="565.0,276.0,565.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR26_95_BR26">
+                <polyline points="565.0,360.0,565.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR26_95_INTERNAL_95_VL1_95_T11_95_TWO">
                 <polyline points="565.0,256.0,565.0,172.0"/>
@@ -532,7 +532,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D27" transform="translate(611.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR28" transform="translate(611.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_T12_95_ONE" transform="translate(611.0,168.0)">
@@ -543,11 +543,11 @@
                 <circle class="sld-winding" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="T12_ONE_N_LABEL" x="-5.0" y="-5.0">T12</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D27_95_INTERNAL_95_VL1_95_D27">
+            <g class="sld-wire" id="_95_VL1_95_D27_95_INTERNAL_95_VL1_95_BR28">
                 <polyline points="615.0,415.0,615.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR28_95_INTERNAL_95_VL1_95_D27">
-                <polyline points="615.0,276.0,615.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR28_95_BR28">
+                <polyline points="615.0,360.0,615.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR28_95_INTERNAL_95_VL1_95_T12_95_ONE">
                 <polyline points="615.0,256.0,615.0,172.0"/>
@@ -581,7 +581,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_10">
-            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_D29" transform="translate(686.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious" id="idINTERNAL_95_VL1_95_BR30" transform="translate(686.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder" id="idT3_95_12_95_ONE" transform="translate(665.0,110.0)">
@@ -590,11 +590,11 @@
             <g class="sld-top-feeder" id="idT3_95_12_95_THREE" transform="translate(715.0,110.0)">
                 <text class="sld-label" id="T3_12_THREE_N_LABEL" x="-5.0" y="-5.0">T3_12</text>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_D29_95_INTERNAL_95_VL1_95_D29">
+            <g class="sld-wire" id="_95_VL1_95_D29_95_INTERNAL_95_VL1_95_BR30">
                 <polyline points="690.0,415.0,690.0,360.0"/>
             </g>
-            <g class="sld-wire" id="_95_VL1_95_BR30_95_INTERNAL_95_VL1_95_D29">
-                <polyline points="690.0,276.0,690.0,360.0"/>
+            <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_BR30_95_BR30">
+                <polyline points="690.0,360.0,690.0,276.0"/>
             </g>
             <g class="sld-wire" id="_95_VL1_95_BR30_95_T3_95_12">
                 <polyline points="690.0,256.0,690.0,184.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCase1.json
+++ b/single-line-diagram-core/src/test/resources/TestCase1.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -123,7 +123,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs", "d", "INTERNAL_vl_d" ]
+        "nodes" : [ "bbs", "d", "INTERNAL_vl_b" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -144,7 +144,7 @@
           "xSpan" : 50.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl_d", "b", "INTERNAL_vl_l" ]
+        "nodes" : [ "INTERNAL_vl_b", "b", "INTERNAL_vl_l" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -173,17 +173,17 @@
     "node1" : "bbs",
     "node2" : "d"
   }, {
+    "node1" : "d",
+    "node2" : "INTERNAL_vl_b"
+  }, {
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
+  }, {
     "node1" : "b",
     "node2" : "INTERNAL_vl_l"
   }, {
     "node1" : "INTERNAL_vl_l",
     "node2" : "l"
-  }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d"
-  }, {
-    "node1" : "d",
-    "node2" : "INTERNAL_vl_d"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase1.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase1.svg
@@ -74,7 +74,7 @@
             <text class="sld-label" id="bbs_default" text-anchor="middle" x="0.0" y="-5.0">bbs</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_d" transform="translate(61.0,326.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b" transform="translate(61.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_l" transform="translate(61.0,138.0)">
@@ -86,11 +86,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="l_default" text-anchor="middle" x="0.0" y="-5.0">l</text>
             </g>
-            <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_d">
+            <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_b">
                 <polyline points="65.0,360.0,65.0,330.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_d">
-                <polyline points="65.0,246.0,65.0,330.0"/>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_b_95_b">
+                <polyline points="65.0,330.0,65.0,246.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_l">
                 <polyline points="65.0,226.0,65.0,142.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11Left3wtOrientation.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11Left3wtOrientation.json
@@ -10,7 +10,7 @@
     "y" : 200.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dgen1",
+      "id" : "INTERNAL_vl1_bgen1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -19,7 +19,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dgen2",
+      "id" : "INTERNAL_vl1_bgen2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 675.0,
@@ -28,7 +28,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dline11_2",
+      "id" : "INTERNAL_vl1_bline11_2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -36,7 +36,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dload1",
+      "id" : "INTERNAL_vl1_bload1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -44,7 +44,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dload2",
+      "id" : "INTERNAL_vl1_bload2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -52,43 +52,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect11",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 400.0,
-      "y" : 280.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect12",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 450.0,
-      "y" : 280.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect21",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 400.0,
-      "y" : 305.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect22",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 450.0,
-      "y" : 305.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf11",
+      "id" : "INTERNAL_vl1_btrf11",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -96,7 +60,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf12",
+      "id" : "INTERNAL_vl1_btrf12",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 625.0,
@@ -104,7 +68,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf13",
+      "id" : "INTERNAL_vl1_btrf13",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -113,7 +77,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf14",
+      "id" : "INTERNAL_vl1_btrf14",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -122,7 +86,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf15",
+      "id" : "INTERNAL_vl1_btrf15",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -130,7 +94,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf16",
+      "id" : "INTERNAL_vl1_btrf16",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -138,7 +102,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf17",
+      "id" : "INTERNAL_vl1_btrf17",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -147,11 +111,47 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf18",
+      "id" : "INTERNAL_vl1_btrf18",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
       "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct11",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 400.0,
+      "y" : 280.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct11",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 450.0,
+      "y" : 280.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct21",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 400.0,
+      "y" : 305.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct21",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 450.0,
+      "y" : 305.0,
+      "orientation" : "RIGHT",
       "open" : false
     }, {
       "type" : "FICTITIOUS",
@@ -992,7 +992,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dsect12" ]
+          "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dtrct11" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1013,7 +1013,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl1_dsect11", "dtrct11", "INTERNAL_vl1_dsect12" ]
+          "nodes" : [ "INTERNAL_vl1_dtrct11", "dtrct11", "INTERNAL_vl1_dtrct11" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -1034,7 +1034,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dsect11" ]
+          "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dtrct11" ]
         } ]
       }
     }, {
@@ -1081,7 +1081,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dsect22" ]
+          "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dtrct21" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1102,7 +1102,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl1_dsect21", "dtrct21", "INTERNAL_vl1_dsect22" ]
+          "nodes" : [ "INTERNAL_vl1_dtrct21", "dtrct21", "INTERNAL_vl1_dtrct21" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -1123,7 +1123,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dsect21" ]
+          "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dtrct21" ]
         } ]
       }
     }, {
@@ -1171,7 +1171,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_dload1" ]
+          "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_bload1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1192,7 +1192,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dload1", "bload1", "INTERNAL_vl1_load1" ]
+          "nodes" : [ "INTERNAL_vl1_bload1", "bload1", "INTERNAL_vl1_load1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1261,7 +1261,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_dtrf11" ]
+          "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_btrf11" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1282,7 +1282,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1351,7 +1351,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_dtrf15" ]
+          "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_btrf15" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1372,7 +1372,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1441,7 +1441,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_dtrf16" ]
+          "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_btrf16" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1462,7 +1462,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf16", "btrf16", "INTERNAL_vl1_trf6_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf16", "btrf16", "INTERNAL_vl1_trf6_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1531,7 +1531,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dline11_2", "INTERNAL_vl1_dline11_2" ]
+          "nodes" : [ "bbs1", "dline11_2", "INTERNAL_vl1_bline11_2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1552,7 +1552,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dline11_2", "bline11_2", "INTERNAL_vl1_line1_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_bline11_2", "bline11_2", "INTERNAL_vl1_line1_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1621,7 +1621,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_dload2" ]
+          "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_bload2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1642,7 +1642,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dload2", "bload2", "INTERNAL_vl1_load2" ]
+          "nodes" : [ "INTERNAL_vl1_bload2", "bload2", "INTERNAL_vl1_load2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1711,7 +1711,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_dtrf12" ]
+          "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_btrf12" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1732,7 +1732,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1801,7 +1801,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_dtrf18" ]
+          "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_btrf18" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1822,7 +1822,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf18", "btrf18", "INTERNAL_vl1_trf8_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf18", "btrf18", "INTERNAL_vl1_trf8_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1891,7 +1891,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_dgen1" ]
+          "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_bgen1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1912,7 +1912,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dgen1", "bgen1", "INTERNAL_vl1_gen1" ]
+          "nodes" : [ "INTERNAL_vl1_bgen1", "bgen1", "INTERNAL_vl1_gen1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1981,7 +1981,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_dtrf13" ]
+          "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_btrf13" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2002,7 +2002,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2071,7 +2071,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_dtrf17" ]
+          "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_btrf17" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2092,7 +2092,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf17", "btrf17", "INTERNAL_vl1_trf7_TWO" ]
+          "nodes" : [ "INTERNAL_vl1_btrf17", "btrf17", "INTERNAL_vl1_trf7_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2161,7 +2161,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_dgen2" ]
+          "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_bgen2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2182,7 +2182,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dgen2", "bgen2", "INTERNAL_vl1_gen2" ]
+          "nodes" : [ "INTERNAL_vl1_bgen2", "bgen2", "INTERNAL_vl1_gen2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2251,7 +2251,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_dtrf14" ]
+          "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_btrf14" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2272,7 +2272,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2348,6 +2348,108 @@
     }, {
       "node1" : "bbs1",
       "node2" : "dline11_2"
+    }, {
+      "node1" : "dsect11",
+      "node2" : "INTERNAL_vl1_dtrct11"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct11",
+      "node2" : "dtrct11"
+    }, {
+      "node1" : "dload1",
+      "node2" : "INTERNAL_vl1_bload1"
+    }, {
+      "node1" : "INTERNAL_vl1_bload1",
+      "node2" : "bload1"
+    }, {
+      "node1" : "dtrf11",
+      "node2" : "INTERNAL_vl1_btrf11"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf11",
+      "node2" : "btrf11"
+    }, {
+      "node1" : "dtrf15",
+      "node2" : "INTERNAL_vl1_btrf15"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf15",
+      "node2" : "btrf15"
+    }, {
+      "node1" : "dtrf16",
+      "node2" : "INTERNAL_vl1_btrf16"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf16",
+      "node2" : "btrf16"
+    }, {
+      "node1" : "dline11_2",
+      "node2" : "INTERNAL_vl1_bline11_2"
+    }, {
+      "node1" : "INTERNAL_vl1_bline11_2",
+      "node2" : "bline11_2"
+    }, {
+      "node1" : "dsect12",
+      "node2" : "INTERNAL_vl1_dtrct11"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct11",
+      "node2" : "dtrct11"
+    }, {
+      "node1" : "dload2",
+      "node2" : "INTERNAL_vl1_bload2"
+    }, {
+      "node1" : "INTERNAL_vl1_bload2",
+      "node2" : "bload2"
+    }, {
+      "node1" : "dtrf12",
+      "node2" : "INTERNAL_vl1_btrf12"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf12",
+      "node2" : "btrf12"
+    }, {
+      "node1" : "dtrf18",
+      "node2" : "INTERNAL_vl1_btrf18"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf18",
+      "node2" : "btrf18"
+    }, {
+      "node1" : "dsect21",
+      "node2" : "INTERNAL_vl1_dtrct21"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct21",
+      "node2" : "dtrct21"
+    }, {
+      "node1" : "dgen1",
+      "node2" : "INTERNAL_vl1_bgen1"
+    }, {
+      "node1" : "INTERNAL_vl1_bgen1",
+      "node2" : "bgen1"
+    }, {
+      "node1" : "dtrf13",
+      "node2" : "INTERNAL_vl1_btrf13"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf13",
+      "node2" : "btrf13"
+    }, {
+      "node1" : "dtrf17",
+      "node2" : "INTERNAL_vl1_btrf17"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf17",
+      "node2" : "btrf17"
+    }, {
+      "node1" : "dsect22",
+      "node2" : "INTERNAL_vl1_dtrct21"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct21",
+      "node2" : "dtrct21"
+    }, {
+      "node1" : "dgen2",
+      "node2" : "INTERNAL_vl1_bgen2"
+    }, {
+      "node1" : "INTERNAL_vl1_bgen2",
+      "node2" : "bgen2"
+    }, {
+      "node1" : "dtrf14",
+      "node2" : "INTERNAL_vl1_btrf14"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf14",
+      "node2" : "btrf14"
     }, {
       "node1" : "bload1",
       "node2" : "INTERNAL_vl1_load1"
@@ -2426,108 +2528,6 @@
     }, {
       "node1" : "INTERNAL_vl1_line1_ONE",
       "node2" : "line1_ONE"
-    }, {
-      "node1" : "dtrct11",
-      "node2" : "INTERNAL_vl1_dsect11"
-    }, {
-      "node1" : "dsect11",
-      "node2" : "INTERNAL_vl1_dsect11"
-    }, {
-      "node1" : "bload1",
-      "node2" : "INTERNAL_vl1_dload1"
-    }, {
-      "node1" : "dload1",
-      "node2" : "INTERNAL_vl1_dload1"
-    }, {
-      "node1" : "btrf11",
-      "node2" : "INTERNAL_vl1_dtrf11"
-    }, {
-      "node1" : "dtrf11",
-      "node2" : "INTERNAL_vl1_dtrf11"
-    }, {
-      "node1" : "btrf15",
-      "node2" : "INTERNAL_vl1_dtrf15"
-    }, {
-      "node1" : "dtrf15",
-      "node2" : "INTERNAL_vl1_dtrf15"
-    }, {
-      "node1" : "btrf16",
-      "node2" : "INTERNAL_vl1_dtrf16"
-    }, {
-      "node1" : "dtrf16",
-      "node2" : "INTERNAL_vl1_dtrf16"
-    }, {
-      "node1" : "bline11_2",
-      "node2" : "INTERNAL_vl1_dline11_2"
-    }, {
-      "node1" : "dline11_2",
-      "node2" : "INTERNAL_vl1_dline11_2"
-    }, {
-      "node1" : "dtrct11",
-      "node2" : "INTERNAL_vl1_dsect12"
-    }, {
-      "node1" : "dsect12",
-      "node2" : "INTERNAL_vl1_dsect12"
-    }, {
-      "node1" : "bload2",
-      "node2" : "INTERNAL_vl1_dload2"
-    }, {
-      "node1" : "dload2",
-      "node2" : "INTERNAL_vl1_dload2"
-    }, {
-      "node1" : "btrf12",
-      "node2" : "INTERNAL_vl1_dtrf12"
-    }, {
-      "node1" : "dtrf12",
-      "node2" : "INTERNAL_vl1_dtrf12"
-    }, {
-      "node1" : "btrf18",
-      "node2" : "INTERNAL_vl1_dtrf18"
-    }, {
-      "node1" : "dtrf18",
-      "node2" : "INTERNAL_vl1_dtrf18"
-    }, {
-      "node1" : "dtrct21",
-      "node2" : "INTERNAL_vl1_dsect21"
-    }, {
-      "node1" : "dsect21",
-      "node2" : "INTERNAL_vl1_dsect21"
-    }, {
-      "node1" : "bgen1",
-      "node2" : "INTERNAL_vl1_dgen1"
-    }, {
-      "node1" : "dgen1",
-      "node2" : "INTERNAL_vl1_dgen1"
-    }, {
-      "node1" : "btrf13",
-      "node2" : "INTERNAL_vl1_dtrf13"
-    }, {
-      "node1" : "dtrf13",
-      "node2" : "INTERNAL_vl1_dtrf13"
-    }, {
-      "node1" : "btrf17",
-      "node2" : "INTERNAL_vl1_dtrf17"
-    }, {
-      "node1" : "dtrf17",
-      "node2" : "INTERNAL_vl1_dtrf17"
-    }, {
-      "node1" : "dtrct21",
-      "node2" : "INTERNAL_vl1_dsect22"
-    }, {
-      "node1" : "dsect22",
-      "node2" : "INTERNAL_vl1_dsect22"
-    }, {
-      "node1" : "bgen2",
-      "node2" : "INTERNAL_vl1_dgen2"
-    }, {
-      "node1" : "dgen2",
-      "node2" : "INTERNAL_vl1_dgen2"
-    }, {
-      "node1" : "btrf14",
-      "node2" : "INTERNAL_vl1_dtrf14"
-    }, {
-      "node1" : "dtrf14",
-      "node2" : "INTERNAL_vl1_dtrf14"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],
@@ -2542,7 +2542,7 @@
     "y" : 1025.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dgen4",
+      "id" : "INTERNAL_vl2_bgen4",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -2551,7 +2551,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dload3",
+      "id" : "INTERNAL_vl2_bload3",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2559,23 +2559,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dscpl1",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 75.0,
-      "y" : 240.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dscpl2",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 25.0,
-      "y" : 240.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf21",
+      "id" : "INTERNAL_vl2_btrf21",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2583,7 +2567,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf22",
+      "id" : "INTERNAL_vl2_btrf22",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -2592,7 +2576,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf23",
+      "id" : "INTERNAL_vl2_btrf23",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -2601,7 +2585,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf24",
+      "id" : "INTERNAL_vl2_btrf24",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -2609,7 +2593,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf26",
+      "id" : "INTERNAL_vl2_btrf26",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -2617,7 +2601,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf27",
+      "id" : "INTERNAL_vl2_btrf27",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -2625,12 +2609,28 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf28",
+      "id" : "INTERNAL_vl2_btrf28",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
       "y" : 335.0,
       "orientation" : "DOWN",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl2_ddcpl1",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 75.0,
+      "y" : 240.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl2_ddcpl1",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 25.0,
+      "y" : 240.0,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
@@ -3202,7 +3202,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_dscpl2" ]
+          "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_ddcpl1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3223,7 +3223,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl2_dscpl2", "ddcpl1", "INTERNAL_vl2_dscpl1" ]
+          "nodes" : [ "INTERNAL_vl2_ddcpl1", "ddcpl1", "INTERNAL_vl2_ddcpl1" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -3244,7 +3244,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_dscpl1" ]
+          "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_ddcpl1" ]
         } ]
       }
     }, {
@@ -3292,7 +3292,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_dload3" ]
+          "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_bload3" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3313,7 +3313,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dload3", "bload3", "INTERNAL_vl2_load3" ]
+          "nodes" : [ "INTERNAL_vl2_bload3", "bload3", "INTERNAL_vl2_load3" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3382,7 +3382,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_dtrf21" ]
+          "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_btrf21" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3403,7 +3403,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3472,7 +3472,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_dtrf24" ]
+          "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_btrf24" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3493,7 +3493,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3562,7 +3562,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_dtrf27" ]
+          "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_btrf27" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3583,7 +3583,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf27", "btrf27", "INTERNAL_vl2_trf7_ONE" ]
+          "nodes" : [ "INTERNAL_vl2_btrf27", "btrf27", "INTERNAL_vl2_trf7_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3652,7 +3652,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_dgen4" ]
+          "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_bgen4" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3673,7 +3673,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dgen4", "bgen4", "INTERNAL_vl2_gen4" ]
+          "nodes" : [ "INTERNAL_vl2_bgen4", "bgen4", "INTERNAL_vl2_gen4" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3742,7 +3742,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_dtrf22" ]
+          "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_btrf22" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3763,7 +3763,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3832,7 +3832,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_dtrf23" ]
+          "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_btrf23" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3853,7 +3853,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3922,7 +3922,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_dtrf26" ]
+          "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_btrf26" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3943,7 +3943,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf26", "btrf26", "INTERNAL_vl2_trf6_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf26", "btrf26", "INTERNAL_vl2_trf6_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4012,7 +4012,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_dtrf28" ]
+          "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_btrf28" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4033,7 +4033,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf28", "btrf28", "INTERNAL_vl2_trf8_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf28", "btrf28", "INTERNAL_vl2_trf8_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4092,6 +4092,72 @@
       "node1" : "bbs6",
       "node2" : "dtrf28"
     }, {
+      "node1" : "dscpl1",
+      "node2" : "INTERNAL_vl2_ddcpl1"
+    }, {
+      "node1" : "INTERNAL_vl2_ddcpl1",
+      "node2" : "ddcpl1"
+    }, {
+      "node1" : "dload3",
+      "node2" : "INTERNAL_vl2_bload3"
+    }, {
+      "node1" : "INTERNAL_vl2_bload3",
+      "node2" : "bload3"
+    }, {
+      "node1" : "dtrf21",
+      "node2" : "INTERNAL_vl2_btrf21"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf21",
+      "node2" : "btrf21"
+    }, {
+      "node1" : "dtrf24",
+      "node2" : "INTERNAL_vl2_btrf24"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf24",
+      "node2" : "btrf24"
+    }, {
+      "node1" : "dtrf27",
+      "node2" : "INTERNAL_vl2_btrf27"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf27",
+      "node2" : "btrf27"
+    }, {
+      "node1" : "dscpl2",
+      "node2" : "INTERNAL_vl2_ddcpl1"
+    }, {
+      "node1" : "INTERNAL_vl2_ddcpl1",
+      "node2" : "ddcpl1"
+    }, {
+      "node1" : "dgen4",
+      "node2" : "INTERNAL_vl2_bgen4"
+    }, {
+      "node1" : "INTERNAL_vl2_bgen4",
+      "node2" : "bgen4"
+    }, {
+      "node1" : "dtrf22",
+      "node2" : "INTERNAL_vl2_btrf22"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf22",
+      "node2" : "btrf22"
+    }, {
+      "node1" : "dtrf23",
+      "node2" : "INTERNAL_vl2_btrf23"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf23",
+      "node2" : "btrf23"
+    }, {
+      "node1" : "dtrf26",
+      "node2" : "INTERNAL_vl2_btrf26"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf26",
+      "node2" : "btrf26"
+    }, {
+      "node1" : "dtrf28",
+      "node2" : "INTERNAL_vl2_btrf28"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf28",
+      "node2" : "btrf28"
+    }, {
       "node1" : "bload3",
       "node2" : "INTERNAL_vl2_load3"
     }, {
@@ -4145,72 +4211,6 @@
     }, {
       "node1" : "INTERNAL_vl2_trf8_TWO",
       "node2" : "trf8_TWO"
-    }, {
-      "node1" : "ddcpl1",
-      "node2" : "INTERNAL_vl2_dscpl1"
-    }, {
-      "node1" : "dscpl1",
-      "node2" : "INTERNAL_vl2_dscpl1"
-    }, {
-      "node1" : "bload3",
-      "node2" : "INTERNAL_vl2_dload3"
-    }, {
-      "node1" : "dload3",
-      "node2" : "INTERNAL_vl2_dload3"
-    }, {
-      "node1" : "btrf21",
-      "node2" : "INTERNAL_vl2_dtrf21"
-    }, {
-      "node1" : "dtrf21",
-      "node2" : "INTERNAL_vl2_dtrf21"
-    }, {
-      "node1" : "btrf24",
-      "node2" : "INTERNAL_vl2_dtrf24"
-    }, {
-      "node1" : "dtrf24",
-      "node2" : "INTERNAL_vl2_dtrf24"
-    }, {
-      "node1" : "btrf27",
-      "node2" : "INTERNAL_vl2_dtrf27"
-    }, {
-      "node1" : "dtrf27",
-      "node2" : "INTERNAL_vl2_dtrf27"
-    }, {
-      "node1" : "ddcpl1",
-      "node2" : "INTERNAL_vl2_dscpl2"
-    }, {
-      "node1" : "dscpl2",
-      "node2" : "INTERNAL_vl2_dscpl2"
-    }, {
-      "node1" : "bgen4",
-      "node2" : "INTERNAL_vl2_dgen4"
-    }, {
-      "node1" : "dgen4",
-      "node2" : "INTERNAL_vl2_dgen4"
-    }, {
-      "node1" : "btrf22",
-      "node2" : "INTERNAL_vl2_dtrf22"
-    }, {
-      "node1" : "dtrf22",
-      "node2" : "INTERNAL_vl2_dtrf22"
-    }, {
-      "node1" : "btrf23",
-      "node2" : "INTERNAL_vl2_dtrf23"
-    }, {
-      "node1" : "dtrf23",
-      "node2" : "INTERNAL_vl2_dtrf23"
-    }, {
-      "node1" : "btrf26",
-      "node2" : "INTERNAL_vl2_dtrf26"
-    }, {
-      "node1" : "dtrf26",
-      "node2" : "INTERNAL_vl2_dtrf26"
-    }, {
-      "node1" : "btrf28",
-      "node2" : "INTERNAL_vl2_dtrf28"
-    }, {
-      "node1" : "dtrf28",
-      "node2" : "INTERNAL_vl2_dtrf28"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],
@@ -4225,7 +4225,7 @@
     "y" : 1820.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dload4",
+      "id" : "INTERNAL_vl3_bload4",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -4233,7 +4233,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf25",
+      "id" : "INTERNAL_vl3_btrf25",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -4242,7 +4242,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf36",
+      "id" : "INTERNAL_vl3_btrf36",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -4250,7 +4250,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf37",
+      "id" : "INTERNAL_vl3_btrf37",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -4259,7 +4259,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf38",
+      "id" : "INTERNAL_vl3_btrf38",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -4582,7 +4582,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_dload4" ]
+          "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_bload4" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4603,7 +4603,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dload4", "bload4", "INTERNAL_vl3_load4" ]
+          "nodes" : [ "INTERNAL_vl3_bload4", "bload4", "INTERNAL_vl3_load4" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4672,7 +4672,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_dtrf25" ]
+          "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_btrf25" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4693,7 +4693,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
+          "nodes" : [ "INTERNAL_vl3_btrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4762,7 +4762,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_dtrf36" ]
+          "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_btrf36" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4783,7 +4783,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf36", "btrf36", "INTERNAL_vl3_trf6_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf36", "btrf36", "INTERNAL_vl3_trf6_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4852,7 +4852,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_dtrf37" ]
+          "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_btrf37" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4873,7 +4873,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf37", "btrf37", "INTERNAL_vl3_trf7_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf37", "btrf37", "INTERNAL_vl3_trf7_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4942,7 +4942,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_dtrf38" ]
+          "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_btrf38" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4963,7 +4963,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf38", "btrf38", "INTERNAL_vl3_trf8_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf38", "btrf38", "INTERNAL_vl3_trf8_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -5004,6 +5004,36 @@
       "node1" : "bbs7",
       "node2" : "dtrf38"
     }, {
+      "node1" : "dload4",
+      "node2" : "INTERNAL_vl3_bload4"
+    }, {
+      "node1" : "INTERNAL_vl3_bload4",
+      "node2" : "bload4"
+    }, {
+      "node1" : "dtrf25",
+      "node2" : "INTERNAL_vl3_btrf25"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf25",
+      "node2" : "btrf25"
+    }, {
+      "node1" : "dtrf36",
+      "node2" : "INTERNAL_vl3_btrf36"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf36",
+      "node2" : "btrf36"
+    }, {
+      "node1" : "dtrf37",
+      "node2" : "INTERNAL_vl3_btrf37"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf37",
+      "node2" : "btrf37"
+    }, {
+      "node1" : "dtrf38",
+      "node2" : "INTERNAL_vl3_btrf38"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf38",
+      "node2" : "btrf38"
+    }, {
       "node1" : "bload4",
       "node2" : "INTERNAL_vl3_load4"
     }, {
@@ -5033,36 +5063,6 @@
     }, {
       "node1" : "INTERNAL_vl3_trf8_THREE",
       "node2" : "trf8_THREE"
-    }, {
-      "node1" : "bload4",
-      "node2" : "INTERNAL_vl3_dload4"
-    }, {
-      "node1" : "dload4",
-      "node2" : "INTERNAL_vl3_dload4"
-    }, {
-      "node1" : "btrf25",
-      "node2" : "INTERNAL_vl3_dtrf25"
-    }, {
-      "node1" : "dtrf25",
-      "node2" : "INTERNAL_vl3_dtrf25"
-    }, {
-      "node1" : "btrf36",
-      "node2" : "INTERNAL_vl3_dtrf36"
-    }, {
-      "node1" : "dtrf36",
-      "node2" : "INTERNAL_vl3_dtrf36"
-    }, {
-      "node1" : "btrf37",
-      "node2" : "INTERNAL_vl3_dtrf37"
-    }, {
-      "node1" : "dtrf37",
-      "node2" : "INTERNAL_vl3_dtrf37"
-    }, {
-      "node1" : "btrf38",
-      "node2" : "INTERNAL_vl3_dtrf38"
-    }, {
-      "node1" : "dtrf38",
-      "node2" : "INTERNAL_vl3_dtrf38"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase11Right3wtOrientation.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11Right3wtOrientation.json
@@ -10,7 +10,7 @@
     "y" : 200.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dgen1",
+      "id" : "INTERNAL_vl1_bgen1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -19,7 +19,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dgen2",
+      "id" : "INTERNAL_vl1_bgen2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 675.0,
@@ -28,7 +28,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dline11_2",
+      "id" : "INTERNAL_vl1_bline11_2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -36,7 +36,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dload1",
+      "id" : "INTERNAL_vl1_bload1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -44,7 +44,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dload2",
+      "id" : "INTERNAL_vl1_bload2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -52,43 +52,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect11",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 400.0,
-      "y" : 280.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect12",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 450.0,
-      "y" : 280.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect21",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 400.0,
-      "y" : 305.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect22",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 450.0,
-      "y" : 305.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf11",
+      "id" : "INTERNAL_vl1_btrf11",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -96,7 +60,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf12",
+      "id" : "INTERNAL_vl1_btrf12",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 625.0,
@@ -104,7 +68,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf13",
+      "id" : "INTERNAL_vl1_btrf13",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -113,7 +77,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf14",
+      "id" : "INTERNAL_vl1_btrf14",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -122,7 +86,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf15",
+      "id" : "INTERNAL_vl1_btrf15",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -130,7 +94,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf16",
+      "id" : "INTERNAL_vl1_btrf16",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -138,7 +102,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf17",
+      "id" : "INTERNAL_vl1_btrf17",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -147,11 +111,47 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf18",
+      "id" : "INTERNAL_vl1_btrf18",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
       "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct11",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 400.0,
+      "y" : 280.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct11",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 450.0,
+      "y" : 280.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct21",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 400.0,
+      "y" : 305.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct21",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 450.0,
+      "y" : 305.0,
+      "orientation" : "RIGHT",
       "open" : false
     }, {
       "type" : "FICTITIOUS",
@@ -992,7 +992,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dsect12" ]
+          "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dtrct11" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1013,7 +1013,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl1_dsect11", "dtrct11", "INTERNAL_vl1_dsect12" ]
+          "nodes" : [ "INTERNAL_vl1_dtrct11", "dtrct11", "INTERNAL_vl1_dtrct11" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -1034,7 +1034,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dsect11" ]
+          "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dtrct11" ]
         } ]
       }
     }, {
@@ -1081,7 +1081,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dsect22" ]
+          "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dtrct21" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1102,7 +1102,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl1_dsect21", "dtrct21", "INTERNAL_vl1_dsect22" ]
+          "nodes" : [ "INTERNAL_vl1_dtrct21", "dtrct21", "INTERNAL_vl1_dtrct21" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -1123,7 +1123,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dsect21" ]
+          "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dtrct21" ]
         } ]
       }
     }, {
@@ -1171,7 +1171,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_dload1" ]
+          "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_bload1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1192,7 +1192,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dload1", "bload1", "INTERNAL_vl1_load1" ]
+          "nodes" : [ "INTERNAL_vl1_bload1", "bload1", "INTERNAL_vl1_load1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1261,7 +1261,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_dtrf11" ]
+          "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_btrf11" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1282,7 +1282,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1351,7 +1351,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_dtrf15" ]
+          "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_btrf15" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1372,7 +1372,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1441,7 +1441,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_dtrf16" ]
+          "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_btrf16" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1462,7 +1462,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf16", "btrf16", "INTERNAL_vl1_trf6_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf16", "btrf16", "INTERNAL_vl1_trf6_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1531,7 +1531,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dline11_2", "INTERNAL_vl1_dline11_2" ]
+          "nodes" : [ "bbs1", "dline11_2", "INTERNAL_vl1_bline11_2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1552,7 +1552,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dline11_2", "bline11_2", "INTERNAL_vl1_line1_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_bline11_2", "bline11_2", "INTERNAL_vl1_line1_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1621,7 +1621,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_dload2" ]
+          "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_bload2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1642,7 +1642,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dload2", "bload2", "INTERNAL_vl1_load2" ]
+          "nodes" : [ "INTERNAL_vl1_bload2", "bload2", "INTERNAL_vl1_load2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1711,7 +1711,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_dtrf12" ]
+          "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_btrf12" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1732,7 +1732,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1801,7 +1801,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_dtrf18" ]
+          "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_btrf18" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1822,7 +1822,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf18", "btrf18", "INTERNAL_vl1_trf8_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf18", "btrf18", "INTERNAL_vl1_trf8_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1891,7 +1891,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_dgen1" ]
+          "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_bgen1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1912,7 +1912,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dgen1", "bgen1", "INTERNAL_vl1_gen1" ]
+          "nodes" : [ "INTERNAL_vl1_bgen1", "bgen1", "INTERNAL_vl1_gen1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1981,7 +1981,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_dtrf13" ]
+          "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_btrf13" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2002,7 +2002,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2071,7 +2071,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_dtrf17" ]
+          "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_btrf17" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2092,7 +2092,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf17", "btrf17", "INTERNAL_vl1_trf7_THREE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf17", "btrf17", "INTERNAL_vl1_trf7_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2161,7 +2161,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_dgen2" ]
+          "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_bgen2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2182,7 +2182,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dgen2", "bgen2", "INTERNAL_vl1_gen2" ]
+          "nodes" : [ "INTERNAL_vl1_bgen2", "bgen2", "INTERNAL_vl1_gen2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2251,7 +2251,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_dtrf14" ]
+          "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_btrf14" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2272,7 +2272,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2348,6 +2348,108 @@
     }, {
       "node1" : "bbs1",
       "node2" : "dline11_2"
+    }, {
+      "node1" : "dsect11",
+      "node2" : "INTERNAL_vl1_dtrct11"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct11",
+      "node2" : "dtrct11"
+    }, {
+      "node1" : "dload1",
+      "node2" : "INTERNAL_vl1_bload1"
+    }, {
+      "node1" : "INTERNAL_vl1_bload1",
+      "node2" : "bload1"
+    }, {
+      "node1" : "dtrf11",
+      "node2" : "INTERNAL_vl1_btrf11"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf11",
+      "node2" : "btrf11"
+    }, {
+      "node1" : "dtrf15",
+      "node2" : "INTERNAL_vl1_btrf15"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf15",
+      "node2" : "btrf15"
+    }, {
+      "node1" : "dtrf16",
+      "node2" : "INTERNAL_vl1_btrf16"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf16",
+      "node2" : "btrf16"
+    }, {
+      "node1" : "dline11_2",
+      "node2" : "INTERNAL_vl1_bline11_2"
+    }, {
+      "node1" : "INTERNAL_vl1_bline11_2",
+      "node2" : "bline11_2"
+    }, {
+      "node1" : "dsect12",
+      "node2" : "INTERNAL_vl1_dtrct11"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct11",
+      "node2" : "dtrct11"
+    }, {
+      "node1" : "dload2",
+      "node2" : "INTERNAL_vl1_bload2"
+    }, {
+      "node1" : "INTERNAL_vl1_bload2",
+      "node2" : "bload2"
+    }, {
+      "node1" : "dtrf12",
+      "node2" : "INTERNAL_vl1_btrf12"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf12",
+      "node2" : "btrf12"
+    }, {
+      "node1" : "dtrf18",
+      "node2" : "INTERNAL_vl1_btrf18"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf18",
+      "node2" : "btrf18"
+    }, {
+      "node1" : "dsect21",
+      "node2" : "INTERNAL_vl1_dtrct21"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct21",
+      "node2" : "dtrct21"
+    }, {
+      "node1" : "dgen1",
+      "node2" : "INTERNAL_vl1_bgen1"
+    }, {
+      "node1" : "INTERNAL_vl1_bgen1",
+      "node2" : "bgen1"
+    }, {
+      "node1" : "dtrf13",
+      "node2" : "INTERNAL_vl1_btrf13"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf13",
+      "node2" : "btrf13"
+    }, {
+      "node1" : "dtrf17",
+      "node2" : "INTERNAL_vl1_btrf17"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf17",
+      "node2" : "btrf17"
+    }, {
+      "node1" : "dsect22",
+      "node2" : "INTERNAL_vl1_dtrct21"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct21",
+      "node2" : "dtrct21"
+    }, {
+      "node1" : "dgen2",
+      "node2" : "INTERNAL_vl1_bgen2"
+    }, {
+      "node1" : "INTERNAL_vl1_bgen2",
+      "node2" : "bgen2"
+    }, {
+      "node1" : "dtrf14",
+      "node2" : "INTERNAL_vl1_btrf14"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf14",
+      "node2" : "btrf14"
     }, {
       "node1" : "bload1",
       "node2" : "INTERNAL_vl1_load1"
@@ -2426,108 +2528,6 @@
     }, {
       "node1" : "INTERNAL_vl1_line1_ONE",
       "node2" : "line1_ONE"
-    }, {
-      "node1" : "dtrct11",
-      "node2" : "INTERNAL_vl1_dsect11"
-    }, {
-      "node1" : "dsect11",
-      "node2" : "INTERNAL_vl1_dsect11"
-    }, {
-      "node1" : "bload1",
-      "node2" : "INTERNAL_vl1_dload1"
-    }, {
-      "node1" : "dload1",
-      "node2" : "INTERNAL_vl1_dload1"
-    }, {
-      "node1" : "btrf11",
-      "node2" : "INTERNAL_vl1_dtrf11"
-    }, {
-      "node1" : "dtrf11",
-      "node2" : "INTERNAL_vl1_dtrf11"
-    }, {
-      "node1" : "btrf15",
-      "node2" : "INTERNAL_vl1_dtrf15"
-    }, {
-      "node1" : "dtrf15",
-      "node2" : "INTERNAL_vl1_dtrf15"
-    }, {
-      "node1" : "btrf16",
-      "node2" : "INTERNAL_vl1_dtrf16"
-    }, {
-      "node1" : "dtrf16",
-      "node2" : "INTERNAL_vl1_dtrf16"
-    }, {
-      "node1" : "bline11_2",
-      "node2" : "INTERNAL_vl1_dline11_2"
-    }, {
-      "node1" : "dline11_2",
-      "node2" : "INTERNAL_vl1_dline11_2"
-    }, {
-      "node1" : "dtrct11",
-      "node2" : "INTERNAL_vl1_dsect12"
-    }, {
-      "node1" : "dsect12",
-      "node2" : "INTERNAL_vl1_dsect12"
-    }, {
-      "node1" : "bload2",
-      "node2" : "INTERNAL_vl1_dload2"
-    }, {
-      "node1" : "dload2",
-      "node2" : "INTERNAL_vl1_dload2"
-    }, {
-      "node1" : "btrf12",
-      "node2" : "INTERNAL_vl1_dtrf12"
-    }, {
-      "node1" : "dtrf12",
-      "node2" : "INTERNAL_vl1_dtrf12"
-    }, {
-      "node1" : "btrf18",
-      "node2" : "INTERNAL_vl1_dtrf18"
-    }, {
-      "node1" : "dtrf18",
-      "node2" : "INTERNAL_vl1_dtrf18"
-    }, {
-      "node1" : "dtrct21",
-      "node2" : "INTERNAL_vl1_dsect21"
-    }, {
-      "node1" : "dsect21",
-      "node2" : "INTERNAL_vl1_dsect21"
-    }, {
-      "node1" : "bgen1",
-      "node2" : "INTERNAL_vl1_dgen1"
-    }, {
-      "node1" : "dgen1",
-      "node2" : "INTERNAL_vl1_dgen1"
-    }, {
-      "node1" : "btrf13",
-      "node2" : "INTERNAL_vl1_dtrf13"
-    }, {
-      "node1" : "dtrf13",
-      "node2" : "INTERNAL_vl1_dtrf13"
-    }, {
-      "node1" : "btrf17",
-      "node2" : "INTERNAL_vl1_dtrf17"
-    }, {
-      "node1" : "dtrf17",
-      "node2" : "INTERNAL_vl1_dtrf17"
-    }, {
-      "node1" : "dtrct21",
-      "node2" : "INTERNAL_vl1_dsect22"
-    }, {
-      "node1" : "dsect22",
-      "node2" : "INTERNAL_vl1_dsect22"
-    }, {
-      "node1" : "bgen2",
-      "node2" : "INTERNAL_vl1_dgen2"
-    }, {
-      "node1" : "dgen2",
-      "node2" : "INTERNAL_vl1_dgen2"
-    }, {
-      "node1" : "btrf14",
-      "node2" : "INTERNAL_vl1_dtrf14"
-    }, {
-      "node1" : "dtrf14",
-      "node2" : "INTERNAL_vl1_dtrf14"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],
@@ -2542,7 +2542,7 @@
     "y" : 1025.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dgen4",
+      "id" : "INTERNAL_vl2_bgen4",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -2551,7 +2551,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dload3",
+      "id" : "INTERNAL_vl2_bload3",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2559,23 +2559,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dscpl1",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 75.0,
-      "y" : 240.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dscpl2",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 25.0,
-      "y" : 240.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf21",
+      "id" : "INTERNAL_vl2_btrf21",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2583,7 +2567,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf22",
+      "id" : "INTERNAL_vl2_btrf22",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -2592,7 +2576,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf23",
+      "id" : "INTERNAL_vl2_btrf23",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -2601,7 +2585,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf24",
+      "id" : "INTERNAL_vl2_btrf24",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -2609,7 +2593,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf26",
+      "id" : "INTERNAL_vl2_btrf26",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -2617,7 +2601,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf27",
+      "id" : "INTERNAL_vl2_btrf27",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -2625,12 +2609,28 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf28",
+      "id" : "INTERNAL_vl2_btrf28",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
       "y" : 335.0,
       "orientation" : "DOWN",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl2_ddcpl1",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 75.0,
+      "y" : 240.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl2_ddcpl1",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 25.0,
+      "y" : 240.0,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
@@ -3202,7 +3202,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_dscpl2" ]
+          "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_ddcpl1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3223,7 +3223,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl2_dscpl2", "ddcpl1", "INTERNAL_vl2_dscpl1" ]
+          "nodes" : [ "INTERNAL_vl2_ddcpl1", "ddcpl1", "INTERNAL_vl2_ddcpl1" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -3244,7 +3244,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_dscpl1" ]
+          "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_ddcpl1" ]
         } ]
       }
     }, {
@@ -3292,7 +3292,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_dload3" ]
+          "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_bload3" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3313,7 +3313,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dload3", "bload3", "INTERNAL_vl2_load3" ]
+          "nodes" : [ "INTERNAL_vl2_bload3", "bload3", "INTERNAL_vl2_load3" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3382,7 +3382,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_dtrf21" ]
+          "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_btrf21" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3403,7 +3403,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3472,7 +3472,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_dtrf24" ]
+          "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_btrf24" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3493,7 +3493,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3562,7 +3562,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_dtrf27" ]
+          "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_btrf27" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3583,7 +3583,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf27", "btrf27", "INTERNAL_vl2_trf7_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf27", "btrf27", "INTERNAL_vl2_trf7_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3652,7 +3652,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_dgen4" ]
+          "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_bgen4" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3673,7 +3673,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dgen4", "bgen4", "INTERNAL_vl2_gen4" ]
+          "nodes" : [ "INTERNAL_vl2_bgen4", "bgen4", "INTERNAL_vl2_gen4" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3742,7 +3742,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_dtrf22" ]
+          "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_btrf22" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3763,7 +3763,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3832,7 +3832,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_dtrf23" ]
+          "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_btrf23" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3853,7 +3853,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3922,7 +3922,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_dtrf26" ]
+          "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_btrf26" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3943,7 +3943,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf26", "btrf26", "INTERNAL_vl2_trf6_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf26", "btrf26", "INTERNAL_vl2_trf6_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4012,7 +4012,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_dtrf28" ]
+          "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_btrf28" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4033,7 +4033,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf28", "btrf28", "INTERNAL_vl2_trf8_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf28", "btrf28", "INTERNAL_vl2_trf8_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4092,6 +4092,72 @@
       "node1" : "bbs6",
       "node2" : "dtrf28"
     }, {
+      "node1" : "dscpl1",
+      "node2" : "INTERNAL_vl2_ddcpl1"
+    }, {
+      "node1" : "INTERNAL_vl2_ddcpl1",
+      "node2" : "ddcpl1"
+    }, {
+      "node1" : "dload3",
+      "node2" : "INTERNAL_vl2_bload3"
+    }, {
+      "node1" : "INTERNAL_vl2_bload3",
+      "node2" : "bload3"
+    }, {
+      "node1" : "dtrf21",
+      "node2" : "INTERNAL_vl2_btrf21"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf21",
+      "node2" : "btrf21"
+    }, {
+      "node1" : "dtrf24",
+      "node2" : "INTERNAL_vl2_btrf24"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf24",
+      "node2" : "btrf24"
+    }, {
+      "node1" : "dtrf27",
+      "node2" : "INTERNAL_vl2_btrf27"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf27",
+      "node2" : "btrf27"
+    }, {
+      "node1" : "dscpl2",
+      "node2" : "INTERNAL_vl2_ddcpl1"
+    }, {
+      "node1" : "INTERNAL_vl2_ddcpl1",
+      "node2" : "ddcpl1"
+    }, {
+      "node1" : "dgen4",
+      "node2" : "INTERNAL_vl2_bgen4"
+    }, {
+      "node1" : "INTERNAL_vl2_bgen4",
+      "node2" : "bgen4"
+    }, {
+      "node1" : "dtrf22",
+      "node2" : "INTERNAL_vl2_btrf22"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf22",
+      "node2" : "btrf22"
+    }, {
+      "node1" : "dtrf23",
+      "node2" : "INTERNAL_vl2_btrf23"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf23",
+      "node2" : "btrf23"
+    }, {
+      "node1" : "dtrf26",
+      "node2" : "INTERNAL_vl2_btrf26"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf26",
+      "node2" : "btrf26"
+    }, {
+      "node1" : "dtrf28",
+      "node2" : "INTERNAL_vl2_btrf28"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf28",
+      "node2" : "btrf28"
+    }, {
       "node1" : "bload3",
       "node2" : "INTERNAL_vl2_load3"
     }, {
@@ -4145,72 +4211,6 @@
     }, {
       "node1" : "INTERNAL_vl2_trf8_TWO",
       "node2" : "trf8_TWO"
-    }, {
-      "node1" : "ddcpl1",
-      "node2" : "INTERNAL_vl2_dscpl1"
-    }, {
-      "node1" : "dscpl1",
-      "node2" : "INTERNAL_vl2_dscpl1"
-    }, {
-      "node1" : "bload3",
-      "node2" : "INTERNAL_vl2_dload3"
-    }, {
-      "node1" : "dload3",
-      "node2" : "INTERNAL_vl2_dload3"
-    }, {
-      "node1" : "btrf21",
-      "node2" : "INTERNAL_vl2_dtrf21"
-    }, {
-      "node1" : "dtrf21",
-      "node2" : "INTERNAL_vl2_dtrf21"
-    }, {
-      "node1" : "btrf24",
-      "node2" : "INTERNAL_vl2_dtrf24"
-    }, {
-      "node1" : "dtrf24",
-      "node2" : "INTERNAL_vl2_dtrf24"
-    }, {
-      "node1" : "btrf27",
-      "node2" : "INTERNAL_vl2_dtrf27"
-    }, {
-      "node1" : "dtrf27",
-      "node2" : "INTERNAL_vl2_dtrf27"
-    }, {
-      "node1" : "ddcpl1",
-      "node2" : "INTERNAL_vl2_dscpl2"
-    }, {
-      "node1" : "dscpl2",
-      "node2" : "INTERNAL_vl2_dscpl2"
-    }, {
-      "node1" : "bgen4",
-      "node2" : "INTERNAL_vl2_dgen4"
-    }, {
-      "node1" : "dgen4",
-      "node2" : "INTERNAL_vl2_dgen4"
-    }, {
-      "node1" : "btrf22",
-      "node2" : "INTERNAL_vl2_dtrf22"
-    }, {
-      "node1" : "dtrf22",
-      "node2" : "INTERNAL_vl2_dtrf22"
-    }, {
-      "node1" : "btrf23",
-      "node2" : "INTERNAL_vl2_dtrf23"
-    }, {
-      "node1" : "dtrf23",
-      "node2" : "INTERNAL_vl2_dtrf23"
-    }, {
-      "node1" : "btrf26",
-      "node2" : "INTERNAL_vl2_dtrf26"
-    }, {
-      "node1" : "dtrf26",
-      "node2" : "INTERNAL_vl2_dtrf26"
-    }, {
-      "node1" : "btrf28",
-      "node2" : "INTERNAL_vl2_dtrf28"
-    }, {
-      "node1" : "dtrf28",
-      "node2" : "INTERNAL_vl2_dtrf28"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],
@@ -4225,7 +4225,7 @@
     "y" : 1820.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dload4",
+      "id" : "INTERNAL_vl3_bload4",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -4233,7 +4233,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf25",
+      "id" : "INTERNAL_vl3_btrf25",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -4242,7 +4242,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf36",
+      "id" : "INTERNAL_vl3_btrf36",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -4250,7 +4250,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf37",
+      "id" : "INTERNAL_vl3_btrf37",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -4259,7 +4259,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf38",
+      "id" : "INTERNAL_vl3_btrf38",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -4582,7 +4582,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_dload4" ]
+          "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_bload4" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4603,7 +4603,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dload4", "bload4", "INTERNAL_vl3_load4" ]
+          "nodes" : [ "INTERNAL_vl3_bload4", "bload4", "INTERNAL_vl3_load4" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4672,7 +4672,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_dtrf25" ]
+          "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_btrf25" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4693,7 +4693,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
+          "nodes" : [ "INTERNAL_vl3_btrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4762,7 +4762,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_dtrf36" ]
+          "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_btrf36" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4783,7 +4783,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf36", "btrf36", "INTERNAL_vl3_trf6_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf36", "btrf36", "INTERNAL_vl3_trf6_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4852,7 +4852,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_dtrf37" ]
+          "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_btrf37" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4873,7 +4873,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf37", "btrf37", "INTERNAL_vl3_trf7_ONE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf37", "btrf37", "INTERNAL_vl3_trf7_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4942,7 +4942,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_dtrf38" ]
+          "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_btrf38" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4963,7 +4963,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf38", "btrf38", "INTERNAL_vl3_trf8_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf38", "btrf38", "INTERNAL_vl3_trf8_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -5004,6 +5004,36 @@
       "node1" : "bbs7",
       "node2" : "dtrf38"
     }, {
+      "node1" : "dload4",
+      "node2" : "INTERNAL_vl3_bload4"
+    }, {
+      "node1" : "INTERNAL_vl3_bload4",
+      "node2" : "bload4"
+    }, {
+      "node1" : "dtrf25",
+      "node2" : "INTERNAL_vl3_btrf25"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf25",
+      "node2" : "btrf25"
+    }, {
+      "node1" : "dtrf36",
+      "node2" : "INTERNAL_vl3_btrf36"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf36",
+      "node2" : "btrf36"
+    }, {
+      "node1" : "dtrf37",
+      "node2" : "INTERNAL_vl3_btrf37"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf37",
+      "node2" : "btrf37"
+    }, {
+      "node1" : "dtrf38",
+      "node2" : "INTERNAL_vl3_btrf38"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf38",
+      "node2" : "btrf38"
+    }, {
       "node1" : "bload4",
       "node2" : "INTERNAL_vl3_load4"
     }, {
@@ -5033,36 +5063,6 @@
     }, {
       "node1" : "INTERNAL_vl3_trf8_THREE",
       "node2" : "trf8_THREE"
-    }, {
-      "node1" : "bload4",
-      "node2" : "INTERNAL_vl3_dload4"
-    }, {
-      "node1" : "dload4",
-      "node2" : "INTERNAL_vl3_dload4"
-    }, {
-      "node1" : "btrf25",
-      "node2" : "INTERNAL_vl3_dtrf25"
-    }, {
-      "node1" : "dtrf25",
-      "node2" : "INTERNAL_vl3_dtrf25"
-    }, {
-      "node1" : "btrf36",
-      "node2" : "INTERNAL_vl3_dtrf36"
-    }, {
-      "node1" : "dtrf36",
-      "node2" : "INTERNAL_vl3_dtrf36"
-    }, {
-      "node1" : "btrf37",
-      "node2" : "INTERNAL_vl3_dtrf37"
-    }, {
-      "node1" : "dtrf37",
-      "node2" : "INTERNAL_vl3_dtrf37"
-    }, {
-      "node1" : "btrf38",
-      "node2" : "INTERNAL_vl3_dtrf38"
-    }, {
-      "node1" : "dtrf38",
-      "node2" : "INTERNAL_vl3_dtrf38"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphH.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphH.json
@@ -10,7 +10,7 @@
     "y" : 260.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dgen1",
+      "id" : "INTERNAL_vl1_bgen1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -19,7 +19,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dgen2",
+      "id" : "INTERNAL_vl1_bgen2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 675.0,
@@ -28,7 +28,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dline11_2",
+      "id" : "INTERNAL_vl1_bline11_2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -36,7 +36,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dload1",
+      "id" : "INTERNAL_vl1_bload1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -44,7 +44,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dload2",
+      "id" : "INTERNAL_vl1_bload2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -52,43 +52,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect11",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 400.0,
-      "y" : 280.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect12",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 450.0,
-      "y" : 280.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect21",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 400.0,
-      "y" : 305.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect22",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 450.0,
-      "y" : 305.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf11",
+      "id" : "INTERNAL_vl1_btrf11",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -96,7 +60,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf12",
+      "id" : "INTERNAL_vl1_btrf12",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 625.0,
@@ -104,7 +68,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf13",
+      "id" : "INTERNAL_vl1_btrf13",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -113,7 +77,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf14",
+      "id" : "INTERNAL_vl1_btrf14",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -122,7 +86,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf15",
+      "id" : "INTERNAL_vl1_btrf15",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -130,7 +94,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf16",
+      "id" : "INTERNAL_vl1_btrf16",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -138,7 +102,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf17",
+      "id" : "INTERNAL_vl1_btrf17",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -147,11 +111,47 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf18",
+      "id" : "INTERNAL_vl1_btrf18",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
       "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct11",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 400.0,
+      "y" : 280.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct11",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 450.0,
+      "y" : 280.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct21",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 400.0,
+      "y" : 305.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct21",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 450.0,
+      "y" : 305.0,
+      "orientation" : "RIGHT",
       "open" : false
     }, {
       "type" : "FICTITIOUS",
@@ -992,7 +992,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dsect12" ]
+          "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dtrct11" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1013,7 +1013,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl1_dsect11", "dtrct11", "INTERNAL_vl1_dsect12" ]
+          "nodes" : [ "INTERNAL_vl1_dtrct11", "dtrct11", "INTERNAL_vl1_dtrct11" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -1034,7 +1034,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dsect11" ]
+          "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dtrct11" ]
         } ]
       }
     }, {
@@ -1081,7 +1081,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dsect22" ]
+          "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dtrct21" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1102,7 +1102,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl1_dsect21", "dtrct21", "INTERNAL_vl1_dsect22" ]
+          "nodes" : [ "INTERNAL_vl1_dtrct21", "dtrct21", "INTERNAL_vl1_dtrct21" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -1123,7 +1123,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dsect21" ]
+          "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dtrct21" ]
         } ]
       }
     }, {
@@ -1171,7 +1171,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_dload1" ]
+          "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_bload1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1192,7 +1192,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dload1", "bload1", "INTERNAL_vl1_load1" ]
+          "nodes" : [ "INTERNAL_vl1_bload1", "bload1", "INTERNAL_vl1_load1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1261,7 +1261,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_dtrf11" ]
+          "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_btrf11" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1282,7 +1282,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1351,7 +1351,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_dtrf15" ]
+          "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_btrf15" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1372,7 +1372,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1441,7 +1441,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_dtrf16" ]
+          "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_btrf16" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1462,7 +1462,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf16", "btrf16", "INTERNAL_vl1_trf6_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf16", "btrf16", "INTERNAL_vl1_trf6_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1531,7 +1531,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dline11_2", "INTERNAL_vl1_dline11_2" ]
+          "nodes" : [ "bbs1", "dline11_2", "INTERNAL_vl1_bline11_2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1552,7 +1552,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dline11_2", "bline11_2", "INTERNAL_vl1_line1_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_bline11_2", "bline11_2", "INTERNAL_vl1_line1_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1621,7 +1621,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_dload2" ]
+          "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_bload2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1642,7 +1642,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dload2", "bload2", "INTERNAL_vl1_load2" ]
+          "nodes" : [ "INTERNAL_vl1_bload2", "bload2", "INTERNAL_vl1_load2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1711,7 +1711,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_dtrf12" ]
+          "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_btrf12" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1732,7 +1732,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1801,7 +1801,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_dtrf18" ]
+          "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_btrf18" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1822,7 +1822,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf18", "btrf18", "INTERNAL_vl1_trf8_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf18", "btrf18", "INTERNAL_vl1_trf8_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1891,7 +1891,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_dgen1" ]
+          "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_bgen1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1912,7 +1912,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dgen1", "bgen1", "INTERNAL_vl1_gen1" ]
+          "nodes" : [ "INTERNAL_vl1_bgen1", "bgen1", "INTERNAL_vl1_gen1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1981,7 +1981,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_dtrf13" ]
+          "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_btrf13" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2002,7 +2002,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2071,7 +2071,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_dtrf17" ]
+          "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_btrf17" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2092,7 +2092,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf17", "btrf17", "INTERNAL_vl1_trf7_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf17", "btrf17", "INTERNAL_vl1_trf7_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2161,7 +2161,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_dgen2" ]
+          "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_bgen2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2182,7 +2182,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dgen2", "bgen2", "INTERNAL_vl1_gen2" ]
+          "nodes" : [ "INTERNAL_vl1_bgen2", "bgen2", "INTERNAL_vl1_gen2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2251,7 +2251,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_dtrf14" ]
+          "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_btrf14" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2272,7 +2272,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2348,6 +2348,108 @@
     }, {
       "node1" : "bbs1",
       "node2" : "dline11_2"
+    }, {
+      "node1" : "dsect11",
+      "node2" : "INTERNAL_vl1_dtrct11"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct11",
+      "node2" : "dtrct11"
+    }, {
+      "node1" : "dload1",
+      "node2" : "INTERNAL_vl1_bload1"
+    }, {
+      "node1" : "INTERNAL_vl1_bload1",
+      "node2" : "bload1"
+    }, {
+      "node1" : "dtrf11",
+      "node2" : "INTERNAL_vl1_btrf11"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf11",
+      "node2" : "btrf11"
+    }, {
+      "node1" : "dtrf15",
+      "node2" : "INTERNAL_vl1_btrf15"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf15",
+      "node2" : "btrf15"
+    }, {
+      "node1" : "dtrf16",
+      "node2" : "INTERNAL_vl1_btrf16"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf16",
+      "node2" : "btrf16"
+    }, {
+      "node1" : "dline11_2",
+      "node2" : "INTERNAL_vl1_bline11_2"
+    }, {
+      "node1" : "INTERNAL_vl1_bline11_2",
+      "node2" : "bline11_2"
+    }, {
+      "node1" : "dsect12",
+      "node2" : "INTERNAL_vl1_dtrct11"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct11",
+      "node2" : "dtrct11"
+    }, {
+      "node1" : "dload2",
+      "node2" : "INTERNAL_vl1_bload2"
+    }, {
+      "node1" : "INTERNAL_vl1_bload2",
+      "node2" : "bload2"
+    }, {
+      "node1" : "dtrf12",
+      "node2" : "INTERNAL_vl1_btrf12"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf12",
+      "node2" : "btrf12"
+    }, {
+      "node1" : "dtrf18",
+      "node2" : "INTERNAL_vl1_btrf18"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf18",
+      "node2" : "btrf18"
+    }, {
+      "node1" : "dsect21",
+      "node2" : "INTERNAL_vl1_dtrct21"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct21",
+      "node2" : "dtrct21"
+    }, {
+      "node1" : "dgen1",
+      "node2" : "INTERNAL_vl1_bgen1"
+    }, {
+      "node1" : "INTERNAL_vl1_bgen1",
+      "node2" : "bgen1"
+    }, {
+      "node1" : "dtrf13",
+      "node2" : "INTERNAL_vl1_btrf13"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf13",
+      "node2" : "btrf13"
+    }, {
+      "node1" : "dtrf17",
+      "node2" : "INTERNAL_vl1_btrf17"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf17",
+      "node2" : "btrf17"
+    }, {
+      "node1" : "dsect22",
+      "node2" : "INTERNAL_vl1_dtrct21"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct21",
+      "node2" : "dtrct21"
+    }, {
+      "node1" : "dgen2",
+      "node2" : "INTERNAL_vl1_bgen2"
+    }, {
+      "node1" : "INTERNAL_vl1_bgen2",
+      "node2" : "bgen2"
+    }, {
+      "node1" : "dtrf14",
+      "node2" : "INTERNAL_vl1_btrf14"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf14",
+      "node2" : "btrf14"
     }, {
       "node1" : "bload1",
       "node2" : "INTERNAL_vl1_load1"
@@ -2426,108 +2528,6 @@
     }, {
       "node1" : "INTERNAL_vl1_line1_ONE",
       "node2" : "line1_ONE"
-    }, {
-      "node1" : "dtrct11",
-      "node2" : "INTERNAL_vl1_dsect11"
-    }, {
-      "node1" : "dsect11",
-      "node2" : "INTERNAL_vl1_dsect11"
-    }, {
-      "node1" : "bload1",
-      "node2" : "INTERNAL_vl1_dload1"
-    }, {
-      "node1" : "dload1",
-      "node2" : "INTERNAL_vl1_dload1"
-    }, {
-      "node1" : "btrf11",
-      "node2" : "INTERNAL_vl1_dtrf11"
-    }, {
-      "node1" : "dtrf11",
-      "node2" : "INTERNAL_vl1_dtrf11"
-    }, {
-      "node1" : "btrf15",
-      "node2" : "INTERNAL_vl1_dtrf15"
-    }, {
-      "node1" : "dtrf15",
-      "node2" : "INTERNAL_vl1_dtrf15"
-    }, {
-      "node1" : "btrf16",
-      "node2" : "INTERNAL_vl1_dtrf16"
-    }, {
-      "node1" : "dtrf16",
-      "node2" : "INTERNAL_vl1_dtrf16"
-    }, {
-      "node1" : "bline11_2",
-      "node2" : "INTERNAL_vl1_dline11_2"
-    }, {
-      "node1" : "dline11_2",
-      "node2" : "INTERNAL_vl1_dline11_2"
-    }, {
-      "node1" : "dtrct11",
-      "node2" : "INTERNAL_vl1_dsect12"
-    }, {
-      "node1" : "dsect12",
-      "node2" : "INTERNAL_vl1_dsect12"
-    }, {
-      "node1" : "bload2",
-      "node2" : "INTERNAL_vl1_dload2"
-    }, {
-      "node1" : "dload2",
-      "node2" : "INTERNAL_vl1_dload2"
-    }, {
-      "node1" : "btrf12",
-      "node2" : "INTERNAL_vl1_dtrf12"
-    }, {
-      "node1" : "dtrf12",
-      "node2" : "INTERNAL_vl1_dtrf12"
-    }, {
-      "node1" : "btrf18",
-      "node2" : "INTERNAL_vl1_dtrf18"
-    }, {
-      "node1" : "dtrf18",
-      "node2" : "INTERNAL_vl1_dtrf18"
-    }, {
-      "node1" : "dtrct21",
-      "node2" : "INTERNAL_vl1_dsect21"
-    }, {
-      "node1" : "dsect21",
-      "node2" : "INTERNAL_vl1_dsect21"
-    }, {
-      "node1" : "bgen1",
-      "node2" : "INTERNAL_vl1_dgen1"
-    }, {
-      "node1" : "dgen1",
-      "node2" : "INTERNAL_vl1_dgen1"
-    }, {
-      "node1" : "btrf13",
-      "node2" : "INTERNAL_vl1_dtrf13"
-    }, {
-      "node1" : "dtrf13",
-      "node2" : "INTERNAL_vl1_dtrf13"
-    }, {
-      "node1" : "btrf17",
-      "node2" : "INTERNAL_vl1_dtrf17"
-    }, {
-      "node1" : "dtrf17",
-      "node2" : "INTERNAL_vl1_dtrf17"
-    }, {
-      "node1" : "dtrct21",
-      "node2" : "INTERNAL_vl1_dsect22"
-    }, {
-      "node1" : "dsect22",
-      "node2" : "INTERNAL_vl1_dsect22"
-    }, {
-      "node1" : "bgen2",
-      "node2" : "INTERNAL_vl1_dgen2"
-    }, {
-      "node1" : "dgen2",
-      "node2" : "INTERNAL_vl1_dgen2"
-    }, {
-      "node1" : "btrf14",
-      "node2" : "INTERNAL_vl1_dtrf14"
-    }, {
-      "node1" : "dtrf14",
-      "node2" : "INTERNAL_vl1_dtrf14"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],
@@ -2542,7 +2542,7 @@
     "y" : 260.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dgen4",
+      "id" : "INTERNAL_vl2_bgen4",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -2551,7 +2551,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dload3",
+      "id" : "INTERNAL_vl2_bload3",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2559,23 +2559,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dscpl1",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 75.0,
-      "y" : 240.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dscpl2",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 25.0,
-      "y" : 240.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf21",
+      "id" : "INTERNAL_vl2_btrf21",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2583,7 +2567,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf22",
+      "id" : "INTERNAL_vl2_btrf22",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -2592,7 +2576,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf23",
+      "id" : "INTERNAL_vl2_btrf23",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -2601,7 +2585,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf24",
+      "id" : "INTERNAL_vl2_btrf24",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -2609,7 +2593,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf26",
+      "id" : "INTERNAL_vl2_btrf26",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -2617,7 +2601,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf27",
+      "id" : "INTERNAL_vl2_btrf27",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -2625,12 +2609,28 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf28",
+      "id" : "INTERNAL_vl2_btrf28",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
       "y" : 335.0,
       "orientation" : "DOWN",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl2_ddcpl1",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 75.0,
+      "y" : 240.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl2_ddcpl1",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 25.0,
+      "y" : 240.0,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
@@ -3202,7 +3202,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_dscpl2" ]
+          "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_ddcpl1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3223,7 +3223,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl2_dscpl2", "ddcpl1", "INTERNAL_vl2_dscpl1" ]
+          "nodes" : [ "INTERNAL_vl2_ddcpl1", "ddcpl1", "INTERNAL_vl2_ddcpl1" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -3244,7 +3244,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_dscpl1" ]
+          "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_ddcpl1" ]
         } ]
       }
     }, {
@@ -3292,7 +3292,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_dload3" ]
+          "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_bload3" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3313,7 +3313,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dload3", "bload3", "INTERNAL_vl2_load3" ]
+          "nodes" : [ "INTERNAL_vl2_bload3", "bload3", "INTERNAL_vl2_load3" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3382,7 +3382,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_dtrf21" ]
+          "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_btrf21" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3403,7 +3403,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3472,7 +3472,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_dtrf24" ]
+          "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_btrf24" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3493,7 +3493,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3562,7 +3562,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_dtrf27" ]
+          "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_btrf27" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3583,7 +3583,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf27", "btrf27", "INTERNAL_vl2_trf7_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf27", "btrf27", "INTERNAL_vl2_trf7_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3652,7 +3652,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_dgen4" ]
+          "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_bgen4" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3673,7 +3673,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dgen4", "bgen4", "INTERNAL_vl2_gen4" ]
+          "nodes" : [ "INTERNAL_vl2_bgen4", "bgen4", "INTERNAL_vl2_gen4" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3742,7 +3742,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_dtrf22" ]
+          "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_btrf22" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3763,7 +3763,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3832,7 +3832,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_dtrf23" ]
+          "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_btrf23" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3853,7 +3853,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3922,7 +3922,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_dtrf26" ]
+          "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_btrf26" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3943,7 +3943,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf26", "btrf26", "INTERNAL_vl2_trf6_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf26", "btrf26", "INTERNAL_vl2_trf6_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4012,7 +4012,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_dtrf28" ]
+          "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_btrf28" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4033,7 +4033,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf28", "btrf28", "INTERNAL_vl2_trf8_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf28", "btrf28", "INTERNAL_vl2_trf8_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4092,6 +4092,72 @@
       "node1" : "bbs6",
       "node2" : "dtrf28"
     }, {
+      "node1" : "dscpl1",
+      "node2" : "INTERNAL_vl2_ddcpl1"
+    }, {
+      "node1" : "INTERNAL_vl2_ddcpl1",
+      "node2" : "ddcpl1"
+    }, {
+      "node1" : "dload3",
+      "node2" : "INTERNAL_vl2_bload3"
+    }, {
+      "node1" : "INTERNAL_vl2_bload3",
+      "node2" : "bload3"
+    }, {
+      "node1" : "dtrf21",
+      "node2" : "INTERNAL_vl2_btrf21"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf21",
+      "node2" : "btrf21"
+    }, {
+      "node1" : "dtrf24",
+      "node2" : "INTERNAL_vl2_btrf24"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf24",
+      "node2" : "btrf24"
+    }, {
+      "node1" : "dtrf27",
+      "node2" : "INTERNAL_vl2_btrf27"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf27",
+      "node2" : "btrf27"
+    }, {
+      "node1" : "dscpl2",
+      "node2" : "INTERNAL_vl2_ddcpl1"
+    }, {
+      "node1" : "INTERNAL_vl2_ddcpl1",
+      "node2" : "ddcpl1"
+    }, {
+      "node1" : "dgen4",
+      "node2" : "INTERNAL_vl2_bgen4"
+    }, {
+      "node1" : "INTERNAL_vl2_bgen4",
+      "node2" : "bgen4"
+    }, {
+      "node1" : "dtrf22",
+      "node2" : "INTERNAL_vl2_btrf22"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf22",
+      "node2" : "btrf22"
+    }, {
+      "node1" : "dtrf23",
+      "node2" : "INTERNAL_vl2_btrf23"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf23",
+      "node2" : "btrf23"
+    }, {
+      "node1" : "dtrf26",
+      "node2" : "INTERNAL_vl2_btrf26"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf26",
+      "node2" : "btrf26"
+    }, {
+      "node1" : "dtrf28",
+      "node2" : "INTERNAL_vl2_btrf28"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf28",
+      "node2" : "btrf28"
+    }, {
       "node1" : "bload3",
       "node2" : "INTERNAL_vl2_load3"
     }, {
@@ -4145,72 +4211,6 @@
     }, {
       "node1" : "INTERNAL_vl2_trf8_TWO",
       "node2" : "trf8_TWO"
-    }, {
-      "node1" : "ddcpl1",
-      "node2" : "INTERNAL_vl2_dscpl1"
-    }, {
-      "node1" : "dscpl1",
-      "node2" : "INTERNAL_vl2_dscpl1"
-    }, {
-      "node1" : "bload3",
-      "node2" : "INTERNAL_vl2_dload3"
-    }, {
-      "node1" : "dload3",
-      "node2" : "INTERNAL_vl2_dload3"
-    }, {
-      "node1" : "btrf21",
-      "node2" : "INTERNAL_vl2_dtrf21"
-    }, {
-      "node1" : "dtrf21",
-      "node2" : "INTERNAL_vl2_dtrf21"
-    }, {
-      "node1" : "btrf24",
-      "node2" : "INTERNAL_vl2_dtrf24"
-    }, {
-      "node1" : "dtrf24",
-      "node2" : "INTERNAL_vl2_dtrf24"
-    }, {
-      "node1" : "btrf27",
-      "node2" : "INTERNAL_vl2_dtrf27"
-    }, {
-      "node1" : "dtrf27",
-      "node2" : "INTERNAL_vl2_dtrf27"
-    }, {
-      "node1" : "ddcpl1",
-      "node2" : "INTERNAL_vl2_dscpl2"
-    }, {
-      "node1" : "dscpl2",
-      "node2" : "INTERNAL_vl2_dscpl2"
-    }, {
-      "node1" : "bgen4",
-      "node2" : "INTERNAL_vl2_dgen4"
-    }, {
-      "node1" : "dgen4",
-      "node2" : "INTERNAL_vl2_dgen4"
-    }, {
-      "node1" : "btrf22",
-      "node2" : "INTERNAL_vl2_dtrf22"
-    }, {
-      "node1" : "dtrf22",
-      "node2" : "INTERNAL_vl2_dtrf22"
-    }, {
-      "node1" : "btrf23",
-      "node2" : "INTERNAL_vl2_dtrf23"
-    }, {
-      "node1" : "dtrf23",
-      "node2" : "INTERNAL_vl2_dtrf23"
-    }, {
-      "node1" : "btrf26",
-      "node2" : "INTERNAL_vl2_dtrf26"
-    }, {
-      "node1" : "dtrf26",
-      "node2" : "INTERNAL_vl2_dtrf26"
-    }, {
-      "node1" : "btrf28",
-      "node2" : "INTERNAL_vl2_dtrf28"
-    }, {
-      "node1" : "dtrf28",
-      "node2" : "INTERNAL_vl2_dtrf28"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],
@@ -4225,7 +4225,7 @@
     "y" : 260.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dload4",
+      "id" : "INTERNAL_vl3_bload4",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -4233,7 +4233,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf25",
+      "id" : "INTERNAL_vl3_btrf25",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -4242,7 +4242,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf36",
+      "id" : "INTERNAL_vl3_btrf36",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -4250,7 +4250,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf37",
+      "id" : "INTERNAL_vl3_btrf37",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -4259,7 +4259,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf38",
+      "id" : "INTERNAL_vl3_btrf38",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -4582,7 +4582,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_dload4" ]
+          "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_bload4" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4603,7 +4603,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dload4", "bload4", "INTERNAL_vl3_load4" ]
+          "nodes" : [ "INTERNAL_vl3_bload4", "bload4", "INTERNAL_vl3_load4" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4672,7 +4672,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_dtrf25" ]
+          "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_btrf25" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4693,7 +4693,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
+          "nodes" : [ "INTERNAL_vl3_btrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4762,7 +4762,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_dtrf36" ]
+          "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_btrf36" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4783,7 +4783,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf36", "btrf36", "INTERNAL_vl3_trf6_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf36", "btrf36", "INTERNAL_vl3_trf6_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4852,7 +4852,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_dtrf37" ]
+          "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_btrf37" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4873,7 +4873,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf37", "btrf37", "INTERNAL_vl3_trf7_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf37", "btrf37", "INTERNAL_vl3_trf7_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4942,7 +4942,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_dtrf38" ]
+          "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_btrf38" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4963,7 +4963,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf38", "btrf38", "INTERNAL_vl3_trf8_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf38", "btrf38", "INTERNAL_vl3_trf8_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -5004,6 +5004,36 @@
       "node1" : "bbs7",
       "node2" : "dtrf38"
     }, {
+      "node1" : "dload4",
+      "node2" : "INTERNAL_vl3_bload4"
+    }, {
+      "node1" : "INTERNAL_vl3_bload4",
+      "node2" : "bload4"
+    }, {
+      "node1" : "dtrf25",
+      "node2" : "INTERNAL_vl3_btrf25"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf25",
+      "node2" : "btrf25"
+    }, {
+      "node1" : "dtrf36",
+      "node2" : "INTERNAL_vl3_btrf36"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf36",
+      "node2" : "btrf36"
+    }, {
+      "node1" : "dtrf37",
+      "node2" : "INTERNAL_vl3_btrf37"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf37",
+      "node2" : "btrf37"
+    }, {
+      "node1" : "dtrf38",
+      "node2" : "INTERNAL_vl3_btrf38"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf38",
+      "node2" : "btrf38"
+    }, {
       "node1" : "bload4",
       "node2" : "INTERNAL_vl3_load4"
     }, {
@@ -5033,36 +5063,6 @@
     }, {
       "node1" : "INTERNAL_vl3_trf8_THREE",
       "node2" : "trf8_THREE"
-    }, {
-      "node1" : "bload4",
-      "node2" : "INTERNAL_vl3_dload4"
-    }, {
-      "node1" : "dload4",
-      "node2" : "INTERNAL_vl3_dload4"
-    }, {
-      "node1" : "btrf25",
-      "node2" : "INTERNAL_vl3_dtrf25"
-    }, {
-      "node1" : "dtrf25",
-      "node2" : "INTERNAL_vl3_dtrf25"
-    }, {
-      "node1" : "btrf36",
-      "node2" : "INTERNAL_vl3_dtrf36"
-    }, {
-      "node1" : "dtrf36",
-      "node2" : "INTERNAL_vl3_dtrf36"
-    }, {
-      "node1" : "btrf37",
-      "node2" : "INTERNAL_vl3_dtrf37"
-    }, {
-      "node1" : "dtrf37",
-      "node2" : "INTERNAL_vl3_dtrf37"
-    }, {
-      "node1" : "btrf38",
-      "node2" : "INTERNAL_vl3_dtrf38"
-    }, {
-      "node1" : "dtrf38",
-      "node2" : "INTERNAL_vl3_dtrf38"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHFirst.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHFirst.svg
@@ -214,20 +214,20 @@
             <text class="sld-label" id="bbs4_NW_LABEL" x="-5.0" y="-5.0">bbs4</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dsect11" transform="translate(436.0,428.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(436.0,428.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dsect12" transform="translate(486.0,428.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(486.0,428.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bbs1_95_dsect11">
                 <polyline points="427.5,432.0,440.0,432.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect11">
-                <polyline points="455.0,432.0,440.0,432.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11">
+                <polyline points="440.0,432.0,455.0,432.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect12">
-                <polyline points="475.0,432.0,490.0,432.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11">
+                <polyline points="490.0,432.0,475.0,432.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dsect12_95_bbs2">
                 <polyline points="490.0,432.0,502.5,432.0"/>
@@ -246,20 +246,20 @@
             </g>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dsect21" transform="translate(436.0,453.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(436.0,453.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dsect22" transform="translate(486.0,453.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(486.0,453.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bbs3_95_dsect21">
                 <polyline points="427.5,457.0,440.0,457.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect21">
-                <polyline points="455.0,457.0,440.0,457.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21">
+                <polyline points="440.0,457.0,455.0,457.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect22">
-                <polyline points="475.0,457.0,490.0,457.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21">
+                <polyline points="490.0,457.0,475.0,457.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dsect22_95_bbs4">
                 <polyline points="490.0,457.0,502.5,457.0"/>
@@ -278,7 +278,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dload1" transform="translate(61.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bload1" transform="translate(61.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_load1" transform="translate(61.0,318.0)">
@@ -290,11 +290,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load1_N_LABEL" x="-5.0" y="-5.0">load1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_dload1">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_bload1">
                 <polyline points="65.0,432.0,65.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_dload1">
-                <polyline points="65.0,372.0,65.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bload1_95_bload1">
+                <polyline points="65.0,402.0,65.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_load1">
                 <polyline points="65.0,352.0,65.0,322.0"/>
@@ -322,7 +322,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf11" transform="translate(111.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf11" transform="translate(111.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf1_95_ONE" transform="translate(111.0,318.0)">
@@ -331,11 +331,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf1_95_ONE" transform="translate(115.0,260.0)">
                 <text class="sld-label" id="trf1_ONE_N_LABEL" x="-5.0" y="-5.0">trf1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_dtrf11">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_btrf11">
                 <polyline points="115.0,432.0,115.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_dtrf11">
-                <polyline points="115.0,372.0,115.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf11_95_btrf11">
+                <polyline points="115.0,402.0,115.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_trf1_95_ONE">
                 <polyline points="115.0,352.0,115.0,322.0"/>
@@ -363,7 +363,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf15" transform="translate(261.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf15" transform="translate(261.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf5_95_ONE" transform="translate(261.0,318.0)">
@@ -372,11 +372,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf5_95_ONE" transform="translate(265.0,260.0)">
                 <text class="sld-label" id="trf5_ONE_N_LABEL" x="-5.0" y="-5.0">trf5</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_dtrf15">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_btrf15">
                 <polyline points="265.0,432.0,265.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_dtrf15">
-                <polyline points="265.0,372.0,265.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf15_95_btrf15">
+                <polyline points="265.0,402.0,265.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_trf5_95_ONE">
                 <polyline points="265.0,352.0,265.0,322.0"/>
@@ -404,7 +404,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf16" transform="translate(311.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf16" transform="translate(311.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf6_95_ONE" transform="translate(311.0,318.0)">
@@ -413,11 +413,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf6_95_ONE" transform="translate(315.0,260.0)">
                 <text class="sld-label" id="trf6_ONE_N_LABEL" x="-5.0" y="-5.0">trf61</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_dtrf16">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_btrf16">
                 <polyline points="315.0,432.0,315.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf16_95_INTERNAL_95_vl1_95_dtrf16">
-                <polyline points="315.0,372.0,315.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf16_95_btrf16">
+                <polyline points="315.0,402.0,315.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf16_95_INTERNAL_95_vl1_95_trf6_95_ONE">
                 <polyline points="315.0,352.0,315.0,322.0"/>
@@ -445,7 +445,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dline11_95_2" transform="translate(411.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bline11_95_2" transform="translate(411.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_line1_95_ONE" transform="translate(411.0,318.0)">
@@ -454,11 +454,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idline1_95_ONE" transform="translate(415.0,260.0)">
                 <text class="sld-label" id="line1_ONE_N_LABEL" x="-5.0" y="-5.0">line1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dline11_95_2_95_INTERNAL_95_vl1_95_dline11_95_2">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dline11_95_2_95_INTERNAL_95_vl1_95_bline11_95_2">
                 <polyline points="415.0,432.0,415.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bline11_95_2_95_INTERNAL_95_vl1_95_dline11_95_2">
-                <polyline points="415.0,372.0,415.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bline11_95_2_95_bline11_95_2">
+                <polyline points="415.0,402.0,415.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bline11_95_2_95_INTERNAL_95_vl1_95_line1_95_ONE">
                 <polyline points="415.0,352.0,415.0,322.0"/>
@@ -486,7 +486,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dload2" transform="translate(511.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bload2" transform="translate(511.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_load2" transform="translate(511.0,318.0)">
@@ -498,11 +498,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load2_N_LABEL" x="-5.0" y="-5.0">load2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_dload2">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_bload2">
                 <polyline points="515.0,432.0,515.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_dload2">
-                <polyline points="515.0,372.0,515.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bload2_95_bload2">
+                <polyline points="515.0,402.0,515.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_load2">
                 <polyline points="515.0,352.0,515.0,322.0"/>
@@ -530,7 +530,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf12" transform="translate(661.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf12" transform="translate(661.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf2_95_ONE" transform="translate(661.0,318.0)">
@@ -539,11 +539,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf2_95_ONE" transform="translate(665.0,260.0)">
                 <text class="sld-label" id="trf2_ONE_N_LABEL" x="-5.0" y="-5.0">trf2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_dtrf12">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_btrf12">
                 <polyline points="665.0,432.0,665.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_dtrf12">
-                <polyline points="665.0,372.0,665.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf12_95_btrf12">
+                <polyline points="665.0,402.0,665.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_trf2_95_ONE">
                 <polyline points="665.0,352.0,665.0,322.0"/>
@@ -571,7 +571,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf18" transform="translate(561.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf18" transform="translate(561.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf8_95_ONE" transform="translate(561.0,318.0)">
@@ -580,11 +580,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf8_95_ONE" transform="translate(565.0,260.0)">
                 <text class="sld-label" id="trf8_ONE_N_LABEL" x="-5.0" y="-5.0">trf81</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_dtrf18">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_btrf18">
                 <polyline points="565.0,432.0,565.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_dtrf18">
-                <polyline points="565.0,372.0,565.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf18_95_btrf18">
+                <polyline points="565.0,402.0,565.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_trf8_95_ONE">
                 <polyline points="565.0,352.0,565.0,322.0"/>
@@ -612,7 +612,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_10">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dgen1" transform="translate(161.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_bgen1" transform="translate(161.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_gen1" transform="translate(161.0,563.0)">
@@ -624,11 +624,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen1_S_LABEL" x="-5.0" y="17.0">gen1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_dgen1">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_bgen1">
                 <polyline points="165.0,457.0,165.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_dgen1">
-                <polyline points="165.0,517.0,165.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_bgen1_95_bgen1">
+                <polyline points="165.0,487.0,165.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_gen1">
                 <polyline points="165.0,537.0,165.0,567.0"/>
@@ -656,7 +656,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_11">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf13" transform="translate(211.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf13" transform="translate(211.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf3_95_ONE" transform="translate(211.0,563.0)">
@@ -665,11 +665,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf3_95_ONE" transform="translate(215.0,629.0)">
                 <text class="sld-label" id="trf3_ONE_S_LABEL" x="-5.0" y="5.0">trf3</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_dtrf13">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_btrf13">
                 <polyline points="215.0,457.0,215.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_dtrf13">
-                <polyline points="215.0,517.0,215.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf13_95_btrf13">
+                <polyline points="215.0,487.0,215.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_trf3_95_ONE">
                 <polyline points="215.0,537.0,215.0,567.0"/>
@@ -697,7 +697,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_12">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf17" transform="translate(361.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf17" transform="translate(361.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf7_95_ONE" transform="translate(361.0,563.0)">
@@ -706,11 +706,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf7_95_ONE" transform="translate(365.0,629.0)">
                 <text class="sld-label" id="trf7_ONE_S_LABEL" x="-5.0" y="5.0">trf71</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_dtrf17">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_btrf17">
                 <polyline points="365.0,457.0,365.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf17_95_INTERNAL_95_vl1_95_dtrf17">
-                <polyline points="365.0,517.0,365.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf17_95_btrf17">
+                <polyline points="365.0,487.0,365.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf17_95_INTERNAL_95_vl1_95_trf7_95_ONE">
                 <polyline points="365.0,537.0,365.0,567.0"/>
@@ -738,7 +738,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_13">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dgen2" transform="translate(711.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_bgen2" transform="translate(711.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_gen2" transform="translate(711.0,563.0)">
@@ -750,11 +750,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen2_S_LABEL" x="-5.0" y="17.0">gen2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_dgen2">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_bgen2">
                 <polyline points="715.0,457.0,715.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_dgen2">
-                <polyline points="715.0,517.0,715.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_bgen2_95_bgen2">
+                <polyline points="715.0,487.0,715.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_gen2">
                 <polyline points="715.0,537.0,715.0,567.0"/>
@@ -782,7 +782,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_14">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf14" transform="translate(611.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf14" transform="translate(611.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf4_95_ONE" transform="translate(611.0,563.0)">
@@ -791,11 +791,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf4_95_ONE" transform="translate(615.0,629.0)">
                 <text class="sld-label" id="trf4_ONE_S_LABEL" x="-5.0" y="5.0">trf4</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_dtrf14">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_btrf14">
                 <polyline points="615.0,457.0,615.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_dtrf14">
-                <polyline points="615.0,517.0,615.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf14_95_btrf14">
+                <polyline points="615.0,487.0,615.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_trf4_95_ONE">
                 <polyline points="615.0,537.0,615.0,567.0"/>
@@ -834,22 +834,22 @@
             <text class="sld-label" id="bbs6_NW_LABEL" x="-5.0" y="-5.0">bbs6</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-vertical" id="idINTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dscpl1" transform="translate(941.0,388.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_ddcpl1" transform="translate(941.0,388.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dscpl2" transform="translate(891.0,388.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_ddcpl1" transform="translate(891.0,388.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl1_95_INTERNAL_95_vl2_95_dscpl1">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl1_95_INTERNAL_95_vl2_95_ddcpl1">
                 <polyline points="945.0,432.0,945.0,392.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_ddcpl1_95_INTERNAL_95_vl2_95_dscpl1">
-                <polyline points="930.0,392.0,945.0,392.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_ddcpl1_95_ddcpl1">
+                <polyline points="945.0,392.0,930.0,392.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_ddcpl1_95_INTERNAL_95_vl2_95_dscpl2">
-                <polyline points="910.0,392.0,895.0,392.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_ddcpl1_95_ddcpl1">
+                <polyline points="895.0,392.0,910.0,392.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl2_95_INTERNAL_95_vl2_95_dscpl2">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl2_95_INTERNAL_95_vl2_95_ddcpl1">
                 <polyline points="895.0,457.0,895.0,392.0"/>
             </g>
             <g class="sld-disconnector sld-closed sld-fictitious sld-vl180to300-0" id="iddscpl1" transform="translate(941.0,428.0)">
@@ -866,7 +866,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dload3" transform="translate(991.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_bload3" transform="translate(991.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_load3" transform="translate(991.0,318.0)">
@@ -878,11 +878,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load3_N_LABEL" x="-5.0" y="-5.0">load3</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dload3_95_INTERNAL_95_vl2_95_dload3">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dload3_95_INTERNAL_95_vl2_95_bload3">
                 <polyline points="995.0,432.0,995.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bload3_95_INTERNAL_95_vl2_95_dload3">
-                <polyline points="995.0,372.0,995.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_bload3_95_bload3">
+                <polyline points="995.0,402.0,995.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bload3_95_INTERNAL_95_vl2_95_load3">
                 <polyline points="995.0,352.0,995.0,322.0"/>
@@ -910,7 +910,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf21" transform="translate(1041.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf21" transform="translate(1041.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf1_95_TWO" transform="translate(1041.0,318.0)">
@@ -919,11 +919,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf1_95_TWO" transform="translate(1045.0,260.0)">
                 <text class="sld-label" id="trf1_TWO_N_LABEL" x="-5.0" y="-5.0">trf1</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf21_95_INTERNAL_95_vl2_95_dtrf21">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf21_95_INTERNAL_95_vl2_95_btrf21">
                 <polyline points="1045.0,432.0,1045.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf21_95_INTERNAL_95_vl2_95_dtrf21">
-                <polyline points="1045.0,372.0,1045.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf21_95_btrf21">
+                <polyline points="1045.0,402.0,1045.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf21_95_INTERNAL_95_vl2_95_trf1_95_TWO">
                 <polyline points="1045.0,352.0,1045.0,322.0"/>
@@ -951,7 +951,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf24" transform="translate(1141.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf24" transform="translate(1141.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf4_95_TWO" transform="translate(1141.0,318.0)">
@@ -960,11 +960,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf4_95_TWO" transform="translate(1145.0,260.0)">
                 <text class="sld-label" id="trf4_TWO_N_LABEL" x="-5.0" y="-5.0">trf4</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf24_95_INTERNAL_95_vl2_95_dtrf24">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf24_95_INTERNAL_95_vl2_95_btrf24">
                 <polyline points="1145.0,432.0,1145.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf24_95_INTERNAL_95_vl2_95_dtrf24">
-                <polyline points="1145.0,372.0,1145.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf24_95_btrf24">
+                <polyline points="1145.0,402.0,1145.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf24_95_INTERNAL_95_vl2_95_trf4_95_TWO">
                 <polyline points="1145.0,352.0,1145.0,322.0"/>
@@ -992,7 +992,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf27" transform="translate(1191.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf27" transform="translate(1191.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf7_95_TWO" transform="translate(1191.0,318.0)">
@@ -1001,11 +1001,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf7_95_TWO" transform="translate(1195.0,260.0)">
                 <text class="sld-label" id="trf7_TWO_N_LABEL" x="-5.0" y="-5.0">trf72</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf27_95_INTERNAL_95_vl2_95_dtrf27">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf27_95_INTERNAL_95_vl2_95_btrf27">
                 <polyline points="1195.0,432.0,1195.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf27_95_INTERNAL_95_vl2_95_dtrf27">
-                <polyline points="1195.0,372.0,1195.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf27_95_btrf27">
+                <polyline points="1195.0,402.0,1195.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf27_95_INTERNAL_95_vl2_95_trf7_95_TWO">
                 <polyline points="1195.0,352.0,1195.0,322.0"/>
@@ -1033,7 +1033,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dgen4" transform="translate(1091.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_bgen4" transform="translate(1091.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_gen4" transform="translate(1091.0,563.0)">
@@ -1045,11 +1045,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen4_S_LABEL" x="-5.0" y="17.0">gen4</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dgen4_95_INTERNAL_95_vl2_95_dgen4">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dgen4_95_INTERNAL_95_vl2_95_bgen4">
                 <polyline points="1095.0,457.0,1095.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bgen4_95_INTERNAL_95_vl2_95_dgen4">
-                <polyline points="1095.0,517.0,1095.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_bgen4_95_bgen4">
+                <polyline points="1095.0,487.0,1095.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bgen4_95_INTERNAL_95_vl2_95_gen4">
                 <polyline points="1095.0,537.0,1095.0,567.0"/>
@@ -1077,7 +1077,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf22" transform="translate(1341.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf22" transform="translate(1341.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf2_95_TWO" transform="translate(1341.0,563.0)">
@@ -1086,11 +1086,11 @@
             <g class="sld-bottom-feeder sld-vl180to300-0" id="idtrf2_95_TWO" transform="translate(1345.0,629.0)">
                 <text class="sld-label" id="trf2_TWO_S_LABEL" x="-5.0" y="5.0">trf2</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf22_95_INTERNAL_95_vl2_95_dtrf22">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf22_95_INTERNAL_95_vl2_95_btrf22">
                 <polyline points="1345.0,457.0,1345.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf22_95_INTERNAL_95_vl2_95_dtrf22">
-                <polyline points="1345.0,517.0,1345.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf22_95_btrf22">
+                <polyline points="1345.0,487.0,1345.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf22_95_INTERNAL_95_vl2_95_trf2_95_TWO">
                 <polyline points="1345.0,537.0,1345.0,567.0"/>
@@ -1118,7 +1118,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf23" transform="translate(1391.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf23" transform="translate(1391.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf3_95_TWO" transform="translate(1391.0,563.0)">
@@ -1127,11 +1127,11 @@
             <g class="sld-bottom-feeder sld-vl180to300-0" id="idtrf3_95_TWO" transform="translate(1395.0,629.0)">
                 <text class="sld-label" id="trf3_TWO_S_LABEL" x="-5.0" y="5.0">trf3</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf23_95_INTERNAL_95_vl2_95_dtrf23">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf23_95_INTERNAL_95_vl2_95_btrf23">
                 <polyline points="1395.0,457.0,1395.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf23_95_INTERNAL_95_vl2_95_dtrf23">
-                <polyline points="1395.0,517.0,1395.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf23_95_btrf23">
+                <polyline points="1395.0,487.0,1395.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf23_95_INTERNAL_95_vl2_95_trf3_95_TWO">
                 <polyline points="1395.0,537.0,1395.0,567.0"/>
@@ -1159,7 +1159,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf26" transform="translate(1241.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf26" transform="translate(1241.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf6_95_TWO" transform="translate(1241.0,318.0)">
@@ -1168,11 +1168,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf6_95_TWO" transform="translate(1245.0,260.0)">
                 <text class="sld-label" id="trf6_TWO_N_LABEL" x="-5.0" y="-5.0">trf62</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf26_95_INTERNAL_95_vl2_95_dtrf26">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf26_95_INTERNAL_95_vl2_95_btrf26">
                 <polyline points="1245.0,457.0,1245.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf26_95_INTERNAL_95_vl2_95_dtrf26">
-                <polyline points="1245.0,372.0,1245.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf26_95_btrf26">
+                <polyline points="1245.0,402.0,1245.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf26_95_INTERNAL_95_vl2_95_trf6_95_TWO">
                 <polyline points="1245.0,352.0,1245.0,322.0"/>
@@ -1200,7 +1200,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf28" transform="translate(1291.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf28" transform="translate(1291.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf8_95_TWO" transform="translate(1291.0,563.0)">
@@ -1209,11 +1209,11 @@
             <g class="sld-bottom-feeder sld-vl180to300-0" id="idtrf8_95_TWO" transform="translate(1295.0,629.0)">
                 <text class="sld-label" id="trf8_TWO_S_LABEL" x="-5.0" y="5.0">trf82</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf28_95_INTERNAL_95_vl2_95_dtrf28">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf28_95_INTERNAL_95_vl2_95_btrf28">
                 <polyline points="1295.0,457.0,1295.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf28_95_INTERNAL_95_vl2_95_dtrf28">
-                <polyline points="1295.0,517.0,1295.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf28_95_btrf28">
+                <polyline points="1295.0,487.0,1295.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf28_95_INTERNAL_95_vl2_95_trf8_95_TWO">
                 <polyline points="1295.0,537.0,1295.0,567.0"/>
@@ -1248,7 +1248,7 @@
             <text class="sld-label" id="bbs7_NW_LABEL" x="-5.0" y="-5.0">bbs7</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dload4" transform="translate(1541.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_bload4" transform="translate(1541.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_load4" transform="translate(1541.0,318.0)">
@@ -1260,11 +1260,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load4_N_LABEL" x="-5.0" y="-5.0">load4</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dload4_95_INTERNAL_95_vl3_95_dload4">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dload4_95_INTERNAL_95_vl3_95_bload4">
                 <polyline points="1545.0,432.0,1545.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_bload4_95_INTERNAL_95_vl3_95_dload4">
-                <polyline points="1545.0,372.0,1545.0,402.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_bload4_95_bload4">
+                <polyline points="1545.0,402.0,1545.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_bload4_95_INTERNAL_95_vl3_95_load4">
                 <polyline points="1545.0,352.0,1545.0,322.0"/>
@@ -1292,7 +1292,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf25" transform="translate(1591.0,458.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf25" transform="translate(1591.0,458.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf5_95_TWO" transform="translate(1591.0,538.0)">
@@ -1301,11 +1301,11 @@
             <g class="sld-bottom-feeder sld-vl50to70-0" id="idtrf5_95_TWO" transform="translate(1595.0,604.0)">
                 <text class="sld-label" id="trf5_TWO_S_LABEL" x="-5.0" y="5.0">trf5</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf25_95_INTERNAL_95_vl3_95_dtrf25">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf25_95_INTERNAL_95_vl3_95_btrf25">
                 <polyline points="1595.0,432.0,1595.0,462.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf25_95_INTERNAL_95_vl3_95_dtrf25">
-                <polyline points="1595.0,492.0,1595.0,462.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf25_95_btrf25">
+                <polyline points="1595.0,462.0,1595.0,492.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf25_95_INTERNAL_95_vl3_95_trf5_95_TWO">
                 <polyline points="1595.0,512.0,1595.0,542.0"/>
@@ -1333,7 +1333,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf36" transform="translate(1641.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf36" transform="translate(1641.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf6_95_THREE" transform="translate(1641.0,318.0)">
@@ -1342,11 +1342,11 @@
             <g class="sld-top-feeder sld-vl50to70-0" id="idtrf6_95_THREE" transform="translate(1645.0,260.0)">
                 <text class="sld-label" id="trf6_THREE_N_LABEL" x="-5.0" y="-5.0">trf63</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf36_95_INTERNAL_95_vl3_95_dtrf36">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf36_95_INTERNAL_95_vl3_95_btrf36">
                 <polyline points="1645.0,432.0,1645.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf36_95_INTERNAL_95_vl3_95_dtrf36">
-                <polyline points="1645.0,372.0,1645.0,402.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf36_95_btrf36">
+                <polyline points="1645.0,402.0,1645.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf36_95_INTERNAL_95_vl3_95_trf6_95_THREE">
                 <polyline points="1645.0,352.0,1645.0,322.0"/>
@@ -1374,7 +1374,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf37" transform="translate(1691.0,458.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf37" transform="translate(1691.0,458.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf7_95_THREE" transform="translate(1691.0,538.0)">
@@ -1383,11 +1383,11 @@
             <g class="sld-bottom-feeder sld-vl50to70-0" id="idtrf7_95_THREE" transform="translate(1695.0,604.0)">
                 <text class="sld-label" id="trf7_THREE_S_LABEL" x="-5.0" y="5.0">trf73</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf37_95_INTERNAL_95_vl3_95_dtrf37">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf37_95_INTERNAL_95_vl3_95_btrf37">
                 <polyline points="1695.0,432.0,1695.0,462.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf37_95_INTERNAL_95_vl3_95_dtrf37">
-                <polyline points="1695.0,492.0,1695.0,462.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf37_95_btrf37">
+                <polyline points="1695.0,462.0,1695.0,492.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf37_95_INTERNAL_95_vl3_95_trf7_95_THREE">
                 <polyline points="1695.0,512.0,1695.0,542.0"/>
@@ -1415,7 +1415,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf38" transform="translate(1741.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf38" transform="translate(1741.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf8_95_THREE" transform="translate(1741.0,318.0)">
@@ -1424,11 +1424,11 @@
             <g class="sld-top-feeder sld-vl50to70-0" id="idtrf8_95_THREE" transform="translate(1745.0,260.0)">
                 <text class="sld-label" id="trf8_THREE_N_LABEL" x="-5.0" y="-5.0">trf83</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf38_95_INTERNAL_95_vl3_95_dtrf38">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf38_95_INTERNAL_95_vl3_95_btrf38">
                 <polyline points="1745.0,432.0,1745.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf38_95_INTERNAL_95_vl3_95_dtrf38">
-                <polyline points="1745.0,372.0,1745.0,402.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf38_95_btrf38">
+                <polyline points="1745.0,402.0,1745.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf38_95_INTERNAL_95_vl3_95_trf8_95_THREE">
                 <polyline points="1745.0,352.0,1745.0,322.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHLast.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHLast.svg
@@ -214,20 +214,20 @@
             <text class="sld-label" id="bbs4_NW_LABEL" x="-5.0" y="-5.0">bbs4</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dsect11" transform="translate(436.0,428.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(436.0,428.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dsect12" transform="translate(486.0,428.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(486.0,428.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bbs1_95_dsect11">
                 <polyline points="427.5,432.0,440.0,432.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect11">
-                <polyline points="455.0,432.0,440.0,432.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11">
+                <polyline points="440.0,432.0,455.0,432.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect12">
-                <polyline points="475.0,432.0,490.0,432.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11">
+                <polyline points="490.0,432.0,475.0,432.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dsect12_95_bbs2">
                 <polyline points="490.0,432.0,502.5,432.0"/>
@@ -246,20 +246,20 @@
             </g>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dsect21" transform="translate(436.0,453.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(436.0,453.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dsect22" transform="translate(486.0,453.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(486.0,453.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bbs3_95_dsect21">
                 <polyline points="427.5,457.0,440.0,457.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect21">
-                <polyline points="455.0,457.0,440.0,457.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21">
+                <polyline points="440.0,457.0,455.0,457.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect22">
-                <polyline points="475.0,457.0,490.0,457.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21">
+                <polyline points="490.0,457.0,475.0,457.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dsect22_95_bbs4">
                 <polyline points="490.0,457.0,502.5,457.0"/>
@@ -278,7 +278,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dload1" transform="translate(61.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bload1" transform="translate(61.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_load1" transform="translate(61.0,318.0)">
@@ -290,11 +290,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load1_N_LABEL" x="-5.0" y="-5.0">load1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_dload1">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_bload1">
                 <polyline points="65.0,432.0,65.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_dload1">
-                <polyline points="65.0,372.0,65.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bload1_95_bload1">
+                <polyline points="65.0,402.0,65.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_load1">
                 <polyline points="65.0,352.0,65.0,322.0"/>
@@ -322,7 +322,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf11" transform="translate(111.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf11" transform="translate(111.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf1_95_ONE" transform="translate(111.0,318.0)">
@@ -331,11 +331,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf1_95_ONE" transform="translate(115.0,260.0)">
                 <text class="sld-label" id="trf1_ONE_N_LABEL" x="-5.0" y="-5.0">trf1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_dtrf11">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_btrf11">
                 <polyline points="115.0,432.0,115.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_dtrf11">
-                <polyline points="115.0,372.0,115.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf11_95_btrf11">
+                <polyline points="115.0,402.0,115.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_trf1_95_ONE">
                 <polyline points="115.0,352.0,115.0,322.0"/>
@@ -363,7 +363,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf15" transform="translate(261.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf15" transform="translate(261.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf5_95_ONE" transform="translate(261.0,318.0)">
@@ -372,11 +372,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf5_95_ONE" transform="translate(265.0,260.0)">
                 <text class="sld-label" id="trf5_ONE_N_LABEL" x="-5.0" y="-5.0">trf5</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_dtrf15">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_btrf15">
                 <polyline points="265.0,432.0,265.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_dtrf15">
-                <polyline points="265.0,372.0,265.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf15_95_btrf15">
+                <polyline points="265.0,402.0,265.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_trf5_95_ONE">
                 <polyline points="265.0,352.0,265.0,322.0"/>
@@ -404,7 +404,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf16" transform="translate(311.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf16" transform="translate(311.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf6_95_ONE" transform="translate(311.0,318.0)">
@@ -413,11 +413,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf6_95_ONE" transform="translate(315.0,260.0)">
                 <text class="sld-label" id="trf6_ONE_N_LABEL" x="-5.0" y="-5.0">trf61</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_dtrf16">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_btrf16">
                 <polyline points="315.0,432.0,315.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf16_95_INTERNAL_95_vl1_95_dtrf16">
-                <polyline points="315.0,372.0,315.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf16_95_btrf16">
+                <polyline points="315.0,402.0,315.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf16_95_INTERNAL_95_vl1_95_trf6_95_ONE">
                 <polyline points="315.0,352.0,315.0,322.0"/>
@@ -445,7 +445,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dline11_95_2" transform="translate(411.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bline11_95_2" transform="translate(411.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_line1_95_ONE" transform="translate(411.0,318.0)">
@@ -454,11 +454,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idline1_95_ONE" transform="translate(415.0,260.0)">
                 <text class="sld-label" id="line1_ONE_N_LABEL" x="-5.0" y="-5.0">line1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dline11_95_2_95_INTERNAL_95_vl1_95_dline11_95_2">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dline11_95_2_95_INTERNAL_95_vl1_95_bline11_95_2">
                 <polyline points="415.0,432.0,415.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bline11_95_2_95_INTERNAL_95_vl1_95_dline11_95_2">
-                <polyline points="415.0,372.0,415.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bline11_95_2_95_bline11_95_2">
+                <polyline points="415.0,402.0,415.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bline11_95_2_95_INTERNAL_95_vl1_95_line1_95_ONE">
                 <polyline points="415.0,352.0,415.0,322.0"/>
@@ -486,7 +486,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dload2" transform="translate(511.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bload2" transform="translate(511.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_load2" transform="translate(511.0,318.0)">
@@ -498,11 +498,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load2_N_LABEL" x="-5.0" y="-5.0">load2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_dload2">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_bload2">
                 <polyline points="515.0,432.0,515.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_dload2">
-                <polyline points="515.0,372.0,515.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bload2_95_bload2">
+                <polyline points="515.0,402.0,515.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_load2">
                 <polyline points="515.0,352.0,515.0,322.0"/>
@@ -530,7 +530,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf12" transform="translate(661.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf12" transform="translate(661.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf2_95_ONE" transform="translate(661.0,318.0)">
@@ -539,11 +539,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf2_95_ONE" transform="translate(665.0,260.0)">
                 <text class="sld-label" id="trf2_ONE_N_LABEL" x="-5.0" y="-5.0">trf2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_dtrf12">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_btrf12">
                 <polyline points="665.0,432.0,665.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_dtrf12">
-                <polyline points="665.0,372.0,665.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf12_95_btrf12">
+                <polyline points="665.0,402.0,665.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_trf2_95_ONE">
                 <polyline points="665.0,352.0,665.0,322.0"/>
@@ -571,7 +571,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf18" transform="translate(561.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf18" transform="translate(561.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf8_95_ONE" transform="translate(561.0,318.0)">
@@ -580,11 +580,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf8_95_ONE" transform="translate(565.0,260.0)">
                 <text class="sld-label" id="trf8_ONE_N_LABEL" x="-5.0" y="-5.0">trf81</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_dtrf18">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_btrf18">
                 <polyline points="565.0,432.0,565.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_dtrf18">
-                <polyline points="565.0,372.0,565.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf18_95_btrf18">
+                <polyline points="565.0,402.0,565.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_trf8_95_ONE">
                 <polyline points="565.0,352.0,565.0,322.0"/>
@@ -612,7 +612,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_10">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dgen1" transform="translate(161.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_bgen1" transform="translate(161.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_gen1" transform="translate(161.0,563.0)">
@@ -624,11 +624,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen1_S_LABEL" x="-5.0" y="17.0">gen1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_dgen1">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_bgen1">
                 <polyline points="165.0,457.0,165.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_dgen1">
-                <polyline points="165.0,517.0,165.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_bgen1_95_bgen1">
+                <polyline points="165.0,487.0,165.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_gen1">
                 <polyline points="165.0,537.0,165.0,567.0"/>
@@ -656,7 +656,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_11">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf13" transform="translate(211.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf13" transform="translate(211.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf3_95_ONE" transform="translate(211.0,563.0)">
@@ -665,11 +665,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf3_95_ONE" transform="translate(215.0,629.0)">
                 <text class="sld-label" id="trf3_ONE_S_LABEL" x="-5.0" y="5.0">trf3</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_dtrf13">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_btrf13">
                 <polyline points="215.0,457.0,215.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_dtrf13">
-                <polyline points="215.0,517.0,215.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf13_95_btrf13">
+                <polyline points="215.0,487.0,215.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_trf3_95_ONE">
                 <polyline points="215.0,537.0,215.0,567.0"/>
@@ -697,7 +697,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_12">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf17" transform="translate(361.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf17" transform="translate(361.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf7_95_ONE" transform="translate(361.0,563.0)">
@@ -706,11 +706,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf7_95_ONE" transform="translate(365.0,629.0)">
                 <text class="sld-label" id="trf7_ONE_S_LABEL" x="-5.0" y="5.0">trf71</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_dtrf17">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_btrf17">
                 <polyline points="365.0,457.0,365.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf17_95_INTERNAL_95_vl1_95_dtrf17">
-                <polyline points="365.0,517.0,365.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf17_95_btrf17">
+                <polyline points="365.0,487.0,365.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf17_95_INTERNAL_95_vl1_95_trf7_95_ONE">
                 <polyline points="365.0,537.0,365.0,567.0"/>
@@ -738,7 +738,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_13">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dgen2" transform="translate(711.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_bgen2" transform="translate(711.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_gen2" transform="translate(711.0,563.0)">
@@ -750,11 +750,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen2_S_LABEL" x="-5.0" y="17.0">gen2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_dgen2">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_bgen2">
                 <polyline points="715.0,457.0,715.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_dgen2">
-                <polyline points="715.0,517.0,715.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_bgen2_95_bgen2">
+                <polyline points="715.0,487.0,715.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_gen2">
                 <polyline points="715.0,537.0,715.0,567.0"/>
@@ -782,7 +782,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_14">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf14" transform="translate(611.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf14" transform="translate(611.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf4_95_ONE" transform="translate(611.0,563.0)">
@@ -791,11 +791,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf4_95_ONE" transform="translate(615.0,629.0)">
                 <text class="sld-label" id="trf4_ONE_S_LABEL" x="-5.0" y="5.0">trf4</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_dtrf14">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_btrf14">
                 <polyline points="615.0,457.0,615.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_dtrf14">
-                <polyline points="615.0,517.0,615.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf14_95_btrf14">
+                <polyline points="615.0,487.0,615.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_trf4_95_ONE">
                 <polyline points="615.0,537.0,615.0,567.0"/>
@@ -834,22 +834,22 @@
             <text class="sld-label" id="bbs6_NW_LABEL" x="-5.0" y="-5.0">bbs6</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-vertical" id="idINTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dscpl1" transform="translate(941.0,388.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_ddcpl1" transform="translate(941.0,388.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dscpl2" transform="translate(891.0,388.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_ddcpl1" transform="translate(891.0,388.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl1_95_INTERNAL_95_vl2_95_dscpl1">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl1_95_INTERNAL_95_vl2_95_ddcpl1">
                 <polyline points="945.0,432.0,945.0,392.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_ddcpl1_95_INTERNAL_95_vl2_95_dscpl1">
-                <polyline points="930.0,392.0,945.0,392.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_ddcpl1_95_ddcpl1">
+                <polyline points="945.0,392.0,930.0,392.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_ddcpl1_95_INTERNAL_95_vl2_95_dscpl2">
-                <polyline points="910.0,392.0,895.0,392.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_ddcpl1_95_ddcpl1">
+                <polyline points="895.0,392.0,910.0,392.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl2_95_INTERNAL_95_vl2_95_dscpl2">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl2_95_INTERNAL_95_vl2_95_ddcpl1">
                 <polyline points="895.0,457.0,895.0,392.0"/>
             </g>
             <g class="sld-disconnector sld-closed sld-fictitious sld-vl180to300-0" id="iddscpl1" transform="translate(941.0,428.0)">
@@ -866,7 +866,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dload3" transform="translate(991.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_bload3" transform="translate(991.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_load3" transform="translate(991.0,318.0)">
@@ -878,11 +878,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load3_N_LABEL" x="-5.0" y="-5.0">load3</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dload3_95_INTERNAL_95_vl2_95_dload3">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dload3_95_INTERNAL_95_vl2_95_bload3">
                 <polyline points="995.0,432.0,995.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bload3_95_INTERNAL_95_vl2_95_dload3">
-                <polyline points="995.0,372.0,995.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_bload3_95_bload3">
+                <polyline points="995.0,402.0,995.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bload3_95_INTERNAL_95_vl2_95_load3">
                 <polyline points="995.0,352.0,995.0,322.0"/>
@@ -910,7 +910,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf21" transform="translate(1041.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf21" transform="translate(1041.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf1_95_TWO" transform="translate(1041.0,318.0)">
@@ -919,11 +919,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf1_95_TWO" transform="translate(1045.0,260.0)">
                 <text class="sld-label" id="trf1_TWO_N_LABEL" x="-5.0" y="-5.0">trf1</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf21_95_INTERNAL_95_vl2_95_dtrf21">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf21_95_INTERNAL_95_vl2_95_btrf21">
                 <polyline points="1045.0,432.0,1045.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf21_95_INTERNAL_95_vl2_95_dtrf21">
-                <polyline points="1045.0,372.0,1045.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf21_95_btrf21">
+                <polyline points="1045.0,402.0,1045.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf21_95_INTERNAL_95_vl2_95_trf1_95_TWO">
                 <polyline points="1045.0,352.0,1045.0,322.0"/>
@@ -951,7 +951,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf24" transform="translate(1141.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf24" transform="translate(1141.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf4_95_TWO" transform="translate(1141.0,318.0)">
@@ -960,11 +960,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf4_95_TWO" transform="translate(1145.0,260.0)">
                 <text class="sld-label" id="trf4_TWO_N_LABEL" x="-5.0" y="-5.0">trf4</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf24_95_INTERNAL_95_vl2_95_dtrf24">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf24_95_INTERNAL_95_vl2_95_btrf24">
                 <polyline points="1145.0,432.0,1145.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf24_95_INTERNAL_95_vl2_95_dtrf24">
-                <polyline points="1145.0,372.0,1145.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf24_95_btrf24">
+                <polyline points="1145.0,402.0,1145.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf24_95_INTERNAL_95_vl2_95_trf4_95_TWO">
                 <polyline points="1145.0,352.0,1145.0,322.0"/>
@@ -992,7 +992,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf27" transform="translate(1191.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf27" transform="translate(1191.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf7_95_TWO" transform="translate(1191.0,318.0)">
@@ -1001,11 +1001,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf7_95_TWO" transform="translate(1195.0,260.0)">
                 <text class="sld-label" id="trf7_TWO_N_LABEL" x="-5.0" y="-5.0">trf72</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf27_95_INTERNAL_95_vl2_95_dtrf27">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf27_95_INTERNAL_95_vl2_95_btrf27">
                 <polyline points="1195.0,432.0,1195.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf27_95_INTERNAL_95_vl2_95_dtrf27">
-                <polyline points="1195.0,372.0,1195.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf27_95_btrf27">
+                <polyline points="1195.0,402.0,1195.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf27_95_INTERNAL_95_vl2_95_trf7_95_TWO">
                 <polyline points="1195.0,352.0,1195.0,322.0"/>
@@ -1033,7 +1033,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dgen4" transform="translate(1091.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_bgen4" transform="translate(1091.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_gen4" transform="translate(1091.0,563.0)">
@@ -1045,11 +1045,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen4_S_LABEL" x="-5.0" y="17.0">gen4</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dgen4_95_INTERNAL_95_vl2_95_dgen4">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dgen4_95_INTERNAL_95_vl2_95_bgen4">
                 <polyline points="1095.0,457.0,1095.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bgen4_95_INTERNAL_95_vl2_95_dgen4">
-                <polyline points="1095.0,517.0,1095.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_bgen4_95_bgen4">
+                <polyline points="1095.0,487.0,1095.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bgen4_95_INTERNAL_95_vl2_95_gen4">
                 <polyline points="1095.0,537.0,1095.0,567.0"/>
@@ -1077,7 +1077,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf22" transform="translate(1341.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf22" transform="translate(1341.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf2_95_TWO" transform="translate(1341.0,563.0)">
@@ -1086,11 +1086,11 @@
             <g class="sld-bottom-feeder sld-vl180to300-0" id="idtrf2_95_TWO" transform="translate(1345.0,629.0)">
                 <text class="sld-label" id="trf2_TWO_S_LABEL" x="-5.0" y="5.0">trf2</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf22_95_INTERNAL_95_vl2_95_dtrf22">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf22_95_INTERNAL_95_vl2_95_btrf22">
                 <polyline points="1345.0,457.0,1345.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf22_95_INTERNAL_95_vl2_95_dtrf22">
-                <polyline points="1345.0,517.0,1345.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf22_95_btrf22">
+                <polyline points="1345.0,487.0,1345.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf22_95_INTERNAL_95_vl2_95_trf2_95_TWO">
                 <polyline points="1345.0,537.0,1345.0,567.0"/>
@@ -1118,7 +1118,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf23" transform="translate(1391.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf23" transform="translate(1391.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf3_95_TWO" transform="translate(1391.0,563.0)">
@@ -1127,11 +1127,11 @@
             <g class="sld-bottom-feeder sld-vl180to300-0" id="idtrf3_95_TWO" transform="translate(1395.0,629.0)">
                 <text class="sld-label" id="trf3_TWO_S_LABEL" x="-5.0" y="5.0">trf3</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf23_95_INTERNAL_95_vl2_95_dtrf23">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf23_95_INTERNAL_95_vl2_95_btrf23">
                 <polyline points="1395.0,457.0,1395.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf23_95_INTERNAL_95_vl2_95_dtrf23">
-                <polyline points="1395.0,517.0,1395.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf23_95_btrf23">
+                <polyline points="1395.0,487.0,1395.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf23_95_INTERNAL_95_vl2_95_trf3_95_TWO">
                 <polyline points="1395.0,537.0,1395.0,567.0"/>
@@ -1159,7 +1159,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf26" transform="translate(1241.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf26" transform="translate(1241.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf6_95_TWO" transform="translate(1241.0,318.0)">
@@ -1168,11 +1168,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf6_95_TWO" transform="translate(1245.0,260.0)">
                 <text class="sld-label" id="trf6_TWO_N_LABEL" x="-5.0" y="-5.0">trf62</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf26_95_INTERNAL_95_vl2_95_dtrf26">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf26_95_INTERNAL_95_vl2_95_btrf26">
                 <polyline points="1245.0,457.0,1245.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf26_95_INTERNAL_95_vl2_95_dtrf26">
-                <polyline points="1245.0,372.0,1245.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf26_95_btrf26">
+                <polyline points="1245.0,402.0,1245.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf26_95_INTERNAL_95_vl2_95_trf6_95_TWO">
                 <polyline points="1245.0,352.0,1245.0,322.0"/>
@@ -1200,7 +1200,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf28" transform="translate(1291.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf28" transform="translate(1291.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf8_95_TWO" transform="translate(1291.0,563.0)">
@@ -1209,11 +1209,11 @@
             <g class="sld-bottom-feeder sld-vl180to300-0" id="idtrf8_95_TWO" transform="translate(1295.0,629.0)">
                 <text class="sld-label" id="trf8_TWO_S_LABEL" x="-5.0" y="5.0">trf82</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf28_95_INTERNAL_95_vl2_95_dtrf28">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf28_95_INTERNAL_95_vl2_95_btrf28">
                 <polyline points="1295.0,457.0,1295.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf28_95_INTERNAL_95_vl2_95_dtrf28">
-                <polyline points="1295.0,517.0,1295.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf28_95_btrf28">
+                <polyline points="1295.0,487.0,1295.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf28_95_INTERNAL_95_vl2_95_trf8_95_TWO">
                 <polyline points="1295.0,537.0,1295.0,567.0"/>
@@ -1248,7 +1248,7 @@
             <text class="sld-label" id="bbs7_NW_LABEL" x="-5.0" y="-5.0">bbs7</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dload4" transform="translate(1541.0,423.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_bload4" transform="translate(1541.0,423.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_load4" transform="translate(1541.0,343.0)">
@@ -1260,11 +1260,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load4_N_LABEL" x="-5.0" y="-5.0">load4</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dload4_95_INTERNAL_95_vl3_95_dload4">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dload4_95_INTERNAL_95_vl3_95_bload4">
                 <polyline points="1545.0,457.0,1545.0,427.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_bload4_95_INTERNAL_95_vl3_95_dload4">
-                <polyline points="1545.0,397.0,1545.0,427.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_bload4_95_bload4">
+                <polyline points="1545.0,427.0,1545.0,397.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_bload4_95_INTERNAL_95_vl3_95_load4">
                 <polyline points="1545.0,377.0,1545.0,347.0"/>
@@ -1292,7 +1292,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf25" transform="translate(1591.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf25" transform="translate(1591.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf5_95_TWO" transform="translate(1591.0,563.0)">
@@ -1301,11 +1301,11 @@
             <g class="sld-bottom-feeder sld-vl50to70-0" id="idtrf5_95_TWO" transform="translate(1595.0,629.0)">
                 <text class="sld-label" id="trf5_TWO_S_LABEL" x="-5.0" y="5.0">trf5</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf25_95_INTERNAL_95_vl3_95_dtrf25">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf25_95_INTERNAL_95_vl3_95_btrf25">
                 <polyline points="1595.0,457.0,1595.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf25_95_INTERNAL_95_vl3_95_dtrf25">
-                <polyline points="1595.0,517.0,1595.0,487.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf25_95_btrf25">
+                <polyline points="1595.0,487.0,1595.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf25_95_INTERNAL_95_vl3_95_trf5_95_TWO">
                 <polyline points="1595.0,537.0,1595.0,567.0"/>
@@ -1333,7 +1333,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf36" transform="translate(1641.0,423.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf36" transform="translate(1641.0,423.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf6_95_THREE" transform="translate(1641.0,343.0)">
@@ -1342,11 +1342,11 @@
             <g class="sld-top-feeder sld-vl50to70-0" id="idtrf6_95_THREE" transform="translate(1645.0,285.0)">
                 <text class="sld-label" id="trf6_THREE_N_LABEL" x="-5.0" y="-5.0">trf63</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf36_95_INTERNAL_95_vl3_95_dtrf36">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf36_95_INTERNAL_95_vl3_95_btrf36">
                 <polyline points="1645.0,457.0,1645.0,427.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf36_95_INTERNAL_95_vl3_95_dtrf36">
-                <polyline points="1645.0,397.0,1645.0,427.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf36_95_btrf36">
+                <polyline points="1645.0,427.0,1645.0,397.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf36_95_INTERNAL_95_vl3_95_trf6_95_THREE">
                 <polyline points="1645.0,377.0,1645.0,347.0"/>
@@ -1374,7 +1374,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf37" transform="translate(1691.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf37" transform="translate(1691.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf7_95_THREE" transform="translate(1691.0,563.0)">
@@ -1383,11 +1383,11 @@
             <g class="sld-bottom-feeder sld-vl50to70-0" id="idtrf7_95_THREE" transform="translate(1695.0,629.0)">
                 <text class="sld-label" id="trf7_THREE_S_LABEL" x="-5.0" y="5.0">trf73</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf37_95_INTERNAL_95_vl3_95_dtrf37">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf37_95_INTERNAL_95_vl3_95_btrf37">
                 <polyline points="1695.0,457.0,1695.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf37_95_INTERNAL_95_vl3_95_dtrf37">
-                <polyline points="1695.0,517.0,1695.0,487.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf37_95_btrf37">
+                <polyline points="1695.0,487.0,1695.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf37_95_INTERNAL_95_vl3_95_trf7_95_THREE">
                 <polyline points="1695.0,537.0,1695.0,567.0"/>
@@ -1415,7 +1415,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf38" transform="translate(1741.0,423.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf38" transform="translate(1741.0,423.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf8_95_THREE" transform="translate(1741.0,343.0)">
@@ -1424,11 +1424,11 @@
             <g class="sld-top-feeder sld-vl50to70-0" id="idtrf8_95_THREE" transform="translate(1745.0,285.0)">
                 <text class="sld-label" id="trf8_THREE_N_LABEL" x="-5.0" y="-5.0">trf83</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf38_95_INTERNAL_95_vl3_95_dtrf38">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf38_95_INTERNAL_95_vl3_95_btrf38">
                 <polyline points="1745.0,457.0,1745.0,427.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf38_95_INTERNAL_95_vl3_95_dtrf38">
-                <polyline points="1745.0,397.0,1745.0,427.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf38_95_btrf38">
+                <polyline points="1745.0,427.0,1745.0,397.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf38_95_INTERNAL_95_vl3_95_trf8_95_THREE">
                 <polyline points="1745.0,377.0,1745.0,347.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHMiddle.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHMiddle.svg
@@ -214,20 +214,20 @@
             <text class="sld-label" id="bbs4_NW_LABEL" x="-5.0" y="-5.0">bbs4</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dsect11" transform="translate(436.0,428.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(436.0,428.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dsect12" transform="translate(486.0,428.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(486.0,428.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bbs1_95_dsect11">
                 <polyline points="427.5,432.0,440.0,432.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect11">
-                <polyline points="455.0,432.0,440.0,432.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11">
+                <polyline points="440.0,432.0,455.0,432.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect12">
-                <polyline points="475.0,432.0,490.0,432.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11">
+                <polyline points="490.0,432.0,475.0,432.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dsect12_95_bbs2">
                 <polyline points="490.0,432.0,502.5,432.0"/>
@@ -246,20 +246,20 @@
             </g>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dsect21" transform="translate(436.0,453.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(436.0,453.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dsect22" transform="translate(486.0,453.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(486.0,453.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bbs3_95_dsect21">
                 <polyline points="427.5,457.0,440.0,457.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect21">
-                <polyline points="455.0,457.0,440.0,457.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21">
+                <polyline points="440.0,457.0,455.0,457.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect22">
-                <polyline points="475.0,457.0,490.0,457.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21">
+                <polyline points="490.0,457.0,475.0,457.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dsect22_95_bbs4">
                 <polyline points="490.0,457.0,502.5,457.0"/>
@@ -278,7 +278,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dload1" transform="translate(61.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bload1" transform="translate(61.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_load1" transform="translate(61.0,318.0)">
@@ -290,11 +290,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load1_N_LABEL" x="-5.0" y="-5.0">load1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_dload1">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_bload1">
                 <polyline points="65.0,432.0,65.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_dload1">
-                <polyline points="65.0,372.0,65.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bload1_95_bload1">
+                <polyline points="65.0,402.0,65.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_load1">
                 <polyline points="65.0,352.0,65.0,322.0"/>
@@ -322,7 +322,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf11" transform="translate(111.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf11" transform="translate(111.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf1_95_ONE" transform="translate(111.0,318.0)">
@@ -331,11 +331,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf1_95_ONE" transform="translate(115.0,260.0)">
                 <text class="sld-label" id="trf1_ONE_N_LABEL" x="-5.0" y="-5.0">trf1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_dtrf11">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_btrf11">
                 <polyline points="115.0,432.0,115.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_dtrf11">
-                <polyline points="115.0,372.0,115.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf11_95_btrf11">
+                <polyline points="115.0,402.0,115.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_trf1_95_ONE">
                 <polyline points="115.0,352.0,115.0,322.0"/>
@@ -363,7 +363,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf15" transform="translate(261.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf15" transform="translate(261.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf5_95_ONE" transform="translate(261.0,318.0)">
@@ -372,11 +372,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf5_95_ONE" transform="translate(265.0,260.0)">
                 <text class="sld-label" id="trf5_ONE_N_LABEL" x="-5.0" y="-5.0">trf5</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_dtrf15">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_btrf15">
                 <polyline points="265.0,432.0,265.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_dtrf15">
-                <polyline points="265.0,372.0,265.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf15_95_btrf15">
+                <polyline points="265.0,402.0,265.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_trf5_95_ONE">
                 <polyline points="265.0,352.0,265.0,322.0"/>
@@ -404,7 +404,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf16" transform="translate(311.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf16" transform="translate(311.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf6_95_ONE" transform="translate(311.0,318.0)">
@@ -413,11 +413,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf6_95_ONE" transform="translate(315.0,260.0)">
                 <text class="sld-label" id="trf6_ONE_N_LABEL" x="-5.0" y="-5.0">trf61</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_dtrf16">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_btrf16">
                 <polyline points="315.0,432.0,315.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf16_95_INTERNAL_95_vl1_95_dtrf16">
-                <polyline points="315.0,372.0,315.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf16_95_btrf16">
+                <polyline points="315.0,402.0,315.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf16_95_INTERNAL_95_vl1_95_trf6_95_ONE">
                 <polyline points="315.0,352.0,315.0,322.0"/>
@@ -445,7 +445,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dline11_95_2" transform="translate(411.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bline11_95_2" transform="translate(411.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_line1_95_ONE" transform="translate(411.0,318.0)">
@@ -454,11 +454,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idline1_95_ONE" transform="translate(415.0,260.0)">
                 <text class="sld-label" id="line1_ONE_N_LABEL" x="-5.0" y="-5.0">line1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dline11_95_2_95_INTERNAL_95_vl1_95_dline11_95_2">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dline11_95_2_95_INTERNAL_95_vl1_95_bline11_95_2">
                 <polyline points="415.0,432.0,415.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bline11_95_2_95_INTERNAL_95_vl1_95_dline11_95_2">
-                <polyline points="415.0,372.0,415.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bline11_95_2_95_bline11_95_2">
+                <polyline points="415.0,402.0,415.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bline11_95_2_95_INTERNAL_95_vl1_95_line1_95_ONE">
                 <polyline points="415.0,352.0,415.0,322.0"/>
@@ -486,7 +486,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dload2" transform="translate(511.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bload2" transform="translate(511.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_load2" transform="translate(511.0,318.0)">
@@ -498,11 +498,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load2_N_LABEL" x="-5.0" y="-5.0">load2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_dload2">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_bload2">
                 <polyline points="515.0,432.0,515.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_dload2">
-                <polyline points="515.0,372.0,515.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bload2_95_bload2">
+                <polyline points="515.0,402.0,515.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_load2">
                 <polyline points="515.0,352.0,515.0,322.0"/>
@@ -530,7 +530,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf12" transform="translate(661.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf12" transform="translate(661.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf2_95_ONE" transform="translate(661.0,318.0)">
@@ -539,11 +539,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf2_95_ONE" transform="translate(665.0,260.0)">
                 <text class="sld-label" id="trf2_ONE_N_LABEL" x="-5.0" y="-5.0">trf2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_dtrf12">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_btrf12">
                 <polyline points="665.0,432.0,665.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_dtrf12">
-                <polyline points="665.0,372.0,665.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf12_95_btrf12">
+                <polyline points="665.0,402.0,665.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_trf2_95_ONE">
                 <polyline points="665.0,352.0,665.0,322.0"/>
@@ -571,7 +571,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf18" transform="translate(561.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf18" transform="translate(561.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf8_95_ONE" transform="translate(561.0,318.0)">
@@ -580,11 +580,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf8_95_ONE" transform="translate(565.0,260.0)">
                 <text class="sld-label" id="trf8_ONE_N_LABEL" x="-5.0" y="-5.0">trf81</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_dtrf18">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_btrf18">
                 <polyline points="565.0,432.0,565.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_dtrf18">
-                <polyline points="565.0,372.0,565.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf18_95_btrf18">
+                <polyline points="565.0,402.0,565.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_trf8_95_ONE">
                 <polyline points="565.0,352.0,565.0,322.0"/>
@@ -612,7 +612,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_10">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dgen1" transform="translate(161.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_bgen1" transform="translate(161.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_gen1" transform="translate(161.0,563.0)">
@@ -624,11 +624,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen1_S_LABEL" x="-5.0" y="17.0">gen1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_dgen1">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_bgen1">
                 <polyline points="165.0,457.0,165.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_dgen1">
-                <polyline points="165.0,517.0,165.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_bgen1_95_bgen1">
+                <polyline points="165.0,487.0,165.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_gen1">
                 <polyline points="165.0,537.0,165.0,567.0"/>
@@ -656,7 +656,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_11">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf13" transform="translate(211.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf13" transform="translate(211.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf3_95_ONE" transform="translate(211.0,563.0)">
@@ -665,11 +665,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf3_95_ONE" transform="translate(215.0,629.0)">
                 <text class="sld-label" id="trf3_ONE_S_LABEL" x="-5.0" y="5.0">trf3</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_dtrf13">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_btrf13">
                 <polyline points="215.0,457.0,215.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_dtrf13">
-                <polyline points="215.0,517.0,215.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf13_95_btrf13">
+                <polyline points="215.0,487.0,215.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_trf3_95_ONE">
                 <polyline points="215.0,537.0,215.0,567.0"/>
@@ -697,7 +697,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_12">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf17" transform="translate(361.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf17" transform="translate(361.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf7_95_ONE" transform="translate(361.0,563.0)">
@@ -706,11 +706,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf7_95_ONE" transform="translate(365.0,629.0)">
                 <text class="sld-label" id="trf7_ONE_S_LABEL" x="-5.0" y="5.0">trf71</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_dtrf17">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_btrf17">
                 <polyline points="365.0,457.0,365.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf17_95_INTERNAL_95_vl1_95_dtrf17">
-                <polyline points="365.0,517.0,365.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf17_95_btrf17">
+                <polyline points="365.0,487.0,365.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf17_95_INTERNAL_95_vl1_95_trf7_95_ONE">
                 <polyline points="365.0,537.0,365.0,567.0"/>
@@ -738,7 +738,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_13">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dgen2" transform="translate(711.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_bgen2" transform="translate(711.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_gen2" transform="translate(711.0,563.0)">
@@ -750,11 +750,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen2_S_LABEL" x="-5.0" y="17.0">gen2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_dgen2">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_bgen2">
                 <polyline points="715.0,457.0,715.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_dgen2">
-                <polyline points="715.0,517.0,715.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_bgen2_95_bgen2">
+                <polyline points="715.0,487.0,715.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_gen2">
                 <polyline points="715.0,537.0,715.0,567.0"/>
@@ -782,7 +782,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_14">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf14" transform="translate(611.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf14" transform="translate(611.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf4_95_ONE" transform="translate(611.0,563.0)">
@@ -791,11 +791,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf4_95_ONE" transform="translate(615.0,629.0)">
                 <text class="sld-label" id="trf4_ONE_S_LABEL" x="-5.0" y="5.0">trf4</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_dtrf14">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_btrf14">
                 <polyline points="615.0,457.0,615.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_dtrf14">
-                <polyline points="615.0,517.0,615.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf14_95_btrf14">
+                <polyline points="615.0,487.0,615.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_trf4_95_ONE">
                 <polyline points="615.0,537.0,615.0,567.0"/>
@@ -834,22 +834,22 @@
             <text class="sld-label" id="bbs6_NW_LABEL" x="-5.0" y="-5.0">bbs6</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-vertical" id="idINTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dscpl1" transform="translate(941.0,388.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_ddcpl1" transform="translate(941.0,388.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dscpl2" transform="translate(891.0,388.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_ddcpl1" transform="translate(891.0,388.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl1_95_INTERNAL_95_vl2_95_dscpl1">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl1_95_INTERNAL_95_vl2_95_ddcpl1">
                 <polyline points="945.0,432.0,945.0,392.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_ddcpl1_95_INTERNAL_95_vl2_95_dscpl1">
-                <polyline points="930.0,392.0,945.0,392.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_ddcpl1_95_ddcpl1">
+                <polyline points="945.0,392.0,930.0,392.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_ddcpl1_95_INTERNAL_95_vl2_95_dscpl2">
-                <polyline points="910.0,392.0,895.0,392.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_ddcpl1_95_ddcpl1">
+                <polyline points="895.0,392.0,910.0,392.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl2_95_INTERNAL_95_vl2_95_dscpl2">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl2_95_INTERNAL_95_vl2_95_ddcpl1">
                 <polyline points="895.0,457.0,895.0,392.0"/>
             </g>
             <g class="sld-disconnector sld-closed sld-fictitious sld-vl180to300-0" id="iddscpl1" transform="translate(941.0,428.0)">
@@ -866,7 +866,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dload3" transform="translate(991.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_bload3" transform="translate(991.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_load3" transform="translate(991.0,318.0)">
@@ -878,11 +878,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load3_N_LABEL" x="-5.0" y="-5.0">load3</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dload3_95_INTERNAL_95_vl2_95_dload3">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dload3_95_INTERNAL_95_vl2_95_bload3">
                 <polyline points="995.0,432.0,995.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bload3_95_INTERNAL_95_vl2_95_dload3">
-                <polyline points="995.0,372.0,995.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_bload3_95_bload3">
+                <polyline points="995.0,402.0,995.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bload3_95_INTERNAL_95_vl2_95_load3">
                 <polyline points="995.0,352.0,995.0,322.0"/>
@@ -910,7 +910,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf21" transform="translate(1041.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf21" transform="translate(1041.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf1_95_TWO" transform="translate(1041.0,318.0)">
@@ -919,11 +919,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf1_95_TWO" transform="translate(1045.0,260.0)">
                 <text class="sld-label" id="trf1_TWO_N_LABEL" x="-5.0" y="-5.0">trf1</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf21_95_INTERNAL_95_vl2_95_dtrf21">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf21_95_INTERNAL_95_vl2_95_btrf21">
                 <polyline points="1045.0,432.0,1045.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf21_95_INTERNAL_95_vl2_95_dtrf21">
-                <polyline points="1045.0,372.0,1045.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf21_95_btrf21">
+                <polyline points="1045.0,402.0,1045.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf21_95_INTERNAL_95_vl2_95_trf1_95_TWO">
                 <polyline points="1045.0,352.0,1045.0,322.0"/>
@@ -951,7 +951,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf24" transform="translate(1141.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf24" transform="translate(1141.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf4_95_TWO" transform="translate(1141.0,318.0)">
@@ -960,11 +960,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf4_95_TWO" transform="translate(1145.0,260.0)">
                 <text class="sld-label" id="trf4_TWO_N_LABEL" x="-5.0" y="-5.0">trf4</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf24_95_INTERNAL_95_vl2_95_dtrf24">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf24_95_INTERNAL_95_vl2_95_btrf24">
                 <polyline points="1145.0,432.0,1145.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf24_95_INTERNAL_95_vl2_95_dtrf24">
-                <polyline points="1145.0,372.0,1145.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf24_95_btrf24">
+                <polyline points="1145.0,402.0,1145.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf24_95_INTERNAL_95_vl2_95_trf4_95_TWO">
                 <polyline points="1145.0,352.0,1145.0,322.0"/>
@@ -992,7 +992,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf27" transform="translate(1191.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf27" transform="translate(1191.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf7_95_TWO" transform="translate(1191.0,318.0)">
@@ -1001,11 +1001,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf7_95_TWO" transform="translate(1195.0,260.0)">
                 <text class="sld-label" id="trf7_TWO_N_LABEL" x="-5.0" y="-5.0">trf72</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf27_95_INTERNAL_95_vl2_95_dtrf27">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf27_95_INTERNAL_95_vl2_95_btrf27">
                 <polyline points="1195.0,432.0,1195.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf27_95_INTERNAL_95_vl2_95_dtrf27">
-                <polyline points="1195.0,372.0,1195.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf27_95_btrf27">
+                <polyline points="1195.0,402.0,1195.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf27_95_INTERNAL_95_vl2_95_trf7_95_TWO">
                 <polyline points="1195.0,352.0,1195.0,322.0"/>
@@ -1033,7 +1033,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dgen4" transform="translate(1091.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_bgen4" transform="translate(1091.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_gen4" transform="translate(1091.0,563.0)">
@@ -1045,11 +1045,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen4_S_LABEL" x="-5.0" y="17.0">gen4</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dgen4_95_INTERNAL_95_vl2_95_dgen4">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dgen4_95_INTERNAL_95_vl2_95_bgen4">
                 <polyline points="1095.0,457.0,1095.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bgen4_95_INTERNAL_95_vl2_95_dgen4">
-                <polyline points="1095.0,517.0,1095.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_bgen4_95_bgen4">
+                <polyline points="1095.0,487.0,1095.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bgen4_95_INTERNAL_95_vl2_95_gen4">
                 <polyline points="1095.0,537.0,1095.0,567.0"/>
@@ -1077,7 +1077,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf22" transform="translate(1341.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf22" transform="translate(1341.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf2_95_TWO" transform="translate(1341.0,563.0)">
@@ -1086,11 +1086,11 @@
             <g class="sld-bottom-feeder sld-vl180to300-0" id="idtrf2_95_TWO" transform="translate(1345.0,629.0)">
                 <text class="sld-label" id="trf2_TWO_S_LABEL" x="-5.0" y="5.0">trf2</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf22_95_INTERNAL_95_vl2_95_dtrf22">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf22_95_INTERNAL_95_vl2_95_btrf22">
                 <polyline points="1345.0,457.0,1345.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf22_95_INTERNAL_95_vl2_95_dtrf22">
-                <polyline points="1345.0,517.0,1345.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf22_95_btrf22">
+                <polyline points="1345.0,487.0,1345.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf22_95_INTERNAL_95_vl2_95_trf2_95_TWO">
                 <polyline points="1345.0,537.0,1345.0,567.0"/>
@@ -1118,7 +1118,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf23" transform="translate(1391.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf23" transform="translate(1391.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf3_95_TWO" transform="translate(1391.0,563.0)">
@@ -1127,11 +1127,11 @@
             <g class="sld-bottom-feeder sld-vl180to300-0" id="idtrf3_95_TWO" transform="translate(1395.0,629.0)">
                 <text class="sld-label" id="trf3_TWO_S_LABEL" x="-5.0" y="5.0">trf3</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf23_95_INTERNAL_95_vl2_95_dtrf23">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf23_95_INTERNAL_95_vl2_95_btrf23">
                 <polyline points="1395.0,457.0,1395.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf23_95_INTERNAL_95_vl2_95_dtrf23">
-                <polyline points="1395.0,517.0,1395.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf23_95_btrf23">
+                <polyline points="1395.0,487.0,1395.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf23_95_INTERNAL_95_vl2_95_trf3_95_TWO">
                 <polyline points="1395.0,537.0,1395.0,567.0"/>
@@ -1159,7 +1159,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf26" transform="translate(1241.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf26" transform="translate(1241.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf6_95_TWO" transform="translate(1241.0,318.0)">
@@ -1168,11 +1168,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf6_95_TWO" transform="translate(1245.0,260.0)">
                 <text class="sld-label" id="trf6_TWO_N_LABEL" x="-5.0" y="-5.0">trf62</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf26_95_INTERNAL_95_vl2_95_dtrf26">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf26_95_INTERNAL_95_vl2_95_btrf26">
                 <polyline points="1245.0,457.0,1245.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf26_95_INTERNAL_95_vl2_95_dtrf26">
-                <polyline points="1245.0,372.0,1245.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf26_95_btrf26">
+                <polyline points="1245.0,402.0,1245.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf26_95_INTERNAL_95_vl2_95_trf6_95_TWO">
                 <polyline points="1245.0,352.0,1245.0,322.0"/>
@@ -1200,7 +1200,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf28" transform="translate(1291.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf28" transform="translate(1291.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf8_95_TWO" transform="translate(1291.0,563.0)">
@@ -1209,11 +1209,11 @@
             <g class="sld-bottom-feeder sld-vl180to300-0" id="idtrf8_95_TWO" transform="translate(1295.0,629.0)">
                 <text class="sld-label" id="trf8_TWO_S_LABEL" x="-5.0" y="5.0">trf82</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf28_95_INTERNAL_95_vl2_95_dtrf28">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf28_95_INTERNAL_95_vl2_95_btrf28">
                 <polyline points="1295.0,457.0,1295.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf28_95_INTERNAL_95_vl2_95_dtrf28">
-                <polyline points="1295.0,517.0,1295.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf28_95_btrf28">
+                <polyline points="1295.0,487.0,1295.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf28_95_INTERNAL_95_vl2_95_trf8_95_TWO">
                 <polyline points="1295.0,537.0,1295.0,567.0"/>
@@ -1248,7 +1248,7 @@
             <text class="sld-label" id="bbs7_NW_LABEL" x="-5.0" y="-5.0">bbs7</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dload4" transform="translate(1541.0,410.5)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_bload4" transform="translate(1541.0,410.5)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_load4" transform="translate(1541.0,330.5)">
@@ -1260,11 +1260,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load4_N_LABEL" x="-5.0" y="-5.0">load4</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dload4_95_INTERNAL_95_vl3_95_dload4">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dload4_95_INTERNAL_95_vl3_95_bload4">
                 <polyline points="1545.0,444.5,1545.0,414.5"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_bload4_95_INTERNAL_95_vl3_95_dload4">
-                <polyline points="1545.0,384.5,1545.0,414.5"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_bload4_95_bload4">
+                <polyline points="1545.0,414.5,1545.0,384.5"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_bload4_95_INTERNAL_95_vl3_95_load4">
                 <polyline points="1545.0,364.5,1545.0,334.5"/>
@@ -1292,7 +1292,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf25" transform="translate(1591.0,470.5)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf25" transform="translate(1591.0,470.5)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf5_95_TWO" transform="translate(1591.0,550.5)">
@@ -1301,11 +1301,11 @@
             <g class="sld-bottom-feeder sld-vl50to70-0" id="idtrf5_95_TWO" transform="translate(1595.0,616.5)">
                 <text class="sld-label" id="trf5_TWO_S_LABEL" x="-5.0" y="5.0">trf5</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf25_95_INTERNAL_95_vl3_95_dtrf25">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf25_95_INTERNAL_95_vl3_95_btrf25">
                 <polyline points="1595.0,444.5,1595.0,474.5"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf25_95_INTERNAL_95_vl3_95_dtrf25">
-                <polyline points="1595.0,504.5,1595.0,474.5"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf25_95_btrf25">
+                <polyline points="1595.0,474.5,1595.0,504.5"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf25_95_INTERNAL_95_vl3_95_trf5_95_TWO">
                 <polyline points="1595.0,524.5,1595.0,554.5"/>
@@ -1333,7 +1333,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf36" transform="translate(1641.0,410.5)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf36" transform="translate(1641.0,410.5)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf6_95_THREE" transform="translate(1641.0,330.5)">
@@ -1342,11 +1342,11 @@
             <g class="sld-top-feeder sld-vl50to70-0" id="idtrf6_95_THREE" transform="translate(1645.0,272.5)">
                 <text class="sld-label" id="trf6_THREE_N_LABEL" x="-5.0" y="-5.0">trf63</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf36_95_INTERNAL_95_vl3_95_dtrf36">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf36_95_INTERNAL_95_vl3_95_btrf36">
                 <polyline points="1645.0,444.5,1645.0,414.5"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf36_95_INTERNAL_95_vl3_95_dtrf36">
-                <polyline points="1645.0,384.5,1645.0,414.5"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf36_95_btrf36">
+                <polyline points="1645.0,414.5,1645.0,384.5"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf36_95_INTERNAL_95_vl3_95_trf6_95_THREE">
                 <polyline points="1645.0,364.5,1645.0,334.5"/>
@@ -1374,7 +1374,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf37" transform="translate(1691.0,470.5)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf37" transform="translate(1691.0,470.5)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf7_95_THREE" transform="translate(1691.0,550.5)">
@@ -1383,11 +1383,11 @@
             <g class="sld-bottom-feeder sld-vl50to70-0" id="idtrf7_95_THREE" transform="translate(1695.0,616.5)">
                 <text class="sld-label" id="trf7_THREE_S_LABEL" x="-5.0" y="5.0">trf73</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf37_95_INTERNAL_95_vl3_95_dtrf37">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf37_95_INTERNAL_95_vl3_95_btrf37">
                 <polyline points="1695.0,444.5,1695.0,474.5"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf37_95_INTERNAL_95_vl3_95_dtrf37">
-                <polyline points="1695.0,504.5,1695.0,474.5"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf37_95_btrf37">
+                <polyline points="1695.0,474.5,1695.0,504.5"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf37_95_INTERNAL_95_vl3_95_trf7_95_THREE">
                 <polyline points="1695.0,524.5,1695.0,554.5"/>
@@ -1415,7 +1415,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf38" transform="translate(1741.0,410.5)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf38" transform="translate(1741.0,410.5)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf8_95_THREE" transform="translate(1741.0,330.5)">
@@ -1424,11 +1424,11 @@
             <g class="sld-top-feeder sld-vl50to70-0" id="idtrf8_95_THREE" transform="translate(1745.0,272.5)">
                 <text class="sld-label" id="trf8_THREE_N_LABEL" x="-5.0" y="-5.0">trf83</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf38_95_INTERNAL_95_vl3_95_dtrf38">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf38_95_INTERNAL_95_vl3_95_btrf38">
                 <polyline points="1745.0,444.5,1745.0,414.5"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf38_95_INTERNAL_95_vl3_95_dtrf38">
-                <polyline points="1745.0,384.5,1745.0,414.5"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf38_95_btrf38">
+                <polyline points="1745.0,414.5,1745.0,384.5"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf38_95_INTERNAL_95_vl3_95_trf8_95_THREE">
                 <polyline points="1745.0,364.5,1745.0,334.5"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHNone.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHNone.svg
@@ -214,20 +214,20 @@
             <text class="sld-label" id="bbs4_NW_LABEL" x="-5.0" y="-5.0">bbs4</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dsect11" transform="translate(436.0,428.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(436.0,428.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dsect12" transform="translate(486.0,428.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(486.0,428.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bbs1_95_dsect11">
                 <polyline points="427.5,432.0,440.0,432.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect11">
-                <polyline points="455.0,432.0,440.0,432.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11">
+                <polyline points="440.0,432.0,455.0,432.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect12">
-                <polyline points="475.0,432.0,490.0,432.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11">
+                <polyline points="490.0,432.0,475.0,432.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dsect12_95_bbs2">
                 <polyline points="490.0,432.0,502.5,432.0"/>
@@ -246,20 +246,20 @@
             </g>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dsect21" transform="translate(436.0,453.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(436.0,453.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dsect22" transform="translate(486.0,453.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(486.0,453.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bbs3_95_dsect21">
                 <polyline points="427.5,457.0,440.0,457.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect21">
-                <polyline points="455.0,457.0,440.0,457.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21">
+                <polyline points="440.0,457.0,455.0,457.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect22">
-                <polyline points="475.0,457.0,490.0,457.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21">
+                <polyline points="490.0,457.0,475.0,457.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dsect22_95_bbs4">
                 <polyline points="490.0,457.0,502.5,457.0"/>
@@ -278,7 +278,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dload1" transform="translate(61.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bload1" transform="translate(61.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_load1" transform="translate(61.0,318.0)">
@@ -290,11 +290,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load1_N_LABEL" x="-5.0" y="-5.0">load1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_dload1">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_bload1">
                 <polyline points="65.0,432.0,65.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_dload1">
-                <polyline points="65.0,372.0,65.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bload1_95_bload1">
+                <polyline points="65.0,402.0,65.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_load1">
                 <polyline points="65.0,352.0,65.0,322.0"/>
@@ -322,7 +322,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf11" transform="translate(111.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf11" transform="translate(111.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf1_95_ONE" transform="translate(111.0,318.0)">
@@ -331,11 +331,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf1_95_ONE" transform="translate(115.0,260.0)">
                 <text class="sld-label" id="trf1_ONE_N_LABEL" x="-5.0" y="-5.0">trf1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_dtrf11">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_btrf11">
                 <polyline points="115.0,432.0,115.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_dtrf11">
-                <polyline points="115.0,372.0,115.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf11_95_btrf11">
+                <polyline points="115.0,402.0,115.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_trf1_95_ONE">
                 <polyline points="115.0,352.0,115.0,322.0"/>
@@ -363,7 +363,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf15" transform="translate(261.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf15" transform="translate(261.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf5_95_ONE" transform="translate(261.0,318.0)">
@@ -372,11 +372,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf5_95_ONE" transform="translate(265.0,260.0)">
                 <text class="sld-label" id="trf5_ONE_N_LABEL" x="-5.0" y="-5.0">trf5</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_dtrf15">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_btrf15">
                 <polyline points="265.0,432.0,265.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_dtrf15">
-                <polyline points="265.0,372.0,265.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf15_95_btrf15">
+                <polyline points="265.0,402.0,265.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_trf5_95_ONE">
                 <polyline points="265.0,352.0,265.0,322.0"/>
@@ -404,7 +404,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf16" transform="translate(311.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf16" transform="translate(311.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf6_95_ONE" transform="translate(311.0,318.0)">
@@ -413,11 +413,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf6_95_ONE" transform="translate(315.0,260.0)">
                 <text class="sld-label" id="trf6_ONE_N_LABEL" x="-5.0" y="-5.0">trf61</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_dtrf16">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_btrf16">
                 <polyline points="315.0,432.0,315.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf16_95_INTERNAL_95_vl1_95_dtrf16">
-                <polyline points="315.0,372.0,315.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf16_95_btrf16">
+                <polyline points="315.0,402.0,315.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf16_95_INTERNAL_95_vl1_95_trf6_95_ONE">
                 <polyline points="315.0,352.0,315.0,322.0"/>
@@ -445,7 +445,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dline11_95_2" transform="translate(411.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bline11_95_2" transform="translate(411.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_line1_95_ONE" transform="translate(411.0,318.0)">
@@ -454,11 +454,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idline1_95_ONE" transform="translate(415.0,260.0)">
                 <text class="sld-label" id="line1_ONE_N_LABEL" x="-5.0" y="-5.0">line1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dline11_95_2_95_INTERNAL_95_vl1_95_dline11_95_2">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dline11_95_2_95_INTERNAL_95_vl1_95_bline11_95_2">
                 <polyline points="415.0,432.0,415.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bline11_95_2_95_INTERNAL_95_vl1_95_dline11_95_2">
-                <polyline points="415.0,372.0,415.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bline11_95_2_95_bline11_95_2">
+                <polyline points="415.0,402.0,415.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bline11_95_2_95_INTERNAL_95_vl1_95_line1_95_ONE">
                 <polyline points="415.0,352.0,415.0,322.0"/>
@@ -486,7 +486,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dload2" transform="translate(511.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bload2" transform="translate(511.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_load2" transform="translate(511.0,318.0)">
@@ -498,11 +498,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load2_N_LABEL" x="-5.0" y="-5.0">load2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_dload2">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_bload2">
                 <polyline points="515.0,432.0,515.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_dload2">
-                <polyline points="515.0,372.0,515.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bload2_95_bload2">
+                <polyline points="515.0,402.0,515.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_load2">
                 <polyline points="515.0,352.0,515.0,322.0"/>
@@ -530,7 +530,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf12" transform="translate(661.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf12" transform="translate(661.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf2_95_ONE" transform="translate(661.0,318.0)">
@@ -539,11 +539,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf2_95_ONE" transform="translate(665.0,260.0)">
                 <text class="sld-label" id="trf2_ONE_N_LABEL" x="-5.0" y="-5.0">trf2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_dtrf12">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_btrf12">
                 <polyline points="665.0,432.0,665.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_dtrf12">
-                <polyline points="665.0,372.0,665.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf12_95_btrf12">
+                <polyline points="665.0,402.0,665.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_trf2_95_ONE">
                 <polyline points="665.0,352.0,665.0,322.0"/>
@@ -571,7 +571,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf18" transform="translate(561.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf18" transform="translate(561.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf8_95_ONE" transform="translate(561.0,318.0)">
@@ -580,11 +580,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf8_95_ONE" transform="translate(565.0,260.0)">
                 <text class="sld-label" id="trf8_ONE_N_LABEL" x="-5.0" y="-5.0">trf81</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_dtrf18">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_btrf18">
                 <polyline points="565.0,432.0,565.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_dtrf18">
-                <polyline points="565.0,372.0,565.0,402.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf18_95_btrf18">
+                <polyline points="565.0,402.0,565.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_trf8_95_ONE">
                 <polyline points="565.0,352.0,565.0,322.0"/>
@@ -612,7 +612,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_10">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dgen1" transform="translate(161.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_bgen1" transform="translate(161.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_gen1" transform="translate(161.0,563.0)">
@@ -624,11 +624,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen1_S_LABEL" x="-5.0" y="17.0">gen1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_dgen1">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_bgen1">
                 <polyline points="165.0,457.0,165.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_dgen1">
-                <polyline points="165.0,517.0,165.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_bgen1_95_bgen1">
+                <polyline points="165.0,487.0,165.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_gen1">
                 <polyline points="165.0,537.0,165.0,567.0"/>
@@ -656,7 +656,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_11">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf13" transform="translate(211.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf13" transform="translate(211.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf3_95_ONE" transform="translate(211.0,563.0)">
@@ -665,11 +665,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf3_95_ONE" transform="translate(215.0,629.0)">
                 <text class="sld-label" id="trf3_ONE_S_LABEL" x="-5.0" y="5.0">trf3</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_dtrf13">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_btrf13">
                 <polyline points="215.0,457.0,215.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_dtrf13">
-                <polyline points="215.0,517.0,215.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf13_95_btrf13">
+                <polyline points="215.0,487.0,215.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_trf3_95_ONE">
                 <polyline points="215.0,537.0,215.0,567.0"/>
@@ -697,7 +697,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_12">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf17" transform="translate(361.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf17" transform="translate(361.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf7_95_ONE" transform="translate(361.0,563.0)">
@@ -706,11 +706,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf7_95_ONE" transform="translate(365.0,629.0)">
                 <text class="sld-label" id="trf7_ONE_S_LABEL" x="-5.0" y="5.0">trf71</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_dtrf17">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_btrf17">
                 <polyline points="365.0,457.0,365.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf17_95_INTERNAL_95_vl1_95_dtrf17">
-                <polyline points="365.0,517.0,365.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf17_95_btrf17">
+                <polyline points="365.0,487.0,365.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf17_95_INTERNAL_95_vl1_95_trf7_95_ONE">
                 <polyline points="365.0,537.0,365.0,567.0"/>
@@ -738,7 +738,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_13">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dgen2" transform="translate(711.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_bgen2" transform="translate(711.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_gen2" transform="translate(711.0,563.0)">
@@ -750,11 +750,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen2_S_LABEL" x="-5.0" y="17.0">gen2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_dgen2">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_bgen2">
                 <polyline points="715.0,457.0,715.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_dgen2">
-                <polyline points="715.0,517.0,715.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_bgen2_95_bgen2">
+                <polyline points="715.0,487.0,715.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_gen2">
                 <polyline points="715.0,537.0,715.0,567.0"/>
@@ -782,7 +782,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_14">
-            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf14" transform="translate(611.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf14" transform="translate(611.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf4_95_ONE" transform="translate(611.0,563.0)">
@@ -791,11 +791,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf4_95_ONE" transform="translate(615.0,629.0)">
                 <text class="sld-label" id="trf4_ONE_S_LABEL" x="-5.0" y="5.0">trf4</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_dtrf14">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_btrf14">
                 <polyline points="615.0,457.0,615.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_dtrf14">
-                <polyline points="615.0,517.0,615.0,487.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf14_95_btrf14">
+                <polyline points="615.0,487.0,615.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_trf4_95_ONE">
                 <polyline points="615.0,537.0,615.0,567.0"/>
@@ -834,22 +834,22 @@
             <text class="sld-label" id="bbs6_NW_LABEL" x="-5.0" y="-5.0">bbs6</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-vertical" id="idINTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dscpl1" transform="translate(941.0,388.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_ddcpl1" transform="translate(941.0,388.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dscpl2" transform="translate(891.0,388.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_ddcpl1" transform="translate(891.0,388.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl1_95_INTERNAL_95_vl2_95_dscpl1">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl1_95_INTERNAL_95_vl2_95_ddcpl1">
                 <polyline points="945.0,432.0,945.0,392.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_ddcpl1_95_INTERNAL_95_vl2_95_dscpl1">
-                <polyline points="930.0,392.0,945.0,392.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_ddcpl1_95_ddcpl1">
+                <polyline points="945.0,392.0,930.0,392.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_ddcpl1_95_INTERNAL_95_vl2_95_dscpl2">
-                <polyline points="910.0,392.0,895.0,392.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_ddcpl1_95_ddcpl1">
+                <polyline points="895.0,392.0,910.0,392.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl2_95_INTERNAL_95_vl2_95_dscpl2">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dscpl2_95_INTERNAL_95_vl2_95_ddcpl1">
                 <polyline points="895.0,457.0,895.0,392.0"/>
             </g>
             <g class="sld-disconnector sld-closed sld-fictitious sld-vl180to300-0" id="iddscpl1" transform="translate(941.0,428.0)">
@@ -866,7 +866,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dload3" transform="translate(991.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_bload3" transform="translate(991.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_load3" transform="translate(991.0,318.0)">
@@ -878,11 +878,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load3_N_LABEL" x="-5.0" y="-5.0">load3</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dload3_95_INTERNAL_95_vl2_95_dload3">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dload3_95_INTERNAL_95_vl2_95_bload3">
                 <polyline points="995.0,432.0,995.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bload3_95_INTERNAL_95_vl2_95_dload3">
-                <polyline points="995.0,372.0,995.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_bload3_95_bload3">
+                <polyline points="995.0,402.0,995.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bload3_95_INTERNAL_95_vl2_95_load3">
                 <polyline points="995.0,352.0,995.0,322.0"/>
@@ -910,7 +910,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf21" transform="translate(1041.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf21" transform="translate(1041.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf1_95_TWO" transform="translate(1041.0,318.0)">
@@ -919,11 +919,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf1_95_TWO" transform="translate(1045.0,260.0)">
                 <text class="sld-label" id="trf1_TWO_N_LABEL" x="-5.0" y="-5.0">trf1</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf21_95_INTERNAL_95_vl2_95_dtrf21">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf21_95_INTERNAL_95_vl2_95_btrf21">
                 <polyline points="1045.0,432.0,1045.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf21_95_INTERNAL_95_vl2_95_dtrf21">
-                <polyline points="1045.0,372.0,1045.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf21_95_btrf21">
+                <polyline points="1045.0,402.0,1045.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf21_95_INTERNAL_95_vl2_95_trf1_95_TWO">
                 <polyline points="1045.0,352.0,1045.0,322.0"/>
@@ -951,7 +951,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf24" transform="translate(1141.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf24" transform="translate(1141.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf4_95_TWO" transform="translate(1141.0,318.0)">
@@ -960,11 +960,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf4_95_TWO" transform="translate(1145.0,260.0)">
                 <text class="sld-label" id="trf4_TWO_N_LABEL" x="-5.0" y="-5.0">trf4</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf24_95_INTERNAL_95_vl2_95_dtrf24">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf24_95_INTERNAL_95_vl2_95_btrf24">
                 <polyline points="1145.0,432.0,1145.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf24_95_INTERNAL_95_vl2_95_dtrf24">
-                <polyline points="1145.0,372.0,1145.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf24_95_btrf24">
+                <polyline points="1145.0,402.0,1145.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf24_95_INTERNAL_95_vl2_95_trf4_95_TWO">
                 <polyline points="1145.0,352.0,1145.0,322.0"/>
@@ -992,7 +992,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf27" transform="translate(1191.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf27" transform="translate(1191.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf7_95_TWO" transform="translate(1191.0,318.0)">
@@ -1001,11 +1001,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf7_95_TWO" transform="translate(1195.0,260.0)">
                 <text class="sld-label" id="trf7_TWO_N_LABEL" x="-5.0" y="-5.0">trf72</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf27_95_INTERNAL_95_vl2_95_dtrf27">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf27_95_INTERNAL_95_vl2_95_btrf27">
                 <polyline points="1195.0,432.0,1195.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf27_95_INTERNAL_95_vl2_95_dtrf27">
-                <polyline points="1195.0,372.0,1195.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf27_95_btrf27">
+                <polyline points="1195.0,402.0,1195.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf27_95_INTERNAL_95_vl2_95_trf7_95_TWO">
                 <polyline points="1195.0,352.0,1195.0,322.0"/>
@@ -1033,7 +1033,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dgen4" transform="translate(1091.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_bgen4" transform="translate(1091.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_gen4" transform="translate(1091.0,563.0)">
@@ -1045,11 +1045,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen4_S_LABEL" x="-5.0" y="17.0">gen4</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dgen4_95_INTERNAL_95_vl2_95_dgen4">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dgen4_95_INTERNAL_95_vl2_95_bgen4">
                 <polyline points="1095.0,457.0,1095.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bgen4_95_INTERNAL_95_vl2_95_dgen4">
-                <polyline points="1095.0,517.0,1095.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_bgen4_95_bgen4">
+                <polyline points="1095.0,487.0,1095.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_bgen4_95_INTERNAL_95_vl2_95_gen4">
                 <polyline points="1095.0,537.0,1095.0,567.0"/>
@@ -1077,7 +1077,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf22" transform="translate(1341.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf22" transform="translate(1341.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf2_95_TWO" transform="translate(1341.0,563.0)">
@@ -1086,11 +1086,11 @@
             <g class="sld-bottom-feeder sld-vl180to300-0" id="idtrf2_95_TWO" transform="translate(1345.0,629.0)">
                 <text class="sld-label" id="trf2_TWO_S_LABEL" x="-5.0" y="5.0">trf2</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf22_95_INTERNAL_95_vl2_95_dtrf22">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf22_95_INTERNAL_95_vl2_95_btrf22">
                 <polyline points="1345.0,457.0,1345.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf22_95_INTERNAL_95_vl2_95_dtrf22">
-                <polyline points="1345.0,517.0,1345.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf22_95_btrf22">
+                <polyline points="1345.0,487.0,1345.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf22_95_INTERNAL_95_vl2_95_trf2_95_TWO">
                 <polyline points="1345.0,537.0,1345.0,567.0"/>
@@ -1118,7 +1118,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf23" transform="translate(1391.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf23" transform="translate(1391.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf3_95_TWO" transform="translate(1391.0,563.0)">
@@ -1127,11 +1127,11 @@
             <g class="sld-bottom-feeder sld-vl180to300-0" id="idtrf3_95_TWO" transform="translate(1395.0,629.0)">
                 <text class="sld-label" id="trf3_TWO_S_LABEL" x="-5.0" y="5.0">trf3</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf23_95_INTERNAL_95_vl2_95_dtrf23">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf23_95_INTERNAL_95_vl2_95_btrf23">
                 <polyline points="1395.0,457.0,1395.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf23_95_INTERNAL_95_vl2_95_dtrf23">
-                <polyline points="1395.0,517.0,1395.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf23_95_btrf23">
+                <polyline points="1395.0,487.0,1395.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf23_95_INTERNAL_95_vl2_95_trf3_95_TWO">
                 <polyline points="1395.0,537.0,1395.0,567.0"/>
@@ -1159,7 +1159,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf26" transform="translate(1241.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf26" transform="translate(1241.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf6_95_TWO" transform="translate(1241.0,318.0)">
@@ -1168,11 +1168,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf6_95_TWO" transform="translate(1245.0,260.0)">
                 <text class="sld-label" id="trf6_TWO_N_LABEL" x="-5.0" y="-5.0">trf62</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf26_95_INTERNAL_95_vl2_95_dtrf26">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf26_95_INTERNAL_95_vl2_95_btrf26">
                 <polyline points="1245.0,457.0,1245.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf26_95_INTERNAL_95_vl2_95_dtrf26">
-                <polyline points="1245.0,372.0,1245.0,402.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf26_95_btrf26">
+                <polyline points="1245.0,402.0,1245.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf26_95_INTERNAL_95_vl2_95_trf6_95_TWO">
                 <polyline points="1245.0,352.0,1245.0,322.0"/>
@@ -1200,7 +1200,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_dtrf28" transform="translate(1291.0,483.0)">
+            <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_btrf28" transform="translate(1291.0,483.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf8_95_TWO" transform="translate(1291.0,563.0)">
@@ -1209,11 +1209,11 @@
             <g class="sld-bottom-feeder sld-vl180to300-0" id="idtrf8_95_TWO" transform="translate(1295.0,629.0)">
                 <text class="sld-label" id="trf8_TWO_S_LABEL" x="-5.0" y="5.0">trf82</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf28_95_INTERNAL_95_vl2_95_dtrf28">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_dtrf28_95_INTERNAL_95_vl2_95_btrf28">
                 <polyline points="1295.0,457.0,1295.0,487.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf28_95_INTERNAL_95_vl2_95_dtrf28">
-                <polyline points="1295.0,517.0,1295.0,487.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_btrf28_95_btrf28">
+                <polyline points="1295.0,487.0,1295.0,517.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_btrf28_95_INTERNAL_95_vl2_95_trf8_95_TWO">
                 <polyline points="1295.0,537.0,1295.0,567.0"/>
@@ -1248,7 +1248,7 @@
             <text class="sld-label" id="bbs7_NW_LABEL" x="-5.0" y="-5.0">bbs7</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dload4" transform="translate(1541.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_bload4" transform="translate(1541.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_load4" transform="translate(1541.0,318.0)">
@@ -1260,11 +1260,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load4_N_LABEL" x="-5.0" y="-5.0">load4</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dload4_95_INTERNAL_95_vl3_95_dload4">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dload4_95_INTERNAL_95_vl3_95_bload4">
                 <polyline points="1545.0,432.0,1545.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_bload4_95_INTERNAL_95_vl3_95_dload4">
-                <polyline points="1545.0,372.0,1545.0,402.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_bload4_95_bload4">
+                <polyline points="1545.0,402.0,1545.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_bload4_95_INTERNAL_95_vl3_95_load4">
                 <polyline points="1545.0,352.0,1545.0,322.0"/>
@@ -1292,7 +1292,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf25" transform="translate(1591.0,458.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf25" transform="translate(1591.0,458.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf5_95_TWO" transform="translate(1591.0,538.0)">
@@ -1301,11 +1301,11 @@
             <g class="sld-bottom-feeder sld-vl50to70-0" id="idtrf5_95_TWO" transform="translate(1595.0,604.0)">
                 <text class="sld-label" id="trf5_TWO_S_LABEL" x="-5.0" y="5.0">trf5</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf25_95_INTERNAL_95_vl3_95_dtrf25">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf25_95_INTERNAL_95_vl3_95_btrf25">
                 <polyline points="1595.0,432.0,1595.0,462.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf25_95_INTERNAL_95_vl3_95_dtrf25">
-                <polyline points="1595.0,492.0,1595.0,462.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf25_95_btrf25">
+                <polyline points="1595.0,462.0,1595.0,492.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf25_95_INTERNAL_95_vl3_95_trf5_95_TWO">
                 <polyline points="1595.0,512.0,1595.0,542.0"/>
@@ -1333,7 +1333,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf36" transform="translate(1641.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf36" transform="translate(1641.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf6_95_THREE" transform="translate(1641.0,318.0)">
@@ -1342,11 +1342,11 @@
             <g class="sld-top-feeder sld-vl50to70-0" id="idtrf6_95_THREE" transform="translate(1645.0,260.0)">
                 <text class="sld-label" id="trf6_THREE_N_LABEL" x="-5.0" y="-5.0">trf63</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf36_95_INTERNAL_95_vl3_95_dtrf36">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf36_95_INTERNAL_95_vl3_95_btrf36">
                 <polyline points="1645.0,432.0,1645.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf36_95_INTERNAL_95_vl3_95_dtrf36">
-                <polyline points="1645.0,372.0,1645.0,402.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf36_95_btrf36">
+                <polyline points="1645.0,402.0,1645.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf36_95_INTERNAL_95_vl3_95_trf6_95_THREE">
                 <polyline points="1645.0,352.0,1645.0,322.0"/>
@@ -1374,7 +1374,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf37" transform="translate(1691.0,458.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf37" transform="translate(1691.0,458.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf7_95_THREE" transform="translate(1691.0,538.0)">
@@ -1383,11 +1383,11 @@
             <g class="sld-bottom-feeder sld-vl50to70-0" id="idtrf7_95_THREE" transform="translate(1695.0,604.0)">
                 <text class="sld-label" id="trf7_THREE_S_LABEL" x="-5.0" y="5.0">trf73</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf37_95_INTERNAL_95_vl3_95_dtrf37">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf37_95_INTERNAL_95_vl3_95_btrf37">
                 <polyline points="1695.0,432.0,1695.0,462.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf37_95_INTERNAL_95_vl3_95_dtrf37">
-                <polyline points="1695.0,492.0,1695.0,462.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf37_95_btrf37">
+                <polyline points="1695.0,462.0,1695.0,492.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf37_95_INTERNAL_95_vl3_95_trf7_95_THREE">
                 <polyline points="1695.0,512.0,1695.0,542.0"/>
@@ -1415,7 +1415,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_dtrf38" transform="translate(1741.0,398.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_btrf38" transform="translate(1741.0,398.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_trf8_95_THREE" transform="translate(1741.0,318.0)">
@@ -1424,11 +1424,11 @@
             <g class="sld-top-feeder sld-vl50to70-0" id="idtrf8_95_THREE" transform="translate(1745.0,260.0)">
                 <text class="sld-label" id="trf8_THREE_N_LABEL" x="-5.0" y="-5.0">trf83</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf38_95_INTERNAL_95_vl3_95_dtrf38">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_dtrf38_95_INTERNAL_95_vl3_95_btrf38">
                 <polyline points="1745.0,432.0,1745.0,402.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf38_95_INTERNAL_95_vl3_95_dtrf38">
-                <polyline points="1745.0,372.0,1745.0,402.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_btrf38_95_btrf38">
+                <polyline points="1745.0,402.0,1745.0,372.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_btrf38_95_INTERNAL_95_vl3_95_trf8_95_THREE">
                 <polyline points="1745.0,352.0,1745.0,322.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHRaw.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHRaw.json
@@ -10,7 +10,7 @@
     "y" : 260.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dgen1",
+      "id" : "INTERNAL_vl1_bgen1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -19,7 +19,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dgen2",
+      "id" : "INTERNAL_vl1_bgen2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 675.0,
@@ -28,7 +28,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dline11_2",
+      "id" : "INTERNAL_vl1_bline11_2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -36,7 +36,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dload1",
+      "id" : "INTERNAL_vl1_bload1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -44,7 +44,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dload2",
+      "id" : "INTERNAL_vl1_bload2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -52,43 +52,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect11",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 400.0,
-      "y" : 280.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect12",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 450.0,
-      "y" : 280.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect21",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 400.0,
-      "y" : 305.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect22",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 450.0,
-      "y" : 305.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf11",
+      "id" : "INTERNAL_vl1_btrf11",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -96,7 +60,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf12",
+      "id" : "INTERNAL_vl1_btrf12",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 625.0,
@@ -104,7 +68,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf13",
+      "id" : "INTERNAL_vl1_btrf13",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -113,7 +77,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf14",
+      "id" : "INTERNAL_vl1_btrf14",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -122,7 +86,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf15",
+      "id" : "INTERNAL_vl1_btrf15",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -130,7 +94,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf16",
+      "id" : "INTERNAL_vl1_btrf16",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -138,7 +102,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf17",
+      "id" : "INTERNAL_vl1_btrf17",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -147,11 +111,47 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf18",
+      "id" : "INTERNAL_vl1_btrf18",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
       "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct11",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 400.0,
+      "y" : 280.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct11",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 450.0,
+      "y" : 280.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct21",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 400.0,
+      "y" : 305.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct21",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 450.0,
+      "y" : 305.0,
+      "orientation" : "RIGHT",
       "open" : false
     }, {
       "type" : "FICTITIOUS",
@@ -992,7 +992,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dsect12" ]
+          "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dtrct11" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1013,7 +1013,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl1_dsect11", "dtrct11", "INTERNAL_vl1_dsect12" ]
+          "nodes" : [ "INTERNAL_vl1_dtrct11", "dtrct11", "INTERNAL_vl1_dtrct11" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -1034,7 +1034,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dsect11" ]
+          "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dtrct11" ]
         } ]
       }
     }, {
@@ -1081,7 +1081,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dsect22" ]
+          "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dtrct21" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1102,7 +1102,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl1_dsect21", "dtrct21", "INTERNAL_vl1_dsect22" ]
+          "nodes" : [ "INTERNAL_vl1_dtrct21", "dtrct21", "INTERNAL_vl1_dtrct21" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -1123,7 +1123,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dsect21" ]
+          "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dtrct21" ]
         } ]
       }
     }, {
@@ -1171,7 +1171,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_dload1" ]
+          "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_bload1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1192,7 +1192,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dload1", "bload1", "INTERNAL_vl1_load1" ]
+          "nodes" : [ "INTERNAL_vl1_bload1", "bload1", "INTERNAL_vl1_load1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1261,7 +1261,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_dtrf11" ]
+          "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_btrf11" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1282,7 +1282,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1351,7 +1351,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_dtrf15" ]
+          "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_btrf15" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1372,7 +1372,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1441,7 +1441,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_dtrf16" ]
+          "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_btrf16" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1462,7 +1462,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf16", "btrf16", "INTERNAL_vl1_trf6_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf16", "btrf16", "INTERNAL_vl1_trf6_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1531,7 +1531,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dline11_2", "INTERNAL_vl1_dline11_2" ]
+          "nodes" : [ "bbs1", "dline11_2", "INTERNAL_vl1_bline11_2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1552,7 +1552,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dline11_2", "bline11_2", "INTERNAL_vl1_line1_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_bline11_2", "bline11_2", "INTERNAL_vl1_line1_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1621,7 +1621,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_dload2" ]
+          "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_bload2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1642,7 +1642,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dload2", "bload2", "INTERNAL_vl1_load2" ]
+          "nodes" : [ "INTERNAL_vl1_bload2", "bload2", "INTERNAL_vl1_load2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1711,7 +1711,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_dtrf12" ]
+          "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_btrf12" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1732,7 +1732,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1801,7 +1801,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_dtrf18" ]
+          "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_btrf18" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1822,7 +1822,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf18", "btrf18", "INTERNAL_vl1_trf8_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf18", "btrf18", "INTERNAL_vl1_trf8_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1891,7 +1891,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_dgen1" ]
+          "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_bgen1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1912,7 +1912,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dgen1", "bgen1", "INTERNAL_vl1_gen1" ]
+          "nodes" : [ "INTERNAL_vl1_bgen1", "bgen1", "INTERNAL_vl1_gen1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1981,7 +1981,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_dtrf13" ]
+          "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_btrf13" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2002,7 +2002,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2071,7 +2071,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_dtrf17" ]
+          "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_btrf17" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2092,7 +2092,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf17", "btrf17", "INTERNAL_vl1_trf7_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf17", "btrf17", "INTERNAL_vl1_trf7_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2161,7 +2161,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_dgen2" ]
+          "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_bgen2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2182,7 +2182,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dgen2", "bgen2", "INTERNAL_vl1_gen2" ]
+          "nodes" : [ "INTERNAL_vl1_bgen2", "bgen2", "INTERNAL_vl1_gen2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2251,7 +2251,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_dtrf14" ]
+          "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_btrf14" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2272,7 +2272,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2348,6 +2348,108 @@
     }, {
       "node1" : "bbs1",
       "node2" : "dline11_2"
+    }, {
+      "node1" : "dsect11",
+      "node2" : "INTERNAL_vl1_dtrct11"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct11",
+      "node2" : "dtrct11"
+    }, {
+      "node1" : "dload1",
+      "node2" : "INTERNAL_vl1_bload1"
+    }, {
+      "node1" : "INTERNAL_vl1_bload1",
+      "node2" : "bload1"
+    }, {
+      "node1" : "dtrf11",
+      "node2" : "INTERNAL_vl1_btrf11"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf11",
+      "node2" : "btrf11"
+    }, {
+      "node1" : "dtrf15",
+      "node2" : "INTERNAL_vl1_btrf15"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf15",
+      "node2" : "btrf15"
+    }, {
+      "node1" : "dtrf16",
+      "node2" : "INTERNAL_vl1_btrf16"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf16",
+      "node2" : "btrf16"
+    }, {
+      "node1" : "dline11_2",
+      "node2" : "INTERNAL_vl1_bline11_2"
+    }, {
+      "node1" : "INTERNAL_vl1_bline11_2",
+      "node2" : "bline11_2"
+    }, {
+      "node1" : "dsect12",
+      "node2" : "INTERNAL_vl1_dtrct11"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct11",
+      "node2" : "dtrct11"
+    }, {
+      "node1" : "dload2",
+      "node2" : "INTERNAL_vl1_bload2"
+    }, {
+      "node1" : "INTERNAL_vl1_bload2",
+      "node2" : "bload2"
+    }, {
+      "node1" : "dtrf12",
+      "node2" : "INTERNAL_vl1_btrf12"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf12",
+      "node2" : "btrf12"
+    }, {
+      "node1" : "dtrf18",
+      "node2" : "INTERNAL_vl1_btrf18"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf18",
+      "node2" : "btrf18"
+    }, {
+      "node1" : "dsect21",
+      "node2" : "INTERNAL_vl1_dtrct21"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct21",
+      "node2" : "dtrct21"
+    }, {
+      "node1" : "dgen1",
+      "node2" : "INTERNAL_vl1_bgen1"
+    }, {
+      "node1" : "INTERNAL_vl1_bgen1",
+      "node2" : "bgen1"
+    }, {
+      "node1" : "dtrf13",
+      "node2" : "INTERNAL_vl1_btrf13"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf13",
+      "node2" : "btrf13"
+    }, {
+      "node1" : "dtrf17",
+      "node2" : "INTERNAL_vl1_btrf17"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf17",
+      "node2" : "btrf17"
+    }, {
+      "node1" : "dsect22",
+      "node2" : "INTERNAL_vl1_dtrct21"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct21",
+      "node2" : "dtrct21"
+    }, {
+      "node1" : "dgen2",
+      "node2" : "INTERNAL_vl1_bgen2"
+    }, {
+      "node1" : "INTERNAL_vl1_bgen2",
+      "node2" : "bgen2"
+    }, {
+      "node1" : "dtrf14",
+      "node2" : "INTERNAL_vl1_btrf14"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf14",
+      "node2" : "btrf14"
     }, {
       "node1" : "bload1",
       "node2" : "INTERNAL_vl1_load1"
@@ -2426,108 +2528,6 @@
     }, {
       "node1" : "INTERNAL_vl1_line1_ONE",
       "node2" : "line1_ONE"
-    }, {
-      "node1" : "dtrct11",
-      "node2" : "INTERNAL_vl1_dsect11"
-    }, {
-      "node1" : "dsect11",
-      "node2" : "INTERNAL_vl1_dsect11"
-    }, {
-      "node1" : "bload1",
-      "node2" : "INTERNAL_vl1_dload1"
-    }, {
-      "node1" : "dload1",
-      "node2" : "INTERNAL_vl1_dload1"
-    }, {
-      "node1" : "btrf11",
-      "node2" : "INTERNAL_vl1_dtrf11"
-    }, {
-      "node1" : "dtrf11",
-      "node2" : "INTERNAL_vl1_dtrf11"
-    }, {
-      "node1" : "btrf15",
-      "node2" : "INTERNAL_vl1_dtrf15"
-    }, {
-      "node1" : "dtrf15",
-      "node2" : "INTERNAL_vl1_dtrf15"
-    }, {
-      "node1" : "btrf16",
-      "node2" : "INTERNAL_vl1_dtrf16"
-    }, {
-      "node1" : "dtrf16",
-      "node2" : "INTERNAL_vl1_dtrf16"
-    }, {
-      "node1" : "bline11_2",
-      "node2" : "INTERNAL_vl1_dline11_2"
-    }, {
-      "node1" : "dline11_2",
-      "node2" : "INTERNAL_vl1_dline11_2"
-    }, {
-      "node1" : "dtrct11",
-      "node2" : "INTERNAL_vl1_dsect12"
-    }, {
-      "node1" : "dsect12",
-      "node2" : "INTERNAL_vl1_dsect12"
-    }, {
-      "node1" : "bload2",
-      "node2" : "INTERNAL_vl1_dload2"
-    }, {
-      "node1" : "dload2",
-      "node2" : "INTERNAL_vl1_dload2"
-    }, {
-      "node1" : "btrf12",
-      "node2" : "INTERNAL_vl1_dtrf12"
-    }, {
-      "node1" : "dtrf12",
-      "node2" : "INTERNAL_vl1_dtrf12"
-    }, {
-      "node1" : "btrf18",
-      "node2" : "INTERNAL_vl1_dtrf18"
-    }, {
-      "node1" : "dtrf18",
-      "node2" : "INTERNAL_vl1_dtrf18"
-    }, {
-      "node1" : "dtrct21",
-      "node2" : "INTERNAL_vl1_dsect21"
-    }, {
-      "node1" : "dsect21",
-      "node2" : "INTERNAL_vl1_dsect21"
-    }, {
-      "node1" : "bgen1",
-      "node2" : "INTERNAL_vl1_dgen1"
-    }, {
-      "node1" : "dgen1",
-      "node2" : "INTERNAL_vl1_dgen1"
-    }, {
-      "node1" : "btrf13",
-      "node2" : "INTERNAL_vl1_dtrf13"
-    }, {
-      "node1" : "dtrf13",
-      "node2" : "INTERNAL_vl1_dtrf13"
-    }, {
-      "node1" : "btrf17",
-      "node2" : "INTERNAL_vl1_dtrf17"
-    }, {
-      "node1" : "dtrf17",
-      "node2" : "INTERNAL_vl1_dtrf17"
-    }, {
-      "node1" : "dtrct21",
-      "node2" : "INTERNAL_vl1_dsect22"
-    }, {
-      "node1" : "dsect22",
-      "node2" : "INTERNAL_vl1_dsect22"
-    }, {
-      "node1" : "bgen2",
-      "node2" : "INTERNAL_vl1_dgen2"
-    }, {
-      "node1" : "dgen2",
-      "node2" : "INTERNAL_vl1_dgen2"
-    }, {
-      "node1" : "btrf14",
-      "node2" : "INTERNAL_vl1_dtrf14"
-    }, {
-      "node1" : "dtrf14",
-      "node2" : "INTERNAL_vl1_dtrf14"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],
@@ -2542,7 +2542,7 @@
     "y" : 260.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dgen4",
+      "id" : "INTERNAL_vl2_bgen4",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -2551,7 +2551,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dload3",
+      "id" : "INTERNAL_vl2_bload3",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2559,23 +2559,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dscpl1",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 75.0,
-      "y" : 240.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dscpl2",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 25.0,
-      "y" : 240.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf21",
+      "id" : "INTERNAL_vl2_btrf21",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2583,7 +2567,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf22",
+      "id" : "INTERNAL_vl2_btrf22",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -2592,7 +2576,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf23",
+      "id" : "INTERNAL_vl2_btrf23",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -2601,7 +2585,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf24",
+      "id" : "INTERNAL_vl2_btrf24",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -2609,7 +2593,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf26",
+      "id" : "INTERNAL_vl2_btrf26",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -2617,7 +2601,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf27",
+      "id" : "INTERNAL_vl2_btrf27",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -2625,12 +2609,28 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf28",
+      "id" : "INTERNAL_vl2_btrf28",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
       "y" : 335.0,
       "orientation" : "DOWN",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl2_ddcpl1",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 75.0,
+      "y" : 240.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl2_ddcpl1",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 25.0,
+      "y" : 240.0,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
@@ -3202,7 +3202,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_dscpl2" ]
+          "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_ddcpl1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3223,7 +3223,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl2_dscpl2", "ddcpl1", "INTERNAL_vl2_dscpl1" ]
+          "nodes" : [ "INTERNAL_vl2_ddcpl1", "ddcpl1", "INTERNAL_vl2_ddcpl1" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -3244,7 +3244,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_dscpl1" ]
+          "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_ddcpl1" ]
         } ]
       }
     }, {
@@ -3292,7 +3292,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_dload3" ]
+          "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_bload3" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3313,7 +3313,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dload3", "bload3", "INTERNAL_vl2_load3" ]
+          "nodes" : [ "INTERNAL_vl2_bload3", "bload3", "INTERNAL_vl2_load3" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3382,7 +3382,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_dtrf21" ]
+          "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_btrf21" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3403,7 +3403,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3472,7 +3472,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_dtrf24" ]
+          "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_btrf24" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3493,7 +3493,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3562,7 +3562,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_dtrf27" ]
+          "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_btrf27" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3583,7 +3583,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf27", "btrf27", "INTERNAL_vl2_trf7_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf27", "btrf27", "INTERNAL_vl2_trf7_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3652,7 +3652,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_dgen4" ]
+          "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_bgen4" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3673,7 +3673,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dgen4", "bgen4", "INTERNAL_vl2_gen4" ]
+          "nodes" : [ "INTERNAL_vl2_bgen4", "bgen4", "INTERNAL_vl2_gen4" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3742,7 +3742,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_dtrf22" ]
+          "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_btrf22" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3763,7 +3763,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3832,7 +3832,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_dtrf23" ]
+          "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_btrf23" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3853,7 +3853,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3922,7 +3922,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_dtrf26" ]
+          "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_btrf26" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3943,7 +3943,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf26", "btrf26", "INTERNAL_vl2_trf6_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf26", "btrf26", "INTERNAL_vl2_trf6_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4012,7 +4012,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_dtrf28" ]
+          "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_btrf28" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4033,7 +4033,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf28", "btrf28", "INTERNAL_vl2_trf8_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf28", "btrf28", "INTERNAL_vl2_trf8_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4092,6 +4092,72 @@
       "node1" : "bbs6",
       "node2" : "dtrf28"
     }, {
+      "node1" : "dscpl1",
+      "node2" : "INTERNAL_vl2_ddcpl1"
+    }, {
+      "node1" : "INTERNAL_vl2_ddcpl1",
+      "node2" : "ddcpl1"
+    }, {
+      "node1" : "dload3",
+      "node2" : "INTERNAL_vl2_bload3"
+    }, {
+      "node1" : "INTERNAL_vl2_bload3",
+      "node2" : "bload3"
+    }, {
+      "node1" : "dtrf21",
+      "node2" : "INTERNAL_vl2_btrf21"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf21",
+      "node2" : "btrf21"
+    }, {
+      "node1" : "dtrf24",
+      "node2" : "INTERNAL_vl2_btrf24"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf24",
+      "node2" : "btrf24"
+    }, {
+      "node1" : "dtrf27",
+      "node2" : "INTERNAL_vl2_btrf27"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf27",
+      "node2" : "btrf27"
+    }, {
+      "node1" : "dscpl2",
+      "node2" : "INTERNAL_vl2_ddcpl1"
+    }, {
+      "node1" : "INTERNAL_vl2_ddcpl1",
+      "node2" : "ddcpl1"
+    }, {
+      "node1" : "dgen4",
+      "node2" : "INTERNAL_vl2_bgen4"
+    }, {
+      "node1" : "INTERNAL_vl2_bgen4",
+      "node2" : "bgen4"
+    }, {
+      "node1" : "dtrf22",
+      "node2" : "INTERNAL_vl2_btrf22"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf22",
+      "node2" : "btrf22"
+    }, {
+      "node1" : "dtrf23",
+      "node2" : "INTERNAL_vl2_btrf23"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf23",
+      "node2" : "btrf23"
+    }, {
+      "node1" : "dtrf26",
+      "node2" : "INTERNAL_vl2_btrf26"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf26",
+      "node2" : "btrf26"
+    }, {
+      "node1" : "dtrf28",
+      "node2" : "INTERNAL_vl2_btrf28"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf28",
+      "node2" : "btrf28"
+    }, {
       "node1" : "bload3",
       "node2" : "INTERNAL_vl2_load3"
     }, {
@@ -4145,72 +4211,6 @@
     }, {
       "node1" : "INTERNAL_vl2_trf8_TWO",
       "node2" : "trf8_TWO"
-    }, {
-      "node1" : "ddcpl1",
-      "node2" : "INTERNAL_vl2_dscpl1"
-    }, {
-      "node1" : "dscpl1",
-      "node2" : "INTERNAL_vl2_dscpl1"
-    }, {
-      "node1" : "bload3",
-      "node2" : "INTERNAL_vl2_dload3"
-    }, {
-      "node1" : "dload3",
-      "node2" : "INTERNAL_vl2_dload3"
-    }, {
-      "node1" : "btrf21",
-      "node2" : "INTERNAL_vl2_dtrf21"
-    }, {
-      "node1" : "dtrf21",
-      "node2" : "INTERNAL_vl2_dtrf21"
-    }, {
-      "node1" : "btrf24",
-      "node2" : "INTERNAL_vl2_dtrf24"
-    }, {
-      "node1" : "dtrf24",
-      "node2" : "INTERNAL_vl2_dtrf24"
-    }, {
-      "node1" : "btrf27",
-      "node2" : "INTERNAL_vl2_dtrf27"
-    }, {
-      "node1" : "dtrf27",
-      "node2" : "INTERNAL_vl2_dtrf27"
-    }, {
-      "node1" : "ddcpl1",
-      "node2" : "INTERNAL_vl2_dscpl2"
-    }, {
-      "node1" : "dscpl2",
-      "node2" : "INTERNAL_vl2_dscpl2"
-    }, {
-      "node1" : "bgen4",
-      "node2" : "INTERNAL_vl2_dgen4"
-    }, {
-      "node1" : "dgen4",
-      "node2" : "INTERNAL_vl2_dgen4"
-    }, {
-      "node1" : "btrf22",
-      "node2" : "INTERNAL_vl2_dtrf22"
-    }, {
-      "node1" : "dtrf22",
-      "node2" : "INTERNAL_vl2_dtrf22"
-    }, {
-      "node1" : "btrf23",
-      "node2" : "INTERNAL_vl2_dtrf23"
-    }, {
-      "node1" : "dtrf23",
-      "node2" : "INTERNAL_vl2_dtrf23"
-    }, {
-      "node1" : "btrf26",
-      "node2" : "INTERNAL_vl2_dtrf26"
-    }, {
-      "node1" : "dtrf26",
-      "node2" : "INTERNAL_vl2_dtrf26"
-    }, {
-      "node1" : "btrf28",
-      "node2" : "INTERNAL_vl2_dtrf28"
-    }, {
-      "node1" : "dtrf28",
-      "node2" : "INTERNAL_vl2_dtrf28"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],
@@ -4225,7 +4225,7 @@
     "y" : 260.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dload4",
+      "id" : "INTERNAL_vl3_bload4",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -4233,7 +4233,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf25",
+      "id" : "INTERNAL_vl3_btrf25",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -4242,7 +4242,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf36",
+      "id" : "INTERNAL_vl3_btrf36",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -4250,7 +4250,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf37",
+      "id" : "INTERNAL_vl3_btrf37",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -4259,7 +4259,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf38",
+      "id" : "INTERNAL_vl3_btrf38",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -4582,7 +4582,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_dload4" ]
+          "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_bload4" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4603,7 +4603,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dload4", "bload4", "INTERNAL_vl3_load4" ]
+          "nodes" : [ "INTERNAL_vl3_bload4", "bload4", "INTERNAL_vl3_load4" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4672,7 +4672,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_dtrf25" ]
+          "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_btrf25" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4693,7 +4693,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
+          "nodes" : [ "INTERNAL_vl3_btrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4762,7 +4762,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_dtrf36" ]
+          "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_btrf36" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4783,7 +4783,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf36", "btrf36", "INTERNAL_vl3_trf6_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf36", "btrf36", "INTERNAL_vl3_trf6_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4852,7 +4852,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_dtrf37" ]
+          "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_btrf37" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4873,7 +4873,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf37", "btrf37", "INTERNAL_vl3_trf7_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf37", "btrf37", "INTERNAL_vl3_trf7_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4942,7 +4942,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_dtrf38" ]
+          "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_btrf38" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4963,7 +4963,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf38", "btrf38", "INTERNAL_vl3_trf8_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf38", "btrf38", "INTERNAL_vl3_trf8_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -5004,6 +5004,36 @@
       "node1" : "bbs7",
       "node2" : "dtrf38"
     }, {
+      "node1" : "dload4",
+      "node2" : "INTERNAL_vl3_bload4"
+    }, {
+      "node1" : "INTERNAL_vl3_bload4",
+      "node2" : "bload4"
+    }, {
+      "node1" : "dtrf25",
+      "node2" : "INTERNAL_vl3_btrf25"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf25",
+      "node2" : "btrf25"
+    }, {
+      "node1" : "dtrf36",
+      "node2" : "INTERNAL_vl3_btrf36"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf36",
+      "node2" : "btrf36"
+    }, {
+      "node1" : "dtrf37",
+      "node2" : "INTERNAL_vl3_btrf37"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf37",
+      "node2" : "btrf37"
+    }, {
+      "node1" : "dtrf38",
+      "node2" : "INTERNAL_vl3_btrf38"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf38",
+      "node2" : "btrf38"
+    }, {
       "node1" : "bload4",
       "node2" : "INTERNAL_vl3_load4"
     }, {
@@ -5033,36 +5063,6 @@
     }, {
       "node1" : "INTERNAL_vl3_trf8_THREE",
       "node2" : "trf8_THREE"
-    }, {
-      "node1" : "bload4",
-      "node2" : "INTERNAL_vl3_dload4"
-    }, {
-      "node1" : "dload4",
-      "node2" : "INTERNAL_vl3_dload4"
-    }, {
-      "node1" : "btrf25",
-      "node2" : "INTERNAL_vl3_dtrf25"
-    }, {
-      "node1" : "dtrf25",
-      "node2" : "INTERNAL_vl3_dtrf25"
-    }, {
-      "node1" : "btrf36",
-      "node2" : "INTERNAL_vl3_dtrf36"
-    }, {
-      "node1" : "dtrf36",
-      "node2" : "INTERNAL_vl3_dtrf36"
-    }, {
-      "node1" : "btrf37",
-      "node2" : "INTERNAL_vl3_dtrf37"
-    }, {
-      "node1" : "dtrf37",
-      "node2" : "INTERNAL_vl3_dtrf37"
-    }, {
-      "node1" : "btrf38",
-      "node2" : "INTERNAL_vl3_dtrf38"
-    }, {
-      "node1" : "dtrf38",
-      "node2" : "INTERNAL_vl3_dtrf38"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphV.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphV.json
@@ -10,7 +10,7 @@
     "y" : 200.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dgen1",
+      "id" : "INTERNAL_vl1_bgen1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -19,7 +19,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dgen2",
+      "id" : "INTERNAL_vl1_bgen2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 675.0,
@@ -28,7 +28,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dline11_2",
+      "id" : "INTERNAL_vl1_bline11_2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -36,7 +36,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dload1",
+      "id" : "INTERNAL_vl1_bload1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -44,7 +44,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dload2",
+      "id" : "INTERNAL_vl1_bload2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -52,43 +52,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect11",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 400.0,
-      "y" : 280.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect12",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 450.0,
-      "y" : 280.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect21",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 400.0,
-      "y" : 305.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect22",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 450.0,
-      "y" : 305.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf11",
+      "id" : "INTERNAL_vl1_btrf11",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -96,7 +60,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf12",
+      "id" : "INTERNAL_vl1_btrf12",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 625.0,
@@ -104,7 +68,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf13",
+      "id" : "INTERNAL_vl1_btrf13",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -113,7 +77,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf14",
+      "id" : "INTERNAL_vl1_btrf14",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -122,7 +86,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf15",
+      "id" : "INTERNAL_vl1_btrf15",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -130,7 +94,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf16",
+      "id" : "INTERNAL_vl1_btrf16",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -138,7 +102,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf17",
+      "id" : "INTERNAL_vl1_btrf17",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -147,11 +111,47 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf18",
+      "id" : "INTERNAL_vl1_btrf18",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
       "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct11",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 400.0,
+      "y" : 280.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct11",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 450.0,
+      "y" : 280.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct21",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 400.0,
+      "y" : 305.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct21",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 450.0,
+      "y" : 305.0,
+      "orientation" : "RIGHT",
       "open" : false
     }, {
       "type" : "FICTITIOUS",
@@ -992,7 +992,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dsect12" ]
+          "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dtrct11" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1013,7 +1013,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl1_dsect11", "dtrct11", "INTERNAL_vl1_dsect12" ]
+          "nodes" : [ "INTERNAL_vl1_dtrct11", "dtrct11", "INTERNAL_vl1_dtrct11" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -1034,7 +1034,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dsect11" ]
+          "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dtrct11" ]
         } ]
       }
     }, {
@@ -1081,7 +1081,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dsect22" ]
+          "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dtrct21" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1102,7 +1102,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl1_dsect21", "dtrct21", "INTERNAL_vl1_dsect22" ]
+          "nodes" : [ "INTERNAL_vl1_dtrct21", "dtrct21", "INTERNAL_vl1_dtrct21" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -1123,7 +1123,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dsect21" ]
+          "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dtrct21" ]
         } ]
       }
     }, {
@@ -1171,7 +1171,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_dload1" ]
+          "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_bload1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1192,7 +1192,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dload1", "bload1", "INTERNAL_vl1_load1" ]
+          "nodes" : [ "INTERNAL_vl1_bload1", "bload1", "INTERNAL_vl1_load1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1261,7 +1261,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_dtrf11" ]
+          "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_btrf11" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1282,7 +1282,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1351,7 +1351,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_dtrf15" ]
+          "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_btrf15" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1372,7 +1372,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1441,7 +1441,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_dtrf16" ]
+          "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_btrf16" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1462,7 +1462,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf16", "btrf16", "INTERNAL_vl1_trf6_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf16", "btrf16", "INTERNAL_vl1_trf6_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1531,7 +1531,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dline11_2", "INTERNAL_vl1_dline11_2" ]
+          "nodes" : [ "bbs1", "dline11_2", "INTERNAL_vl1_bline11_2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1552,7 +1552,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dline11_2", "bline11_2", "INTERNAL_vl1_line1_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_bline11_2", "bline11_2", "INTERNAL_vl1_line1_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1621,7 +1621,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_dload2" ]
+          "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_bload2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1642,7 +1642,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dload2", "bload2", "INTERNAL_vl1_load2" ]
+          "nodes" : [ "INTERNAL_vl1_bload2", "bload2", "INTERNAL_vl1_load2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1711,7 +1711,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_dtrf12" ]
+          "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_btrf12" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1732,7 +1732,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1801,7 +1801,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_dtrf18" ]
+          "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_btrf18" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1822,7 +1822,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf18", "btrf18", "INTERNAL_vl1_trf8_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf18", "btrf18", "INTERNAL_vl1_trf8_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1891,7 +1891,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_dgen1" ]
+          "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_bgen1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1912,7 +1912,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dgen1", "bgen1", "INTERNAL_vl1_gen1" ]
+          "nodes" : [ "INTERNAL_vl1_bgen1", "bgen1", "INTERNAL_vl1_gen1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1981,7 +1981,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_dtrf13" ]
+          "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_btrf13" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2002,7 +2002,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2071,7 +2071,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_dtrf17" ]
+          "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_btrf17" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2092,7 +2092,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf17", "btrf17", "INTERNAL_vl1_trf7_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf17", "btrf17", "INTERNAL_vl1_trf7_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2161,7 +2161,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_dgen2" ]
+          "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_bgen2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2182,7 +2182,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dgen2", "bgen2", "INTERNAL_vl1_gen2" ]
+          "nodes" : [ "INTERNAL_vl1_bgen2", "bgen2", "INTERNAL_vl1_gen2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2251,7 +2251,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_dtrf14" ]
+          "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_btrf14" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2272,7 +2272,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2348,6 +2348,108 @@
     }, {
       "node1" : "bbs1",
       "node2" : "dline11_2"
+    }, {
+      "node1" : "dsect11",
+      "node2" : "INTERNAL_vl1_dtrct11"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct11",
+      "node2" : "dtrct11"
+    }, {
+      "node1" : "dload1",
+      "node2" : "INTERNAL_vl1_bload1"
+    }, {
+      "node1" : "INTERNAL_vl1_bload1",
+      "node2" : "bload1"
+    }, {
+      "node1" : "dtrf11",
+      "node2" : "INTERNAL_vl1_btrf11"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf11",
+      "node2" : "btrf11"
+    }, {
+      "node1" : "dtrf15",
+      "node2" : "INTERNAL_vl1_btrf15"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf15",
+      "node2" : "btrf15"
+    }, {
+      "node1" : "dtrf16",
+      "node2" : "INTERNAL_vl1_btrf16"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf16",
+      "node2" : "btrf16"
+    }, {
+      "node1" : "dline11_2",
+      "node2" : "INTERNAL_vl1_bline11_2"
+    }, {
+      "node1" : "INTERNAL_vl1_bline11_2",
+      "node2" : "bline11_2"
+    }, {
+      "node1" : "dsect12",
+      "node2" : "INTERNAL_vl1_dtrct11"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct11",
+      "node2" : "dtrct11"
+    }, {
+      "node1" : "dload2",
+      "node2" : "INTERNAL_vl1_bload2"
+    }, {
+      "node1" : "INTERNAL_vl1_bload2",
+      "node2" : "bload2"
+    }, {
+      "node1" : "dtrf12",
+      "node2" : "INTERNAL_vl1_btrf12"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf12",
+      "node2" : "btrf12"
+    }, {
+      "node1" : "dtrf18",
+      "node2" : "INTERNAL_vl1_btrf18"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf18",
+      "node2" : "btrf18"
+    }, {
+      "node1" : "dsect21",
+      "node2" : "INTERNAL_vl1_dtrct21"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct21",
+      "node2" : "dtrct21"
+    }, {
+      "node1" : "dgen1",
+      "node2" : "INTERNAL_vl1_bgen1"
+    }, {
+      "node1" : "INTERNAL_vl1_bgen1",
+      "node2" : "bgen1"
+    }, {
+      "node1" : "dtrf13",
+      "node2" : "INTERNAL_vl1_btrf13"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf13",
+      "node2" : "btrf13"
+    }, {
+      "node1" : "dtrf17",
+      "node2" : "INTERNAL_vl1_btrf17"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf17",
+      "node2" : "btrf17"
+    }, {
+      "node1" : "dsect22",
+      "node2" : "INTERNAL_vl1_dtrct21"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct21",
+      "node2" : "dtrct21"
+    }, {
+      "node1" : "dgen2",
+      "node2" : "INTERNAL_vl1_bgen2"
+    }, {
+      "node1" : "INTERNAL_vl1_bgen2",
+      "node2" : "bgen2"
+    }, {
+      "node1" : "dtrf14",
+      "node2" : "INTERNAL_vl1_btrf14"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf14",
+      "node2" : "btrf14"
     }, {
       "node1" : "bload1",
       "node2" : "INTERNAL_vl1_load1"
@@ -2426,108 +2528,6 @@
     }, {
       "node1" : "INTERNAL_vl1_line1_ONE",
       "node2" : "line1_ONE"
-    }, {
-      "node1" : "dtrct11",
-      "node2" : "INTERNAL_vl1_dsect11"
-    }, {
-      "node1" : "dsect11",
-      "node2" : "INTERNAL_vl1_dsect11"
-    }, {
-      "node1" : "bload1",
-      "node2" : "INTERNAL_vl1_dload1"
-    }, {
-      "node1" : "dload1",
-      "node2" : "INTERNAL_vl1_dload1"
-    }, {
-      "node1" : "btrf11",
-      "node2" : "INTERNAL_vl1_dtrf11"
-    }, {
-      "node1" : "dtrf11",
-      "node2" : "INTERNAL_vl1_dtrf11"
-    }, {
-      "node1" : "btrf15",
-      "node2" : "INTERNAL_vl1_dtrf15"
-    }, {
-      "node1" : "dtrf15",
-      "node2" : "INTERNAL_vl1_dtrf15"
-    }, {
-      "node1" : "btrf16",
-      "node2" : "INTERNAL_vl1_dtrf16"
-    }, {
-      "node1" : "dtrf16",
-      "node2" : "INTERNAL_vl1_dtrf16"
-    }, {
-      "node1" : "bline11_2",
-      "node2" : "INTERNAL_vl1_dline11_2"
-    }, {
-      "node1" : "dline11_2",
-      "node2" : "INTERNAL_vl1_dline11_2"
-    }, {
-      "node1" : "dtrct11",
-      "node2" : "INTERNAL_vl1_dsect12"
-    }, {
-      "node1" : "dsect12",
-      "node2" : "INTERNAL_vl1_dsect12"
-    }, {
-      "node1" : "bload2",
-      "node2" : "INTERNAL_vl1_dload2"
-    }, {
-      "node1" : "dload2",
-      "node2" : "INTERNAL_vl1_dload2"
-    }, {
-      "node1" : "btrf12",
-      "node2" : "INTERNAL_vl1_dtrf12"
-    }, {
-      "node1" : "dtrf12",
-      "node2" : "INTERNAL_vl1_dtrf12"
-    }, {
-      "node1" : "btrf18",
-      "node2" : "INTERNAL_vl1_dtrf18"
-    }, {
-      "node1" : "dtrf18",
-      "node2" : "INTERNAL_vl1_dtrf18"
-    }, {
-      "node1" : "dtrct21",
-      "node2" : "INTERNAL_vl1_dsect21"
-    }, {
-      "node1" : "dsect21",
-      "node2" : "INTERNAL_vl1_dsect21"
-    }, {
-      "node1" : "bgen1",
-      "node2" : "INTERNAL_vl1_dgen1"
-    }, {
-      "node1" : "dgen1",
-      "node2" : "INTERNAL_vl1_dgen1"
-    }, {
-      "node1" : "btrf13",
-      "node2" : "INTERNAL_vl1_dtrf13"
-    }, {
-      "node1" : "dtrf13",
-      "node2" : "INTERNAL_vl1_dtrf13"
-    }, {
-      "node1" : "btrf17",
-      "node2" : "INTERNAL_vl1_dtrf17"
-    }, {
-      "node1" : "dtrf17",
-      "node2" : "INTERNAL_vl1_dtrf17"
-    }, {
-      "node1" : "dtrct21",
-      "node2" : "INTERNAL_vl1_dsect22"
-    }, {
-      "node1" : "dsect22",
-      "node2" : "INTERNAL_vl1_dsect22"
-    }, {
-      "node1" : "bgen2",
-      "node2" : "INTERNAL_vl1_dgen2"
-    }, {
-      "node1" : "dgen2",
-      "node2" : "INTERNAL_vl1_dgen2"
-    }, {
-      "node1" : "btrf14",
-      "node2" : "INTERNAL_vl1_dtrf14"
-    }, {
-      "node1" : "dtrf14",
-      "node2" : "INTERNAL_vl1_dtrf14"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],
@@ -2542,7 +2542,7 @@
     "y" : 1025.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dgen4",
+      "id" : "INTERNAL_vl2_bgen4",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -2551,7 +2551,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dload3",
+      "id" : "INTERNAL_vl2_bload3",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2559,23 +2559,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dscpl1",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 75.0,
-      "y" : 240.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dscpl2",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 25.0,
-      "y" : 240.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf21",
+      "id" : "INTERNAL_vl2_btrf21",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2583,7 +2567,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf22",
+      "id" : "INTERNAL_vl2_btrf22",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -2592,7 +2576,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf23",
+      "id" : "INTERNAL_vl2_btrf23",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -2601,7 +2585,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf24",
+      "id" : "INTERNAL_vl2_btrf24",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -2609,7 +2593,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf26",
+      "id" : "INTERNAL_vl2_btrf26",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -2617,7 +2601,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf27",
+      "id" : "INTERNAL_vl2_btrf27",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -2625,12 +2609,28 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf28",
+      "id" : "INTERNAL_vl2_btrf28",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
       "y" : 335.0,
       "orientation" : "DOWN",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl2_ddcpl1",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 75.0,
+      "y" : 240.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl2_ddcpl1",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 25.0,
+      "y" : 240.0,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
@@ -3202,7 +3202,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_dscpl2" ]
+          "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_ddcpl1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3223,7 +3223,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl2_dscpl2", "ddcpl1", "INTERNAL_vl2_dscpl1" ]
+          "nodes" : [ "INTERNAL_vl2_ddcpl1", "ddcpl1", "INTERNAL_vl2_ddcpl1" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -3244,7 +3244,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_dscpl1" ]
+          "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_ddcpl1" ]
         } ]
       }
     }, {
@@ -3292,7 +3292,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_dload3" ]
+          "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_bload3" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3313,7 +3313,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dload3", "bload3", "INTERNAL_vl2_load3" ]
+          "nodes" : [ "INTERNAL_vl2_bload3", "bload3", "INTERNAL_vl2_load3" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3382,7 +3382,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_dtrf21" ]
+          "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_btrf21" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3403,7 +3403,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3472,7 +3472,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_dtrf24" ]
+          "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_btrf24" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3493,7 +3493,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3562,7 +3562,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_dtrf27" ]
+          "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_btrf27" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3583,7 +3583,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf27", "btrf27", "INTERNAL_vl2_trf7_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf27", "btrf27", "INTERNAL_vl2_trf7_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3652,7 +3652,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_dgen4" ]
+          "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_bgen4" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3673,7 +3673,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dgen4", "bgen4", "INTERNAL_vl2_gen4" ]
+          "nodes" : [ "INTERNAL_vl2_bgen4", "bgen4", "INTERNAL_vl2_gen4" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3742,7 +3742,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_dtrf22" ]
+          "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_btrf22" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3763,7 +3763,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3832,7 +3832,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_dtrf23" ]
+          "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_btrf23" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3853,7 +3853,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3922,7 +3922,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_dtrf26" ]
+          "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_btrf26" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3943,7 +3943,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf26", "btrf26", "INTERNAL_vl2_trf6_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf26", "btrf26", "INTERNAL_vl2_trf6_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4012,7 +4012,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_dtrf28" ]
+          "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_btrf28" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4033,7 +4033,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf28", "btrf28", "INTERNAL_vl2_trf8_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf28", "btrf28", "INTERNAL_vl2_trf8_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4092,6 +4092,72 @@
       "node1" : "bbs6",
       "node2" : "dtrf28"
     }, {
+      "node1" : "dscpl1",
+      "node2" : "INTERNAL_vl2_ddcpl1"
+    }, {
+      "node1" : "INTERNAL_vl2_ddcpl1",
+      "node2" : "ddcpl1"
+    }, {
+      "node1" : "dload3",
+      "node2" : "INTERNAL_vl2_bload3"
+    }, {
+      "node1" : "INTERNAL_vl2_bload3",
+      "node2" : "bload3"
+    }, {
+      "node1" : "dtrf21",
+      "node2" : "INTERNAL_vl2_btrf21"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf21",
+      "node2" : "btrf21"
+    }, {
+      "node1" : "dtrf24",
+      "node2" : "INTERNAL_vl2_btrf24"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf24",
+      "node2" : "btrf24"
+    }, {
+      "node1" : "dtrf27",
+      "node2" : "INTERNAL_vl2_btrf27"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf27",
+      "node2" : "btrf27"
+    }, {
+      "node1" : "dscpl2",
+      "node2" : "INTERNAL_vl2_ddcpl1"
+    }, {
+      "node1" : "INTERNAL_vl2_ddcpl1",
+      "node2" : "ddcpl1"
+    }, {
+      "node1" : "dgen4",
+      "node2" : "INTERNAL_vl2_bgen4"
+    }, {
+      "node1" : "INTERNAL_vl2_bgen4",
+      "node2" : "bgen4"
+    }, {
+      "node1" : "dtrf22",
+      "node2" : "INTERNAL_vl2_btrf22"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf22",
+      "node2" : "btrf22"
+    }, {
+      "node1" : "dtrf23",
+      "node2" : "INTERNAL_vl2_btrf23"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf23",
+      "node2" : "btrf23"
+    }, {
+      "node1" : "dtrf26",
+      "node2" : "INTERNAL_vl2_btrf26"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf26",
+      "node2" : "btrf26"
+    }, {
+      "node1" : "dtrf28",
+      "node2" : "INTERNAL_vl2_btrf28"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf28",
+      "node2" : "btrf28"
+    }, {
       "node1" : "bload3",
       "node2" : "INTERNAL_vl2_load3"
     }, {
@@ -4145,72 +4211,6 @@
     }, {
       "node1" : "INTERNAL_vl2_trf8_TWO",
       "node2" : "trf8_TWO"
-    }, {
-      "node1" : "ddcpl1",
-      "node2" : "INTERNAL_vl2_dscpl1"
-    }, {
-      "node1" : "dscpl1",
-      "node2" : "INTERNAL_vl2_dscpl1"
-    }, {
-      "node1" : "bload3",
-      "node2" : "INTERNAL_vl2_dload3"
-    }, {
-      "node1" : "dload3",
-      "node2" : "INTERNAL_vl2_dload3"
-    }, {
-      "node1" : "btrf21",
-      "node2" : "INTERNAL_vl2_dtrf21"
-    }, {
-      "node1" : "dtrf21",
-      "node2" : "INTERNAL_vl2_dtrf21"
-    }, {
-      "node1" : "btrf24",
-      "node2" : "INTERNAL_vl2_dtrf24"
-    }, {
-      "node1" : "dtrf24",
-      "node2" : "INTERNAL_vl2_dtrf24"
-    }, {
-      "node1" : "btrf27",
-      "node2" : "INTERNAL_vl2_dtrf27"
-    }, {
-      "node1" : "dtrf27",
-      "node2" : "INTERNAL_vl2_dtrf27"
-    }, {
-      "node1" : "ddcpl1",
-      "node2" : "INTERNAL_vl2_dscpl2"
-    }, {
-      "node1" : "dscpl2",
-      "node2" : "INTERNAL_vl2_dscpl2"
-    }, {
-      "node1" : "bgen4",
-      "node2" : "INTERNAL_vl2_dgen4"
-    }, {
-      "node1" : "dgen4",
-      "node2" : "INTERNAL_vl2_dgen4"
-    }, {
-      "node1" : "btrf22",
-      "node2" : "INTERNAL_vl2_dtrf22"
-    }, {
-      "node1" : "dtrf22",
-      "node2" : "INTERNAL_vl2_dtrf22"
-    }, {
-      "node1" : "btrf23",
-      "node2" : "INTERNAL_vl2_dtrf23"
-    }, {
-      "node1" : "dtrf23",
-      "node2" : "INTERNAL_vl2_dtrf23"
-    }, {
-      "node1" : "btrf26",
-      "node2" : "INTERNAL_vl2_dtrf26"
-    }, {
-      "node1" : "dtrf26",
-      "node2" : "INTERNAL_vl2_dtrf26"
-    }, {
-      "node1" : "btrf28",
-      "node2" : "INTERNAL_vl2_dtrf28"
-    }, {
-      "node1" : "dtrf28",
-      "node2" : "INTERNAL_vl2_dtrf28"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],
@@ -4225,7 +4225,7 @@
     "y" : 1820.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dload4",
+      "id" : "INTERNAL_vl3_bload4",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -4233,7 +4233,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf25",
+      "id" : "INTERNAL_vl3_btrf25",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -4242,7 +4242,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf36",
+      "id" : "INTERNAL_vl3_btrf36",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -4250,7 +4250,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf37",
+      "id" : "INTERNAL_vl3_btrf37",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -4259,7 +4259,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf38",
+      "id" : "INTERNAL_vl3_btrf38",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -4582,7 +4582,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_dload4" ]
+          "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_bload4" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4603,7 +4603,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dload4", "bload4", "INTERNAL_vl3_load4" ]
+          "nodes" : [ "INTERNAL_vl3_bload4", "bload4", "INTERNAL_vl3_load4" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4672,7 +4672,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_dtrf25" ]
+          "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_btrf25" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4693,7 +4693,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
+          "nodes" : [ "INTERNAL_vl3_btrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4762,7 +4762,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_dtrf36" ]
+          "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_btrf36" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4783,7 +4783,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf36", "btrf36", "INTERNAL_vl3_trf6_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf36", "btrf36", "INTERNAL_vl3_trf6_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4852,7 +4852,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_dtrf37" ]
+          "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_btrf37" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4873,7 +4873,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf37", "btrf37", "INTERNAL_vl3_trf7_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf37", "btrf37", "INTERNAL_vl3_trf7_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4942,7 +4942,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_dtrf38" ]
+          "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_btrf38" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4963,7 +4963,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf38", "btrf38", "INTERNAL_vl3_trf8_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf38", "btrf38", "INTERNAL_vl3_trf8_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -5004,6 +5004,36 @@
       "node1" : "bbs7",
       "node2" : "dtrf38"
     }, {
+      "node1" : "dload4",
+      "node2" : "INTERNAL_vl3_bload4"
+    }, {
+      "node1" : "INTERNAL_vl3_bload4",
+      "node2" : "bload4"
+    }, {
+      "node1" : "dtrf25",
+      "node2" : "INTERNAL_vl3_btrf25"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf25",
+      "node2" : "btrf25"
+    }, {
+      "node1" : "dtrf36",
+      "node2" : "INTERNAL_vl3_btrf36"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf36",
+      "node2" : "btrf36"
+    }, {
+      "node1" : "dtrf37",
+      "node2" : "INTERNAL_vl3_btrf37"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf37",
+      "node2" : "btrf37"
+    }, {
+      "node1" : "dtrf38",
+      "node2" : "INTERNAL_vl3_btrf38"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf38",
+      "node2" : "btrf38"
+    }, {
       "node1" : "bload4",
       "node2" : "INTERNAL_vl3_load4"
     }, {
@@ -5033,36 +5063,6 @@
     }, {
       "node1" : "INTERNAL_vl3_trf8_THREE",
       "node2" : "trf8_THREE"
-    }, {
-      "node1" : "bload4",
-      "node2" : "INTERNAL_vl3_dload4"
-    }, {
-      "node1" : "dload4",
-      "node2" : "INTERNAL_vl3_dload4"
-    }, {
-      "node1" : "btrf25",
-      "node2" : "INTERNAL_vl3_dtrf25"
-    }, {
-      "node1" : "dtrf25",
-      "node2" : "INTERNAL_vl3_dtrf25"
-    }, {
-      "node1" : "btrf36",
-      "node2" : "INTERNAL_vl3_dtrf36"
-    }, {
-      "node1" : "dtrf36",
-      "node2" : "INTERNAL_vl3_dtrf36"
-    }, {
-      "node1" : "btrf37",
-      "node2" : "INTERNAL_vl3_dtrf37"
-    }, {
-      "node1" : "dtrf37",
-      "node2" : "INTERNAL_vl3_dtrf37"
-    }, {
-      "node1" : "btrf38",
-      "node2" : "INTERNAL_vl3_dtrf38"
-    }, {
-      "node1" : "dtrf38",
-      "node2" : "INTERNAL_vl3_dtrf38"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphVRaw.json
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphVRaw.json
@@ -10,7 +10,7 @@
     "y" : 200.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dgen1",
+      "id" : "INTERNAL_vl1_bgen1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -19,7 +19,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dgen2",
+      "id" : "INTERNAL_vl1_bgen2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 675.0,
@@ -28,7 +28,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dline11_2",
+      "id" : "INTERNAL_vl1_bline11_2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -36,7 +36,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dload1",
+      "id" : "INTERNAL_vl1_bload1",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -44,7 +44,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dload2",
+      "id" : "INTERNAL_vl1_bload2",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -52,43 +52,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect11",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 400.0,
-      "y" : 280.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect12",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 450.0,
-      "y" : 280.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect21",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 400.0,
-      "y" : 305.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dsect22",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 450.0,
-      "y" : 305.0,
-      "orientation" : "RIGHT",
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf11",
+      "id" : "INTERNAL_vl1_btrf11",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -96,7 +60,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf12",
+      "id" : "INTERNAL_vl1_btrf12",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 625.0,
@@ -104,7 +68,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf13",
+      "id" : "INTERNAL_vl1_btrf13",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -113,7 +77,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf14",
+      "id" : "INTERNAL_vl1_btrf14",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 575.0,
@@ -122,7 +86,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf15",
+      "id" : "INTERNAL_vl1_btrf15",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -130,7 +94,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf16",
+      "id" : "INTERNAL_vl1_btrf16",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -138,7 +102,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf17",
+      "id" : "INTERNAL_vl1_btrf17",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -147,11 +111,47 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl1_dtrf18",
+      "id" : "INTERNAL_vl1_btrf18",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
       "y" : 250.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct11",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 400.0,
+      "y" : 280.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct11",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 450.0,
+      "y" : 280.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct21",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 400.0,
+      "y" : 305.0,
+      "orientation" : "RIGHT",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl1_dtrct21",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 450.0,
+      "y" : 305.0,
+      "orientation" : "RIGHT",
       "open" : false
     }, {
       "type" : "FICTITIOUS",
@@ -992,7 +992,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dsect12" ]
+          "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dtrct11" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1013,7 +1013,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl1_dsect11", "dtrct11", "INTERNAL_vl1_dsect12" ]
+          "nodes" : [ "INTERNAL_vl1_dtrct11", "dtrct11", "INTERNAL_vl1_dtrct11" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -1034,7 +1034,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dsect11" ]
+          "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dtrct11" ]
         } ]
       }
     }, {
@@ -1081,7 +1081,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dsect22" ]
+          "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dtrct21" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1102,7 +1102,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl1_dsect21", "dtrct21", "INTERNAL_vl1_dsect22" ]
+          "nodes" : [ "INTERNAL_vl1_dtrct21", "dtrct21", "INTERNAL_vl1_dtrct21" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -1123,7 +1123,7 @@
             "xSpan" : 0.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dsect21" ]
+          "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dtrct21" ]
         } ]
       }
     }, {
@@ -1171,7 +1171,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_dload1" ]
+          "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_bload1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1192,7 +1192,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dload1", "bload1", "INTERNAL_vl1_load1" ]
+          "nodes" : [ "INTERNAL_vl1_bload1", "bload1", "INTERNAL_vl1_load1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1261,7 +1261,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_dtrf11" ]
+          "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_btrf11" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1282,7 +1282,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1351,7 +1351,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_dtrf15" ]
+          "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_btrf15" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1372,7 +1372,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1441,7 +1441,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_dtrf16" ]
+          "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_btrf16" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1462,7 +1462,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf16", "btrf16", "INTERNAL_vl1_trf6_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf16", "btrf16", "INTERNAL_vl1_trf6_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1531,7 +1531,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs1", "dline11_2", "INTERNAL_vl1_dline11_2" ]
+          "nodes" : [ "bbs1", "dline11_2", "INTERNAL_vl1_bline11_2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1552,7 +1552,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dline11_2", "bline11_2", "INTERNAL_vl1_line1_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_bline11_2", "bline11_2", "INTERNAL_vl1_line1_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1621,7 +1621,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_dload2" ]
+          "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_bload2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1642,7 +1642,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dload2", "bload2", "INTERNAL_vl1_load2" ]
+          "nodes" : [ "INTERNAL_vl1_bload2", "bload2", "INTERNAL_vl1_load2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1711,7 +1711,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_dtrf12" ]
+          "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_btrf12" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1732,7 +1732,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1801,7 +1801,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_dtrf18" ]
+          "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_btrf18" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1822,7 +1822,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf18", "btrf18", "INTERNAL_vl1_trf8_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf18", "btrf18", "INTERNAL_vl1_trf8_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1891,7 +1891,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_dgen1" ]
+          "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_bgen1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -1912,7 +1912,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dgen1", "bgen1", "INTERNAL_vl1_gen1" ]
+          "nodes" : [ "INTERNAL_vl1_bgen1", "bgen1", "INTERNAL_vl1_gen1" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -1981,7 +1981,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_dtrf13" ]
+          "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_btrf13" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2002,7 +2002,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2071,7 +2071,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_dtrf17" ]
+          "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_btrf17" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2092,7 +2092,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf17", "btrf17", "INTERNAL_vl1_trf7_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf17", "btrf17", "INTERNAL_vl1_trf7_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2161,7 +2161,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_dgen2" ]
+          "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_bgen2" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2182,7 +2182,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dgen2", "bgen2", "INTERNAL_vl1_gen2" ]
+          "nodes" : [ "INTERNAL_vl1_bgen2", "bgen2", "INTERNAL_vl1_gen2" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2251,7 +2251,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_dtrf14" ]
+          "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_btrf14" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -2272,7 +2272,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl1_dtrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
+          "nodes" : [ "INTERNAL_vl1_btrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -2348,6 +2348,108 @@
     }, {
       "node1" : "bbs1",
       "node2" : "dline11_2"
+    }, {
+      "node1" : "dsect11",
+      "node2" : "INTERNAL_vl1_dtrct11"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct11",
+      "node2" : "dtrct11"
+    }, {
+      "node1" : "dload1",
+      "node2" : "INTERNAL_vl1_bload1"
+    }, {
+      "node1" : "INTERNAL_vl1_bload1",
+      "node2" : "bload1"
+    }, {
+      "node1" : "dtrf11",
+      "node2" : "INTERNAL_vl1_btrf11"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf11",
+      "node2" : "btrf11"
+    }, {
+      "node1" : "dtrf15",
+      "node2" : "INTERNAL_vl1_btrf15"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf15",
+      "node2" : "btrf15"
+    }, {
+      "node1" : "dtrf16",
+      "node2" : "INTERNAL_vl1_btrf16"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf16",
+      "node2" : "btrf16"
+    }, {
+      "node1" : "dline11_2",
+      "node2" : "INTERNAL_vl1_bline11_2"
+    }, {
+      "node1" : "INTERNAL_vl1_bline11_2",
+      "node2" : "bline11_2"
+    }, {
+      "node1" : "dsect12",
+      "node2" : "INTERNAL_vl1_dtrct11"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct11",
+      "node2" : "dtrct11"
+    }, {
+      "node1" : "dload2",
+      "node2" : "INTERNAL_vl1_bload2"
+    }, {
+      "node1" : "INTERNAL_vl1_bload2",
+      "node2" : "bload2"
+    }, {
+      "node1" : "dtrf12",
+      "node2" : "INTERNAL_vl1_btrf12"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf12",
+      "node2" : "btrf12"
+    }, {
+      "node1" : "dtrf18",
+      "node2" : "INTERNAL_vl1_btrf18"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf18",
+      "node2" : "btrf18"
+    }, {
+      "node1" : "dsect21",
+      "node2" : "INTERNAL_vl1_dtrct21"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct21",
+      "node2" : "dtrct21"
+    }, {
+      "node1" : "dgen1",
+      "node2" : "INTERNAL_vl1_bgen1"
+    }, {
+      "node1" : "INTERNAL_vl1_bgen1",
+      "node2" : "bgen1"
+    }, {
+      "node1" : "dtrf13",
+      "node2" : "INTERNAL_vl1_btrf13"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf13",
+      "node2" : "btrf13"
+    }, {
+      "node1" : "dtrf17",
+      "node2" : "INTERNAL_vl1_btrf17"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf17",
+      "node2" : "btrf17"
+    }, {
+      "node1" : "dsect22",
+      "node2" : "INTERNAL_vl1_dtrct21"
+    }, {
+      "node1" : "INTERNAL_vl1_dtrct21",
+      "node2" : "dtrct21"
+    }, {
+      "node1" : "dgen2",
+      "node2" : "INTERNAL_vl1_bgen2"
+    }, {
+      "node1" : "INTERNAL_vl1_bgen2",
+      "node2" : "bgen2"
+    }, {
+      "node1" : "dtrf14",
+      "node2" : "INTERNAL_vl1_btrf14"
+    }, {
+      "node1" : "INTERNAL_vl1_btrf14",
+      "node2" : "btrf14"
     }, {
       "node1" : "bload1",
       "node2" : "INTERNAL_vl1_load1"
@@ -2426,108 +2528,6 @@
     }, {
       "node1" : "INTERNAL_vl1_line1_ONE",
       "node2" : "line1_ONE"
-    }, {
-      "node1" : "dtrct11",
-      "node2" : "INTERNAL_vl1_dsect11"
-    }, {
-      "node1" : "dsect11",
-      "node2" : "INTERNAL_vl1_dsect11"
-    }, {
-      "node1" : "bload1",
-      "node2" : "INTERNAL_vl1_dload1"
-    }, {
-      "node1" : "dload1",
-      "node2" : "INTERNAL_vl1_dload1"
-    }, {
-      "node1" : "btrf11",
-      "node2" : "INTERNAL_vl1_dtrf11"
-    }, {
-      "node1" : "dtrf11",
-      "node2" : "INTERNAL_vl1_dtrf11"
-    }, {
-      "node1" : "btrf15",
-      "node2" : "INTERNAL_vl1_dtrf15"
-    }, {
-      "node1" : "dtrf15",
-      "node2" : "INTERNAL_vl1_dtrf15"
-    }, {
-      "node1" : "btrf16",
-      "node2" : "INTERNAL_vl1_dtrf16"
-    }, {
-      "node1" : "dtrf16",
-      "node2" : "INTERNAL_vl1_dtrf16"
-    }, {
-      "node1" : "bline11_2",
-      "node2" : "INTERNAL_vl1_dline11_2"
-    }, {
-      "node1" : "dline11_2",
-      "node2" : "INTERNAL_vl1_dline11_2"
-    }, {
-      "node1" : "dtrct11",
-      "node2" : "INTERNAL_vl1_dsect12"
-    }, {
-      "node1" : "dsect12",
-      "node2" : "INTERNAL_vl1_dsect12"
-    }, {
-      "node1" : "bload2",
-      "node2" : "INTERNAL_vl1_dload2"
-    }, {
-      "node1" : "dload2",
-      "node2" : "INTERNAL_vl1_dload2"
-    }, {
-      "node1" : "btrf12",
-      "node2" : "INTERNAL_vl1_dtrf12"
-    }, {
-      "node1" : "dtrf12",
-      "node2" : "INTERNAL_vl1_dtrf12"
-    }, {
-      "node1" : "btrf18",
-      "node2" : "INTERNAL_vl1_dtrf18"
-    }, {
-      "node1" : "dtrf18",
-      "node2" : "INTERNAL_vl1_dtrf18"
-    }, {
-      "node1" : "dtrct21",
-      "node2" : "INTERNAL_vl1_dsect21"
-    }, {
-      "node1" : "dsect21",
-      "node2" : "INTERNAL_vl1_dsect21"
-    }, {
-      "node1" : "bgen1",
-      "node2" : "INTERNAL_vl1_dgen1"
-    }, {
-      "node1" : "dgen1",
-      "node2" : "INTERNAL_vl1_dgen1"
-    }, {
-      "node1" : "btrf13",
-      "node2" : "INTERNAL_vl1_dtrf13"
-    }, {
-      "node1" : "dtrf13",
-      "node2" : "INTERNAL_vl1_dtrf13"
-    }, {
-      "node1" : "btrf17",
-      "node2" : "INTERNAL_vl1_dtrf17"
-    }, {
-      "node1" : "dtrf17",
-      "node2" : "INTERNAL_vl1_dtrf17"
-    }, {
-      "node1" : "dtrct21",
-      "node2" : "INTERNAL_vl1_dsect22"
-    }, {
-      "node1" : "dsect22",
-      "node2" : "INTERNAL_vl1_dsect22"
-    }, {
-      "node1" : "bgen2",
-      "node2" : "INTERNAL_vl1_dgen2"
-    }, {
-      "node1" : "dgen2",
-      "node2" : "INTERNAL_vl1_dgen2"
-    }, {
-      "node1" : "btrf14",
-      "node2" : "INTERNAL_vl1_dtrf14"
-    }, {
-      "node1" : "dtrf14",
-      "node2" : "INTERNAL_vl1_dtrf14"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],
@@ -2542,7 +2542,7 @@
     "y" : 1025.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dgen4",
+      "id" : "INTERNAL_vl2_bgen4",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -2551,7 +2551,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dload3",
+      "id" : "INTERNAL_vl2_bload3",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -2559,23 +2559,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dscpl1",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 75.0,
-      "y" : 240.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dscpl2",
-      "componentType" : "NODE",
-      "fictitious" : true,
-      "x" : 25.0,
-      "y" : 240.0,
-      "open" : false
-    }, {
-      "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf21",
+      "id" : "INTERNAL_vl2_btrf21",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -2583,7 +2567,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf22",
+      "id" : "INTERNAL_vl2_btrf22",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 475.0,
@@ -2592,7 +2576,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf23",
+      "id" : "INTERNAL_vl2_btrf23",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 525.0,
@@ -2601,7 +2585,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf24",
+      "id" : "INTERNAL_vl2_btrf24",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 275.0,
@@ -2609,7 +2593,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf26",
+      "id" : "INTERNAL_vl2_btrf26",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 375.0,
@@ -2617,7 +2601,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf27",
+      "id" : "INTERNAL_vl2_btrf27",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 325.0,
@@ -2625,12 +2609,28 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl2_dtrf28",
+      "id" : "INTERNAL_vl2_btrf28",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 425.0,
       "y" : 335.0,
       "orientation" : "DOWN",
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl2_ddcpl1",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 75.0,
+      "y" : 240.0,
+      "open" : false
+    }, {
+      "type" : "FICTITIOUS",
+      "id" : "INTERNAL_vl2_ddcpl1",
+      "componentType" : "NODE",
+      "fictitious" : true,
+      "x" : 25.0,
+      "y" : 240.0,
       "open" : false
     }, {
       "type" : "FICTITIOUS",
@@ -3202,7 +3202,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_dscpl2" ]
+          "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_ddcpl1" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3223,7 +3223,7 @@
             "xSpan" : 50.0,
             "ySpan" : 40.0
           },
-          "nodes" : [ "INTERNAL_vl2_dscpl2", "ddcpl1", "INTERNAL_vl2_dscpl1" ]
+          "nodes" : [ "INTERNAL_vl2_ddcpl1", "ddcpl1", "INTERNAL_vl2_ddcpl1" ]
         }, {
           "type" : "LEGPRIMARY",
           "cardinalities" : [ {
@@ -3244,7 +3244,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_dscpl1" ]
+          "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_ddcpl1" ]
         } ]
       }
     }, {
@@ -3292,7 +3292,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_dload3" ]
+          "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_bload3" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3313,7 +3313,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dload3", "bload3", "INTERNAL_vl2_load3" ]
+          "nodes" : [ "INTERNAL_vl2_bload3", "bload3", "INTERNAL_vl2_load3" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3382,7 +3382,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_dtrf21" ]
+          "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_btrf21" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3403,7 +3403,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3472,7 +3472,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_dtrf24" ]
+          "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_btrf24" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3493,7 +3493,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3562,7 +3562,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_dtrf27" ]
+          "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_btrf27" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3583,7 +3583,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf27", "btrf27", "INTERNAL_vl2_trf7_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf27", "btrf27", "INTERNAL_vl2_trf7_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3652,7 +3652,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_dgen4" ]
+          "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_bgen4" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3673,7 +3673,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dgen4", "bgen4", "INTERNAL_vl2_gen4" ]
+          "nodes" : [ "INTERNAL_vl2_bgen4", "bgen4", "INTERNAL_vl2_gen4" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3742,7 +3742,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_dtrf22" ]
+          "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_btrf22" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3763,7 +3763,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3832,7 +3832,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_dtrf23" ]
+          "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_btrf23" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3853,7 +3853,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -3922,7 +3922,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_dtrf26" ]
+          "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_btrf26" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -3943,7 +3943,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf26", "btrf26", "INTERNAL_vl2_trf6_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf26", "btrf26", "INTERNAL_vl2_trf6_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4012,7 +4012,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_dtrf28" ]
+          "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_btrf28" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4033,7 +4033,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl2_dtrf28", "btrf28", "INTERNAL_vl2_trf8_TWO" ]
+          "nodes" : [ "INTERNAL_vl2_btrf28", "btrf28", "INTERNAL_vl2_trf8_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4092,6 +4092,72 @@
       "node1" : "bbs6",
       "node2" : "dtrf28"
     }, {
+      "node1" : "dscpl1",
+      "node2" : "INTERNAL_vl2_ddcpl1"
+    }, {
+      "node1" : "INTERNAL_vl2_ddcpl1",
+      "node2" : "ddcpl1"
+    }, {
+      "node1" : "dload3",
+      "node2" : "INTERNAL_vl2_bload3"
+    }, {
+      "node1" : "INTERNAL_vl2_bload3",
+      "node2" : "bload3"
+    }, {
+      "node1" : "dtrf21",
+      "node2" : "INTERNAL_vl2_btrf21"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf21",
+      "node2" : "btrf21"
+    }, {
+      "node1" : "dtrf24",
+      "node2" : "INTERNAL_vl2_btrf24"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf24",
+      "node2" : "btrf24"
+    }, {
+      "node1" : "dtrf27",
+      "node2" : "INTERNAL_vl2_btrf27"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf27",
+      "node2" : "btrf27"
+    }, {
+      "node1" : "dscpl2",
+      "node2" : "INTERNAL_vl2_ddcpl1"
+    }, {
+      "node1" : "INTERNAL_vl2_ddcpl1",
+      "node2" : "ddcpl1"
+    }, {
+      "node1" : "dgen4",
+      "node2" : "INTERNAL_vl2_bgen4"
+    }, {
+      "node1" : "INTERNAL_vl2_bgen4",
+      "node2" : "bgen4"
+    }, {
+      "node1" : "dtrf22",
+      "node2" : "INTERNAL_vl2_btrf22"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf22",
+      "node2" : "btrf22"
+    }, {
+      "node1" : "dtrf23",
+      "node2" : "INTERNAL_vl2_btrf23"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf23",
+      "node2" : "btrf23"
+    }, {
+      "node1" : "dtrf26",
+      "node2" : "INTERNAL_vl2_btrf26"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf26",
+      "node2" : "btrf26"
+    }, {
+      "node1" : "dtrf28",
+      "node2" : "INTERNAL_vl2_btrf28"
+    }, {
+      "node1" : "INTERNAL_vl2_btrf28",
+      "node2" : "btrf28"
+    }, {
       "node1" : "bload3",
       "node2" : "INTERNAL_vl2_load3"
     }, {
@@ -4145,72 +4211,6 @@
     }, {
       "node1" : "INTERNAL_vl2_trf8_TWO",
       "node2" : "trf8_TWO"
-    }, {
-      "node1" : "ddcpl1",
-      "node2" : "INTERNAL_vl2_dscpl1"
-    }, {
-      "node1" : "dscpl1",
-      "node2" : "INTERNAL_vl2_dscpl1"
-    }, {
-      "node1" : "bload3",
-      "node2" : "INTERNAL_vl2_dload3"
-    }, {
-      "node1" : "dload3",
-      "node2" : "INTERNAL_vl2_dload3"
-    }, {
-      "node1" : "btrf21",
-      "node2" : "INTERNAL_vl2_dtrf21"
-    }, {
-      "node1" : "dtrf21",
-      "node2" : "INTERNAL_vl2_dtrf21"
-    }, {
-      "node1" : "btrf24",
-      "node2" : "INTERNAL_vl2_dtrf24"
-    }, {
-      "node1" : "dtrf24",
-      "node2" : "INTERNAL_vl2_dtrf24"
-    }, {
-      "node1" : "btrf27",
-      "node2" : "INTERNAL_vl2_dtrf27"
-    }, {
-      "node1" : "dtrf27",
-      "node2" : "INTERNAL_vl2_dtrf27"
-    }, {
-      "node1" : "ddcpl1",
-      "node2" : "INTERNAL_vl2_dscpl2"
-    }, {
-      "node1" : "dscpl2",
-      "node2" : "INTERNAL_vl2_dscpl2"
-    }, {
-      "node1" : "bgen4",
-      "node2" : "INTERNAL_vl2_dgen4"
-    }, {
-      "node1" : "dgen4",
-      "node2" : "INTERNAL_vl2_dgen4"
-    }, {
-      "node1" : "btrf22",
-      "node2" : "INTERNAL_vl2_dtrf22"
-    }, {
-      "node1" : "dtrf22",
-      "node2" : "INTERNAL_vl2_dtrf22"
-    }, {
-      "node1" : "btrf23",
-      "node2" : "INTERNAL_vl2_dtrf23"
-    }, {
-      "node1" : "dtrf23",
-      "node2" : "INTERNAL_vl2_dtrf23"
-    }, {
-      "node1" : "btrf26",
-      "node2" : "INTERNAL_vl2_dtrf26"
-    }, {
-      "node1" : "dtrf26",
-      "node2" : "INTERNAL_vl2_dtrf26"
-    }, {
-      "node1" : "btrf28",
-      "node2" : "INTERNAL_vl2_dtrf28"
-    }, {
-      "node1" : "dtrf28",
-      "node2" : "INTERNAL_vl2_dtrf28"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],
@@ -4225,7 +4225,7 @@
     "y" : 1820.0,
     "nodes" : [ {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dload4",
+      "id" : "INTERNAL_vl3_bload4",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 25.0,
@@ -4233,7 +4233,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf25",
+      "id" : "INTERNAL_vl3_btrf25",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 75.0,
@@ -4242,7 +4242,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf36",
+      "id" : "INTERNAL_vl3_btrf36",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 125.0,
@@ -4250,7 +4250,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf37",
+      "id" : "INTERNAL_vl3_btrf37",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 175.0,
@@ -4259,7 +4259,7 @@
       "open" : false
     }, {
       "type" : "FICTITIOUS",
-      "id" : "INTERNAL_vl3_dtrf38",
+      "id" : "INTERNAL_vl3_btrf38",
       "componentType" : "NODE",
       "fictitious" : true,
       "x" : 225.0,
@@ -4582,7 +4582,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_dload4" ]
+          "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_bload4" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4603,7 +4603,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dload4", "bload4", "INTERNAL_vl3_load4" ]
+          "nodes" : [ "INTERNAL_vl3_bload4", "bload4", "INTERNAL_vl3_load4" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4672,7 +4672,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_dtrf25" ]
+          "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_btrf25" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4693,7 +4693,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
+          "nodes" : [ "INTERNAL_vl3_btrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4762,7 +4762,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_dtrf36" ]
+          "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_btrf36" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4783,7 +4783,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf36", "btrf36", "INTERNAL_vl3_trf6_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf36", "btrf36", "INTERNAL_vl3_trf6_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4852,7 +4852,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_dtrf37" ]
+          "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_btrf37" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4873,7 +4873,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf37", "btrf37", "INTERNAL_vl3_trf7_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf37", "btrf37", "INTERNAL_vl3_trf7_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -4942,7 +4942,7 @@
             "xSpan" : 50.0,
             "ySpan" : 0.0
           },
-          "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_dtrf38" ]
+          "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_btrf38" ]
         }, {
           "type" : "BODYPRIMARY",
           "cardinalities" : [ {
@@ -4963,7 +4963,7 @@
             "xSpan" : 50.0,
             "ySpan" : 188.0
           },
-          "nodes" : [ "INTERNAL_vl3_dtrf38", "btrf38", "INTERNAL_vl3_trf8_THREE" ]
+          "nodes" : [ "INTERNAL_vl3_btrf38", "btrf38", "INTERNAL_vl3_trf8_THREE" ]
         }, {
           "type" : "FEEDERPRIMARY",
           "cardinalities" : [ {
@@ -5004,6 +5004,36 @@
       "node1" : "bbs7",
       "node2" : "dtrf38"
     }, {
+      "node1" : "dload4",
+      "node2" : "INTERNAL_vl3_bload4"
+    }, {
+      "node1" : "INTERNAL_vl3_bload4",
+      "node2" : "bload4"
+    }, {
+      "node1" : "dtrf25",
+      "node2" : "INTERNAL_vl3_btrf25"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf25",
+      "node2" : "btrf25"
+    }, {
+      "node1" : "dtrf36",
+      "node2" : "INTERNAL_vl3_btrf36"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf36",
+      "node2" : "btrf36"
+    }, {
+      "node1" : "dtrf37",
+      "node2" : "INTERNAL_vl3_btrf37"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf37",
+      "node2" : "btrf37"
+    }, {
+      "node1" : "dtrf38",
+      "node2" : "INTERNAL_vl3_btrf38"
+    }, {
+      "node1" : "INTERNAL_vl3_btrf38",
+      "node2" : "btrf38"
+    }, {
       "node1" : "bload4",
       "node2" : "INTERNAL_vl3_load4"
     }, {
@@ -5033,36 +5063,6 @@
     }, {
       "node1" : "INTERNAL_vl3_trf8_THREE",
       "node2" : "trf8_THREE"
-    }, {
-      "node1" : "bload4",
-      "node2" : "INTERNAL_vl3_dload4"
-    }, {
-      "node1" : "dload4",
-      "node2" : "INTERNAL_vl3_dload4"
-    }, {
-      "node1" : "btrf25",
-      "node2" : "INTERNAL_vl3_dtrf25"
-    }, {
-      "node1" : "dtrf25",
-      "node2" : "INTERNAL_vl3_dtrf25"
-    }, {
-      "node1" : "btrf36",
-      "node2" : "INTERNAL_vl3_dtrf36"
-    }, {
-      "node1" : "dtrf36",
-      "node2" : "INTERNAL_vl3_dtrf36"
-    }, {
-      "node1" : "btrf37",
-      "node2" : "INTERNAL_vl3_dtrf37"
-    }, {
-      "node1" : "dtrf37",
-      "node2" : "INTERNAL_vl3_dtrf37"
-    }, {
-      "node1" : "btrf38",
-      "node2" : "INTERNAL_vl3_dtrf38"
-    }, {
-      "node1" : "dtrf38",
-      "node2" : "INTERNAL_vl3_dtrf38"
     } ],
     "multitermNodes" : [ ],
     "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL1.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dgen1",
+    "id" : "INTERNAL_vl1_bgen1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dgen2",
+    "id" : "INTERNAL_vl1_bgen2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1240.0,
@@ -26,7 +26,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dload1",
+    "id" : "INTERNAL_vl1_bload1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 40.0,
@@ -34,7 +34,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dload2",
+    "id" : "INTERNAL_vl1_bload2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 840.0,
@@ -42,43 +42,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dsect11",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 720.0,
-    "y" : 280.0,
-    "orientation" : "RIGHT",
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dsect12",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 800.0,
-    "y" : 280.0,
-    "orientation" : "RIGHT",
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dsect21",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 720.0,
-    "y" : 305.0,
-    "orientation" : "RIGHT",
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dsect22",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 800.0,
-    "y" : 305.0,
-    "orientation" : "RIGHT",
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dtrf11",
+    "id" : "INTERNAL_vl1_btrf11",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 120.0,
@@ -86,7 +50,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dtrf12",
+    "id" : "INTERNAL_vl1_btrf12",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1160.0,
@@ -94,7 +58,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dtrf13",
+    "id" : "INTERNAL_vl1_btrf13",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 280.0,
@@ -103,7 +67,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dtrf14",
+    "id" : "INTERNAL_vl1_btrf14",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1080.0,
@@ -112,7 +76,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dtrf15",
+    "id" : "INTERNAL_vl1_btrf15",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 360.0,
@@ -120,7 +84,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dtrf16",
+    "id" : "INTERNAL_vl1_btrf16",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 480.0,
@@ -128,7 +92,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dtrf17",
+    "id" : "INTERNAL_vl1_btrf17",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 640.0,
@@ -137,11 +101,47 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_dtrf18",
+    "id" : "INTERNAL_vl1_btrf18",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 960.0,
     "y" : 250.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl1_dtrct11",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 720.0,
+    "y" : 280.0,
+    "orientation" : "RIGHT",
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl1_dtrct11",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 800.0,
+    "y" : 280.0,
+    "orientation" : "RIGHT",
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl1_dtrct21",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 720.0,
+    "y" : 305.0,
+    "orientation" : "RIGHT",
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl1_dtrct21",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 800.0,
+    "y" : 305.0,
+    "orientation" : "RIGHT",
     "open" : false
   }, {
     "type" : "FICTITIOUS",
@@ -1044,7 +1044,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dsect12" ]
+        "nodes" : [ "bbs2", "dsect12", "INTERNAL_vl1_dtrct11" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1065,7 +1065,7 @@
           "xSpan" : 80.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl1_dsect11", "dtrct11", "INTERNAL_vl1_dsect12" ]
+        "nodes" : [ "INTERNAL_vl1_dtrct11", "dtrct11", "INTERNAL_vl1_dtrct11" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -1086,7 +1086,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dsect11" ]
+        "nodes" : [ "bbs1", "dsect11", "INTERNAL_vl1_dtrct11" ]
       } ]
     }
   }, {
@@ -1133,7 +1133,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dsect22" ]
+        "nodes" : [ "bbs4", "dsect22", "INTERNAL_vl1_dtrct21" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1154,7 +1154,7 @@
           "xSpan" : 80.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl1_dsect21", "dtrct21", "INTERNAL_vl1_dsect22" ]
+        "nodes" : [ "INTERNAL_vl1_dtrct21", "dtrct21", "INTERNAL_vl1_dtrct21" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -1175,7 +1175,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dsect21" ]
+        "nodes" : [ "bbs3", "dsect21", "INTERNAL_vl1_dtrct21" ]
       } ]
     }
   }, {
@@ -1223,7 +1223,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_dload1" ]
+        "nodes" : [ "bbs1", "dload1", "INTERNAL_vl1_bload1" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1244,7 +1244,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl1_dload1", "bload1", "INTERNAL_vl1_load1" ]
+        "nodes" : [ "INTERNAL_vl1_bload1", "bload1", "INTERNAL_vl1_load1" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -1313,7 +1313,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_dtrf11" ]
+        "nodes" : [ "bbs1", "dtrf11", "INTERNAL_vl1_btrf11" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1334,7 +1334,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl1_dtrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
+        "nodes" : [ "INTERNAL_vl1_btrf11", "btrf11", "INTERNAL_vl1_trf1_ONE" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -1403,7 +1403,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_dtrf15" ]
+        "nodes" : [ "bbs1", "dtrf15", "INTERNAL_vl1_btrf15" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1424,7 +1424,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl1_dtrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
+        "nodes" : [ "INTERNAL_vl1_btrf15", "btrf15", "INTERNAL_vl1_trf5_ONE" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -1493,7 +1493,7 @@
           "xSpan" : 160.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_dtrf16" ]
+        "nodes" : [ "bbs1", "dtrf16", "INTERNAL_vl1_btrf16" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1514,7 +1514,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl1_dtrf16", "btrf16", "trf6" ]
+        "nodes" : [ "INTERNAL_vl1_btrf16", "btrf16", "trf6" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1625,7 +1625,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_dload2" ]
+        "nodes" : [ "bbs2", "dload2", "INTERNAL_vl1_bload2" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1646,7 +1646,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl1_dload2", "bload2", "INTERNAL_vl1_load2" ]
+        "nodes" : [ "INTERNAL_vl1_bload2", "bload2", "INTERNAL_vl1_load2" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -1715,7 +1715,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_dtrf12" ]
+        "nodes" : [ "bbs2", "dtrf12", "INTERNAL_vl1_btrf12" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1736,7 +1736,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl1_dtrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
+        "nodes" : [ "INTERNAL_vl1_btrf12", "btrf12", "INTERNAL_vl1_trf2_ONE" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -1805,7 +1805,7 @@
           "xSpan" : 160.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_dtrf18" ]
+        "nodes" : [ "bbs2", "dtrf18", "INTERNAL_vl1_btrf18" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1826,7 +1826,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl1_dtrf18", "btrf18", "trf8" ]
+        "nodes" : [ "INTERNAL_vl1_btrf18", "btrf18", "trf8" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1937,7 +1937,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_dgen1" ]
+        "nodes" : [ "bbs3", "dgen1", "INTERNAL_vl1_bgen1" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1958,7 +1958,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl1_dgen1", "bgen1", "INTERNAL_vl1_gen1" ]
+        "nodes" : [ "INTERNAL_vl1_bgen1", "bgen1", "INTERNAL_vl1_gen1" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -2027,7 +2027,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_dtrf13" ]
+        "nodes" : [ "bbs3", "dtrf13", "INTERNAL_vl1_btrf13" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -2048,7 +2048,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl1_dtrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
+        "nodes" : [ "INTERNAL_vl1_btrf13", "btrf13", "INTERNAL_vl1_trf3_ONE" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -2117,7 +2117,7 @@
           "xSpan" : 160.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_dtrf17" ]
+        "nodes" : [ "bbs3", "dtrf17", "INTERNAL_vl1_btrf17" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -2138,7 +2138,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl1_dtrf17", "btrf17", "trf7" ]
+        "nodes" : [ "INTERNAL_vl1_btrf17", "btrf17", "trf7" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -2249,7 +2249,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_dgen2" ]
+        "nodes" : [ "bbs4", "dgen2", "INTERNAL_vl1_bgen2" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -2270,7 +2270,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl1_dgen2", "bgen2", "INTERNAL_vl1_gen2" ]
+        "nodes" : [ "INTERNAL_vl1_bgen2", "bgen2", "INTERNAL_vl1_gen2" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -2339,7 +2339,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_dtrf14" ]
+        "nodes" : [ "bbs4", "dtrf14", "INTERNAL_vl1_btrf14" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -2360,7 +2360,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl1_dtrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
+        "nodes" : [ "INTERNAL_vl1_btrf14", "btrf14", "INTERNAL_vl1_trf4_ONE" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -2461,6 +2461,102 @@
     "node1" : "btrf18",
     "node2" : "trf8"
   }, {
+    "node1" : "dsect11",
+    "node2" : "INTERNAL_vl1_dtrct11"
+  }, {
+    "node1" : "INTERNAL_vl1_dtrct11",
+    "node2" : "dtrct11"
+  }, {
+    "node1" : "dload1",
+    "node2" : "INTERNAL_vl1_bload1"
+  }, {
+    "node1" : "INTERNAL_vl1_bload1",
+    "node2" : "bload1"
+  }, {
+    "node1" : "dtrf11",
+    "node2" : "INTERNAL_vl1_btrf11"
+  }, {
+    "node1" : "INTERNAL_vl1_btrf11",
+    "node2" : "btrf11"
+  }, {
+    "node1" : "dtrf15",
+    "node2" : "INTERNAL_vl1_btrf15"
+  }, {
+    "node1" : "INTERNAL_vl1_btrf15",
+    "node2" : "btrf15"
+  }, {
+    "node1" : "dtrf16",
+    "node2" : "INTERNAL_vl1_btrf16"
+  }, {
+    "node1" : "INTERNAL_vl1_btrf16",
+    "node2" : "btrf16"
+  }, {
+    "node1" : "dsect12",
+    "node2" : "INTERNAL_vl1_dtrct11"
+  }, {
+    "node1" : "INTERNAL_vl1_dtrct11",
+    "node2" : "dtrct11"
+  }, {
+    "node1" : "dload2",
+    "node2" : "INTERNAL_vl1_bload2"
+  }, {
+    "node1" : "INTERNAL_vl1_bload2",
+    "node2" : "bload2"
+  }, {
+    "node1" : "dtrf12",
+    "node2" : "INTERNAL_vl1_btrf12"
+  }, {
+    "node1" : "INTERNAL_vl1_btrf12",
+    "node2" : "btrf12"
+  }, {
+    "node1" : "dtrf18",
+    "node2" : "INTERNAL_vl1_btrf18"
+  }, {
+    "node1" : "INTERNAL_vl1_btrf18",
+    "node2" : "btrf18"
+  }, {
+    "node1" : "dsect21",
+    "node2" : "INTERNAL_vl1_dtrct21"
+  }, {
+    "node1" : "INTERNAL_vl1_dtrct21",
+    "node2" : "dtrct21"
+  }, {
+    "node1" : "dgen1",
+    "node2" : "INTERNAL_vl1_bgen1"
+  }, {
+    "node1" : "INTERNAL_vl1_bgen1",
+    "node2" : "bgen1"
+  }, {
+    "node1" : "dtrf13",
+    "node2" : "INTERNAL_vl1_btrf13"
+  }, {
+    "node1" : "INTERNAL_vl1_btrf13",
+    "node2" : "btrf13"
+  }, {
+    "node1" : "dtrf17",
+    "node2" : "INTERNAL_vl1_btrf17"
+  }, {
+    "node1" : "INTERNAL_vl1_btrf17",
+    "node2" : "btrf17"
+  }, {
+    "node1" : "dsect22",
+    "node2" : "INTERNAL_vl1_dtrct21"
+  }, {
+    "node1" : "INTERNAL_vl1_dtrct21",
+    "node2" : "dtrct21"
+  }, {
+    "node1" : "dgen2",
+    "node2" : "INTERNAL_vl1_bgen2"
+  }, {
+    "node1" : "INTERNAL_vl1_bgen2",
+    "node2" : "bgen2"
+  }, {
+    "node1" : "dtrf14",
+    "node2" : "INTERNAL_vl1_btrf14"
+  }, {
+    "node1" : "INTERNAL_vl1_btrf14",
+    "node2" : "btrf14"
+  }, {
     "node1" : "bload1",
     "node2" : "INTERNAL_vl1_load1"
   }, {
@@ -2514,102 +2610,6 @@
   }, {
     "node1" : "INTERNAL_vl1_trf5_ONE",
     "node2" : "trf5_ONE"
-  }, {
-    "node1" : "dtrct11",
-    "node2" : "INTERNAL_vl1_dsect11"
-  }, {
-    "node1" : "dsect11",
-    "node2" : "INTERNAL_vl1_dsect11"
-  }, {
-    "node1" : "bload1",
-    "node2" : "INTERNAL_vl1_dload1"
-  }, {
-    "node1" : "dload1",
-    "node2" : "INTERNAL_vl1_dload1"
-  }, {
-    "node1" : "btrf11",
-    "node2" : "INTERNAL_vl1_dtrf11"
-  }, {
-    "node1" : "dtrf11",
-    "node2" : "INTERNAL_vl1_dtrf11"
-  }, {
-    "node1" : "btrf15",
-    "node2" : "INTERNAL_vl1_dtrf15"
-  }, {
-    "node1" : "dtrf15",
-    "node2" : "INTERNAL_vl1_dtrf15"
-  }, {
-    "node1" : "btrf16",
-    "node2" : "INTERNAL_vl1_dtrf16"
-  }, {
-    "node1" : "dtrf16",
-    "node2" : "INTERNAL_vl1_dtrf16"
-  }, {
-    "node1" : "dtrct11",
-    "node2" : "INTERNAL_vl1_dsect12"
-  }, {
-    "node1" : "dsect12",
-    "node2" : "INTERNAL_vl1_dsect12"
-  }, {
-    "node1" : "bload2",
-    "node2" : "INTERNAL_vl1_dload2"
-  }, {
-    "node1" : "dload2",
-    "node2" : "INTERNAL_vl1_dload2"
-  }, {
-    "node1" : "btrf12",
-    "node2" : "INTERNAL_vl1_dtrf12"
-  }, {
-    "node1" : "dtrf12",
-    "node2" : "INTERNAL_vl1_dtrf12"
-  }, {
-    "node1" : "btrf18",
-    "node2" : "INTERNAL_vl1_dtrf18"
-  }, {
-    "node1" : "dtrf18",
-    "node2" : "INTERNAL_vl1_dtrf18"
-  }, {
-    "node1" : "dtrct21",
-    "node2" : "INTERNAL_vl1_dsect21"
-  }, {
-    "node1" : "dsect21",
-    "node2" : "INTERNAL_vl1_dsect21"
-  }, {
-    "node1" : "bgen1",
-    "node2" : "INTERNAL_vl1_dgen1"
-  }, {
-    "node1" : "dgen1",
-    "node2" : "INTERNAL_vl1_dgen1"
-  }, {
-    "node1" : "btrf13",
-    "node2" : "INTERNAL_vl1_dtrf13"
-  }, {
-    "node1" : "dtrf13",
-    "node2" : "INTERNAL_vl1_dtrf13"
-  }, {
-    "node1" : "btrf17",
-    "node2" : "INTERNAL_vl1_dtrf17"
-  }, {
-    "node1" : "dtrf17",
-    "node2" : "INTERNAL_vl1_dtrf17"
-  }, {
-    "node1" : "dtrct21",
-    "node2" : "INTERNAL_vl1_dsect22"
-  }, {
-    "node1" : "dsect22",
-    "node2" : "INTERNAL_vl1_dsect22"
-  }, {
-    "node1" : "bgen2",
-    "node2" : "INTERNAL_vl1_dgen2"
-  }, {
-    "node1" : "dgen2",
-    "node2" : "INTERNAL_vl1_dgen2"
-  }, {
-    "node1" : "btrf14",
-    "node2" : "INTERNAL_vl1_dtrf14"
-  }, {
-    "node1" : "dtrf14",
-    "node2" : "INTERNAL_vl1_dtrf14"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL2.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_dgen4",
+    "id" : "INTERNAL_vl2_bgen4",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 360.0,
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_dload3",
+    "id" : "INTERNAL_vl2_bload3",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -25,23 +25,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_dscpl1",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 120.0,
-    "y" : 240.0,
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_dscpl2",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 40.0,
-    "y" : 240.0,
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_dtrf21",
+    "id" : "INTERNAL_vl2_btrf21",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 280.0,
@@ -49,7 +33,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_dtrf22",
+    "id" : "INTERNAL_vl2_btrf22",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1000.0,
@@ -58,7 +42,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_dtrf23",
+    "id" : "INTERNAL_vl2_btrf23",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 1080.0,
@@ -67,7 +51,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_dtrf24",
+    "id" : "INTERNAL_vl2_btrf24",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 440.0,
@@ -75,7 +59,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_dtrf26",
+    "id" : "INTERNAL_vl2_btrf26",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 720.0,
@@ -83,7 +67,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_dtrf27",
+    "id" : "INTERNAL_vl2_btrf27",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 560.0,
@@ -91,12 +75,28 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_dtrf28",
+    "id" : "INTERNAL_vl2_btrf28",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 880.0,
     "y" : 335.0,
     "orientation" : "DOWN",
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl2_ddcpl1",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 120.0,
+    "y" : 240.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl2_ddcpl1",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 40.0,
+    "y" : 240.0,
     "open" : false
   }, {
     "type" : "FICTITIOUS",
@@ -780,7 +780,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_dscpl2" ]
+        "nodes" : [ "bbs6", "dscpl2", "INTERNAL_vl2_ddcpl1" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -801,7 +801,7 @@
           "xSpan" : 80.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl2_dscpl2", "ddcpl1", "INTERNAL_vl2_dscpl1" ]
+        "nodes" : [ "INTERNAL_vl2_ddcpl1", "ddcpl1", "INTERNAL_vl2_ddcpl1" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -822,7 +822,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_dscpl1" ]
+        "nodes" : [ "bbs5", "dscpl1", "INTERNAL_vl2_ddcpl1" ]
       } ]
     }
   }, {
@@ -870,7 +870,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_dload3" ]
+        "nodes" : [ "bbs5", "dload3", "INTERNAL_vl2_bload3" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -891,7 +891,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl2_dload3", "bload3", "INTERNAL_vl2_load3" ]
+        "nodes" : [ "INTERNAL_vl2_bload3", "bload3", "INTERNAL_vl2_load3" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -960,7 +960,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_dtrf21" ]
+        "nodes" : [ "bbs5", "dtrf21", "INTERNAL_vl2_btrf21" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -981,7 +981,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl2_dtrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
+        "nodes" : [ "INTERNAL_vl2_btrf21", "btrf21", "INTERNAL_vl2_trf1_TWO" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -1050,7 +1050,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_dtrf24" ]
+        "nodes" : [ "bbs5", "dtrf24", "INTERNAL_vl2_btrf24" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1071,7 +1071,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl2_dtrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
+        "nodes" : [ "INTERNAL_vl2_btrf24", "btrf24", "INTERNAL_vl2_trf4_TWO" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -1140,7 +1140,7 @@
           "xSpan" : 160.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_dtrf27" ]
+        "nodes" : [ "bbs5", "dtrf27", "INTERNAL_vl2_btrf27" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1161,7 +1161,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl2_dtrf27", "btrf27", "trf7" ]
+        "nodes" : [ "INTERNAL_vl2_btrf27", "btrf27", "trf7" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1272,7 +1272,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_dgen4" ]
+        "nodes" : [ "bbs6", "dgen4", "INTERNAL_vl2_bgen4" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1293,7 +1293,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl2_dgen4", "bgen4", "INTERNAL_vl2_gen4" ]
+        "nodes" : [ "INTERNAL_vl2_bgen4", "bgen4", "INTERNAL_vl2_gen4" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -1362,7 +1362,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_dtrf22" ]
+        "nodes" : [ "bbs6", "dtrf22", "INTERNAL_vl2_btrf22" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1383,7 +1383,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl2_dtrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
+        "nodes" : [ "INTERNAL_vl2_btrf22", "btrf22", "INTERNAL_vl2_trf2_TWO" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -1452,7 +1452,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_dtrf23" ]
+        "nodes" : [ "bbs6", "dtrf23", "INTERNAL_vl2_btrf23" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1473,7 +1473,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl2_dtrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
+        "nodes" : [ "INTERNAL_vl2_btrf23", "btrf23", "INTERNAL_vl2_trf3_TWO" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -1542,7 +1542,7 @@
           "xSpan" : 160.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_dtrf26" ]
+        "nodes" : [ "bbs6", "dtrf26", "INTERNAL_vl2_btrf26" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1563,7 +1563,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl2_dtrf26", "btrf26", "trf6" ]
+        "nodes" : [ "INTERNAL_vl2_btrf26", "btrf26", "trf6" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1674,7 +1674,7 @@
           "xSpan" : 160.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_dtrf28" ]
+        "nodes" : [ "bbs6", "dtrf28", "INTERNAL_vl2_btrf28" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1695,7 +1695,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl2_dtrf28", "btrf28", "trf8" ]
+        "nodes" : [ "INTERNAL_vl2_btrf28", "btrf28", "trf8" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1823,6 +1823,72 @@
     "node1" : "btrf28",
     "node2" : "trf8"
   }, {
+    "node1" : "dscpl1",
+    "node2" : "INTERNAL_vl2_ddcpl1"
+  }, {
+    "node1" : "INTERNAL_vl2_ddcpl1",
+    "node2" : "ddcpl1"
+  }, {
+    "node1" : "dload3",
+    "node2" : "INTERNAL_vl2_bload3"
+  }, {
+    "node1" : "INTERNAL_vl2_bload3",
+    "node2" : "bload3"
+  }, {
+    "node1" : "dtrf21",
+    "node2" : "INTERNAL_vl2_btrf21"
+  }, {
+    "node1" : "INTERNAL_vl2_btrf21",
+    "node2" : "btrf21"
+  }, {
+    "node1" : "dtrf24",
+    "node2" : "INTERNAL_vl2_btrf24"
+  }, {
+    "node1" : "INTERNAL_vl2_btrf24",
+    "node2" : "btrf24"
+  }, {
+    "node1" : "dtrf27",
+    "node2" : "INTERNAL_vl2_btrf27"
+  }, {
+    "node1" : "INTERNAL_vl2_btrf27",
+    "node2" : "btrf27"
+  }, {
+    "node1" : "dscpl2",
+    "node2" : "INTERNAL_vl2_ddcpl1"
+  }, {
+    "node1" : "INTERNAL_vl2_ddcpl1",
+    "node2" : "ddcpl1"
+  }, {
+    "node1" : "dgen4",
+    "node2" : "INTERNAL_vl2_bgen4"
+  }, {
+    "node1" : "INTERNAL_vl2_bgen4",
+    "node2" : "bgen4"
+  }, {
+    "node1" : "dtrf22",
+    "node2" : "INTERNAL_vl2_btrf22"
+  }, {
+    "node1" : "INTERNAL_vl2_btrf22",
+    "node2" : "btrf22"
+  }, {
+    "node1" : "dtrf23",
+    "node2" : "INTERNAL_vl2_btrf23"
+  }, {
+    "node1" : "INTERNAL_vl2_btrf23",
+    "node2" : "btrf23"
+  }, {
+    "node1" : "dtrf26",
+    "node2" : "INTERNAL_vl2_btrf26"
+  }, {
+    "node1" : "INTERNAL_vl2_btrf26",
+    "node2" : "btrf26"
+  }, {
+    "node1" : "dtrf28",
+    "node2" : "INTERNAL_vl2_btrf28"
+  }, {
+    "node1" : "INTERNAL_vl2_btrf28",
+    "node2" : "btrf28"
+  }, {
     "node1" : "bload3",
     "node2" : "INTERNAL_vl2_load3"
   }, {
@@ -1858,72 +1924,6 @@
   }, {
     "node1" : "INTERNAL_vl2_trf4_TWO",
     "node2" : "trf4_TWO"
-  }, {
-    "node1" : "ddcpl1",
-    "node2" : "INTERNAL_vl2_dscpl1"
-  }, {
-    "node1" : "dscpl1",
-    "node2" : "INTERNAL_vl2_dscpl1"
-  }, {
-    "node1" : "bload3",
-    "node2" : "INTERNAL_vl2_dload3"
-  }, {
-    "node1" : "dload3",
-    "node2" : "INTERNAL_vl2_dload3"
-  }, {
-    "node1" : "btrf21",
-    "node2" : "INTERNAL_vl2_dtrf21"
-  }, {
-    "node1" : "dtrf21",
-    "node2" : "INTERNAL_vl2_dtrf21"
-  }, {
-    "node1" : "btrf24",
-    "node2" : "INTERNAL_vl2_dtrf24"
-  }, {
-    "node1" : "dtrf24",
-    "node2" : "INTERNAL_vl2_dtrf24"
-  }, {
-    "node1" : "btrf27",
-    "node2" : "INTERNAL_vl2_dtrf27"
-  }, {
-    "node1" : "dtrf27",
-    "node2" : "INTERNAL_vl2_dtrf27"
-  }, {
-    "node1" : "ddcpl1",
-    "node2" : "INTERNAL_vl2_dscpl2"
-  }, {
-    "node1" : "dscpl2",
-    "node2" : "INTERNAL_vl2_dscpl2"
-  }, {
-    "node1" : "bgen4",
-    "node2" : "INTERNAL_vl2_dgen4"
-  }, {
-    "node1" : "dgen4",
-    "node2" : "INTERNAL_vl2_dgen4"
-  }, {
-    "node1" : "btrf22",
-    "node2" : "INTERNAL_vl2_dtrf22"
-  }, {
-    "node1" : "dtrf22",
-    "node2" : "INTERNAL_vl2_dtrf22"
-  }, {
-    "node1" : "btrf23",
-    "node2" : "INTERNAL_vl2_dtrf23"
-  }, {
-    "node1" : "dtrf23",
-    "node2" : "INTERNAL_vl2_dtrf23"
-  }, {
-    "node1" : "btrf26",
-    "node2" : "INTERNAL_vl2_dtrf26"
-  }, {
-    "node1" : "dtrf26",
-    "node2" : "INTERNAL_vl2_dtrf26"
-  }, {
-    "node1" : "btrf28",
-    "node2" : "INTERNAL_vl2_dtrf28"
-  }, {
-    "node1" : "dtrf28",
-    "node2" : "INTERNAL_vl2_dtrf28"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphVL3.json
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphVL3.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl3_dload4",
+    "id" : "INTERNAL_vl3_bload4",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 40.0,
@@ -16,7 +16,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl3_dself4",
+    "id" : "INTERNAL_vl3_bself4",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 120.0,
@@ -25,7 +25,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl3_dself5",
+    "id" : "INTERNAL_vl3_bself5",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 760.0,
@@ -34,7 +34,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl3_dself6",
+    "id" : "INTERNAL_vl3_bself6",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 840.0,
@@ -43,7 +43,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl3_dtrf25",
+    "id" : "INTERNAL_vl3_btrf25",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -52,7 +52,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl3_dtrf36",
+    "id" : "INTERNAL_vl3_btrf36",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 320.0,
@@ -60,7 +60,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl3_dtrf37",
+    "id" : "INTERNAL_vl3_btrf37",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 480.0,
@@ -69,7 +69,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl3_dtrf38",
+    "id" : "INTERNAL_vl3_btrf38",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 640.0,
@@ -667,7 +667,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_dload4" ]
+        "nodes" : [ "bbs7", "dload4", "INTERNAL_vl3_bload4" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -688,7 +688,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl3_dload4", "bload4", "INTERNAL_vl3_load4" ]
+        "nodes" : [ "INTERNAL_vl3_bload4", "bload4", "INTERNAL_vl3_load4" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -757,7 +757,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs7", "dself4", "INTERNAL_vl3_dself4" ]
+        "nodes" : [ "bbs7", "dself4", "INTERNAL_vl3_bself4" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -778,7 +778,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl3_dself4", "bself4", "INTERNAL_vl3_self4" ]
+        "nodes" : [ "INTERNAL_vl3_bself4", "bself4", "INTERNAL_vl3_self4" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -847,7 +847,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_dtrf25" ]
+        "nodes" : [ "bbs7", "dtrf25", "INTERNAL_vl3_btrf25" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -868,7 +868,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl3_dtrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
+        "nodes" : [ "INTERNAL_vl3_btrf25", "btrf25", "INTERNAL_vl3_trf5_TWO" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -937,7 +937,7 @@
           "xSpan" : 160.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_dtrf36" ]
+        "nodes" : [ "bbs7", "dtrf36", "INTERNAL_vl3_btrf36" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -958,7 +958,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl3_dtrf36", "btrf36", "trf6" ]
+        "nodes" : [ "INTERNAL_vl3_btrf36", "btrf36", "trf6" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1069,7 +1069,7 @@
           "xSpan" : 160.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_dtrf37" ]
+        "nodes" : [ "bbs7", "dtrf37", "INTERNAL_vl3_btrf37" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1090,7 +1090,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl3_dtrf37", "btrf37", "trf7" ]
+        "nodes" : [ "INTERNAL_vl3_btrf37", "btrf37", "trf7" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1201,7 +1201,7 @@
           "xSpan" : 160.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_dtrf38" ]
+        "nodes" : [ "bbs7", "dtrf38", "INTERNAL_vl3_btrf38" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1222,7 +1222,7 @@
           "xSpan" : 160.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl3_dtrf38", "btrf38", "trf8" ]
+        "nodes" : [ "INTERNAL_vl3_btrf38", "btrf38", "trf8" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -1333,7 +1333,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs7", "dself5", "INTERNAL_vl3_dself5" ]
+        "nodes" : [ "bbs7", "dself5", "INTERNAL_vl3_bself5" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1354,7 +1354,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl3_dself5", "bself5", "INTERNAL_vl3_self5" ]
+        "nodes" : [ "INTERNAL_vl3_bself5", "bself5", "INTERNAL_vl3_self5" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -1423,7 +1423,7 @@
           "xSpan" : 80.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs8", "dself6", "INTERNAL_vl3_dself6" ]
+        "nodes" : [ "bbs8", "dself6", "INTERNAL_vl3_bself6" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -1444,7 +1444,7 @@
           "xSpan" : 80.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl3_dself6", "bself6", "INTERNAL_vl3_self6" ]
+        "nodes" : [ "INTERNAL_vl3_bself6", "bself6", "INTERNAL_vl3_self6" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -1521,6 +1521,54 @@
     "node1" : "bbs8",
     "node2" : "dself6"
   }, {
+    "node1" : "dload4",
+    "node2" : "INTERNAL_vl3_bload4"
+  }, {
+    "node1" : "INTERNAL_vl3_bload4",
+    "node2" : "bload4"
+  }, {
+    "node1" : "dself4",
+    "node2" : "INTERNAL_vl3_bself4"
+  }, {
+    "node1" : "INTERNAL_vl3_bself4",
+    "node2" : "bself4"
+  }, {
+    "node1" : "dtrf25",
+    "node2" : "INTERNAL_vl3_btrf25"
+  }, {
+    "node1" : "INTERNAL_vl3_btrf25",
+    "node2" : "btrf25"
+  }, {
+    "node1" : "dtrf36",
+    "node2" : "INTERNAL_vl3_btrf36"
+  }, {
+    "node1" : "INTERNAL_vl3_btrf36",
+    "node2" : "btrf36"
+  }, {
+    "node1" : "dtrf37",
+    "node2" : "INTERNAL_vl3_btrf37"
+  }, {
+    "node1" : "INTERNAL_vl3_btrf37",
+    "node2" : "btrf37"
+  }, {
+    "node1" : "dtrf38",
+    "node2" : "INTERNAL_vl3_btrf38"
+  }, {
+    "node1" : "INTERNAL_vl3_btrf38",
+    "node2" : "btrf38"
+  }, {
+    "node1" : "dself5",
+    "node2" : "INTERNAL_vl3_bself5"
+  }, {
+    "node1" : "INTERNAL_vl3_bself5",
+    "node2" : "bself5"
+  }, {
+    "node1" : "dself6",
+    "node2" : "INTERNAL_vl3_bself6"
+  }, {
+    "node1" : "INTERNAL_vl3_bself6",
+    "node2" : "bself6"
+  }, {
     "node1" : "bload4",
     "node2" : "INTERNAL_vl3_load4"
   }, {
@@ -1550,54 +1598,6 @@
   }, {
     "node1" : "INTERNAL_vl3_self6",
     "node2" : "self6"
-  }, {
-    "node1" : "bload4",
-    "node2" : "INTERNAL_vl3_dload4"
-  }, {
-    "node1" : "dload4",
-    "node2" : "INTERNAL_vl3_dload4"
-  }, {
-    "node1" : "bself4",
-    "node2" : "INTERNAL_vl3_dself4"
-  }, {
-    "node1" : "dself4",
-    "node2" : "INTERNAL_vl3_dself4"
-  }, {
-    "node1" : "btrf25",
-    "node2" : "INTERNAL_vl3_dtrf25"
-  }, {
-    "node1" : "dtrf25",
-    "node2" : "INTERNAL_vl3_dtrf25"
-  }, {
-    "node1" : "btrf36",
-    "node2" : "INTERNAL_vl3_dtrf36"
-  }, {
-    "node1" : "dtrf36",
-    "node2" : "INTERNAL_vl3_dtrf36"
-  }, {
-    "node1" : "btrf37",
-    "node2" : "INTERNAL_vl3_dtrf37"
-  }, {
-    "node1" : "dtrf37",
-    "node2" : "INTERNAL_vl3_dtrf37"
-  }, {
-    "node1" : "btrf38",
-    "node2" : "INTERNAL_vl3_dtrf38"
-  }, {
-    "node1" : "dtrf38",
-    "node2" : "INTERNAL_vl3_dtrf38"
-  }, {
-    "node1" : "bself5",
-    "node2" : "INTERNAL_vl3_dself5"
-  }, {
-    "node1" : "dself5",
-    "node2" : "INTERNAL_vl3_dself5"
-  }, {
-    "node1" : "bself6",
-    "node2" : "INTERNAL_vl3_dself6"
-  }, {
-    "node1" : "dself6",
-    "node2" : "INTERNAL_vl3_dself6"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -115,20 +115,20 @@
             <text class="sld-label" id="bbs4_NW_LABEL" x="-5.0" y="-5.0">bbs4</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dsect11" transform="translate(756.0,248.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(756.0,248.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dsect12" transform="translate(836.0,248.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(836.0,248.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_bbs1_95_dsect11">
                 <polyline points="740.0,252.0,760.0,252.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect11">
-                <polyline points="790.0,252.0,760.0,252.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11">
+                <polyline points="760.0,252.0,790.0,252.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect12">
-                <polyline points="810.0,252.0,840.0,252.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11">
+                <polyline points="840.0,252.0,810.0,252.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dsect12_95_bbs2">
                 <polyline points="840.0,252.0,860.0,252.0"/>
@@ -147,20 +147,20 @@
             </g>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_1">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dsect21" transform="translate(756.0,273.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(756.0,273.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dsect22" transform="translate(836.0,273.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(836.0,273.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_bbs3_95_dsect21">
                 <polyline points="740.0,277.0,760.0,277.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect21">
-                <polyline points="790.0,277.0,760.0,277.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21">
+                <polyline points="760.0,277.0,790.0,277.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect22">
-                <polyline points="810.0,277.0,840.0,277.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21">
+                <polyline points="840.0,277.0,810.0,277.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dsect22_95_bbs4">
                 <polyline points="840.0,277.0,860.0,277.0"/>
@@ -179,7 +179,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dload1" transform="translate(76.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_bload1" transform="translate(76.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_load1" transform="translate(76.0,138.0)">
@@ -191,11 +191,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load1_N_LABEL" x="-5.0" y="-5.0">load1</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_dload1">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_bload1">
                 <polyline points="80.0,252.0,80.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_dload1">
-                <polyline points="80.0,192.0,80.0,222.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_bload1_95_bload1">
+                <polyline points="80.0,222.0,80.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_load1">
                 <polyline points="80.0,172.0,80.0,142.0"/>
@@ -223,7 +223,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dtrf11" transform="translate(156.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_btrf11" transform="translate(156.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_trf1_95_ONE" transform="translate(156.0,138.0)">
@@ -234,11 +234,11 @@
                 <circle class="sld-vl180to300 sld-winding" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="trf1_ONE_N_LABEL" x="-5.0" y="-5.0">trf1</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_dtrf11">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_btrf11">
                 <polyline points="160.0,252.0,160.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_dtrf11">
-                <polyline points="160.0,192.0,160.0,222.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf11_95_btrf11">
+                <polyline points="160.0,222.0,160.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_trf1_95_ONE">
                 <polyline points="160.0,172.0,160.0,142.0"/>
@@ -266,7 +266,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dtrf15" transform="translate(396.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_btrf15" transform="translate(396.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_trf5_95_ONE" transform="translate(396.0,138.0)">
@@ -277,11 +277,11 @@
                 <circle class="sld-vl50to70 sld-winding" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="trf5_ONE_N_LABEL" x="-5.0" y="-5.0">trf5</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_dtrf15">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_btrf15">
                 <polyline points="400.0,252.0,400.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_dtrf15">
-                <polyline points="400.0,192.0,400.0,222.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf15_95_btrf15">
+                <polyline points="400.0,222.0,400.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_trf5_95_ONE">
                 <polyline points="400.0,172.0,400.0,142.0"/>
@@ -309,7 +309,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dtrf16" transform="translate(516.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_btrf16" transform="translate(516.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder sld-vl300to500" id="idtrf6_95_TWO" transform="translate(480.0,80.0)">
@@ -318,11 +318,11 @@
             <g class="sld-top-feeder sld-vl300to500" id="idtrf6_95_THREE" transform="translate(560.0,80.0)">
                 <text class="sld-label" id="trf6_THREE_N_LABEL" x="-5.0" y="-5.0">trf61</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_dtrf16">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_btrf16">
                 <polyline points="520.0,252.0,520.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf16_95_INTERNAL_95_vl1_95_dtrf16">
-                <polyline points="520.0,192.0,520.0,222.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf16_95_btrf16">
+                <polyline points="520.0,222.0,520.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf16_95_trf6">
                 <polyline points="520.0,172.0,520.0,154.0"/>
@@ -368,7 +368,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dload2" transform="translate(876.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_bload2" transform="translate(876.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_load2" transform="translate(876.0,138.0)">
@@ -380,11 +380,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load2_N_LABEL" x="-5.0" y="-5.0">load2</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_dload2">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_bload2">
                 <polyline points="880.0,252.0,880.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_dload2">
-                <polyline points="880.0,192.0,880.0,222.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_bload2_95_bload2">
+                <polyline points="880.0,222.0,880.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_load2">
                 <polyline points="880.0,172.0,880.0,142.0"/>
@@ -412,7 +412,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dtrf12" transform="translate(1196.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_btrf12" transform="translate(1196.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_trf2_95_ONE" transform="translate(1196.0,138.0)">
@@ -423,11 +423,11 @@
                 <circle class="sld-vl180to300 sld-winding" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="trf2_ONE_N_LABEL" x="-5.0" y="-5.0">trf2</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_dtrf12">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_btrf12">
                 <polyline points="1200.0,252.0,1200.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_dtrf12">
-                <polyline points="1200.0,192.0,1200.0,222.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf12_95_btrf12">
+                <polyline points="1200.0,222.0,1200.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_trf2_95_ONE">
                 <polyline points="1200.0,172.0,1200.0,142.0"/>
@@ -455,7 +455,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dtrf18" transform="translate(996.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_btrf18" transform="translate(996.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder sld-vl300to500" id="idtrf8_95_TWO" transform="translate(960.0,80.0)">
@@ -464,11 +464,11 @@
             <g class="sld-top-feeder sld-vl300to500" id="idtrf8_95_THREE" transform="translate(1040.0,80.0)">
                 <text class="sld-label" id="trf8_THREE_N_LABEL" x="-5.0" y="-5.0">trf81</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_dtrf18">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_btrf18">
                 <polyline points="1000.0,252.0,1000.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_dtrf18">
-                <polyline points="1000.0,192.0,1000.0,222.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf18_95_btrf18">
+                <polyline points="1000.0,222.0,1000.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf18_95_trf8">
                 <polyline points="1000.0,172.0,1000.0,154.0"/>
@@ -514,7 +514,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dgen1" transform="translate(236.0,303.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_bgen1" transform="translate(236.0,303.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_gen1" transform="translate(236.0,383.0)">
@@ -526,11 +526,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen1_S_LABEL" x="-5.0" y="17.0">gen1</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_dgen1">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_bgen1">
                 <polyline points="240.0,277.0,240.0,307.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_dgen1">
-                <polyline points="240.0,337.0,240.0,307.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_bgen1_95_bgen1">
+                <polyline points="240.0,307.0,240.0,337.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_gen1">
                 <polyline points="240.0,357.0,240.0,387.0"/>
@@ -558,7 +558,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_10">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dtrf13" transform="translate(316.0,303.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_btrf13" transform="translate(316.0,303.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_trf3_95_ONE" transform="translate(316.0,383.0)">
@@ -569,11 +569,11 @@
                 <circle class="sld-vl180to300 sld-winding" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
                 <text class="sld-label" id="trf3_ONE_S_LABEL" x="-5.0" y="20.0">trf3</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_dtrf13">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_btrf13">
                 <polyline points="320.0,277.0,320.0,307.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_dtrf13">
-                <polyline points="320.0,337.0,320.0,307.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf13_95_btrf13">
+                <polyline points="320.0,307.0,320.0,337.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_trf3_95_ONE">
                 <polyline points="320.0,357.0,320.0,387.0"/>
@@ -601,7 +601,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_11">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dtrf17" transform="translate(676.0,303.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_btrf17" transform="translate(676.0,303.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder sld-vl300to500" id="idtrf7_95_TWO" transform="translate(640.0,449.0)">
@@ -610,11 +610,11 @@
             <g class="sld-bottom-feeder sld-vl300to500" id="idtrf7_95_THREE" transform="translate(720.0,449.0)">
                 <text class="sld-label" id="trf7_THREE_S_LABEL" x="-5.0" y="5.0">trf71</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_dtrf17">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_btrf17">
                 <polyline points="680.0,277.0,680.0,307.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf17_95_INTERNAL_95_vl1_95_dtrf17">
-                <polyline points="680.0,337.0,680.0,307.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf17_95_btrf17">
+                <polyline points="680.0,307.0,680.0,337.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf17_95_trf7">
                 <polyline points="680.0,357.0,680.0,375.0"/>
@@ -660,7 +660,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_12">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dgen2" transform="translate(1276.0,303.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_bgen2" transform="translate(1276.0,303.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_gen2" transform="translate(1276.0,383.0)">
@@ -672,11 +672,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen2_S_LABEL" x="-5.0" y="17.0">gen2</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_dgen2">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_bgen2">
                 <polyline points="1280.0,277.0,1280.0,307.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_dgen2">
-                <polyline points="1280.0,337.0,1280.0,307.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_bgen2_95_bgen2">
+                <polyline points="1280.0,307.0,1280.0,337.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_gen2">
                 <polyline points="1280.0,357.0,1280.0,387.0"/>
@@ -704,7 +704,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_13">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_dtrf14" transform="translate(1116.0,303.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_btrf14" transform="translate(1116.0,303.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_trf4_95_ONE" transform="translate(1116.0,383.0)">
@@ -715,11 +715,11 @@
                 <circle class="sld-vl180to300 sld-winding" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
                 <text class="sld-label" id="trf4_ONE_S_LABEL" x="-5.0" y="20.0">trf4</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_dtrf14">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_btrf14">
                 <polyline points="1120.0,277.0,1120.0,307.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_dtrf14">
-                <polyline points="1120.0,337.0,1120.0,307.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf14_95_btrf14">
+                <polyline points="1120.0,307.0,1120.0,337.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_trf4_95_ONE">
                 <polyline points="1120.0,357.0,1120.0,387.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -179,20 +179,20 @@
             <text class="sld-label" id="bbs4_NW_LABEL" x="-5.0" y="-5.0">bbs4</text>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dsect11" transform="translate(756.0,248.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(756.0,248.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dsect12" transform="translate(836.0,248.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrct11" transform="translate(836.0,248.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bbs1_95_dsect11">
                 <polyline points="740.0,252.0,760.0,252.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect11">
-                <polyline points="790.0,252.0,760.0,252.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11">
+                <polyline points="760.0,252.0,790.0,252.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect12">
-                <polyline points="810.0,252.0,840.0,252.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11">
+                <polyline points="840.0,252.0,810.0,252.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dsect12_95_bbs2">
                 <polyline points="840.0,252.0,860.0,252.0"/>
@@ -211,20 +211,20 @@
             </g>
         </g>
         <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_1">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dsect21" transform="translate(756.0,273.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(756.0,273.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dsect22" transform="translate(836.0,273.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrct21" transform="translate(836.0,273.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bbs3_95_dsect21">
                 <polyline points="740.0,277.0,760.0,277.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect21">
-                <polyline points="790.0,277.0,760.0,277.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21">
+                <polyline points="760.0,277.0,790.0,277.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect22">
-                <polyline points="810.0,277.0,840.0,277.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21">
+                <polyline points="840.0,277.0,810.0,277.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dsect22_95_bbs4">
                 <polyline points="840.0,277.0,860.0,277.0"/>
@@ -243,7 +243,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dload1" transform="translate(76.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bload1" transform="translate(76.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_load1" transform="translate(76.0,138.0)">
@@ -255,11 +255,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load1_N_LABEL" x="-5.0" y="-5.0">load1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_dload1">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_bload1">
                 <polyline points="80.0,252.0,80.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_dload1">
-                <polyline points="80.0,192.0,80.0,222.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bload1_95_bload1">
+                <polyline points="80.0,222.0,80.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_load1">
                 <polyline points="80.0,172.0,80.0,142.0"/>
@@ -287,7 +287,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf11" transform="translate(156.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf11" transform="translate(156.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf1_95_ONE" transform="translate(156.0,138.0)">
@@ -298,11 +298,11 @@
                 <circle class="sld-vl180to300-0 sld-winding" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="trf1_ONE_N_LABEL" x="-5.0" y="-5.0">trf1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_dtrf11">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_btrf11">
                 <polyline points="160.0,252.0,160.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_dtrf11">
-                <polyline points="160.0,192.0,160.0,222.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf11_95_btrf11">
+                <polyline points="160.0,222.0,160.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_trf1_95_ONE">
                 <polyline points="160.0,172.0,160.0,142.0"/>
@@ -330,7 +330,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_4">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf15" transform="translate(396.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf15" transform="translate(396.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf5_95_ONE" transform="translate(396.0,138.0)">
@@ -341,11 +341,11 @@
                 <circle class="sld-vl50to70-0 sld-winding" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="trf5_ONE_N_LABEL" x="-5.0" y="-5.0">trf5</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_dtrf15">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_btrf15">
                 <polyline points="400.0,252.0,400.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_dtrf15">
-                <polyline points="400.0,192.0,400.0,222.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf15_95_btrf15">
+                <polyline points="400.0,222.0,400.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_trf5_95_ONE">
                 <polyline points="400.0,172.0,400.0,142.0"/>
@@ -373,7 +373,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_5">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf16" transform="translate(516.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf16" transform="translate(516.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf6_95_TWO" transform="translate(480.0,80.0)">
@@ -382,11 +382,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf6_95_THREE" transform="translate(560.0,80.0)">
                 <text class="sld-label" id="trf6_THREE_N_LABEL" x="-5.0" y="-5.0">trf61</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_dtrf16">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_btrf16">
                 <polyline points="520.0,252.0,520.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf16_95_INTERNAL_95_vl1_95_dtrf16">
-                <polyline points="520.0,192.0,520.0,222.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf16_95_btrf16">
+                <polyline points="520.0,222.0,520.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf16_95_trf6">
                 <polyline points="520.0,172.0,520.0,154.0"/>
@@ -432,7 +432,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_6">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dload2" transform="translate(876.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bload2" transform="translate(876.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_load2" transform="translate(876.0,138.0)">
@@ -444,11 +444,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="load2_N_LABEL" x="-5.0" y="-5.0">load2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_dload2">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_bload2">
                 <polyline points="880.0,252.0,880.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_dload2">
-                <polyline points="880.0,192.0,880.0,222.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bload2_95_bload2">
+                <polyline points="880.0,222.0,880.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_load2">
                 <polyline points="880.0,172.0,880.0,142.0"/>
@@ -476,7 +476,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_7">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf12" transform="translate(1196.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf12" transform="translate(1196.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf2_95_ONE" transform="translate(1196.0,138.0)">
@@ -487,11 +487,11 @@
                 <circle class="sld-vl180to300-0 sld-winding" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="trf2_ONE_N_LABEL" x="-5.0" y="-5.0">trf2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_dtrf12">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_btrf12">
                 <polyline points="1200.0,252.0,1200.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_dtrf12">
-                <polyline points="1200.0,192.0,1200.0,222.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf12_95_btrf12">
+                <polyline points="1200.0,222.0,1200.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_trf2_95_ONE">
                 <polyline points="1200.0,172.0,1200.0,142.0"/>
@@ -519,7 +519,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_8">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_dtrf18" transform="translate(996.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_btrf18" transform="translate(996.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf8_95_TWO" transform="translate(960.0,80.0)">
@@ -528,11 +528,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="idtrf8_95_THREE" transform="translate(1040.0,80.0)">
                 <text class="sld-label" id="trf8_THREE_N_LABEL" x="-5.0" y="-5.0">trf81</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_dtrf18">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_btrf18">
                 <polyline points="1000.0,252.0,1000.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_dtrf18">
-                <polyline points="1000.0,192.0,1000.0,222.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf18_95_btrf18">
+                <polyline points="1000.0,222.0,1000.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_btrf18_95_trf8">
                 <polyline points="1000.0,172.0,1000.0,154.0"/>
@@ -578,7 +578,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_9">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dgen1" transform="translate(236.0,303.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_bgen1" transform="translate(236.0,303.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_gen1" transform="translate(236.0,383.0)">
@@ -590,11 +590,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen1_S_LABEL" x="-5.0" y="17.0">gen1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_dgen1">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_bgen1">
                 <polyline points="240.0,277.0,240.0,307.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_dgen1">
-                <polyline points="240.0,337.0,240.0,307.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_bgen1_95_bgen1">
+                <polyline points="240.0,307.0,240.0,337.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_gen1">
                 <polyline points="240.0,357.0,240.0,387.0"/>
@@ -622,7 +622,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_10">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf13" transform="translate(316.0,303.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf13" transform="translate(316.0,303.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf3_95_ONE" transform="translate(316.0,383.0)">
@@ -633,11 +633,11 @@
                 <circle class="sld-vl180to300-0 sld-winding" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
                 <text class="sld-label" id="trf3_ONE_S_LABEL" x="-5.0" y="20.0">trf3</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_dtrf13">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_btrf13">
                 <polyline points="320.0,277.0,320.0,307.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_dtrf13">
-                <polyline points="320.0,337.0,320.0,307.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf13_95_btrf13">
+                <polyline points="320.0,307.0,320.0,337.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_trf3_95_ONE">
                 <polyline points="320.0,357.0,320.0,387.0"/>
@@ -665,7 +665,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_11">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf17" transform="translate(676.0,303.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf17" transform="translate(676.0,303.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf7_95_TWO" transform="translate(640.0,449.0)">
@@ -674,11 +674,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-1" id="idtrf7_95_THREE" transform="translate(720.0,449.0)">
                 <text class="sld-label" id="trf7_THREE_S_LABEL" x="-5.0" y="5.0">trf71</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_dtrf17">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_btrf17">
                 <polyline points="680.0,277.0,680.0,307.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf17_95_INTERNAL_95_vl1_95_dtrf17">
-                <polyline points="680.0,337.0,680.0,307.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf17_95_btrf17">
+                <polyline points="680.0,307.0,680.0,337.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf17_95_trf7">
                 <polyline points="680.0,357.0,680.0,375.0"/>
@@ -724,7 +724,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_12">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dgen2" transform="translate(1276.0,303.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_bgen2" transform="translate(1276.0,303.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_gen2" transform="translate(1276.0,383.0)">
@@ -736,11 +736,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="gen2_S_LABEL" x="-5.0" y="17.0">gen2</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_dgen2">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_bgen2">
                 <polyline points="1280.0,277.0,1280.0,307.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_dgen2">
-                <polyline points="1280.0,337.0,1280.0,307.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_bgen2_95_bgen2">
+                <polyline points="1280.0,307.0,1280.0,337.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_gen2">
                 <polyline points="1280.0,357.0,1280.0,387.0"/>
@@ -768,7 +768,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_13">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_dtrf14" transform="translate(1116.0,303.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_btrf14" transform="translate(1116.0,303.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-1" id="idINTERNAL_95_vl1_95_trf4_95_ONE" transform="translate(1116.0,383.0)">
@@ -779,11 +779,11 @@
                 <circle class="sld-vl180to300-0 sld-winding" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
                 <text class="sld-label" id="trf4_ONE_S_LABEL" x="-5.0" y="20.0">trf4</text>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_dtrf14">
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_btrf14">
                 <polyline points="1120.0,277.0,1120.0,307.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_dtrf14">
-                <polyline points="1120.0,337.0,1120.0,307.0"/>
+            <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_btrf14_95_btrf14">
+                <polyline points="1120.0,307.0,1120.0,337.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_trf4_95_ONE">
                 <polyline points="1120.0,357.0,1120.0,387.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCase14UpToNFeederInfos.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase14UpToNFeederInfos.svg
@@ -74,7 +74,7 @@
             <text class="sld-label" id="bbs_NW_LABEL" x="-5.0" y="-5.0">bbs</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_d" transform="translate(61.0,326.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b" transform="translate(61.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_l" transform="translate(61.0,188.0)">
@@ -86,11 +86,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="l_N_LABEL" x="-5.0" y="-5.0">l</text>
             </g>
-            <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_d">
+            <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_b">
                 <polyline points="65.0,360.0,65.0,330.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_d">
-                <polyline points="65.0,271.0,65.0,330.0"/>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_b_95_b">
+                <polyline points="65.0,330.0,65.0,271.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_l">
                 <polyline points="65.0,251.0,65.0,192.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg height="358.0" viewBox="0 0 430.0 358.0" width="430.0" xmlns="http://www.w3.org/2000/svg">
+<svg height="385.0" viewBox="0 0 480.0 385.0" width="480.0" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 /* ----------------------------------------------------------------------- */
 /* File: tautologies.css ------------------------------------------------- */
@@ -66,23 +66,24 @@
     <rect class="sld-frame" height="100%" width="100%"/>
     <g>
         <g class="sld-grid" id="GRID_vl1">
-            <line x1="40.0" x2="40.0" y1="80.0" y2="278.0"/>
-            <line x1="90.0" x2="90.0" y1="80.0" y2="278.0"/>
-            <line x1="140.0" x2="140.0" y1="80.0" y2="278.0"/>
-            <line x1="190.0" x2="190.0" y1="80.0" y2="278.0"/>
-            <line x1="240.0" x2="240.0" y1="80.0" y2="278.0"/>
-            <line x1="290.0" x2="290.0" y1="80.0" y2="278.0"/>
-            <line x1="340.0" x2="340.0" y1="80.0" y2="278.0"/>
-            <line x1="390.0" x2="390.0" y1="80.0" y2="278.0"/>
-            <line x1="40.0" x2="390.0" y1="223.0" y2="223.0"/>
-            <line x1="40.0" x2="390.0" y1="213.0" y2="213.0"/>
-            <line x1="40.0" x2="390.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="40.0" y1="80.0" y2="305.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="305.0"/>
+            <line x1="140.0" x2="140.0" y1="80.0" y2="305.0"/>
+            <line x1="190.0" x2="190.0" y1="80.0" y2="305.0"/>
+            <line x1="240.0" x2="240.0" y1="80.0" y2="305.0"/>
+            <line x1="290.0" x2="290.0" y1="80.0" y2="305.0"/>
+            <line x1="340.0" x2="340.0" y1="80.0" y2="305.0"/>
+            <line x1="390.0" x2="390.0" y1="80.0" y2="305.0"/>
+            <line x1="440.0" x2="440.0" y1="80.0" y2="305.0"/>
+            <line x1="40.0" x2="440.0" y1="250.0" y2="250.0"/>
+            <line x1="40.0" x2="440.0" y1="240.0" y2="240.0"/>
+            <line x1="40.0" x2="440.0" y1="142.0" y2="142.0"/>
         </g>
-        <g class="sld-busbar-section" id="idbbs1" transform="translate(52.5,253.0)">
+        <g class="sld-busbar-section" id="idbbs1" transform="translate(52.5,280.0)">
             <line x1="0" x2="125.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs21" transform="translate(52.5,278.0)">
+        <g class="sld-busbar-section" id="idbbs21" transform="translate(52.5,305.0)">
             <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs21_NW_LABEL" x="-5.0" y="-5.0">bbs21</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs21_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
@@ -90,21 +91,21 @@
                 <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
             </g>
         </g>
-        <g class="sld-busbar-section" id="idbbs22" transform="translate(152.5,278.0)">
+        <g class="sld-busbar-section" id="idbbs22" transform="translate(152.5,305.0)">
             <line x1="0" x2="25.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs22_NW_LABEL" x="-5.0" y="-5.0">bbs22</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs13" transform="translate(202.5,253.0)">
-            <line x1="0" x2="175.0" y1="0" y2="0"/>
+        <g class="sld-busbar-section" id="idbbs13" transform="translate(202.5,280.0)">
+            <line x1="0" x2="225.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs13_NW_LABEL" x="-5.0" y="-5.0">bbs13</text>
-            <g class="sld-voltage-indicator sld-powered" id="idbbs13_VOLTAGE_INDICATOR" transform="translate(150.0,-5.0)">
+            <g class="sld-voltage-indicator sld-powered" id="idbbs13_VOLTAGE_INDICATOR" transform="translate(200.0,-5.0)">
                 <rect class="sld-powered" height="10" rx="1" ry="1" width="20"/>
                 <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
                 <text class="sld-label" x="0.0" y="-5.0">Top</text>
             </g>
         </g>
-        <g class="sld-busbar-section" id="idbbs23" transform="translate(202.5,278.0)">
-            <line x1="0" x2="175.0" y1="0" y2="0"/>
+        <g class="sld-busbar-section" id="idbbs23" transform="translate(202.5,305.0)">
+            <line x1="0" x2="225.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs23_NW_LABEL" x="-5.0" y="-5.0">bbs23</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs23_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
                 <rect class="sld-powered" height="10" rx="1" ry="1" width="20"/>
@@ -113,7 +114,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_3" transform="translate(111.0,219.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_3" transform="translate(111.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadA" transform="translate(111.0,138.0)">
@@ -125,17 +126,17 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadA_N_LABEL" x="-5.0" y="-5.0">loadA</text>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_d1_95_INTERNAL_95_vl1_95_3">
-                <polyline points="115.0,253.0,115.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_dA1_95_INTERNAL_95_vl1_95_3">
+                <polyline points="115.0,280.0,115.0,250.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_3_95_fA">
-                <polyline points="115.0,223.0,115.0,192.5"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_3_95_bA">
+                <polyline points="115.0,250.0,115.0,206.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_d2_95_INTERNAL_95_vl1_95_3">
-                <polyline points="115.0,278.0,115.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_dA2_95_INTERNAL_95_vl1_95_3">
+                <polyline points="115.0,305.0,115.0,250.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_fA_95_INTERNAL_95_vl1_95_loadA">
-                <polyline points="115.0,172.5,115.0,142.0"/>
+            <g class="sld-wire" id="_95_vl1_95_bA_95_INTERNAL_95_vl1_95_loadA">
+                <polyline points="115.0,186.0,115.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadA_95_loadA">
                 <polyline points="115.0,142.0,115.0,84.5"/>
@@ -150,21 +151,21 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd1" transform="translate(111.0,249.0)">
+            <g class="sld-disconnector sld-closed" id="iddA1" transform="translate(111.0,276.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idfA" transform="translate(105.0,172.5)">
+            <g class="sld-breaker sld-closed" id="idbA" transform="translate(105.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd2" transform="translate(111.0,274.0)">
+            <g class="sld-disconnector sld-closed" id="iddA2" transform="translate(111.0,301.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(161.0,219.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(161.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadB" transform="translate(161.0,138.0)">
@@ -176,20 +177,20 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadB_N_LABEL" x="-5.0" y="-5.0">loadB</text>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="165.0,223.0,165.0,192.5"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_bB">
+                <polyline points="165.0,250.0,165.0,206.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,278.0,165.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_dB1_95_INTERNAL_95_vl1_95_5">
+                <polyline points="165.0,305.0,165.0,250.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,253.0,165.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_dB2_95_INTERNAL_95_vl1_95_5">
+                <polyline points="165.0,280.0,165.0,250.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="165.0,223.0,190.0,223.0,190.0,196.0"/>
+                <polyline points="165.0,250.0,190.0,250.0,190.0,223.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_fB_95_INTERNAL_95_vl1_95_loadB">
-                <polyline points="165.0,172.5,165.0,142.0"/>
+            <g class="sld-wire" id="_95_vl1_95_bB_95_INTERNAL_95_vl1_95_loadB">
+                <polyline points="165.0,186.0,165.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadB_95_loadB">
                 <polyline points="165.0,142.0,165.0,84.5"/>
@@ -204,136 +205,193 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-breaker sld-closed" id="idfB" transform="translate(155.0,172.5)">
+            <g class="sld-breaker sld-closed" id="idbB" transform="translate(155.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idb1" transform="translate(161.0,274.0)">
+            <g class="sld-disconnector sld-closed" id="iddB1" transform="translate(161.0,301.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idb2" transform="translate(161.0,249.0)">
+            <g class="sld-disconnector sld-closed" id="iddB2" transform="translate(161.0,276.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_2">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(161.0,219.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(161.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_1" transform="translate(186.0,192.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_1" transform="translate(186.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_2" transform="translate(236.0,192.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_2" transform="translate(236.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(286.0,165.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(311.0,192.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="165.0,223.0,165.0,192.5"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_bB">
+                <polyline points="165.0,250.0,165.0,206.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,278.0,165.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_dB1_95_INTERNAL_95_vl1_95_5">
+                <polyline points="165.0,305.0,165.0,250.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,253.0,165.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_dB2_95_INTERNAL_95_vl1_95_5">
+                <polyline points="165.0,280.0,165.0,250.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="165.0,223.0,190.0,223.0,190.0,196.0"/>
+                <polyline points="165.0,250.0,190.0,250.0,190.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="205.0,196.0,190.0,196.0"/>
+                <polyline points="205.0,223.0,190.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="225.0,196.0,240.0,196.0"/>
+                <polyline points="225.0,223.0,240.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="290.0,169.0,240.0,169.0,240.0,196.0"/>
+                <polyline points="315.0,196.0,240.0,196.0,240.0,223.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="265.0,186.0,265.0,169.0,290.0,169.0"/>
+            <g class="sld-wire" id="_95_vl1_95_bCD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="265.0,213.0,265.0,196.0,315.0,196.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="315.0,186.0,315.0,169.0,290.0,169.0"/>
+            <g class="sld-wire" id="_95_vl1_95_bCD2_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="315.0,213.0,315.0,196.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_bCD3_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="365.0,213.0,365.0,196.0,315.0,196.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_bD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="277.5,179.0,277.5,196.0,315.0,196.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="290.0,169.0,290.0,142.0"/>
+                <polyline points="315.0,196.0,352.5,196.0,352.5,142.0"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idlink" transform="translate(205.0,186.0)">
+            <g class="sld-breaker sld-closed" id="idlink" transform="translate(205.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(286.0,165.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(311.0,192.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_c1" transform="translate(261.0,219.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_bCD1" transform="translate(261.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_c2" transform="translate(311.0,219.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_bCD2" transform="translate(311.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC" transform="translate(286.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_bCD3" transform="translate(361.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load sld-top-feeder" id="idloadC" transform="translate(282.0,75.5)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadD" transform="translate(273.5,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-load sld-top-feeder" id="idloadD" transform="translate(269.5,75.5)">
+                <rect height="9" width="16"/>
+                <line x1="0" x2="16" y1="0" y2="9"/>
+                <line x1="16" x2="0" y1="0" y2="9"/>
+                <text class="sld-label" id="loadD_N_LABEL" x="-5.0" y="-5.0">loadD</text>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC" transform="translate(348.5,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-load sld-top-feeder" id="idloadC" transform="translate(344.5,75.5)">
                 <rect height="9" width="16"/>
                 <line x1="0" x2="16" y1="0" y2="9"/>
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadC_N_LABEL" x="-5.0" y="-5.0">loadC</text>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="265.0,186.0,265.0,169.0,290.0,169.0"/>
+            <g class="sld-wire" id="_95_vl1_95_bCD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="265.0,213.0,265.0,196.0,315.0,196.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="315.0,186.0,315.0,169.0,290.0,169.0"/>
+            <g class="sld-wire" id="_95_vl1_95_bCD2_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="315.0,213.0,315.0,196.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_bCD3_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="365.0,213.0,365.0,196.0,315.0,196.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_bD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="277.5,179.0,277.5,196.0,315.0,196.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="290.0,169.0,290.0,142.0"/>
+                <polyline points="315.0,196.0,352.5,196.0,352.5,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="290.0,169.0,240.0,169.0,240.0,196.0"/>
+                <polyline points="315.0,196.0,240.0,196.0,240.0,223.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c1_95_c1">
-                <polyline points="265.0,223.0,265.0,206.0"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_bCD1_95_bCD1">
+                <polyline points="265.0,250.0,265.0,233.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
-                <polyline points="265.0,278.0,265.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_bCD1_95_INTERNAL_95_vl1_95_bCD1">
+                <polyline points="265.0,305.0,265.0,250.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
-                <polyline points="315.0,223.0,315.0,206.0"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_bCD2_95_bCD2">
+                <polyline points="315.0,250.0,315.0,233.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
-                <polyline points="315.0,253.0,315.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_bCD2_95_INTERNAL_95_vl1_95_bCD2">
+                <polyline points="315.0,280.0,315.0,250.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_bCD3_95_bCD3">
+                <polyline points="365.0,250.0,365.0,233.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_bCD3_95_INTERNAL_95_vl1_95_bCD3">
+                <polyline points="365.0,280.0,365.0,250.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_bD1_95_INTERNAL_95_vl1_95_loadD">
+                <polyline points="277.5,159.0,277.5,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadD_95_loadD">
+                <polyline points="277.5,142.0,277.5,84.5"/>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idloadD_ARROW_ACTIVE" transform="translate(272.5,99.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idloadD_ARROW_REACTIVE" transform="translate(272.5,119.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
-                <polyline points="290.0,142.0,290.0,84.5"/>
+                <polyline points="352.5,142.0,352.5,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(285.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(347.5,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(285.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(347.5,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-breaker sld-closed" id="idc1" transform="translate(255.0,186.0)">
+            <g class="sld-breaker sld-closed" id="idbCD1" transform="translate(255.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_c1" transform="translate(261.0,274.0)">
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_bCD1" transform="translate(261.0,301.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idc2" transform="translate(305.0,186.0)">
+            <g class="sld-breaker sld-closed" id="idbCD2" transform="translate(305.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_c2" transform="translate(311.0,249.0)">
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_bCD2" transform="translate(311.0,276.0)">
                 <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idbCD3" transform="translate(355.0,213.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_bCD3" transform="translate(361.0,276.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idbD1" transform="translate(267.5,159.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>
     </g>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg height="357.0" viewBox="0 0 430.0 357.0" width="430.0" xmlns="http://www.w3.org/2000/svg">
+<svg height="358.0" viewBox="0 0 430.0 358.0" width="430.0" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 /* ----------------------------------------------------------------------- */
 /* File: tautologies.css ------------------------------------------------- */
@@ -66,23 +66,23 @@
     <rect class="sld-frame" height="100%" width="100%"/>
     <g>
         <g class="sld-grid" id="GRID_vl1">
-            <line x1="40.0" x2="40.0" y1="80.0" y2="277.0"/>
-            <line x1="90.0" x2="90.0" y1="80.0" y2="277.0"/>
-            <line x1="140.0" x2="140.0" y1="80.0" y2="277.0"/>
-            <line x1="190.0" x2="190.0" y1="80.0" y2="277.0"/>
-            <line x1="240.0" x2="240.0" y1="80.0" y2="277.0"/>
-            <line x1="290.0" x2="290.0" y1="80.0" y2="277.0"/>
-            <line x1="340.0" x2="340.0" y1="80.0" y2="277.0"/>
-            <line x1="390.0" x2="390.0" y1="80.0" y2="277.0"/>
-            <line x1="40.0" x2="390.0" y1="222.0" y2="222.0"/>
-            <line x1="40.0" x2="390.0" y1="212.0" y2="212.0"/>
+            <line x1="40.0" x2="40.0" y1="80.0" y2="278.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="278.0"/>
+            <line x1="140.0" x2="140.0" y1="80.0" y2="278.0"/>
+            <line x1="190.0" x2="190.0" y1="80.0" y2="278.0"/>
+            <line x1="240.0" x2="240.0" y1="80.0" y2="278.0"/>
+            <line x1="290.0" x2="290.0" y1="80.0" y2="278.0"/>
+            <line x1="340.0" x2="340.0" y1="80.0" y2="278.0"/>
+            <line x1="390.0" x2="390.0" y1="80.0" y2="278.0"/>
+            <line x1="40.0" x2="390.0" y1="223.0" y2="223.0"/>
+            <line x1="40.0" x2="390.0" y1="213.0" y2="213.0"/>
             <line x1="40.0" x2="390.0" y1="142.0" y2="142.0"/>
         </g>
-        <g class="sld-busbar-section" id="idbbs1" transform="translate(52.5,252.0)">
+        <g class="sld-busbar-section" id="idbbs1" transform="translate(52.5,253.0)">
             <line x1="0" x2="125.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs21" transform="translate(52.5,277.0)">
+        <g class="sld-busbar-section" id="idbbs21" transform="translate(52.5,278.0)">
             <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs21_NW_LABEL" x="-5.0" y="-5.0">bbs21</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs21_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
@@ -90,11 +90,11 @@
                 <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
             </g>
         </g>
-        <g class="sld-busbar-section" id="idbbs22" transform="translate(152.5,277.0)">
+        <g class="sld-busbar-section" id="idbbs22" transform="translate(152.5,278.0)">
             <line x1="0" x2="25.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs22_NW_LABEL" x="-5.0" y="-5.0">bbs22</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs13" transform="translate(202.5,252.0)">
+        <g class="sld-busbar-section" id="idbbs13" transform="translate(202.5,253.0)">
             <line x1="0" x2="175.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs13_NW_LABEL" x="-5.0" y="-5.0">bbs13</text>
             <g class="sld-voltage-indicator sld-powered" id="idbbs13_VOLTAGE_INDICATOR" transform="translate(150.0,-5.0)">
@@ -103,7 +103,7 @@
                 <text class="sld-label" x="0.0" y="-5.0">Top</text>
             </g>
         </g>
-        <g class="sld-busbar-section" id="idbbs23" transform="translate(202.5,277.0)">
+        <g class="sld-busbar-section" id="idbbs23" transform="translate(202.5,278.0)">
             <line x1="0" x2="175.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs23_NW_LABEL" x="-5.0" y="-5.0">bbs23</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs23_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
@@ -113,7 +113,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_3" transform="translate(111.0,218.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_3" transform="translate(111.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadA" transform="translate(111.0,138.0)">
@@ -126,16 +126,16 @@
                 <text class="sld-label" id="loadA_N_LABEL" x="-5.0" y="-5.0">loadA</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_d1_95_INTERNAL_95_vl1_95_3">
-                <polyline points="115.0,252.0,115.0,222.0"/>
+                <polyline points="115.0,253.0,115.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_3_95_fA">
-                <polyline points="115.0,222.0,115.0,192.0"/>
+                <polyline points="115.0,223.0,115.0,192.5"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_d2_95_INTERNAL_95_vl1_95_3">
-                <polyline points="115.0,277.0,115.0,222.0"/>
+                <polyline points="115.0,278.0,115.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_fA_95_INTERNAL_95_vl1_95_loadA">
-                <polyline points="115.0,172.0,115.0,142.0"/>
+                <polyline points="115.0,172.5,115.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadA_95_loadA">
                 <polyline points="115.0,142.0,115.0,84.5"/>
@@ -150,21 +150,21 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd1" transform="translate(111.0,248.0)">
+            <g class="sld-disconnector sld-closed" id="idd1" transform="translate(111.0,249.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idfA" transform="translate(105.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idfA" transform="translate(105.0,172.5)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd2" transform="translate(111.0,273.0)">
+            <g class="sld-disconnector sld-closed" id="idd2" transform="translate(111.0,274.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(161.0,218.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(161.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadB" transform="translate(161.0,138.0)">
@@ -177,19 +177,19 @@
                 <text class="sld-label" id="loadB_N_LABEL" x="-5.0" y="-5.0">loadB</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="165.0,222.0,165.0,192.0"/>
+                <polyline points="165.0,223.0,165.0,192.5"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,277.0,165.0,222.0"/>
+                <polyline points="165.0,278.0,165.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,252.0,165.0,222.0"/>
+                <polyline points="165.0,253.0,165.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="165.0,222.0,190.0,222.0,190.0,182.0"/>
+                <polyline points="165.0,223.0,190.0,223.0,190.0,196.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_fB_95_INTERNAL_95_vl1_95_loadB">
-                <polyline points="165.0,172.0,165.0,142.0"/>
+                <polyline points="165.0,172.5,165.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadB_95_loadB">
                 <polyline points="165.0,142.0,165.0,84.5"/>
@@ -204,85 +204,78 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-breaker sld-closed" id="idfB" transform="translate(155.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idfB" transform="translate(155.0,172.5)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idb1" transform="translate(161.0,273.0)">
+            <g class="sld-disconnector sld-closed" id="idb1" transform="translate(161.0,274.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idb2" transform="translate(161.0,248.0)">
+            <g class="sld-disconnector sld-closed" id="idb2" transform="translate(161.0,249.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_2">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(161.0,218.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(161.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_1" transform="translate(186.0,178.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_1" transform="translate(186.0,192.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_2" transform="translate(236.0,178.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_2" transform="translate(236.0,192.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC" transform="translate(286.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(286.0,165.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="165.0,222.0,165.0,192.0"/>
+                <polyline points="165.0,223.0,165.0,192.5"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,277.0,165.0,222.0"/>
+                <polyline points="165.0,278.0,165.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,252.0,165.0,222.0"/>
+                <polyline points="165.0,253.0,165.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="165.0,222.0,190.0,222.0,190.0,182.0"/>
+                <polyline points="165.0,223.0,190.0,223.0,190.0,196.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="205.0,182.0,190.0,182.0"/>
+                <polyline points="205.0,196.0,190.0,196.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="225.0,182.0,240.0,182.0"/>
+                <polyline points="225.0,196.0,240.0,196.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="290.0,142.0,240.0,142.0,240.0,182.0"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
+                <polyline points="290.0,169.0,240.0,169.0,240.0,196.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="265.0,172.0,265.0,142.0,290.0,142.0"/>
+            <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="265.0,186.0,265.0,169.0,290.0,169.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="315.0,172.0,315.0,142.0,290.0,142.0"/>
+            <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="315.0,186.0,315.0,169.0,290.0,169.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
-                <polyline points="290.0,142.0,290.0,84.5"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
+                <polyline points="290.0,169.0,290.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(285.0,99.5)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">-</text>
-            </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(285.0,119.5)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">-</text>
-            </g>
-            <g class="sld-breaker sld-closed" id="idlink" transform="translate(205.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idlink" transform="translate(205.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(286.0,165.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_c1" transform="translate(261.0,219.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_c2" transform="translate(311.0,219.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC" transform="translate(286.0,138.0)">
-                <circle cx="4" cy="4" r="4"/>
-            </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_c1" transform="translate(261.0,218.0)">
-                <circle cx="4" cy="4" r="4"/>
-            </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_c2" transform="translate(311.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-load sld-top-feeder" id="idloadC" transform="translate(282.0,75.5)">
@@ -291,11 +284,29 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadC_N_LABEL" x="-5.0" y="-5.0">loadC</text>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="265.0,172.0,265.0,142.0,290.0,142.0"/>
+            <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="265.0,186.0,265.0,169.0,290.0,169.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="315.0,172.0,315.0,142.0,290.0,142.0"/>
+            <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="315.0,186.0,315.0,169.0,290.0,169.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
+                <polyline points="290.0,169.0,290.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
+                <polyline points="290.0,169.0,240.0,169.0,240.0,196.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c1_95_c1">
+                <polyline points="265.0,223.0,265.0,206.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
+                <polyline points="265.0,278.0,265.0,223.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
+                <polyline points="315.0,223.0,315.0,206.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
+                <polyline points="315.0,253.0,315.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
                 <polyline points="290.0,142.0,290.0,84.5"/>
@@ -310,33 +321,18 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="290.0,142.0,240.0,142.0,240.0,182.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c1_95_c1">
-                <polyline points="265.0,222.0,265.0,192.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
-                <polyline points="265.0,277.0,265.0,222.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
-                <polyline points="315.0,222.0,315.0,192.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
-                <polyline points="315.0,252.0,315.0,222.0"/>
-            </g>
-            <g class="sld-breaker sld-closed" id="idc1" transform="translate(255.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idc1" transform="translate(255.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_c1" transform="translate(261.0,273.0)">
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_c1" transform="translate(261.0,274.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idc2" transform="translate(305.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idc2" transform="translate(305.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_c2" transform="translate(311.0,248.0)">
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_c2" transform="translate(311.0,249.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg height="358.0" viewBox="0 0 530.0 358.0" width="530.0" xmlns="http://www.w3.org/2000/svg">
+<svg height="385.0" viewBox="0 0 580.0 385.0" width="580.0" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 /* ----------------------------------------------------------------------- */
 /* File: tautologies.css ------------------------------------------------- */
@@ -144,21 +144,22 @@
     <rect class="sld-frame" height="100%" width="100%"/>
     <g>
         <g class="sld-grid" id="GRID_vl1">
-            <line x1="40.0" x2="40.0" y1="80.0" y2="278.0"/>
-            <line x1="90.0" x2="90.0" y1="80.0" y2="278.0"/>
-            <line x1="140.0" x2="140.0" y1="80.0" y2="278.0"/>
-            <line x1="190.0" x2="190.0" y1="80.0" y2="278.0"/>
-            <line x1="240.0" x2="240.0" y1="80.0" y2="278.0"/>
-            <line x1="290.0" x2="290.0" y1="80.0" y2="278.0"/>
-            <line x1="340.0" x2="340.0" y1="80.0" y2="278.0"/>
-            <line x1="390.0" x2="390.0" y1="80.0" y2="278.0"/>
-            <line x1="440.0" x2="440.0" y1="80.0" y2="278.0"/>
-            <line x1="490.0" x2="490.0" y1="80.0" y2="278.0"/>
-            <line x1="40.0" x2="490.0" y1="223.0" y2="223.0"/>
-            <line x1="40.0" x2="490.0" y1="213.0" y2="213.0"/>
-            <line x1="40.0" x2="490.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="40.0" y1="80.0" y2="305.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="305.0"/>
+            <line x1="140.0" x2="140.0" y1="80.0" y2="305.0"/>
+            <line x1="190.0" x2="190.0" y1="80.0" y2="305.0"/>
+            <line x1="240.0" x2="240.0" y1="80.0" y2="305.0"/>
+            <line x1="290.0" x2="290.0" y1="80.0" y2="305.0"/>
+            <line x1="340.0" x2="340.0" y1="80.0" y2="305.0"/>
+            <line x1="390.0" x2="390.0" y1="80.0" y2="305.0"/>
+            <line x1="440.0" x2="440.0" y1="80.0" y2="305.0"/>
+            <line x1="490.0" x2="490.0" y1="80.0" y2="305.0"/>
+            <line x1="540.0" x2="540.0" y1="80.0" y2="305.0"/>
+            <line x1="40.0" x2="540.0" y1="250.0" y2="250.0"/>
+            <line x1="40.0" x2="540.0" y1="240.0" y2="240.0"/>
+            <line x1="40.0" x2="540.0" y1="142.0" y2="142.0"/>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs1" transform="translate(52.5,253.0)">
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs1" transform="translate(52.5,280.0)">
             <line x1="0" x2="225.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
             <g class="sld-voltage-indicator sld-powered" id="idbbs1_VOLTAGE_INDICATOR" transform="translate(200.0,-5.0)">
@@ -167,7 +168,7 @@
                 <text class="sld-label" x="0.0" y="-5.0">Top</text>
             </g>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs21" transform="translate(52.5,278.0)">
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs21" transform="translate(52.5,305.0)">
             <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs21_NW_LABEL" x="-5.0" y="-5.0">bbs21</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs21_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
@@ -175,7 +176,7 @@
                 <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
             </g>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs22" transform="translate(152.5,278.0)">
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs22" transform="translate(152.5,305.0)">
             <line x1="0" x2="125.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs22_NW_LABEL" x="-5.0" y="-5.0">bbs22</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs22_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
@@ -184,17 +185,17 @@
                 <text class="sld-label" x="0.0" y="15.0">Bottom</text>
             </g>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs13" transform="translate(302.5,253.0)">
-            <line x1="0" x2="175.0" y1="0" y2="0"/>
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs13" transform="translate(302.5,280.0)">
+            <line x1="0" x2="225.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs13_NW_LABEL" x="-5.0" y="-5.0">bbs13</text>
-            <g class="sld-voltage-indicator sld-powered" id="idbbs13_VOLTAGE_INDICATOR" transform="translate(150.0,-5.0)">
+            <g class="sld-voltage-indicator sld-powered" id="idbbs13_VOLTAGE_INDICATOR" transform="translate(200.0,-5.0)">
                 <rect class="sld-powered" height="10" rx="1" ry="1" width="20"/>
                 <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
                 <text class="sld-label" x="0.0" y="-5.0">Top</text>
             </g>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs23" transform="translate(302.5,278.0)">
-            <line x1="0" x2="175.0" y1="0" y2="0"/>
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs23" transform="translate(302.5,305.0)">
+            <line x1="0" x2="225.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs23_NW_LABEL" x="-5.0" y="-5.0">bbs23</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs23_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
                 <rect class="sld-powered" height="10" rx="1" ry="1" width="20"/>
@@ -203,7 +204,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_3" transform="translate(111.0,219.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_3" transform="translate(111.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadA" transform="translate(111.0,138.0)">
@@ -215,17 +216,17 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadA_N_LABEL" x="-5.0" y="-5.0">loadA</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d1_95_INTERNAL_95_vl1_95_3">
-                <polyline points="115.0,253.0,115.0,223.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dA1_95_INTERNAL_95_vl1_95_3">
+                <polyline points="115.0,280.0,115.0,250.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_3_95_fA">
-                <polyline points="115.0,223.0,115.0,192.5"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_3_95_bA">
+                <polyline points="115.0,250.0,115.0,206.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d2_95_INTERNAL_95_vl1_95_3">
-                <polyline points="115.0,278.0,115.0,223.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dA2_95_INTERNAL_95_vl1_95_3">
+                <polyline points="115.0,305.0,115.0,250.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_fA_95_INTERNAL_95_vl1_95_loadA">
-                <polyline points="115.0,172.5,115.0,142.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bA_95_INTERNAL_95_vl1_95_loadA">
+                <polyline points="115.0,186.0,115.0,142.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadA_95_loadA">
                 <polyline points="115.0,142.0,115.0,84.5"/>
@@ -240,21 +241,21 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idd1" transform="translate(111.0,249.0)">
+            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="iddA1" transform="translate(111.0,276.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idfA" transform="translate(105.0,172.5)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idbA" transform="translate(105.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idd2" transform="translate(111.0,274.0)">
+            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="iddA2" transform="translate(111.0,301.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,219.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadB" transform="translate(211.0,138.0)">
@@ -266,20 +267,20 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadB_N_LABEL" x="-5.0" y="-5.0">loadB</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="215.0,223.0,215.0,192.5"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_bB">
+                <polyline points="215.0,250.0,215.0,206.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="215.0,278.0,215.0,223.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dB1_95_INTERNAL_95_vl1_95_5">
+                <polyline points="215.0,305.0,215.0,250.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="215.0,253.0,215.0,223.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dB2_95_INTERNAL_95_vl1_95_5">
+                <polyline points="215.0,280.0,215.0,250.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="215.0,223.0,240.0,223.0,240.0,196.0"/>
+                <polyline points="215.0,250.0,240.0,250.0,240.0,223.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_fB_95_INTERNAL_95_vl1_95_loadB">
-                <polyline points="215.0,172.5,215.0,142.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bB_95_INTERNAL_95_vl1_95_loadB">
+                <polyline points="215.0,186.0,215.0,142.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadB_95_loadB">
                 <polyline points="215.0,142.0,215.0,84.5"/>
@@ -294,136 +295,193 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idfB" transform="translate(205.0,172.5)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idbB" transform="translate(205.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idb1" transform="translate(211.0,274.0)">
+            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="iddB1" transform="translate(211.0,301.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idb2" transform="translate(211.0,249.0)">
+            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="iddB2" transform="translate(211.0,276.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_2">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,219.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_1" transform="translate(236.0,192.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_1" transform="translate(236.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_2" transform="translate(336.0,192.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_2" transform="translate(336.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(386.0,165.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(411.0,192.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="215.0,223.0,215.0,192.5"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_bB">
+                <polyline points="215.0,250.0,215.0,206.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="215.0,278.0,215.0,223.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dB1_95_INTERNAL_95_vl1_95_5">
+                <polyline points="215.0,305.0,215.0,250.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="215.0,253.0,215.0,223.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dB2_95_INTERNAL_95_vl1_95_5">
+                <polyline points="215.0,280.0,215.0,250.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="215.0,223.0,240.0,223.0,240.0,196.0"/>
+                <polyline points="215.0,250.0,240.0,250.0,240.0,223.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="280.0,196.0,240.0,196.0"/>
+                <polyline points="280.0,223.0,240.0,223.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="300.0,196.0,340.0,196.0"/>
+                <polyline points="300.0,223.0,340.0,223.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="390.0,169.0,340.0,169.0,340.0,196.0"/>
+                <polyline points="415.0,196.0,340.0,196.0,340.0,223.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="365.0,186.0,365.0,169.0,390.0,169.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bCD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="365.0,213.0,365.0,196.0,415.0,196.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="415.0,186.0,415.0,169.0,390.0,169.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bCD2_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="415.0,213.0,415.0,196.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bCD3_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="465.0,213.0,465.0,196.0,415.0,196.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="377.5,179.0,377.5,196.0,415.0,196.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="390.0,169.0,390.0,142.0"/>
+                <polyline points="415.0,196.0,452.5,196.0,452.5,142.0"/>
             </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idlink" transform="translate(280.0,186.0)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idlink" transform="translate(280.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(386.0,165.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(411.0,192.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_c1" transform="translate(361.0,219.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bCD1" transform="translate(361.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_c2" transform="translate(411.0,219.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bCD2" transform="translate(411.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC" transform="translate(386.0,138.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_bCD3" transform="translate(461.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load sld-top-feeder sld-vl300to500-0" id="idloadC" transform="translate(382.0,75.5)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadD" transform="translate(373.5,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-load sld-top-feeder sld-vl300to500-0" id="idloadD" transform="translate(369.5,75.5)">
+                <rect height="9" width="16"/>
+                <line x1="0" x2="16" y1="0" y2="9"/>
+                <line x1="16" x2="0" y1="0" y2="9"/>
+                <text class="sld-label" id="loadD_N_LABEL" x="-5.0" y="-5.0">loadD</text>
+            </g>
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC" transform="translate(448.5,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-load sld-top-feeder sld-vl300to500-0" id="idloadC" transform="translate(444.5,75.5)">
                 <rect height="9" width="16"/>
                 <line x1="0" x2="16" y1="0" y2="9"/>
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadC_N_LABEL" x="-5.0" y="-5.0">loadC</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="365.0,186.0,365.0,169.0,390.0,169.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bCD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="365.0,213.0,365.0,196.0,415.0,196.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="415.0,186.0,415.0,169.0,390.0,169.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bCD2_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="415.0,213.0,415.0,196.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bCD3_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="465.0,213.0,465.0,196.0,415.0,196.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="377.5,179.0,377.5,196.0,415.0,196.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="390.0,169.0,390.0,142.0"/>
+                <polyline points="415.0,196.0,452.5,196.0,452.5,142.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="390.0,169.0,340.0,169.0,340.0,196.0"/>
+                <polyline points="415.0,196.0,340.0,196.0,340.0,223.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_c1_95_c1">
-                <polyline points="365.0,223.0,365.0,206.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bCD1_95_bCD1">
+                <polyline points="365.0,250.0,365.0,233.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
-                <polyline points="365.0,278.0,365.0,223.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_bCD1_95_INTERNAL_95_vl1_95_bCD1">
+                <polyline points="365.0,305.0,365.0,250.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
-                <polyline points="415.0,223.0,415.0,206.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bCD2_95_bCD2">
+                <polyline points="415.0,250.0,415.0,233.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
-                <polyline points="415.0,253.0,415.0,223.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_bCD2_95_INTERNAL_95_vl1_95_bCD2">
+                <polyline points="415.0,280.0,415.0,250.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bCD3_95_bCD3">
+                <polyline points="465.0,250.0,465.0,233.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_bCD3_95_INTERNAL_95_vl1_95_bCD3">
+                <polyline points="465.0,280.0,465.0,250.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bD1_95_INTERNAL_95_vl1_95_loadD">
+                <polyline points="377.5,159.0,377.5,142.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadD_95_loadD">
+                <polyline points="377.5,142.0,377.5,84.5"/>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idloadD_ARROW_ACTIVE" transform="translate(372.5,99.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idloadD_ARROW_REACTIVE" transform="translate(372.5,119.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
-                <polyline points="390.0,142.0,390.0,84.5"/>
+                <polyline points="452.5,142.0,452.5,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(385.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(447.5,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(385.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(447.5,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idc1" transform="translate(355.0,186.0)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idbCD1" transform="translate(355.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_c1" transform="translate(361.0,274.0)">
+            <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_bCD1" transform="translate(361.0,301.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idc2" transform="translate(405.0,186.0)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idbCD2" transform="translate(405.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_c2" transform="translate(411.0,249.0)">
+            <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_bCD2" transform="translate(411.0,276.0)">
                 <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idbCD3" transform="translate(455.0,213.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_bCD3" transform="translate(461.0,276.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idbD1" transform="translate(367.5,159.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>
     </g>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg height="357.0" viewBox="0 0 530.0 357.0" width="530.0" xmlns="http://www.w3.org/2000/svg">
+<svg height="358.0" viewBox="0 0 530.0 358.0" width="530.0" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 /* ----------------------------------------------------------------------- */
 /* File: tautologies.css ------------------------------------------------- */
@@ -144,21 +144,21 @@
     <rect class="sld-frame" height="100%" width="100%"/>
     <g>
         <g class="sld-grid" id="GRID_vl1">
-            <line x1="40.0" x2="40.0" y1="80.0" y2="277.0"/>
-            <line x1="90.0" x2="90.0" y1="80.0" y2="277.0"/>
-            <line x1="140.0" x2="140.0" y1="80.0" y2="277.0"/>
-            <line x1="190.0" x2="190.0" y1="80.0" y2="277.0"/>
-            <line x1="240.0" x2="240.0" y1="80.0" y2="277.0"/>
-            <line x1="290.0" x2="290.0" y1="80.0" y2="277.0"/>
-            <line x1="340.0" x2="340.0" y1="80.0" y2="277.0"/>
-            <line x1="390.0" x2="390.0" y1="80.0" y2="277.0"/>
-            <line x1="440.0" x2="440.0" y1="80.0" y2="277.0"/>
-            <line x1="490.0" x2="490.0" y1="80.0" y2="277.0"/>
-            <line x1="40.0" x2="490.0" y1="222.0" y2="222.0"/>
-            <line x1="40.0" x2="490.0" y1="212.0" y2="212.0"/>
+            <line x1="40.0" x2="40.0" y1="80.0" y2="278.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="278.0"/>
+            <line x1="140.0" x2="140.0" y1="80.0" y2="278.0"/>
+            <line x1="190.0" x2="190.0" y1="80.0" y2="278.0"/>
+            <line x1="240.0" x2="240.0" y1="80.0" y2="278.0"/>
+            <line x1="290.0" x2="290.0" y1="80.0" y2="278.0"/>
+            <line x1="340.0" x2="340.0" y1="80.0" y2="278.0"/>
+            <line x1="390.0" x2="390.0" y1="80.0" y2="278.0"/>
+            <line x1="440.0" x2="440.0" y1="80.0" y2="278.0"/>
+            <line x1="490.0" x2="490.0" y1="80.0" y2="278.0"/>
+            <line x1="40.0" x2="490.0" y1="223.0" y2="223.0"/>
+            <line x1="40.0" x2="490.0" y1="213.0" y2="213.0"/>
             <line x1="40.0" x2="490.0" y1="142.0" y2="142.0"/>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs1" transform="translate(52.5,252.0)">
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs1" transform="translate(52.5,253.0)">
             <line x1="0" x2="225.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
             <g class="sld-voltage-indicator sld-powered" id="idbbs1_VOLTAGE_INDICATOR" transform="translate(200.0,-5.0)">
@@ -167,7 +167,7 @@
                 <text class="sld-label" x="0.0" y="-5.0">Top</text>
             </g>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs21" transform="translate(52.5,277.0)">
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs21" transform="translate(52.5,278.0)">
             <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs21_NW_LABEL" x="-5.0" y="-5.0">bbs21</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs21_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
@@ -175,7 +175,7 @@
                 <rect class="sld-unpowered" height="10" rx="1" ry="1" width="20"/>
             </g>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs22" transform="translate(152.5,277.0)">
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs22" transform="translate(152.5,278.0)">
             <line x1="0" x2="125.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs22_NW_LABEL" x="-5.0" y="-5.0">bbs22</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs22_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
@@ -184,7 +184,7 @@
                 <text class="sld-label" x="0.0" y="15.0">Bottom</text>
             </g>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs13" transform="translate(302.5,252.0)">
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs13" transform="translate(302.5,253.0)">
             <line x1="0" x2="175.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs13_NW_LABEL" x="-5.0" y="-5.0">bbs13</text>
             <g class="sld-voltage-indicator sld-powered" id="idbbs13_VOLTAGE_INDICATOR" transform="translate(150.0,-5.0)">
@@ -193,7 +193,7 @@
                 <text class="sld-label" x="0.0" y="-5.0">Top</text>
             </g>
         </g>
-        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs23" transform="translate(302.5,277.0)">
+        <g class="sld-busbar-section sld-vl300to500-0" id="idbbs23" transform="translate(302.5,278.0)">
             <line x1="0" x2="175.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs23_NW_LABEL" x="-5.0" y="-5.0">bbs23</text>
             <g class="sld-voltage-indicator sld-unpowered" id="idbbs23_VOLTAGE_INDICATOR" transform="translate(5.0,-5.0)">
@@ -203,7 +203,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_3" transform="translate(111.0,218.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_3" transform="translate(111.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadA" transform="translate(111.0,138.0)">
@@ -216,16 +216,16 @@
                 <text class="sld-label" id="loadA_N_LABEL" x="-5.0" y="-5.0">loadA</text>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d1_95_INTERNAL_95_vl1_95_3">
-                <polyline points="115.0,252.0,115.0,222.0"/>
+                <polyline points="115.0,253.0,115.0,223.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_3_95_fA">
-                <polyline points="115.0,222.0,115.0,192.0"/>
+                <polyline points="115.0,223.0,115.0,192.5"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d2_95_INTERNAL_95_vl1_95_3">
-                <polyline points="115.0,277.0,115.0,222.0"/>
+                <polyline points="115.0,278.0,115.0,223.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_fA_95_INTERNAL_95_vl1_95_loadA">
-                <polyline points="115.0,172.0,115.0,142.0"/>
+                <polyline points="115.0,172.5,115.0,142.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadA_95_loadA">
                 <polyline points="115.0,142.0,115.0,84.5"/>
@@ -240,21 +240,21 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idd1" transform="translate(111.0,248.0)">
+            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idd1" transform="translate(111.0,249.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idfA" transform="translate(105.0,172.0)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idfA" transform="translate(105.0,172.5)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idd2" transform="translate(111.0,273.0)">
+            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idd2" transform="translate(111.0,274.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,218.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadB" transform="translate(211.0,138.0)">
@@ -267,19 +267,19 @@
                 <text class="sld-label" id="loadB_N_LABEL" x="-5.0" y="-5.0">loadB</text>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="215.0,222.0,215.0,192.0"/>
+                <polyline points="215.0,223.0,215.0,192.5"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="215.0,277.0,215.0,222.0"/>
+                <polyline points="215.0,278.0,215.0,223.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="215.0,252.0,215.0,222.0"/>
+                <polyline points="215.0,253.0,215.0,223.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="215.0,222.0,240.0,222.0,240.0,182.0"/>
+                <polyline points="215.0,223.0,240.0,223.0,240.0,196.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_fB_95_INTERNAL_95_vl1_95_loadB">
-                <polyline points="215.0,172.0,215.0,142.0"/>
+                <polyline points="215.0,172.5,215.0,142.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadB_95_loadB">
                 <polyline points="215.0,142.0,215.0,84.5"/>
@@ -294,85 +294,78 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idfB" transform="translate(205.0,172.0)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idfB" transform="translate(205.0,172.5)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idb1" transform="translate(211.0,273.0)">
+            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idb1" transform="translate(211.0,274.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idb2" transform="translate(211.0,248.0)">
+            <g class="sld-disconnector sld-closed sld-vl300to500-0" id="idb2" transform="translate(211.0,249.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_2">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,218.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_1" transform="translate(236.0,178.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_1" transform="translate(236.0,192.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_2" transform="translate(336.0,178.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_2" transform="translate(336.0,192.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC" transform="translate(386.0,138.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(386.0,165.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="215.0,222.0,215.0,192.0"/>
+                <polyline points="215.0,223.0,215.0,192.5"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="215.0,277.0,215.0,222.0"/>
+                <polyline points="215.0,278.0,215.0,223.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="215.0,252.0,215.0,222.0"/>
+                <polyline points="215.0,253.0,215.0,223.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="215.0,222.0,240.0,222.0,240.0,182.0"/>
+                <polyline points="215.0,223.0,240.0,223.0,240.0,196.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="280.0,182.0,240.0,182.0"/>
+                <polyline points="280.0,196.0,240.0,196.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="300.0,182.0,340.0,182.0"/>
+                <polyline points="300.0,196.0,340.0,196.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="390.0,142.0,340.0,142.0,340.0,182.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
+                <polyline points="390.0,169.0,340.0,169.0,340.0,196.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="365.0,172.0,365.0,142.0,390.0,142.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="365.0,186.0,365.0,169.0,390.0,169.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="415.0,172.0,415.0,142.0,390.0,142.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="415.0,186.0,415.0,169.0,390.0,169.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
-                <polyline points="390.0,142.0,390.0,84.5"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
+                <polyline points="390.0,169.0,390.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(385.0,99.5)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">-</text>
-            </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(385.0,119.5)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">-</text>
-            </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idlink" transform="translate(280.0,172.0)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idlink" transform="translate(280.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(386.0,165.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_c1" transform="translate(361.0,219.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_c2" transform="translate(411.0,219.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_loadC" transform="translate(386.0,138.0)">
-                <circle cx="4" cy="4" r="4"/>
-            </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_c1" transform="translate(361.0,218.0)">
-                <circle cx="4" cy="4" r="4"/>
-            </g>
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_c2" transform="translate(411.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-load sld-top-feeder sld-vl300to500-0" id="idloadC" transform="translate(382.0,75.5)">
@@ -381,11 +374,29 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadC_N_LABEL" x="-5.0" y="-5.0">loadC</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="365.0,172.0,365.0,142.0,390.0,142.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="365.0,186.0,365.0,169.0,390.0,169.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="415.0,172.0,415.0,142.0,390.0,142.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="415.0,186.0,415.0,169.0,390.0,169.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
+                <polyline points="390.0,169.0,390.0,142.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
+                <polyline points="390.0,169.0,340.0,169.0,340.0,196.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_c1_95_c1">
+                <polyline points="365.0,223.0,365.0,206.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
+                <polyline points="365.0,278.0,365.0,223.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
+                <polyline points="415.0,223.0,415.0,206.0"/>
+            </g>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
+                <polyline points="415.0,253.0,415.0,223.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
                 <polyline points="390.0,142.0,390.0,84.5"/>
@@ -400,33 +411,18 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="390.0,142.0,340.0,142.0,340.0,182.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_c1_95_c1">
-                <polyline points="365.0,222.0,365.0,192.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
-                <polyline points="365.0,277.0,365.0,222.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
-                <polyline points="415.0,222.0,415.0,192.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
-                <polyline points="415.0,252.0,415.0,222.0"/>
-            </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idc1" transform="translate(355.0,172.0)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idc1" transform="translate(355.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_c1" transform="translate(361.0,273.0)">
+            <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_c1" transform="translate(361.0,274.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idc2" transform="translate(405.0,172.0)">
+            <g class="sld-breaker sld-closed sld-vl300to500-0" id="idc2" transform="translate(405.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_c2" transform="translate(411.0,248.0)">
+            <g class="sld-bus-connection sld-fictitious sld-vl300to500-0" id="idBUSCO_95_c2" transform="translate(411.0,249.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg height="357.0" viewBox="0 0 330.0 357.0" width="330.0" xmlns="http://www.w3.org/2000/svg">
+<svg height="358.0" viewBox="0 0 330.0 358.0" width="330.0" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 /* ----------------------------------------------------------------------- */
 /* File: tautologies.css ------------------------------------------------- */
@@ -66,38 +66,38 @@
     <rect class="sld-frame" height="100%" width="100%"/>
     <g>
         <g class="sld-grid" id="GRID_vl1">
-            <line x1="40.0" x2="40.0" y1="80.0" y2="277.0"/>
-            <line x1="90.0" x2="90.0" y1="80.0" y2="277.0"/>
-            <line x1="140.0" x2="140.0" y1="80.0" y2="277.0"/>
-            <line x1="190.0" x2="190.0" y1="80.0" y2="277.0"/>
-            <line x1="240.0" x2="240.0" y1="80.0" y2="277.0"/>
-            <line x1="290.0" x2="290.0" y1="80.0" y2="277.0"/>
-            <line x1="40.0" x2="290.0" y1="222.0" y2="222.0"/>
-            <line x1="40.0" x2="290.0" y1="212.0" y2="212.0"/>
+            <line x1="40.0" x2="40.0" y1="80.0" y2="278.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="278.0"/>
+            <line x1="140.0" x2="140.0" y1="80.0" y2="278.0"/>
+            <line x1="190.0" x2="190.0" y1="80.0" y2="278.0"/>
+            <line x1="240.0" x2="240.0" y1="80.0" y2="278.0"/>
+            <line x1="290.0" x2="290.0" y1="80.0" y2="278.0"/>
+            <line x1="40.0" x2="290.0" y1="223.0" y2="223.0"/>
+            <line x1="40.0" x2="290.0" y1="213.0" y2="213.0"/>
             <line x1="40.0" x2="290.0" y1="142.0" y2="142.0"/>
         </g>
-        <g class="sld-busbar-section" id="idbbs1" transform="translate(52.5,252.0)">
+        <g class="sld-busbar-section" id="idbbs1" transform="translate(52.5,253.0)">
             <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs21" transform="translate(52.5,277.0)">
+        <g class="sld-busbar-section" id="idbbs21" transform="translate(52.5,278.0)">
             <line x1="0" x2="25.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs21_NW_LABEL" x="-5.0" y="-5.0">bbs21</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs22" transform="translate(102.5,277.0)">
+        <g class="sld-busbar-section" id="idbbs22" transform="translate(102.5,278.0)">
             <line x1="0" x2="25.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs22_NW_LABEL" x="-5.0" y="-5.0">bbs22</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs13" transform="translate(152.5,252.0)">
+        <g class="sld-busbar-section" id="idbbs13" transform="translate(152.5,253.0)">
             <line x1="0" x2="125.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs13_NW_LABEL" x="-5.0" y="-5.0">bbs13</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs23" transform="translate(152.5,277.0)">
+        <g class="sld-busbar-section" id="idbbs23" transform="translate(152.5,278.0)">
             <line x1="0" x2="125.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs23_NW_LABEL" x="-5.0" y="-5.0">bbs23</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_3" transform="translate(61.0,218.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_3" transform="translate(61.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadA" transform="translate(61.0,138.0)">
@@ -110,16 +110,16 @@
                 <text class="sld-label" id="loadA_N_LABEL" x="-5.0" y="-5.0">loadA</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_d1_95_INTERNAL_95_vl1_95_3">
-                <polyline points="65.0,252.0,65.0,222.0"/>
+                <polyline points="65.0,253.0,65.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_3_95_fA">
-                <polyline points="65.0,222.0,65.0,192.0"/>
+                <polyline points="65.0,223.0,65.0,192.5"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_d2_95_INTERNAL_95_vl1_95_3">
-                <polyline points="65.0,277.0,65.0,222.0"/>
+                <polyline points="65.0,278.0,65.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_fA_95_INTERNAL_95_vl1_95_loadA">
-                <polyline points="65.0,172.0,65.0,142.0"/>
+                <polyline points="65.0,172.5,65.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadA_95_loadA">
                 <polyline points="65.0,142.0,65.0,84.5"/>
@@ -134,21 +134,21 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd1" transform="translate(61.0,248.0)">
+            <g class="sld-disconnector sld-closed" id="idd1" transform="translate(61.0,249.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idfA" transform="translate(55.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idfA" transform="translate(55.0,172.5)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd2" transform="translate(61.0,273.0)">
+            <g class="sld-disconnector sld-closed" id="idd2" transform="translate(61.0,274.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(111.0,218.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(111.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadB" transform="translate(111.0,138.0)">
@@ -161,19 +161,19 @@
                 <text class="sld-label" id="loadB_N_LABEL" x="-5.0" y="-5.0">loadB</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="115.0,222.0,115.0,192.0"/>
+                <polyline points="115.0,223.0,115.0,192.5"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="115.0,277.0,115.0,222.0"/>
+                <polyline points="115.0,278.0,115.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="115.0,252.0,115.0,222.0"/>
+                <polyline points="115.0,253.0,115.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="115.0,222.0,140.0,222.0,140.0,182.0"/>
+                <polyline points="115.0,223.0,140.0,223.0,140.0,196.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_fB_95_INTERNAL_95_vl1_95_loadB">
-                <polyline points="115.0,172.0,115.0,142.0"/>
+                <polyline points="115.0,172.5,115.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadB_95_loadB">
                 <polyline points="115.0,142.0,115.0,84.5"/>
@@ -188,85 +188,78 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-breaker sld-closed" id="idfB" transform="translate(105.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idfB" transform="translate(105.0,172.5)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idb1" transform="translate(111.0,273.0)">
+            <g class="sld-disconnector sld-closed" id="idb1" transform="translate(111.0,274.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idb2" transform="translate(111.0,248.0)">
+            <g class="sld-disconnector sld-closed" id="idb2" transform="translate(111.0,249.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_2">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(111.0,218.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(111.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_1" transform="translate(136.0,178.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_1" transform="translate(136.0,192.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_2" transform="translate(186.0,178.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_2" transform="translate(186.0,192.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC" transform="translate(236.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(236.0,165.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="115.0,222.0,115.0,192.0"/>
+                <polyline points="115.0,223.0,115.0,192.5"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="115.0,277.0,115.0,222.0"/>
+                <polyline points="115.0,278.0,115.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="115.0,252.0,115.0,222.0"/>
+                <polyline points="115.0,253.0,115.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="115.0,222.0,140.0,222.0,140.0,182.0"/>
+                <polyline points="115.0,223.0,140.0,223.0,140.0,196.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="155.0,182.0,140.0,182.0"/>
+                <polyline points="155.0,196.0,140.0,196.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="175.0,182.0,190.0,182.0"/>
+                <polyline points="175.0,196.0,190.0,196.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="240.0,142.0,190.0,142.0,190.0,182.0"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
+                <polyline points="240.0,169.0,190.0,169.0,190.0,196.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="215.0,172.0,215.0,142.0,240.0,142.0"/>
+            <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="215.0,186.0,215.0,169.0,240.0,169.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="265.0,172.0,265.0,142.0,240.0,142.0"/>
+            <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="265.0,186.0,265.0,169.0,240.0,169.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
-                <polyline points="240.0,142.0,240.0,84.5"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
+                <polyline points="240.0,169.0,240.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(235.0,99.5)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">-</text>
-            </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(235.0,119.5)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">-</text>
-            </g>
-            <g class="sld-breaker sld-closed" id="idlink" transform="translate(155.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idlink" transform="translate(155.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(236.0,165.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_c1" transform="translate(211.0,219.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_c2" transform="translate(261.0,219.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC" transform="translate(236.0,138.0)">
-                <circle cx="4" cy="4" r="4"/>
-            </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_c1" transform="translate(211.0,218.0)">
-                <circle cx="4" cy="4" r="4"/>
-            </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_c2" transform="translate(261.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-load sld-top-feeder" id="idloadC" transform="translate(232.0,75.5)">
@@ -275,11 +268,29 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadC_N_LABEL" x="-5.0" y="-5.0">loadC</text>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="215.0,172.0,215.0,142.0,240.0,142.0"/>
+            <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="215.0,186.0,215.0,169.0,240.0,169.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="265.0,172.0,265.0,142.0,240.0,142.0"/>
+            <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="265.0,186.0,265.0,169.0,240.0,169.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
+                <polyline points="240.0,169.0,240.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
+                <polyline points="240.0,169.0,190.0,169.0,190.0,196.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c1_95_c1">
+                <polyline points="215.0,223.0,215.0,206.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
+                <polyline points="215.0,278.0,215.0,223.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
+                <polyline points="265.0,223.0,265.0,206.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
+                <polyline points="265.0,253.0,265.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
                 <polyline points="240.0,142.0,240.0,84.5"/>
@@ -294,33 +305,18 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="240.0,142.0,190.0,142.0,190.0,182.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c1_95_c1">
-                <polyline points="215.0,222.0,215.0,192.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
-                <polyline points="215.0,277.0,215.0,222.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
-                <polyline points="265.0,222.0,265.0,192.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
-                <polyline points="265.0,252.0,265.0,222.0"/>
-            </g>
-            <g class="sld-breaker sld-closed" id="idc1" transform="translate(205.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idc1" transform="translate(205.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_c1" transform="translate(211.0,273.0)">
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_c1" transform="translate(211.0,274.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idc2" transform="translate(255.0,172.0)">
+            <g class="sld-breaker sld-closed" id="idc2" transform="translate(255.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_c2" transform="translate(261.0,248.0)">
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_c2" transform="translate(261.0,249.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg height="358.0" viewBox="0 0 330.0 358.0" width="330.0" xmlns="http://www.w3.org/2000/svg">
+<svg height="385.0" viewBox="0 0 380.0 385.0" width="380.0" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 /* ----------------------------------------------------------------------- */
 /* File: tautologies.css ------------------------------------------------- */
@@ -66,38 +66,39 @@
     <rect class="sld-frame" height="100%" width="100%"/>
     <g>
         <g class="sld-grid" id="GRID_vl1">
-            <line x1="40.0" x2="40.0" y1="80.0" y2="278.0"/>
-            <line x1="90.0" x2="90.0" y1="80.0" y2="278.0"/>
-            <line x1="140.0" x2="140.0" y1="80.0" y2="278.0"/>
-            <line x1="190.0" x2="190.0" y1="80.0" y2="278.0"/>
-            <line x1="240.0" x2="240.0" y1="80.0" y2="278.0"/>
-            <line x1="290.0" x2="290.0" y1="80.0" y2="278.0"/>
-            <line x1="40.0" x2="290.0" y1="223.0" y2="223.0"/>
-            <line x1="40.0" x2="290.0" y1="213.0" y2="213.0"/>
-            <line x1="40.0" x2="290.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="40.0" y1="80.0" y2="305.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="305.0"/>
+            <line x1="140.0" x2="140.0" y1="80.0" y2="305.0"/>
+            <line x1="190.0" x2="190.0" y1="80.0" y2="305.0"/>
+            <line x1="240.0" x2="240.0" y1="80.0" y2="305.0"/>
+            <line x1="290.0" x2="290.0" y1="80.0" y2="305.0"/>
+            <line x1="340.0" x2="340.0" y1="80.0" y2="305.0"/>
+            <line x1="40.0" x2="340.0" y1="250.0" y2="250.0"/>
+            <line x1="40.0" x2="340.0" y1="240.0" y2="240.0"/>
+            <line x1="40.0" x2="340.0" y1="142.0" y2="142.0"/>
         </g>
-        <g class="sld-busbar-section" id="idbbs1" transform="translate(52.5,253.0)">
+        <g class="sld-busbar-section" id="idbbs1" transform="translate(52.5,280.0)">
             <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs21" transform="translate(52.5,278.0)">
+        <g class="sld-busbar-section" id="idbbs21" transform="translate(52.5,305.0)">
             <line x1="0" x2="25.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs21_NW_LABEL" x="-5.0" y="-5.0">bbs21</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs22" transform="translate(102.5,278.0)">
+        <g class="sld-busbar-section" id="idbbs22" transform="translate(102.5,305.0)">
             <line x1="0" x2="25.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs22_NW_LABEL" x="-5.0" y="-5.0">bbs22</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs13" transform="translate(152.5,253.0)">
-            <line x1="0" x2="125.0" y1="0" y2="0"/>
+        <g class="sld-busbar-section" id="idbbs13" transform="translate(152.5,280.0)">
+            <line x1="0" x2="175.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs13_NW_LABEL" x="-5.0" y="-5.0">bbs13</text>
         </g>
-        <g class="sld-busbar-section" id="idbbs23" transform="translate(152.5,278.0)">
-            <line x1="0" x2="125.0" y1="0" y2="0"/>
+        <g class="sld-busbar-section" id="idbbs23" transform="translate(152.5,305.0)">
+            <line x1="0" x2="175.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs23_NW_LABEL" x="-5.0" y="-5.0">bbs23</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_3" transform="translate(61.0,219.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_3" transform="translate(61.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadA" transform="translate(61.0,138.0)">
@@ -109,17 +110,17 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadA_N_LABEL" x="-5.0" y="-5.0">loadA</text>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_d1_95_INTERNAL_95_vl1_95_3">
-                <polyline points="65.0,253.0,65.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_dA1_95_INTERNAL_95_vl1_95_3">
+                <polyline points="65.0,280.0,65.0,250.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_3_95_fA">
-                <polyline points="65.0,223.0,65.0,192.5"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_3_95_bA">
+                <polyline points="65.0,250.0,65.0,206.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_d2_95_INTERNAL_95_vl1_95_3">
-                <polyline points="65.0,278.0,65.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_dA2_95_INTERNAL_95_vl1_95_3">
+                <polyline points="65.0,305.0,65.0,250.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_fA_95_INTERNAL_95_vl1_95_loadA">
-                <polyline points="65.0,172.5,65.0,142.0"/>
+            <g class="sld-wire" id="_95_vl1_95_bA_95_INTERNAL_95_vl1_95_loadA">
+                <polyline points="65.0,186.0,65.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadA_95_loadA">
                 <polyline points="65.0,142.0,65.0,84.5"/>
@@ -134,21 +135,21 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd1" transform="translate(61.0,249.0)">
+            <g class="sld-disconnector sld-closed" id="iddA1" transform="translate(61.0,276.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idfA" transform="translate(55.0,172.5)">
+            <g class="sld-breaker sld-closed" id="idbA" transform="translate(55.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd2" transform="translate(61.0,274.0)">
+            <g class="sld-disconnector sld-closed" id="iddA2" transform="translate(61.0,301.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(111.0,219.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(111.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadB" transform="translate(111.0,138.0)">
@@ -160,20 +161,20 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadB_N_LABEL" x="-5.0" y="-5.0">loadB</text>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="115.0,223.0,115.0,192.5"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_bB">
+                <polyline points="115.0,250.0,115.0,206.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="115.0,278.0,115.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_dB1_95_INTERNAL_95_vl1_95_5">
+                <polyline points="115.0,305.0,115.0,250.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="115.0,253.0,115.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_dB2_95_INTERNAL_95_vl1_95_5">
+                <polyline points="115.0,280.0,115.0,250.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="115.0,223.0,140.0,223.0,140.0,196.0"/>
+                <polyline points="115.0,250.0,140.0,250.0,140.0,223.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_fB_95_INTERNAL_95_vl1_95_loadB">
-                <polyline points="115.0,172.5,115.0,142.0"/>
+            <g class="sld-wire" id="_95_vl1_95_bB_95_INTERNAL_95_vl1_95_loadB">
+                <polyline points="115.0,186.0,115.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadB_95_loadB">
                 <polyline points="115.0,142.0,115.0,84.5"/>
@@ -188,136 +189,193 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-breaker sld-closed" id="idfB" transform="translate(105.0,172.5)">
+            <g class="sld-breaker sld-closed" id="idbB" transform="translate(105.0,186.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idb1" transform="translate(111.0,274.0)">
+            <g class="sld-disconnector sld-closed" id="iddB1" transform="translate(111.0,301.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-disconnector sld-closed" id="idb2" transform="translate(111.0,249.0)">
+            <g class="sld-disconnector sld-closed" id="iddB2" transform="translate(111.0,276.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_2">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(111.0,219.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(111.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_1" transform="translate(136.0,192.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_1" transform="translate(136.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_2" transform="translate(186.0,192.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_Shunt_32_2_46_2" transform="translate(186.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(236.0,165.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(261.0,192.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_fB">
-                <polyline points="115.0,223.0,115.0,192.5"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_bB">
+                <polyline points="115.0,250.0,115.0,206.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="115.0,278.0,115.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_dB1_95_INTERNAL_95_vl1_95_5">
+                <polyline points="115.0,305.0,115.0,250.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="115.0,253.0,115.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_dB2_95_INTERNAL_95_vl1_95_5">
+                <polyline points="115.0,280.0,115.0,250.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="115.0,223.0,140.0,223.0,140.0,196.0"/>
+                <polyline points="115.0,250.0,140.0,250.0,140.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="155.0,196.0,140.0,196.0"/>
+                <polyline points="155.0,223.0,140.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_link_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="175.0,196.0,190.0,196.0"/>
+                <polyline points="175.0,223.0,190.0,223.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="240.0,169.0,190.0,169.0,190.0,196.0"/>
+                <polyline points="265.0,196.0,190.0,196.0,190.0,223.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="215.0,186.0,215.0,169.0,240.0,169.0"/>
+            <g class="sld-wire" id="_95_vl1_95_bCD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="215.0,213.0,215.0,196.0,265.0,196.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="265.0,186.0,265.0,169.0,240.0,169.0"/>
+            <g class="sld-wire" id="_95_vl1_95_bCD2_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="265.0,213.0,265.0,196.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_bCD3_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="315.0,213.0,315.0,196.0,265.0,196.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_bD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="227.5,179.0,227.5,196.0,265.0,196.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="240.0,169.0,240.0,142.0"/>
+                <polyline points="265.0,196.0,302.5,196.0,302.5,142.0"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idlink" transform="translate(155.0,186.0)">
+            <g class="sld-breaker sld-closed" id="idlink" transform="translate(155.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(236.0,165.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC_95_fork" transform="translate(261.0,192.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_c1" transform="translate(211.0,219.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_bCD1" transform="translate(211.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_c2" transform="translate(261.0,219.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_bCD2" transform="translate(261.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC" transform="translate(236.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_bCD3" transform="translate(311.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-load sld-top-feeder" id="idloadC" transform="translate(232.0,75.5)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadD" transform="translate(223.5,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-load sld-top-feeder" id="idloadD" transform="translate(219.5,75.5)">
+                <rect height="9" width="16"/>
+                <line x1="0" x2="16" y1="0" y2="9"/>
+                <line x1="16" x2="0" y1="0" y2="9"/>
+                <text class="sld-label" id="loadD_N_LABEL" x="-5.0" y="-5.0">loadD</text>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_loadC" transform="translate(298.5,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-load sld-top-feeder" id="idloadC" transform="translate(294.5,75.5)">
                 <rect height="9" width="16"/>
                 <line x1="0" x2="16" y1="0" y2="9"/>
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="loadC_N_LABEL" x="-5.0" y="-5.0">loadC</text>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c1_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="215.0,186.0,215.0,169.0,240.0,169.0"/>
+            <g class="sld-wire" id="_95_vl1_95_bCD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="215.0,213.0,215.0,196.0,265.0,196.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_c2_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="265.0,186.0,265.0,169.0,240.0,169.0"/>
+            <g class="sld-wire" id="_95_vl1_95_bCD2_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="265.0,213.0,265.0,196.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_bCD3_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="315.0,213.0,315.0,196.0,265.0,196.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_bD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
+                <polyline points="227.5,179.0,227.5,196.0,265.0,196.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="240.0,169.0,240.0,142.0"/>
+                <polyline points="265.0,196.0,302.5,196.0,302.5,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2">
-                <polyline points="240.0,169.0,190.0,169.0,190.0,196.0"/>
+                <polyline points="265.0,196.0,190.0,196.0,190.0,223.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c1_95_c1">
-                <polyline points="215.0,223.0,215.0,206.0"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_bCD1_95_bCD1">
+                <polyline points="215.0,250.0,215.0,233.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c1_95_INTERNAL_95_vl1_95_c1">
-                <polyline points="215.0,278.0,215.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_bCD1_95_INTERNAL_95_vl1_95_bCD1">
+                <polyline points="215.0,305.0,215.0,250.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_c2_95_c2">
-                <polyline points="265.0,223.0,265.0,206.0"/>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_bCD2_95_bCD2">
+                <polyline points="265.0,250.0,265.0,233.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_c2_95_INTERNAL_95_vl1_95_c2">
-                <polyline points="265.0,253.0,265.0,223.0"/>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_bCD2_95_INTERNAL_95_vl1_95_bCD2">
+                <polyline points="265.0,280.0,265.0,250.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_bCD3_95_bCD3">
+                <polyline points="315.0,250.0,315.0,233.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_BUSCO_95_bCD3_95_INTERNAL_95_vl1_95_bCD3">
+                <polyline points="315.0,280.0,315.0,250.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_bD1_95_INTERNAL_95_vl1_95_loadD">
+                <polyline points="227.5,159.0,227.5,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadD_95_loadD">
+                <polyline points="227.5,142.0,227.5,84.5"/>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idloadD_ARROW_ACTIVE" transform="translate(222.5,99.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idloadD_ARROW_REACTIVE" transform="translate(222.5,119.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
-                <polyline points="240.0,142.0,240.0,84.5"/>
+                <polyline points="302.5,142.0,302.5,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(235.0,99.5)">
+            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(297.5,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(235.0,119.5)">
+            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(297.5,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-breaker sld-closed" id="idc1" transform="translate(205.0,186.0)">
+            <g class="sld-breaker sld-closed" id="idbCD1" transform="translate(205.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_c1" transform="translate(211.0,274.0)">
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_bCD1" transform="translate(211.0,301.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idc2" transform="translate(255.0,186.0)">
+            <g class="sld-breaker sld-closed" id="idbCD2" transform="translate(255.0,213.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_c2" transform="translate(261.0,249.0)">
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_bCD2" transform="translate(261.0,276.0)">
                 <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idbCD3" transform="translate(305.0,213.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_bCD3" transform="translate(311.0,276.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idbD1" transform="translate(217.5,159.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>
     </g>

--- a/single-line-diagram-core/src/test/resources/TestCase1BusBreaker.json
+++ b/single-line-diagram-core/src/test/resources/TestCase1BusBreaker.json
@@ -32,7 +32,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_l_1",
+    "id" : "INTERNAL_vl_l",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -40,7 +40,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_l_2",
+    "id" : "INTERNAL_vl_l",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -259,7 +259,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "b1", "BUSCO_l", "INTERNAL_vl_l_1" ]
+        "nodes" : [ "b1", "BUSCO_l", "INTERNAL_vl_l" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -280,7 +280,7 @@
           "xSpan" : 50.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl_l_1", "INTERNAL_vl_l_2" ]
+        "nodes" : [ "INTERNAL_vl_l", "INTERNAL_vl_l" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -301,7 +301,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "INTERNAL_vl_l_2", "l" ]
+        "nodes" : [ "INTERNAL_vl_l", "l" ]
       } ]
     }
   } ],
@@ -309,32 +309,32 @@
     "node1" : "b1",
     "node2" : "BUSCO_l"
   }, {
-    "node1" : "BUSCO_l",
-    "node2" : "INTERNAL_vl_l_1"
-  }, {
-    "node1" : "INTERNAL_vl_l_1",
-    "node2" : "INTERNAL_vl_l_2"
-  }, {
-    "node1" : "INTERNAL_vl_l_2",
-    "node2" : "l"
-  }, {
     "node1" : "b1",
     "node2" : "BUSCO_sw"
-  }, {
-    "node1" : "BUSCO_sw",
-    "node2" : "INTERNAL_vl_sw"
-  }, {
-    "node1" : "INTERNAL_vl_sw",
-    "node2" : "sw"
   }, {
     "node1" : "b2",
     "node2" : "BUSCO_sw"
   }, {
+    "node1" : "BUSCO_l",
+    "node2" : "INTERNAL_vl_l"
+  }, {
     "node1" : "BUSCO_sw",
     "node2" : "INTERNAL_vl_sw"
   }, {
     "node1" : "INTERNAL_vl_sw",
     "node2" : "sw"
+  }, {
+    "node1" : "BUSCO_sw",
+    "node2" : "INTERNAL_vl_sw"
+  }, {
+    "node1" : "INTERNAL_vl_sw",
+    "node2" : "sw"
+  }, {
+    "node1" : "INTERNAL_vl_l",
+    "node2" : "INTERNAL_vl_l"
+  }, {
+    "node1" : "INTERNAL_vl_l",
+    "node2" : "l"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase1inverted.json
+++ b/single-line-diagram-core/src/test/resources/TestCase1inverted.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -123,7 +123,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs", "d", "INTERNAL_vl_d" ]
+        "nodes" : [ "bbs", "d", "INTERNAL_vl_b" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -144,7 +144,7 @@
           "xSpan" : 50.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl_d", "b", "INTERNAL_vl_l" ]
+        "nodes" : [ "INTERNAL_vl_b", "b", "INTERNAL_vl_l" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -173,17 +173,17 @@
     "node1" : "bbs",
     "node2" : "d"
   }, {
+    "node1" : "d",
+    "node2" : "INTERNAL_vl_b"
+  }, {
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
+  }, {
     "node1" : "b",
     "node2" : "INTERNAL_vl_l"
   }, {
     "node1" : "INTERNAL_vl_l",
     "node2" : "l"
-  }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d"
-  }, {
-    "node1" : "d",
-    "node2" : "INTERNAL_vl_d"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase3Coupling.json
+++ b/single-line-diagram-core/src/test/resources/TestCase3Coupling.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d1",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -16,7 +16,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d2",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -138,7 +138,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "d2", "INTERNAL_vl_d2" ]
+        "nodes" : [ "bbs2", "d2", "INTERNAL_vl_b" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -159,7 +159,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_d2", "b", "INTERNAL_vl_d1" ]
+        "nodes" : [ "INTERNAL_vl_b", "b", "INTERNAL_vl_b" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -180,7 +180,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "d1", "INTERNAL_vl_d1" ]
+        "nodes" : [ "bbs1", "d1", "INTERNAL_vl_b" ]
       } ]
     }
   } ],
@@ -191,17 +191,17 @@
     "node1" : "d2",
     "node2" : "bbs2"
   }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d1"
-  }, {
     "node1" : "d1",
-    "node2" : "INTERNAL_vl_d1"
+    "node2" : "INTERNAL_vl_b"
   }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d2"
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
   }, {
     "node1" : "d2",
-    "node2" : "INTERNAL_vl_d2"
+    "node2" : "INTERNAL_vl_b"
+  }, {
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase3Coupling3Bars.json
+++ b/single-line-diagram-core/src/test/resources/TestCase3Coupling3Bars.json
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d1",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -232,7 +232,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_2", "b", "INTERNAL_vl_d1" ]
+        "nodes" : [ "INTERNAL_vl_2", "b", "INTERNAL_vl_b" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -253,7 +253,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "d1", "INTERNAL_vl_d1" ]
+        "nodes" : [ "bbs1", "d1", "INTERNAL_vl_b" ]
       } ]
     }
   } ],
@@ -276,11 +276,11 @@
     "node1" : "d3",
     "node2" : "bbs3"
   }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d1"
-  }, {
     "node1" : "d1",
-    "node2" : "INTERNAL_vl_d1"
+    "node2" : "INTERNAL_vl_b"
+  }, {
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase3Coupling3Bars2Sections.json
+++ b/single-line-diagram-core/src/test/resources/TestCase3Coupling3Bars2Sections.json
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d1",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -232,7 +232,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_d1", "b", "INTERNAL_vl_2" ]
+        "nodes" : [ "INTERNAL_vl_b", "b", "INTERNAL_vl_2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -253,7 +253,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "d1", "INTERNAL_vl_d1" ]
+        "nodes" : [ "bbs1", "d1", "INTERNAL_vl_b" ]
       } ]
     }
   } ],
@@ -276,11 +276,11 @@
     "node1" : "d3",
     "node2" : "bbs3"
   }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d1"
-  }, {
     "node1" : "d1",
-    "node2" : "INTERNAL_vl_d1"
+    "node2" : "INTERNAL_vl_b"
+  }, {
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase3TripleCoupling.json
+++ b/single-line-diagram-core/src/test/resources/TestCase3TripleCoupling.json
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d1",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -25,7 +25,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d2",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -33,7 +33,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d5",
+    "id" : "INTERNAL_vl_b2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -41,7 +41,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d6",
+    "id" : "INTERNAL_vl_b3",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 275.0,
@@ -49,7 +49,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d7",
+    "id" : "INTERNAL_vl_b3",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -250,7 +250,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "d2", "INTERNAL_vl_d2" ]
+        "nodes" : [ "bbs2", "d2", "INTERNAL_vl_b" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -271,7 +271,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_d2", "b", "INTERNAL_vl_d1" ]
+        "nodes" : [ "INTERNAL_vl_b", "b", "INTERNAL_vl_b" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -292,7 +292,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "d1", "INTERNAL_vl_d1" ]
+        "nodes" : [ "bbs1", "d1", "INTERNAL_vl_b" ]
       } ]
     }
   }, {
@@ -401,7 +401,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_4", "b2", "INTERNAL_vl_d5" ]
+        "nodes" : [ "INTERNAL_vl_4", "b2", "INTERNAL_vl_b2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -422,7 +422,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "d5", "INTERNAL_vl_d5" ]
+        "nodes" : [ "bbs2", "d5", "INTERNAL_vl_b2" ]
       } ]
     }
   }, {
@@ -468,7 +468,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "d7", "INTERNAL_vl_d7" ]
+        "nodes" : [ "bbs2", "d7", "INTERNAL_vl_b3" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -489,7 +489,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_d7", "b3", "INTERNAL_vl_d6" ]
+        "nodes" : [ "INTERNAL_vl_b3", "b3", "INTERNAL_vl_b3" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -510,7 +510,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "d6", "INTERNAL_vl_d6" ]
+        "nodes" : [ "bbs1", "d6", "INTERNAL_vl_b3" ]
       } ]
     }
   } ],
@@ -545,35 +545,35 @@
     "node1" : "d7",
     "node2" : "bbs2"
   }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d1"
-  }, {
     "node1" : "d1",
-    "node2" : "INTERNAL_vl_d1"
+    "node2" : "INTERNAL_vl_b"
   }, {
-    "node1" : "b3",
-    "node2" : "INTERNAL_vl_d6"
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
   }, {
     "node1" : "d6",
-    "node2" : "INTERNAL_vl_d6"
+    "node2" : "INTERNAL_vl_b3"
   }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d2"
+    "node1" : "INTERNAL_vl_b3",
+    "node2" : "b3"
   }, {
     "node1" : "d2",
-    "node2" : "INTERNAL_vl_d2"
+    "node2" : "INTERNAL_vl_b"
   }, {
-    "node1" : "b2",
-    "node2" : "INTERNAL_vl_d5"
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
   }, {
     "node1" : "d5",
-    "node2" : "INTERNAL_vl_d5"
+    "node2" : "INTERNAL_vl_b2"
   }, {
-    "node1" : "b3",
-    "node2" : "INTERNAL_vl_d7"
+    "node1" : "INTERNAL_vl_b2",
+    "node2" : "b2"
   }, {
     "node1" : "d7",
-    "node2" : "INTERNAL_vl_d7"
+    "node2" : "INTERNAL_vl_b3"
+  }, {
+    "node1" : "INTERNAL_vl_b3",
+    "node2" : "b3"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase3TripleCoupling_disconnectorOpen.json
+++ b/single-line-diagram-core/src/test/resources/TestCase3TripleCoupling_disconnectorOpen.json
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d1",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -25,7 +25,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d2",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -33,7 +33,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d5",
+    "id" : "INTERNAL_vl_b2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -41,7 +41,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d6",
+    "id" : "INTERNAL_vl_b3",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 275.0,
@@ -49,7 +49,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d7",
+    "id" : "INTERNAL_vl_b3",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -250,7 +250,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "d2", "INTERNAL_vl_d2" ]
+        "nodes" : [ "bbs2", "d2", "INTERNAL_vl_b" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -271,7 +271,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_d2", "b", "INTERNAL_vl_d1" ]
+        "nodes" : [ "INTERNAL_vl_b", "b", "INTERNAL_vl_b" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -292,7 +292,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "d1", "INTERNAL_vl_d1" ]
+        "nodes" : [ "bbs1", "d1", "INTERNAL_vl_b" ]
       } ]
     }
   }, {
@@ -401,7 +401,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_4", "b2", "INTERNAL_vl_d5" ]
+        "nodes" : [ "INTERNAL_vl_4", "b2", "INTERNAL_vl_b2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -422,7 +422,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "d5", "INTERNAL_vl_d5" ]
+        "nodes" : [ "bbs2", "d5", "INTERNAL_vl_b2" ]
       } ]
     }
   }, {
@@ -468,7 +468,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "d7", "INTERNAL_vl_d7" ]
+        "nodes" : [ "bbs2", "d7", "INTERNAL_vl_b3" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -489,7 +489,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_d7", "b3", "INTERNAL_vl_d6" ]
+        "nodes" : [ "INTERNAL_vl_b3", "b3", "INTERNAL_vl_b3" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -510,7 +510,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "d6", "INTERNAL_vl_d6" ]
+        "nodes" : [ "bbs1", "d6", "INTERNAL_vl_b3" ]
       } ]
     }
   } ],
@@ -545,35 +545,35 @@
     "node1" : "d7",
     "node2" : "bbs2"
   }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d1"
-  }, {
     "node1" : "d1",
-    "node2" : "INTERNAL_vl_d1"
+    "node2" : "INTERNAL_vl_b"
   }, {
-    "node1" : "b3",
-    "node2" : "INTERNAL_vl_d6"
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
   }, {
     "node1" : "d6",
-    "node2" : "INTERNAL_vl_d6"
+    "node2" : "INTERNAL_vl_b3"
   }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d2"
+    "node1" : "INTERNAL_vl_b3",
+    "node2" : "b3"
   }, {
     "node1" : "d2",
-    "node2" : "INTERNAL_vl_d2"
+    "node2" : "INTERNAL_vl_b"
   }, {
-    "node1" : "b2",
-    "node2" : "INTERNAL_vl_d5"
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
   }, {
     "node1" : "d5",
-    "node2" : "INTERNAL_vl_d5"
+    "node2" : "INTERNAL_vl_b2"
   }, {
-    "node1" : "b3",
-    "node2" : "INTERNAL_vl_d7"
+    "node1" : "INTERNAL_vl_b2",
+    "node2" : "b2"
   }, {
     "node1" : "d7",
-    "node2" : "INTERNAL_vl_d7"
+    "node2" : "INTERNAL_vl_b3"
+  }, {
+    "node1" : "INTERNAL_vl_b3",
+    "node2" : "b3"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase4NotParallelel.json
+++ b/single-line-diagram-core/src/test/resources/TestCase4NotParallelel.json
@@ -8,19 +8,19 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss1_0",
+    "id" : "BUSCO_ss1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
-    "x" : 100.0,
+    "x" : 50.0,
     "y" : 280.0,
     "orientation" : "RIGHT",
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss1_1",
+    "id" : "BUSCO_ss1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
-    "x" : 50.0,
+    "x" : 100.0,
     "y" : 280.0,
     "orientation" : "RIGHT",
     "open" : false
@@ -45,7 +45,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dc1",
+    "id" : "INTERNAL_vl_bc",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -78,19 +78,19 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_ss1_0",
+    "id" : "INTERNAL_vl_ss1",
     "componentType" : "NODE",
     "fictitious" : true,
-    "x" : 100.0,
+    "x" : 50.0,
     "y" : 280.0,
     "orientation" : "RIGHT",
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_ss1_1",
+    "id" : "INTERNAL_vl_ss1",
     "componentType" : "NODE",
     "fictitious" : true,
-    "x" : 50.0,
+    "x" : 100.0,
     "y" : 280.0,
     "orientation" : "RIGHT",
     "open" : false
@@ -342,7 +342,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1.2", "BUSCO_ss1_0", "INTERNAL_vl_ss1_0" ]
+        "nodes" : [ "bbs1.2", "BUSCO_ss1", "INTERNAL_vl_ss1" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -363,7 +363,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_ss1_1", "ss1", "INTERNAL_vl_ss1_0" ]
+        "nodes" : [ "INTERNAL_vl_ss1", "ss1", "INTERNAL_vl_ss1" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -384,7 +384,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1.1", "BUSCO_ss1_1", "INTERNAL_vl_ss1_1" ]
+        "nodes" : [ "bbs1.1", "BUSCO_ss1", "INTERNAL_vl_ss1" ]
       } ]
     }
   }, {
@@ -696,7 +696,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1.2", "dc1", "INTERNAL_vl_dc1" ]
+        "nodes" : [ "bbs1.2", "dc1", "INTERNAL_vl_bc" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -717,7 +717,7 @@
           "xSpan" : 50.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl_dc1", "bc", "INTERNAL_vl_gc" ]
+        "nodes" : [ "INTERNAL_vl_bc", "bc", "INTERNAL_vl_gc" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -776,6 +776,30 @@
     "node1" : "dc1",
     "node2" : "bbs1.2"
   }, {
+    "node1" : "bbs1.1",
+    "node2" : "BUSCO_ss1"
+  }, {
+    "node1" : "bbs1.2",
+    "node2" : "BUSCO_ss1"
+  }, {
+    "node1" : "BUSCO_ss1",
+    "node2" : "INTERNAL_vl_ss1"
+  }, {
+    "node1" : "INTERNAL_vl_ss1",
+    "node2" : "ss1"
+  }, {
+    "node1" : "dc1",
+    "node2" : "INTERNAL_vl_bc"
+  }, {
+    "node1" : "INTERNAL_vl_bc",
+    "node2" : "bc"
+  }, {
+    "node1" : "BUSCO_ss1",
+    "node2" : "INTERNAL_vl_ss1"
+  }, {
+    "node1" : "INTERNAL_vl_ss1",
+    "node2" : "ss1"
+  }, {
     "node1" : "ba",
     "node2" : "INTERNAL_vl_la"
   }, {
@@ -793,30 +817,6 @@
   }, {
     "node1" : "INTERNAL_vl_gc",
     "node2" : "gc"
-  }, {
-    "node1" : "bbs1.2",
-    "node2" : "BUSCO_ss1_0"
-  }, {
-    "node1" : "BUSCO_ss1_0",
-    "node2" : "INTERNAL_vl_ss1_0"
-  }, {
-    "node1" : "INTERNAL_vl_ss1_0",
-    "node2" : "ss1"
-  }, {
-    "node1" : "bbs1.1",
-    "node2" : "BUSCO_ss1_1"
-  }, {
-    "node1" : "BUSCO_ss1_1",
-    "node2" : "INTERNAL_vl_ss1_1"
-  }, {
-    "node1" : "INTERNAL_vl_ss1_1",
-    "node2" : "ss1"
-  }, {
-    "node1" : "bc",
-    "node2" : "INTERNAL_vl_dc1"
-  }, {
-    "node1" : "dc1",
-    "node2" : "INTERNAL_vl_dc1"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase5H.json
+++ b/single-line-diagram-core/src/test/resources/TestCase5H.json
@@ -12,7 +12,7 @@
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
-    "y" : 62.0,
+    "y" : 124.66666666666667,
     "orientation" : "RIGHT",
     "open" : false
   }, {
@@ -21,7 +21,7 @@
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
-    "y" : 62.0,
+    "y" : 124.66666666666667,
     "orientation" : "RIGHT",
     "open" : false
   }, {
@@ -41,20 +41,36 @@
     "y" : 250.0,
     "open" : false
   }, {
-    "type" : "SHUNT",
+    "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_la",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
-    "y" : 62.0,
+    "y" : 62.00000000000001,
     "open" : false
   }, {
     "type" : "SHUNT",
+    "id" : "INTERNAL_vl_la_fork",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 25.0,
+    "y" : 124.66666666666667,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_lb",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
-    "y" : 62.0,
+    "y" : 62.00000000000001,
+    "open" : false
+  }, {
+    "type" : "SHUNT",
+    "id" : "INTERNAL_vl_lb_fork",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 125.0,
+    "y" : 124.66666666666667,
     "open" : false
   }, {
     "type" : "SWITCH",
@@ -64,7 +80,7 @@
     "componentType" : "BREAKER",
     "fictitious" : false,
     "x" : 25.0,
-    "y" : 156.0,
+    "y" : 187.33333333333334,
     "open" : false,
     "kind" : "BREAKER"
   }, {
@@ -75,7 +91,7 @@
     "componentType" : "BREAKER",
     "fictitious" : false,
     "x" : 125.0,
-    "y" : 156.0,
+    "y" : 187.33333333333334,
     "open" : false,
     "kind" : "BREAKER"
   }, {
@@ -105,7 +121,7 @@
     "componentType" : "BREAKER",
     "fictitious" : false,
     "x" : 75.0,
-    "y" : 62.0,
+    "y" : 124.66666666666667,
     "orientation" : "RIGHT",
     "open" : false,
     "kind" : "BREAKER"
@@ -139,7 +155,7 @@
     "componentType" : "LOAD",
     "fictitious" : false,
     "x" : 25.0,
-    "y" : 0.0,
+    "y" : 7.105427357601002E-15,
     "open" : false,
     "label" : "la",
     "feederType" : "INJECTION",
@@ -153,7 +169,7 @@
     "componentType" : "LOAD",
     "fictitious" : false,
     "x" : 125.0,
-    "y" : 0.0,
+    "y" : 7.105427357601002E-15,
     "open" : false,
     "label" : "lb",
     "feederType" : "INJECTION",
@@ -176,7 +192,7 @@
         "h" : 0,
         "v" : 0,
         "hSpan" : 2,
-        "vSpan" : 4,
+        "vSpan" : 6,
         "orientation" : "UP"
       },
       "coord" : {
@@ -222,11 +238,32 @@
         },
         "coord" : {
           "x" : 25.0,
-          "y" : 156.0,
+          "y" : 187.33333333333334,
           "xSpan" : 50.0,
-          "ySpan" : 188.0
+          "ySpan" : 125.33333333333333
         },
-        "nodes" : [ "INTERNAL_vl_ba", "ba", "INTERNAL_vl_la" ]
+        "nodes" : [ "INTERNAL_vl_ba", "ba", "INTERNAL_vl_la_fork" ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 4,
+          "hSpan" : 2,
+          "vSpan" : 2,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 93.33333333333334,
+          "xSpan" : 50.0,
+          "ySpan" : 62.666666666666664
+        },
+        "nodes" : [ "INTERNAL_vl_la_fork", "INTERNAL_vl_la" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -236,7 +273,7 @@
         } ],
         "position" : {
           "h" : 0,
-          "v" : 4,
+          "v" : 6,
           "hSpan" : 2,
           "vSpan" : 0,
           "orientation" : "UP"
@@ -273,7 +310,7 @@
         "xSpan" : 0.0,
         "ySpan" : 0.0
       },
-      "nodes" : [ "INTERNAL_vl_la", "INTERNAL_vl_Shunt 1.1", "bs", "INTERNAL_vl_Shunt 1.2", "INTERNAL_vl_lb" ]
+      "nodes" : [ "INTERNAL_vl_la_fork", "INTERNAL_vl_Shunt 1.1", "bs", "INTERNAL_vl_Shunt 1.2", "INTERNAL_vl_lb_fork" ]
     }
   }, {
     "type" : "EXTERN",
@@ -291,7 +328,7 @@
         "h" : 4,
         "v" : 0,
         "hSpan" : 2,
-        "vSpan" : 4,
+        "vSpan" : 6,
         "orientation" : "UP"
       },
       "coord" : {
@@ -337,11 +374,32 @@
         },
         "coord" : {
           "x" : 125.0,
-          "y" : 156.0,
+          "y" : 187.33333333333334,
           "xSpan" : 50.0,
-          "ySpan" : 188.0
+          "ySpan" : 125.33333333333333
         },
-        "nodes" : [ "INTERNAL_vl_bb", "bb", "INTERNAL_vl_lb" ]
+        "nodes" : [ "INTERNAL_vl_bb", "bb", "INTERNAL_vl_lb_fork" ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 4,
+          "hSpan" : 2,
+          "vSpan" : 2,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 93.33333333333334,
+          "xSpan" : 50.0,
+          "ySpan" : 62.666666666666664
+        },
+        "nodes" : [ "INTERNAL_vl_lb_fork", "INTERNAL_vl_lb" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -351,7 +409,7 @@
         } ],
         "position" : {
           "h" : 0,
-          "v" : 4,
+          "v" : 6,
           "hSpan" : 2,
           "vSpan" : 0,
           "orientation" : "UP"
@@ -386,24 +444,30 @@
     "node2" : "bb"
   }, {
     "node1" : "ba",
+    "node2" : "INTERNAL_vl_la_fork"
+  }, {
+    "node1" : "INTERNAL_vl_la_fork",
     "node2" : "INTERNAL_vl_la"
   }, {
     "node1" : "INTERNAL_vl_la",
     "node2" : "la"
   }, {
     "node1" : "bb",
+    "node2" : "INTERNAL_vl_lb_fork"
+  }, {
+    "node1" : "INTERNAL_vl_lb_fork",
     "node2" : "INTERNAL_vl_lb"
   }, {
     "node1" : "INTERNAL_vl_lb",
     "node2" : "lb"
   }, {
-    "node1" : "INTERNAL_vl_la",
+    "node1" : "INTERNAL_vl_la_fork",
     "node2" : "INTERNAL_vl_Shunt 1.1"
   }, {
     "node1" : "bs",
     "node2" : "INTERNAL_vl_Shunt 1.1"
   }, {
-    "node1" : "INTERNAL_vl_lb",
+    "node1" : "INTERNAL_vl_lb_fork",
     "node2" : "INTERNAL_vl_Shunt 1.2"
   }, {
     "node1" : "bs",

--- a/single-line-diagram-core/src/test/resources/TestCase5H.json
+++ b/single-line-diagram-core/src/test/resources/TestCase5H.json
@@ -26,7 +26,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_da",
+    "id" : "INTERNAL_vl_ba",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -34,7 +34,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_db",
+    "id" : "INTERNAL_vl_bb",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -205,7 +205,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs", "da", "INTERNAL_vl_da" ]
+        "nodes" : [ "bbs", "da", "INTERNAL_vl_ba" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -226,7 +226,7 @@
           "xSpan" : 50.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl_da", "ba", "INTERNAL_vl_la" ]
+        "nodes" : [ "INTERNAL_vl_ba", "ba", "INTERNAL_vl_la" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -320,7 +320,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs", "db", "INTERNAL_vl_db" ]
+        "nodes" : [ "bbs", "db", "INTERNAL_vl_bb" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -341,7 +341,7 @@
           "xSpan" : 50.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl_db", "bb", "INTERNAL_vl_lb" ]
+        "nodes" : [ "INTERNAL_vl_bb", "bb", "INTERNAL_vl_lb" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -373,6 +373,18 @@
     "node1" : "db",
     "node2" : "bbs"
   }, {
+    "node1" : "da",
+    "node2" : "INTERNAL_vl_ba"
+  }, {
+    "node1" : "INTERNAL_vl_ba",
+    "node2" : "ba"
+  }, {
+    "node1" : "db",
+    "node2" : "INTERNAL_vl_bb"
+  }, {
+    "node1" : "INTERNAL_vl_bb",
+    "node2" : "bb"
+  }, {
     "node1" : "ba",
     "node2" : "INTERNAL_vl_la"
   }, {
@@ -384,18 +396,6 @@
   }, {
     "node1" : "INTERNAL_vl_lb",
     "node2" : "lb"
-  }, {
-    "node1" : "ba",
-    "node2" : "INTERNAL_vl_da"
-  }, {
-    "node1" : "da",
-    "node2" : "INTERNAL_vl_da"
-  }, {
-    "node1" : "bb",
-    "node2" : "INTERNAL_vl_db"
-  }, {
-    "node1" : "db",
-    "node2" : "INTERNAL_vl_db"
   }, {
     "node1" : "INTERNAL_vl_la",
     "node2" : "INTERNAL_vl_Shunt 1.1"

--- a/single-line-diagram-core/src/test/resources/TestCase5V.json
+++ b/single-line-diagram-core/src/test/resources/TestCase5V.json
@@ -35,7 +35,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_da",
+    "id" : "INTERNAL_vl_ba",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -206,7 +206,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs", "da", "INTERNAL_vl_da" ]
+        "nodes" : [ "bbs", "da", "INTERNAL_vl_ba" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -227,7 +227,7 @@
           "xSpan" : 50.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl_da", "ba", "INTERNAL_vl_la" ]
+        "nodes" : [ "INTERNAL_vl_ba", "ba", "INTERNAL_vl_la" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -380,6 +380,12 @@
     "node1" : "db",
     "node2" : "bbs"
   }, {
+    "node1" : "da",
+    "node2" : "INTERNAL_vl_ba"
+  }, {
+    "node1" : "INTERNAL_vl_ba",
+    "node2" : "ba"
+  }, {
     "node1" : "ba",
     "node2" : "INTERNAL_vl_la"
   }, {
@@ -391,12 +397,6 @@
   }, {
     "node1" : "INTERNAL_vl_lb",
     "node2" : "lb"
-  }, {
-    "node1" : "ba",
-    "node2" : "INTERNAL_vl_da"
-  }, {
-    "node1" : "da",
-    "node2" : "INTERNAL_vl_da"
   }, {
     "node1" : "INTERNAL_vl_la",
     "node2" : "INTERNAL_vl_Shunt 1.1"

--- a/single-line-diagram-core/src/test/resources/TestCase5V.json
+++ b/single-line-diagram-core/src/test/resources/TestCase5V.json
@@ -21,7 +21,7 @@
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
-    "y" : 156.0,
+    "y" : 187.33333333333334,
     "orientation" : "RIGHT",
     "open" : false
   }, {
@@ -30,7 +30,7 @@
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
-    "y" : 156.0,
+    "y" : 187.33333333333334,
     "orientation" : "RIGHT",
     "open" : false
   }, {
@@ -42,12 +42,20 @@
     "y" : 250.0,
     "open" : false
   }, {
-    "type" : "SHUNT",
+    "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_la",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
-    "y" : 62.0,
+    "y" : 62.00000000000001,
+    "open" : false
+  }, {
+    "type" : "SHUNT",
+    "id" : "INTERNAL_vl_la_fork",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 125.0,
+    "y" : 124.66666666666667,
     "open" : false
   }, {
     "type" : "FICTITIOUS",
@@ -65,7 +73,7 @@
     "componentType" : "BREAKER",
     "fictitious" : false,
     "x" : 125.0,
-    "y" : 156.0,
+    "y" : 187.33333333333334,
     "open" : false,
     "kind" : "BREAKER"
   }, {
@@ -106,7 +114,7 @@
     "componentType" : "BREAKER",
     "fictitious" : false,
     "x" : 75.0,
-    "y" : 156.0,
+    "y" : 187.33333333333334,
     "orientation" : "RIGHT",
     "open" : false,
     "kind" : "BREAKER"
@@ -140,7 +148,7 @@
     "componentType" : "LOAD",
     "fictitious" : false,
     "x" : 125.0,
-    "y" : 0.0,
+    "y" : 7.105427357601002E-15,
     "open" : false,
     "label" : "la",
     "feederType" : "INJECTION",
@@ -177,7 +185,7 @@
         "h" : 4,
         "v" : 0,
         "hSpan" : 2,
-        "vSpan" : 4,
+        "vSpan" : 6,
         "orientation" : "UP"
       },
       "coord" : {
@@ -223,11 +231,32 @@
         },
         "coord" : {
           "x" : 125.0,
-          "y" : 156.0,
+          "y" : 187.33333333333334,
           "xSpan" : 50.0,
-          "ySpan" : 188.0
+          "ySpan" : 125.33333333333333
         },
-        "nodes" : [ "INTERNAL_vl_ba", "ba", "INTERNAL_vl_la" ]
+        "nodes" : [ "INTERNAL_vl_ba", "ba", "INTERNAL_vl_la_fork" ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 4,
+          "hSpan" : 2,
+          "vSpan" : 2,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 125.0,
+          "y" : 93.33333333333334,
+          "xSpan" : 50.0,
+          "ySpan" : 62.666666666666664
+        },
+        "nodes" : [ "INTERNAL_vl_la_fork", "INTERNAL_vl_la" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -237,7 +266,7 @@
         } ],
         "position" : {
           "h" : 0,
-          "v" : 4,
+          "v" : 6,
           "hSpan" : 2,
           "vSpan" : 0,
           "orientation" : "UP"
@@ -274,7 +303,7 @@
         "xSpan" : 0.0,
         "ySpan" : 0.0
       },
-      "nodes" : [ "INTERNAL_vl_3", "INTERNAL_vl_Shunt 1.2", "bs", "INTERNAL_vl_Shunt 1.1", "INTERNAL_vl_la" ]
+      "nodes" : [ "INTERNAL_vl_3", "INTERNAL_vl_Shunt 1.2", "bs", "INTERNAL_vl_Shunt 1.1", "INTERNAL_vl_la_fork" ]
     }
   }, {
     "type" : "EXTERN",
@@ -387,6 +416,9 @@
     "node2" : "ba"
   }, {
     "node1" : "ba",
+    "node2" : "INTERNAL_vl_la_fork"
+  }, {
+    "node1" : "INTERNAL_vl_la_fork",
     "node2" : "INTERNAL_vl_la"
   }, {
     "node1" : "INTERNAL_vl_la",
@@ -398,7 +430,7 @@
     "node1" : "INTERNAL_vl_lb",
     "node2" : "lb"
   }, {
-    "node1" : "INTERNAL_vl_la",
+    "node1" : "INTERNAL_vl_la_fork",
     "node2" : "INTERNAL_vl_Shunt 1.1"
   }, {
     "node1" : "bs",

--- a/single-line-diagram-core/src/test/resources/TestCase6CouplingNonFlatHorizontal.json
+++ b/single-line-diagram-core/src/test/resources/TestCase6CouplingNonFlatHorizontal.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ds1_0",
+    "id" : "BUSCO_ds1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ds1_1",
+    "id" : "BUSCO_ds1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -26,7 +26,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ds2_0",
+    "id" : "BUSCO_ds2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -35,7 +35,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ds2_1",
+    "id" : "BUSCO_ds2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -44,7 +44,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d1",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -52,7 +52,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d2",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -60,7 +60,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_ds1_0",
+    "id" : "INTERNAL_vl_ds1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -69,7 +69,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_ds1_1",
+    "id" : "INTERNAL_vl_ds1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -78,7 +78,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_ds2_0",
+    "id" : "INTERNAL_vl_ds2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -87,7 +87,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_ds2_1",
+    "id" : "INTERNAL_vl_ds2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -272,7 +272,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2.2", "d2", "INTERNAL_vl_d2" ]
+        "nodes" : [ "bbs2.2", "d2", "INTERNAL_vl_b" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -293,7 +293,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_d1", "b", "INTERNAL_vl_d2" ]
+        "nodes" : [ "INTERNAL_vl_b", "b", "INTERNAL_vl_b" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -314,7 +314,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1.1", "d1", "INTERNAL_vl_d1" ]
+        "nodes" : [ "bbs1.1", "d1", "INTERNAL_vl_b" ]
       } ]
     }
   }, {
@@ -361,7 +361,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1.2", "BUSCO_ds1_1", "INTERNAL_vl_ds1_1" ]
+        "nodes" : [ "bbs1.2", "BUSCO_ds1", "INTERNAL_vl_ds1" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -382,7 +382,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_ds1_0", "ds1", "INTERNAL_vl_ds1_1" ]
+        "nodes" : [ "INTERNAL_vl_ds1", "ds1", "INTERNAL_vl_ds1" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -403,7 +403,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1.1", "BUSCO_ds1_0", "INTERNAL_vl_ds1_0" ]
+        "nodes" : [ "bbs1.1", "BUSCO_ds1", "INTERNAL_vl_ds1" ]
       } ]
     }
   }, {
@@ -450,7 +450,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2.2", "BUSCO_ds2_1", "INTERNAL_vl_ds2_1" ]
+        "nodes" : [ "bbs2.2", "BUSCO_ds2", "INTERNAL_vl_ds2" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -471,7 +471,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_ds2_0", "ds2", "INTERNAL_vl_ds2_1" ]
+        "nodes" : [ "INTERNAL_vl_ds2", "ds2", "INTERNAL_vl_ds2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -492,7 +492,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2.1", "BUSCO_ds2_0", "INTERNAL_vl_ds2_0" ]
+        "nodes" : [ "bbs2.1", "BUSCO_ds2", "INTERNAL_vl_ds2" ]
       } ]
     }
   } ],
@@ -504,52 +504,52 @@
     "node2" : "bbs2.2"
   }, {
     "node1" : "bbs1.1",
-    "node2" : "BUSCO_ds1_0"
-  }, {
-    "node1" : "BUSCO_ds1_0",
-    "node2" : "INTERNAL_vl_ds1_0"
-  }, {
-    "node1" : "INTERNAL_vl_ds1_0",
-    "node2" : "ds1"
+    "node2" : "BUSCO_ds1"
   }, {
     "node1" : "bbs1.2",
-    "node2" : "BUSCO_ds1_1"
-  }, {
-    "node1" : "BUSCO_ds1_1",
-    "node2" : "INTERNAL_vl_ds1_1"
-  }, {
-    "node1" : "INTERNAL_vl_ds1_1",
-    "node2" : "ds1"
+    "node2" : "BUSCO_ds1"
   }, {
     "node1" : "bbs2.1",
-    "node2" : "BUSCO_ds2_0"
-  }, {
-    "node1" : "BUSCO_ds2_0",
-    "node2" : "INTERNAL_vl_ds2_0"
-  }, {
-    "node1" : "INTERNAL_vl_ds2_0",
-    "node2" : "ds2"
+    "node2" : "BUSCO_ds2"
   }, {
     "node1" : "bbs2.2",
-    "node2" : "BUSCO_ds2_1"
-  }, {
-    "node1" : "BUSCO_ds2_1",
-    "node2" : "INTERNAL_vl_ds2_1"
-  }, {
-    "node1" : "INTERNAL_vl_ds2_1",
-    "node2" : "ds2"
-  }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d1"
+    "node2" : "BUSCO_ds2"
   }, {
     "node1" : "d1",
-    "node2" : "INTERNAL_vl_d1"
+    "node2" : "INTERNAL_vl_b"
   }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d2"
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
+  }, {
+    "node1" : "BUSCO_ds1",
+    "node2" : "INTERNAL_vl_ds1"
+  }, {
+    "node1" : "INTERNAL_vl_ds1",
+    "node2" : "ds1"
+  }, {
+    "node1" : "BUSCO_ds1",
+    "node2" : "INTERNAL_vl_ds1"
+  }, {
+    "node1" : "INTERNAL_vl_ds1",
+    "node2" : "ds1"
+  }, {
+    "node1" : "BUSCO_ds2",
+    "node2" : "INTERNAL_vl_ds2"
+  }, {
+    "node1" : "INTERNAL_vl_ds2",
+    "node2" : "ds2"
   }, {
     "node1" : "d2",
-    "node2" : "INTERNAL_vl_d2"
+    "node2" : "INTERNAL_vl_b"
+  }, {
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
+  }, {
+    "node1" : "BUSCO_ds2",
+    "node2" : "INTERNAL_vl_ds2"
+  }, {
+    "node1" : "INTERNAL_vl_ds2",
+    "node2" : "ds2"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCase6InternalConnection.json
+++ b/single-line-diagram-core/src/test/resources/TestCase6InternalConnection.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_bbs1.1-bbs1.2_1",
+    "id" : "BUSCO_INTERNAL_vl_bbs1.1-bbs1.2_1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_bbs1.1-bbs1.2_2",
+    "id" : "BUSCO_INTERNAL_vl_bbs1.1-bbs1.2_2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -26,7 +26,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ds2_0",
+    "id" : "BUSCO_ds2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -35,12 +35,28 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ds2_1",
+    "id" : "BUSCO_ds2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
     "y" : 305.0,
     "orientation" : "RIGHT",
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl_b",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 25.0,
+    "y" : 240.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl_b",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 125.0,
+    "y" : 240.0,
     "open" : false
   }, {
     "type" : "FICTITIOUS",
@@ -62,23 +78,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d1",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 25.0,
-    "y" : 240.0,
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d2",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 125.0,
-    "y" : 240.0,
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_ds2_0",
+    "id" : "INTERNAL_vl_ds2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -87,7 +87,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_ds2_1",
+    "id" : "INTERNAL_vl_ds2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -260,7 +260,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2.2", "d2", "INTERNAL_vl_d2" ]
+        "nodes" : [ "bbs2.2", "d2", "INTERNAL_vl_b" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -281,7 +281,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_d1", "b", "INTERNAL_vl_d2" ]
+        "nodes" : [ "INTERNAL_vl_b", "b", "INTERNAL_vl_b" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -302,7 +302,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1.1", "d1", "INTERNAL_vl_d1" ]
+        "nodes" : [ "bbs1.1", "d1", "INTERNAL_vl_b" ]
       } ]
     }
   }, {
@@ -349,7 +349,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1.2", "BUSCO_bbs1.1-bbs1.2_2", "INTERNAL_vl_bbs1.1-bbs1.2_2" ]
+        "nodes" : [ "bbs1.2", "BUSCO_INTERNAL_vl_bbs1.1-bbs1.2_2", "INTERNAL_vl_bbs1.1-bbs1.2_2" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -391,7 +391,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1.1", "BUSCO_bbs1.1-bbs1.2_1", "INTERNAL_vl_bbs1.1-bbs1.2_1" ]
+        "nodes" : [ "bbs1.1", "BUSCO_INTERNAL_vl_bbs1.1-bbs1.2_1", "INTERNAL_vl_bbs1.1-bbs1.2_1" ]
       } ]
     }
   }, {
@@ -438,7 +438,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2.2", "BUSCO_ds2_1", "INTERNAL_vl_ds2_1" ]
+        "nodes" : [ "bbs2.2", "BUSCO_ds2", "INTERNAL_vl_ds2" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -459,7 +459,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_ds2_0", "ds2", "INTERNAL_vl_ds2_1" ]
+        "nodes" : [ "INTERNAL_vl_ds2", "ds2", "INTERNAL_vl_ds2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -480,7 +480,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2.1", "BUSCO_ds2_0", "INTERNAL_vl_ds2_0" ]
+        "nodes" : [ "bbs2.1", "BUSCO_ds2", "INTERNAL_vl_ds2" ]
       } ]
     }
   } ],
@@ -491,50 +491,50 @@
     "node1" : "d2",
     "node2" : "bbs2.2"
   }, {
-    "node1" : "bbs2.1",
-    "node2" : "BUSCO_ds2_0"
-  }, {
-    "node1" : "BUSCO_ds2_0",
-    "node2" : "INTERNAL_vl_ds2_0"
-  }, {
-    "node1" : "INTERNAL_vl_ds2_0",
-    "node2" : "ds2"
-  }, {
-    "node1" : "bbs2.2",
-    "node2" : "BUSCO_ds2_1"
-  }, {
-    "node1" : "BUSCO_ds2_1",
-    "node2" : "INTERNAL_vl_ds2_1"
-  }, {
-    "node1" : "INTERNAL_vl_ds2_1",
-    "node2" : "ds2"
-  }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d1"
-  }, {
-    "node1" : "d1",
-    "node2" : "INTERNAL_vl_d1"
-  }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d2"
-  }, {
-    "node1" : "d2",
-    "node2" : "INTERNAL_vl_d2"
-  }, {
-    "node1" : "bbs1.1",
-    "node2" : "BUSCO_bbs1.1-bbs1.2_1"
-  }, {
-    "node1" : "BUSCO_bbs1.1-bbs1.2_1",
-    "node2" : "INTERNAL_vl_bbs1.1-bbs1.2_1"
-  }, {
     "node1" : "INTERNAL_vl_bbs1.1-bbs1.2_1",
     "node2" : "INTERNAL_vl_bbs1.1-bbs1.2_2"
   }, {
-    "node1" : "INTERNAL_vl_bbs1.1-bbs1.2_2",
-    "node2" : "BUSCO_bbs1.1-bbs1.2_2"
+    "node1" : "bbs1.1",
+    "node2" : "BUSCO_INTERNAL_vl_bbs1.1-bbs1.2_1"
+  }, {
+    "node1" : "BUSCO_INTERNAL_vl_bbs1.1-bbs1.2_1",
+    "node2" : "INTERNAL_vl_bbs1.1-bbs1.2_1"
   }, {
     "node1" : "bbs1.2",
-    "node2" : "BUSCO_bbs1.1-bbs1.2_2"
+    "node2" : "BUSCO_INTERNAL_vl_bbs1.1-bbs1.2_2"
+  }, {
+    "node1" : "BUSCO_INTERNAL_vl_bbs1.1-bbs1.2_2",
+    "node2" : "INTERNAL_vl_bbs1.1-bbs1.2_2"
+  }, {
+    "node1" : "bbs2.1",
+    "node2" : "BUSCO_ds2"
+  }, {
+    "node1" : "bbs2.2",
+    "node2" : "BUSCO_ds2"
+  }, {
+    "node1" : "d1",
+    "node2" : "INTERNAL_vl_b"
+  }, {
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
+  }, {
+    "node1" : "BUSCO_ds2",
+    "node2" : "INTERNAL_vl_ds2"
+  }, {
+    "node1" : "INTERNAL_vl_ds2",
+    "node2" : "ds2"
+  }, {
+    "node1" : "d2",
+    "node2" : "INTERNAL_vl_b"
+  }, {
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
+  }, {
+    "node1" : "BUSCO_ds2",
+    "node2" : "INTERNAL_vl_ds2"
+  }, {
+    "node1" : "INTERNAL_vl_ds2",
+    "node2" : "ds2"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.svg
@@ -83,7 +83,7 @@
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_f2" transform="translate(111.0,134.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_d2" transform="translate(61.0,134.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_bD" transform="translate(61.0,134.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_d1_95_INTERNAL_95_vl_95_f1">
@@ -110,10 +110,10 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_f2_95_bD">
                 <polyline points="115.0,138.0,100.0,138.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_bD_95_INTERNAL_95_vl_95_d2">
-                <polyline points="80.0,138.0,65.0,138.0"/>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_bD_95_bD">
+                <polyline points="65.0,138.0,80.0,138.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_d2_95_INTERNAL_95_vl_95_d2">
+            <g class="sld-wire" id="_95_vl_95_d2_95_INTERNAL_95_vl_95_bD">
                 <polyline points="65.0,243.0,65.0,138.0"/>
             </g>
             <g class="sld-disconnector sld-closed" id="idd1" transform="translate(161.0,214.0)">

--- a/single-line-diagram-core/src/test/resources/TestCaseFictitiousBus.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseFictitiousBus.svg
@@ -75,22 +75,22 @@
             <line x1="0" x2="100.0" y1="0" y2="0"/>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L1_95_ONE_95_1" transform="translate(61.0,326.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L1_95_ONE" transform="translate(61.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L1_95_ONE_95_2" transform="translate(61.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L1_95_ONE" transform="translate(61.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder" id="idL1_95_ONE" transform="translate(65.0,80.0)">
                 <text class="sld-label" id="L1_ONE_N_LABEL" x="-5.0" y="-5.0">L1</text>
             </g>
-            <g class="sld-wire" id="_95_vl_95_BUSCO_95_L1_95_ONE_95_INTERNAL_95_vl_95_L1_95_ONE_95_1">
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_L1_95_ONE_95_INTERNAL_95_vl_95_L1_95_ONE">
                 <polyline points="65.0,360.0,65.0,330.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_1_95_INTERNAL_95_vl_95_L1_95_ONE_95_2">
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_INTERNAL_95_vl_95_L1_95_ONE">
                 <polyline points="65.0,330.0,65.0,142.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_2_95_L1_95_ONE">
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_L1_95_ONE">
                 <polyline points="65.0,142.0,65.0,80.0"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idL1_95_ONE_ARROW_ACTIVE" transform="translate(60.0,95.0)">
@@ -108,22 +108,22 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L2_95_ONE_95_1" transform="translate(111.0,386.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L2_95_ONE" transform="translate(111.0,386.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L2_95_ONE_95_2" transform="translate(111.0,574.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L2_95_ONE" transform="translate(111.0,574.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder" id="idL2_95_ONE" transform="translate(115.0,640.0)">
                 <text class="sld-label" id="L2_ONE_S_LABEL" x="-5.0" y="5.0">L2</text>
             </g>
-            <g class="sld-wire" id="_95_vl_95_BUSCO_95_L2_95_ONE_95_INTERNAL_95_vl_95_L2_95_ONE_95_1">
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_L2_95_ONE_95_INTERNAL_95_vl_95_L2_95_ONE">
                 <polyline points="115.0,360.0,115.0,390.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_1_95_INTERNAL_95_vl_95_L2_95_ONE_95_2">
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_INTERNAL_95_vl_95_L2_95_ONE">
                 <polyline points="115.0,390.0,115.0,578.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_2_95_L2_95_ONE">
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_L2_95_ONE">
                 <polyline points="115.0,578.0,115.0,640.0"/>
             </g>
             <g class="sld-arrow-q sld-in" id="idL2_95_ONE_ARROW_REACTIVE" transform="translate(110.0,615.0)">
@@ -141,22 +141,22 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L3_95_ONE_95_1" transform="translate(161.0,326.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L3_95_ONE" transform="translate(161.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L3_95_ONE_95_2" transform="translate(161.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_L3_95_ONE" transform="translate(161.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder" id="idL3_95_ONE" transform="translate(165.0,80.0)">
                 <text class="sld-label" id="L3_ONE_N_LABEL" x="-5.0" y="-5.0">L3</text>
             </g>
-            <g class="sld-wire" id="_95_vl_95_BUSCO_95_L3_95_ONE_95_INTERNAL_95_vl_95_L3_95_ONE_95_1">
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_L3_95_ONE_95_INTERNAL_95_vl_95_L3_95_ONE">
                 <polyline points="165.0,360.0,165.0,330.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_1_95_INTERNAL_95_vl_95_L3_95_ONE_95_2">
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_INTERNAL_95_vl_95_L3_95_ONE">
                 <polyline points="165.0,330.0,165.0,142.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_2_95_L3_95_ONE">
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_L3_95_ONE">
                 <polyline points="165.0,142.0,165.0,80.0"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idL3_95_ONE_ARROW_ACTIVE" transform="translate(160.0,95.0)">

--- a/single-line-diagram-core/src/test/resources/TestCaseFictitiousBusTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseFictitiousBusTopological.svg
@@ -153,22 +153,22 @@
             <line x1="0" x2="100.0" y1="0" y2="0"/>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L1_95_ONE_95_1" transform="translate(61.0,326.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L1_95_ONE" transform="translate(61.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L1_95_ONE_95_2" transform="translate(61.0,138.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L1_95_ONE" transform="translate(61.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder sld-vl50to70-0" id="idL1_95_ONE" transform="translate(65.0,80.0)">
                 <text class="sld-label" id="L1_ONE_N_LABEL" x="-5.0" y="-5.0">L1</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_BUSCO_95_L1_95_ONE_95_INTERNAL_95_vl_95_L1_95_ONE_95_1">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_BUSCO_95_L1_95_ONE_95_INTERNAL_95_vl_95_L1_95_ONE">
                 <polyline points="65.0,360.0,65.0,330.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_1_95_INTERNAL_95_vl_95_L1_95_ONE_95_2">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_INTERNAL_95_vl_95_L1_95_ONE">
                 <polyline points="65.0,330.0,65.0,142.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0 sld-feeder-connected-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_2_95_L1_95_ONE">
+            <g class="sld-wire sld-vl50to70-0 sld-feeder-connected-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_L1_95_ONE">
                 <polyline points="65.0,142.0,65.0,80.0"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idL1_95_ONE_ARROW_ACTIVE" transform="translate(60.0,95.0)">
@@ -186,22 +186,22 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L2_95_ONE_95_1" transform="translate(111.0,386.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L2_95_ONE" transform="translate(111.0,386.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L2_95_ONE_95_2" transform="translate(111.0,574.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L2_95_ONE" transform="translate(111.0,574.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder sld-vl50to70-0" id="idL2_95_ONE" transform="translate(115.0,640.0)">
                 <text class="sld-label" id="L2_ONE_S_LABEL" x="-5.0" y="5.0">L2</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_BUSCO_95_L2_95_ONE_95_INTERNAL_95_vl_95_L2_95_ONE_95_1">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_BUSCO_95_L2_95_ONE_95_INTERNAL_95_vl_95_L2_95_ONE">
                 <polyline points="115.0,360.0,115.0,390.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_1_95_INTERNAL_95_vl_95_L2_95_ONE_95_2">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_INTERNAL_95_vl_95_L2_95_ONE">
                 <polyline points="115.0,390.0,115.0,578.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0 sld-feeder-connected-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_2_95_L2_95_ONE">
+            <g class="sld-wire sld-vl50to70-0 sld-feeder-connected-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_L2_95_ONE">
                 <polyline points="115.0,578.0,115.0,640.0"/>
             </g>
             <g class="sld-arrow-q sld-in" id="idL2_95_ONE_ARROW_REACTIVE" transform="translate(110.0,615.0)">
@@ -219,22 +219,22 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L3_95_ONE_95_1" transform="translate(161.0,326.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L3_95_ONE" transform="translate(161.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L3_95_ONE_95_2" transform="translate(161.0,138.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L3_95_ONE" transform="translate(161.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder sld-vl50to70-0" id="idL3_95_ONE" transform="translate(165.0,80.0)">
                 <text class="sld-label" id="L3_ONE_N_LABEL" x="-5.0" y="-5.0">L3</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_BUSCO_95_L3_95_ONE_95_INTERNAL_95_vl_95_L3_95_ONE_95_1">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_BUSCO_95_L3_95_ONE_95_INTERNAL_95_vl_95_L3_95_ONE">
                 <polyline points="165.0,360.0,165.0,330.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_1_95_INTERNAL_95_vl_95_L3_95_ONE_95_2">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_INTERNAL_95_vl_95_L3_95_ONE">
                 <polyline points="165.0,330.0,165.0,142.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0 sld-feeder-connected-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_2_95_L3_95_ONE">
+            <g class="sld-wire sld-vl50to70-0 sld-feeder-connected-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_L3_95_ONE">
                 <polyline points="165.0,142.0,165.0,80.0"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idL3_95_ONE_ARROW_ACTIVE" transform="translate(160.0,95.0)">

--- a/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
@@ -274,10 +274,13 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_3">
-            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_l" transform="translate(311.0,599.0)">
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_l_95_fork" transform="translate(311.0,536.3333333333333)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_b" transform="translate(311.0,411.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_l" transform="translate(311.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-load sld-bottom-feeder sld-disconnected" id="idl" transform="translate(307.0,660.5)">
@@ -286,8 +289,20 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="l_S_LABEL" x="-5.0" y="14.0">l</text>
             </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_b_95_INTERNAL_95_vl_95_l">
-                <polyline points="315.0,514.0,315.0,603.0"/>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_b_95_INTERNAL_95_vl_95_l_95_fork">
+                <polyline points="315.0,482.6666666666667,315.0,540.3333333333333"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_fork_95_INTERNAL_95_vl_95_l">
+                <polyline points="315.0,540.3333333333333,315.0,603.0"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_fork_95_INTERNAL_95_vl_95_Shunt_32_4_46_1">
+                <polyline points="315.0,540.3333333333333,290.0,540.3333333333333,290.0,524.6666666666666"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_b_95_b">
+                <polyline points="315.0,415.0,315.0,472.6666666666667"/>
+            </g>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_BUSCO_95_b_95_INTERNAL_95_vl_95_b">
+                <polyline points="315.0,385.0,315.0,415.0"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_l">
                 <polyline points="315.0,603.0,315.0,660.5"/>
@@ -302,16 +317,7 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_INTERNAL_95_vl_95_Shunt_32_4_46_1">
-                <polyline points="315.0,603.0,290.0,603.0,290.0,556.0"/>
-            </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_b_95_b">
-                <polyline points="315.0,415.0,315.0,504.0"/>
-            </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_BUSCO_95_b_95_INTERNAL_95_vl_95_b">
-                <polyline points="315.0,385.0,315.0,415.0"/>
-            </g>
-            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb" transform="translate(310.0,504.0)">
+            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb" transform="translate(310.0,472.6666666666667)">
                 <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0"/>
                 <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0"/>
             </g>
@@ -323,13 +329,13 @@
             <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_5" transform="translate(211.0,505.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_Shunt_32_4_46_2" transform="translate(236.0,552.0)">
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_Shunt_32_4_46_2" transform="translate(236.0,520.6666666666666)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_Shunt_32_4_46_1" transform="translate(286.0,552.0)">
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_Shunt_32_4_46_1" transform="translate(286.0,520.6666666666666)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_l" transform="translate(311.0,599.0)">
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_l_95_fork" transform="translate(311.0,536.3333333333333)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_b3_95_INTERNAL_95_vl_95_5">
@@ -339,34 +345,24 @@
                 <polyline points="215.0,509.0,215.0,551.0"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_5_95_INTERNAL_95_vl_95_Shunt_32_4_46_2">
-                <polyline points="215.0,509.0,240.0,509.0,240.0,556.0"/>
+                <polyline points="215.0,509.0,240.0,509.0,240.0,524.6666666666666"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_b5_95_INTERNAL_95_vl_95_Shunt_32_4_46_2">
-                <polyline points="260.0,556.0,240.0,556.0"/>
+                <polyline points="260.0,524.6666666666666,240.0,524.6666666666666"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_b5_95_INTERNAL_95_vl_95_Shunt_32_4_46_1">
-                <polyline points="270.0,556.0,290.0,556.0"/>
+                <polyline points="270.0,524.6666666666666,290.0,524.6666666666666"/>
             </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_INTERNAL_95_vl_95_Shunt_32_4_46_1">
-                <polyline points="315.0,603.0,290.0,603.0,290.0,556.0"/>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_fork_95_INTERNAL_95_vl_95_Shunt_32_4_46_1">
+                <polyline points="315.0,540.3333333333333,290.0,540.3333333333333,290.0,524.6666666666666"/>
             </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_b_95_INTERNAL_95_vl_95_l">
-                <polyline points="315.0,514.0,315.0,603.0"/>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_b_95_INTERNAL_95_vl_95_l_95_fork">
+                <polyline points="315.0,482.6666666666667,315.0,540.3333333333333"/>
             </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_l">
-                <polyline points="315.0,603.0,315.0,660.5"/>
+            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_fork_95_INTERNAL_95_vl_95_l">
+                <polyline points="315.0,540.3333333333333,315.0,603.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(310.0,635.5)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
-                <text class="sld-label" x="15.0" y="5.0">-</text>
-            </g>
-            <g class="sld-arrow-p sld-in" id="idl_ARROW_ACTIVE" transform="translate(310.0,615.5)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
-                <text class="sld-label" x="15.0" y="5.0">-</text>
-            </g>
-            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb5" transform="translate(260.0,551.0)">
+            <g class="sld-load-break-switch sld-open sld-disconnected" id="idb5" transform="translate(260.0,519.6666666666666)">
                 <path class="sld-sw-closed" d="M0,0 V10 H10 V0z M5,2 V8 M0,10 10,0" transform="rotate(90.0,5.0,5.0)"/>
                 <path class="sld-sw-open" d="M0,0 V10 H10 V0z M2,5 H8 M0,10 10,0" transform="rotate(90.0,5.0,5.0)"/>
             </g>
@@ -391,7 +387,7 @@
                 <polyline points="215.0,509.0,215.0,551.0"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_5_95_INTERNAL_95_vl_95_Shunt_32_4_46_2">
-                <polyline points="215.0,509.0,240.0,509.0,240.0,556.0"/>
+                <polyline points="215.0,509.0,240.0,509.0,240.0,524.6666666666666"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_b3_95_b3">
                 <polyline points="215.0,415.0,215.0,457.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCaseShuntArrangementNo.json
+++ b/single-line-diagram-core/src/test/resources/TestCaseShuntArrangementNo.json
@@ -62,19 +62,19 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl_bA",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 25.0,
+    "y" : 250.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_commonFG",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 450.0,
     "y" : 174.8,
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dA",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 25.0,
-    "y" : 250.0,
     "open" : false
   }, {
     "type" : "FICTITIOUS",
@@ -858,7 +858,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "dA", "INTERNAL_vl_dA" ]
+        "nodes" : [ "bbs1", "dA", "INTERNAL_vl_bA" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -879,7 +879,7 @@
           "xSpan" : 50.0,
           "ySpan" : 125.33333333333333
         },
-        "nodes" : [ "INTERNAL_vl_dA", "bA", "INTERNAL_vl_fShuntA" ]
+        "nodes" : [ "INTERNAL_vl_bA", "bA", "INTERNAL_vl_fShuntA" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -2363,6 +2363,12 @@
     "node1" : "bFeederG",
     "node2" : "INTERNAL_vl_commonFG"
   }, {
+    "node1" : "dA",
+    "node2" : "INTERNAL_vl_bA"
+  }, {
+    "node1" : "INTERNAL_vl_bA",
+    "node2" : "bA"
+  }, {
     "node1" : "INTERNAL_vl_fShuntA",
     "node2" : "INTERNAL_vl_loadA"
   }, {
@@ -2422,12 +2428,6 @@
   }, {
     "node1" : "INTERNAL_vl_loadG",
     "node2" : "loadG"
-  }, {
-    "node1" : "bA",
-    "node2" : "INTERNAL_vl_dA"
-  }, {
-    "node1" : "dA",
-    "node2" : "INTERNAL_vl_dA"
   }, {
     "node1" : "INTERNAL_vl_fShuntA",
     "node2" : "INTERNAL_vl_Shunt 1.1"

--- a/single-line-diagram-core/src/test/resources/TestCaseShuntArrangementYes.json
+++ b/single-line-diagram-core/src/test/resources/TestCaseShuntArrangementYes.json
@@ -62,19 +62,19 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl_bA",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 75.0,
+    "y" : 250.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_commonFG",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 550.0,
     "y" : 174.8,
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dA",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 75.0,
-    "y" : 250.0,
     "open" : false
   }, {
     "type" : "FICTITIOUS",
@@ -858,7 +858,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "dA", "INTERNAL_vl_dA" ]
+        "nodes" : [ "bbs1", "dA", "INTERNAL_vl_bA" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -879,7 +879,7 @@
           "xSpan" : 50.0,
           "ySpan" : 125.33333333333333
         },
-        "nodes" : [ "INTERNAL_vl_dA", "bA", "INTERNAL_vl_fShuntA" ]
+        "nodes" : [ "INTERNAL_vl_bA", "bA", "INTERNAL_vl_fShuntA" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -2363,6 +2363,12 @@
     "node1" : "bFeederG",
     "node2" : "INTERNAL_vl_commonFG"
   }, {
+    "node1" : "dA",
+    "node2" : "INTERNAL_vl_bA"
+  }, {
+    "node1" : "INTERNAL_vl_bA",
+    "node2" : "bA"
+  }, {
     "node1" : "INTERNAL_vl_fShuntA",
     "node2" : "INTERNAL_vl_loadA"
   }, {
@@ -2422,12 +2428,6 @@
   }, {
     "node1" : "INTERNAL_vl_loadG",
     "node2" : "loadG"
-  }, {
-    "node1" : "bA",
-    "node2" : "INTERNAL_vl_dA"
-  }, {
-    "node1" : "dA",
-    "node2" : "INTERNAL_vl_dA"
   }, {
     "node1" : "INTERNAL_vl_fShuntA",
     "node2" : "INTERNAL_vl_Shunt 1.1"

--- a/single-line-diagram-core/src/test/resources/TestFeederOnBus.svg
+++ b/single-line-diagram-core/src/test/resources/TestFeederOnBus.svg
@@ -71,22 +71,22 @@
             <text class="sld-label" id="bbs_default" text-anchor="middle" x="0.0" y="-5.0">bbs</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_line_95_ONE_95_1" transform="translate(61.0,218.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_line_95_ONE" transform="translate(61.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_line_95_ONE_95_2" transform="translate(61.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_line_95_ONE" transform="translate(61.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder" id="idline_95_ONE" transform="translate(65.0,80.0)">
                 <text class="sld-label" id="line_ONE_default" text-anchor="middle" x="0.0" y="-5.0">line</text>
             </g>
-            <g class="sld-wire" id="_95_vl_95_BUSCO_95_line_95_ONE_95_INTERNAL_95_vl_95_line_95_ONE_95_1">
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_line_95_ONE_95_INTERNAL_95_vl_95_line_95_ONE">
                 <polyline points="65.0,252.0,65.0,222.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_line_95_ONE_95_1_95_INTERNAL_95_vl_95_line_95_ONE_95_2">
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_line_95_ONE_95_INTERNAL_95_vl_95_line_95_ONE">
                 <polyline points="65.0,222.0,65.0,142.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_line_95_ONE_95_2_95_line_95_ONE">
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_line_95_ONE_95_line_95_ONE">
                 <polyline points="65.0,142.0,65.0,80.0"/>
             </g>
             <g class="sld-arrow-p sld-out" id="idline_95_ONE_ARROW_ACTIVE" transform="translate(60.0,95.0)">

--- a/single-line-diagram-core/src/test/resources/TestFeederOnBusDisconnector.svg
+++ b/single-line-diagram-core/src/test/resources/TestFeederOnBusDisconnector.svg
@@ -71,22 +71,22 @@
             <text class="sld-label" id="bbs_default" text-anchor="middle" x="0.0" y="-5.0">bbs</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_line_95_ONE_95_1" transform="translate(61.0,106.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_line_95_ONE" transform="translate(61.0,106.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_line_95_ONE_95_2" transform="translate(61.0,186.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_line_95_ONE" transform="translate(61.0,186.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-bottom-feeder" id="idline_95_ONE" transform="translate(65.0,252.0)">
                 <text class="sld-label" id="line_ONE_default" text-anchor="middle" x="0.0" y="-5.0">line</text>
             </g>
-            <g class="sld-wire" id="_95_vl_95_busDisconnector_95_INTERNAL_95_vl_95_line_95_ONE_95_1">
+            <g class="sld-wire" id="_95_vl_95_busDisconnector_95_INTERNAL_95_vl_95_line_95_ONE">
                 <polyline points="65.0,80.0,65.0,110.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_line_95_ONE_95_1_95_INTERNAL_95_vl_95_line_95_ONE_95_2">
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_line_95_ONE_95_INTERNAL_95_vl_95_line_95_ONE">
                 <polyline points="65.0,110.0,65.0,190.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_line_95_ONE_95_2_95_line_95_ONE">
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_line_95_ONE_95_line_95_ONE">
                 <polyline points="65.0,190.0,65.0,252.0"/>
             </g>
             <g class="sld-arrow-p sld-out" id="idline_95_ONE_ARROW_ACTIVE" transform="translate(60.0,227.0)">

--- a/single-line-diagram-core/src/test/resources/TestIncompleteFeederIssue.json
+++ b/single-line-diagram-core/src/test/resources/TestIncompleteFeederIssue.json
@@ -16,7 +16,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d1",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -131,7 +131,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs", "d1", "INTERNAL_vl_d1" ]
+        "nodes" : [ "bbs", "d1", "INTERNAL_vl_b" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -152,7 +152,7 @@
           "xSpan" : 50.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl_d1", "b", "d2", "INTERNAL_vl_INTERNAL_vl_fict2" ]
+        "nodes" : [ "INTERNAL_vl_b", "b", "d2", "INTERNAL_vl_INTERNAL_vl_fict2" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -184,17 +184,17 @@
     "node1" : "b",
     "node2" : "d2"
   }, {
+    "node1" : "d1",
+    "node2" : "INTERNAL_vl_b"
+  }, {
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
+  }, {
     "node1" : "d2",
     "node2" : "INTERNAL_vl_INTERNAL_vl_fict2"
   }, {
     "node1" : "INTERNAL_vl_INTERNAL_vl_fict2",
     "node2" : "INTERNAL_vl_fict2"
-  }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d1"
-  }, {
-    "node1" : "d1",
-    "node2" : "INTERNAL_vl_d1"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestInternCellExplicitPosition.json
+++ b/single-line-diagram-core/src/test/resources/TestInternCellExplicitPosition.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dc11",
+    "id" : "INTERNAL_vl_bc1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dc12",
+    "id" : "INTERNAL_vl_bc1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -26,7 +26,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dc21",
+    "id" : "INTERNAL_vl_bc2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 275.0,
@@ -34,7 +34,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dc22",
+    "id" : "INTERNAL_vl_bc2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -42,7 +42,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dl1",
+    "id" : "INTERNAL_vl_bl1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
@@ -50,7 +50,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dl2",
+    "id" : "INTERNAL_vl_bl2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -300,7 +300,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "dc12", "INTERNAL_vl_dc12" ]
+        "nodes" : [ "bbs2", "dc12", "INTERNAL_vl_bc1" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -321,7 +321,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_dc12", "bc1", "INTERNAL_vl_dc11" ]
+        "nodes" : [ "INTERNAL_vl_bc1", "bc1", "INTERNAL_vl_bc1" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -342,7 +342,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "dc11", "INTERNAL_vl_dc11" ]
+        "nodes" : [ "bbs1", "dc11", "INTERNAL_vl_bc1" ]
       } ]
     }
   }, {
@@ -389,7 +389,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "dc22", "INTERNAL_vl_dc22" ]
+        "nodes" : [ "bbs2", "dc22", "INTERNAL_vl_bc2" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -410,7 +410,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_dc22", "bc2", "INTERNAL_vl_dc21" ]
+        "nodes" : [ "INTERNAL_vl_bc2", "bc2", "INTERNAL_vl_bc2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -431,7 +431,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "dc21", "INTERNAL_vl_dc21" ]
+        "nodes" : [ "bbs1", "dc21", "INTERNAL_vl_bc2" ]
       } ]
     }
   }, {
@@ -479,7 +479,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs1", "dl1", "INTERNAL_vl_dl1" ]
+        "nodes" : [ "bbs1", "dl1", "INTERNAL_vl_bl1" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -500,7 +500,7 @@
           "xSpan" : 50.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl_dl1", "bl1", "INTERNAL_vl_l1" ]
+        "nodes" : [ "INTERNAL_vl_bl1", "bl1", "INTERNAL_vl_l1" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -569,7 +569,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs2", "dl2", "INTERNAL_vl_dl2" ]
+        "nodes" : [ "bbs2", "dl2", "INTERNAL_vl_bl2" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -590,7 +590,7 @@
           "xSpan" : 50.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl_dl2", "bl2", "INTERNAL_vl_l2" ]
+        "nodes" : [ "INTERNAL_vl_bl2", "bl2", "INTERNAL_vl_l2" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -634,6 +634,42 @@
     "node1" : "bbs2",
     "node2" : "dc22"
   }, {
+    "node1" : "dl1",
+    "node2" : "INTERNAL_vl_bl1"
+  }, {
+    "node1" : "INTERNAL_vl_bl1",
+    "node2" : "bl1"
+  }, {
+    "node1" : "dc11",
+    "node2" : "INTERNAL_vl_bc1"
+  }, {
+    "node1" : "INTERNAL_vl_bc1",
+    "node2" : "bc1"
+  }, {
+    "node1" : "dc21",
+    "node2" : "INTERNAL_vl_bc2"
+  }, {
+    "node1" : "INTERNAL_vl_bc2",
+    "node2" : "bc2"
+  }, {
+    "node1" : "dl2",
+    "node2" : "INTERNAL_vl_bl2"
+  }, {
+    "node1" : "INTERNAL_vl_bl2",
+    "node2" : "bl2"
+  }, {
+    "node1" : "dc12",
+    "node2" : "INTERNAL_vl_bc1"
+  }, {
+    "node1" : "INTERNAL_vl_bc1",
+    "node2" : "bc1"
+  }, {
+    "node1" : "dc22",
+    "node2" : "INTERNAL_vl_bc2"
+  }, {
+    "node1" : "INTERNAL_vl_bc2",
+    "node2" : "bc2"
+  }, {
     "node1" : "bl1",
     "node2" : "INTERNAL_vl_l1"
   }, {
@@ -645,42 +681,6 @@
   }, {
     "node1" : "INTERNAL_vl_l2",
     "node2" : "l2"
-  }, {
-    "node1" : "bl1",
-    "node2" : "INTERNAL_vl_dl1"
-  }, {
-    "node1" : "dl1",
-    "node2" : "INTERNAL_vl_dl1"
-  }, {
-    "node1" : "bc1",
-    "node2" : "INTERNAL_vl_dc11"
-  }, {
-    "node1" : "dc11",
-    "node2" : "INTERNAL_vl_dc11"
-  }, {
-    "node1" : "bc2",
-    "node2" : "INTERNAL_vl_dc21"
-  }, {
-    "node1" : "dc21",
-    "node2" : "INTERNAL_vl_dc21"
-  }, {
-    "node1" : "bl2",
-    "node2" : "INTERNAL_vl_dl2"
-  }, {
-    "node1" : "dl2",
-    "node2" : "INTERNAL_vl_dl2"
-  }, {
-    "node1" : "bc1",
-    "node2" : "INTERNAL_vl_dc12"
-  }, {
-    "node1" : "dc12",
-    "node2" : "INTERNAL_vl_dc12"
-  }, {
-    "node1" : "bc2",
-    "node2" : "INTERNAL_vl_dc22"
-  }, {
-    "node1" : "dc22",
-    "node2" : "INTERNAL_vl_dc22"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestInternCellShapes.json
+++ b/single-line-diagram-core/src/test/resources/TestInternCellShapes.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_flatDisconector_0",
+    "id" : "BUSCO_flatDisconector",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 150.0,
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_flatDisconector_1",
+    "id" : "BUSCO_flatDisconector",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 200.0,
@@ -26,7 +26,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dCrossOverBk1",
+    "id" : "INTERNAL_vl_crossOverBreaker",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 125.0,
@@ -34,7 +34,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dCrossOverBk2",
+    "id" : "INTERNAL_vl_crossOverBreaker",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 225.0,
@@ -42,7 +42,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dF1",
+    "id" : "INTERNAL_vl_dF2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 275.0,
@@ -50,7 +50,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dFlatBk1",
+    "id" : "INTERNAL_vl_flatBreaker",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -59,7 +59,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dFlatBk2",
+    "id" : "INTERNAL_vl_flatBreaker",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -68,7 +68,25 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dVerticalBk1",
+    "id" : "INTERNAL_vl_flatDisconector",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 150.0,
+    "y" : 280.0,
+    "orientation" : "RIGHT",
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl_flatDisconector",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 200.0,
+    "y" : 280.0,
+    "orientation" : "RIGHT",
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl_verticalBreaker",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -76,29 +94,11 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dVerticalBk2",
+    "id" : "INTERNAL_vl_verticalBreaker",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
     "y" : 240.0,
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_flatDisconector_0",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 150.0,
-    "y" : 280.0,
-    "orientation" : "RIGHT",
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_flatDisconector_1",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 200.0,
-    "y" : 280.0,
-    "orientation" : "RIGHT",
     "open" : false
   }, {
     "type" : "BUS",
@@ -358,7 +358,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs21", "dVerticalBk2", "INTERNAL_vl_dVerticalBk2" ]
+        "nodes" : [ "bbs21", "dVerticalBk2", "INTERNAL_vl_verticalBreaker" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -379,7 +379,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_dVerticalBk2", "verticalBreaker", "INTERNAL_vl_dVerticalBk1" ]
+        "nodes" : [ "INTERNAL_vl_verticalBreaker", "verticalBreaker", "INTERNAL_vl_verticalBreaker" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -400,7 +400,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs11", "dVerticalBk1", "INTERNAL_vl_dVerticalBk1" ]
+        "nodes" : [ "bbs11", "dVerticalBk1", "INTERNAL_vl_verticalBreaker" ]
       } ]
     }
   }, {
@@ -446,7 +446,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs22", "dCrossOverBk2", "INTERNAL_vl_dCrossOverBk2" ]
+        "nodes" : [ "bbs22", "dCrossOverBk2", "INTERNAL_vl_crossOverBreaker" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -467,7 +467,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_dCrossOverBk1", "crossOverBreaker", "INTERNAL_vl_dCrossOverBk2" ]
+        "nodes" : [ "INTERNAL_vl_crossOverBreaker", "crossOverBreaker", "INTERNAL_vl_crossOverBreaker" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -488,7 +488,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs11", "dCrossOverBk1", "INTERNAL_vl_dCrossOverBk1" ]
+        "nodes" : [ "bbs11", "dCrossOverBk1", "INTERNAL_vl_crossOverBreaker" ]
       } ]
     }
   }, {
@@ -535,7 +535,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs12", "BUSCO_flatDisconector_1", "INTERNAL_vl_flatDisconector_1" ]
+        "nodes" : [ "bbs12", "BUSCO_flatDisconector", "INTERNAL_vl_flatDisconector" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -556,7 +556,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_flatDisconector_0", "flatDisconector", "INTERNAL_vl_flatDisconector_1" ]
+        "nodes" : [ "INTERNAL_vl_flatDisconector", "flatDisconector", "INTERNAL_vl_flatDisconector" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -577,7 +577,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs11", "BUSCO_flatDisconector_0", "INTERNAL_vl_flatDisconector_0" ]
+        "nodes" : [ "bbs11", "BUSCO_flatDisconector", "INTERNAL_vl_flatDisconector" ]
       } ]
     }
   }, {
@@ -624,7 +624,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs22", "dFlatBk2", "INTERNAL_vl_dFlatBk2" ]
+        "nodes" : [ "bbs22", "dFlatBk2", "INTERNAL_vl_flatBreaker" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -645,7 +645,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_dFlatBk1", "flatBreaker", "INTERNAL_vl_dFlatBk2" ]
+        "nodes" : [ "INTERNAL_vl_flatBreaker", "flatBreaker", "INTERNAL_vl_flatBreaker" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -666,7 +666,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs21", "dFlatBk1", "INTERNAL_vl_dFlatBk1" ]
+        "nodes" : [ "bbs21", "dFlatBk1", "INTERNAL_vl_flatBreaker" ]
       } ]
     }
   }, {
@@ -713,7 +713,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs12", "dF1", "INTERNAL_vl_dF1" ]
+        "nodes" : [ "bbs12", "dF1", "INTERNAL_vl_dF2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -734,7 +734,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs22", "dF2", "INTERNAL_vl_dF1" ]
+        "nodes" : [ "bbs22", "dF2", "INTERNAL_vl_dF2" ]
       } ]
     }
   } ],
@@ -764,64 +764,64 @@
     "node2" : "dF2"
   }, {
     "node1" : "bbs11",
-    "node2" : "BUSCO_flatDisconector_0"
-  }, {
-    "node1" : "BUSCO_flatDisconector_0",
-    "node2" : "INTERNAL_vl_flatDisconector_0"
-  }, {
-    "node1" : "INTERNAL_vl_flatDisconector_0",
-    "node2" : "flatDisconector"
+    "node2" : "BUSCO_flatDisconector"
   }, {
     "node1" : "bbs12",
-    "node2" : "BUSCO_flatDisconector_1"
-  }, {
-    "node1" : "BUSCO_flatDisconector_1",
-    "node2" : "INTERNAL_vl_flatDisconector_1"
-  }, {
-    "node1" : "INTERNAL_vl_flatDisconector_1",
-    "node2" : "flatDisconector"
-  }, {
-    "node1" : "verticalBreaker",
-    "node2" : "INTERNAL_vl_dVerticalBk1"
+    "node2" : "BUSCO_flatDisconector"
   }, {
     "node1" : "dVerticalBk1",
-    "node2" : "INTERNAL_vl_dVerticalBk1"
+    "node2" : "INTERNAL_vl_verticalBreaker"
   }, {
-    "node1" : "crossOverBreaker",
-    "node2" : "INTERNAL_vl_dCrossOverBk1"
+    "node1" : "INTERNAL_vl_verticalBreaker",
+    "node2" : "verticalBreaker"
   }, {
     "node1" : "dCrossOverBk1",
-    "node2" : "INTERNAL_vl_dCrossOverBk1"
+    "node2" : "INTERNAL_vl_crossOverBreaker"
   }, {
-    "node1" : "flatBreaker",
-    "node2" : "INTERNAL_vl_dFlatBk1"
+    "node1" : "INTERNAL_vl_crossOverBreaker",
+    "node2" : "crossOverBreaker"
+  }, {
+    "node1" : "BUSCO_flatDisconector",
+    "node2" : "INTERNAL_vl_flatDisconector"
+  }, {
+    "node1" : "INTERNAL_vl_flatDisconector",
+    "node2" : "flatDisconector"
   }, {
     "node1" : "dFlatBk1",
-    "node2" : "INTERNAL_vl_dFlatBk1"
+    "node2" : "INTERNAL_vl_flatBreaker"
   }, {
-    "node1" : "verticalBreaker",
-    "node2" : "INTERNAL_vl_dVerticalBk2"
+    "node1" : "INTERNAL_vl_flatBreaker",
+    "node2" : "flatBreaker"
   }, {
     "node1" : "dVerticalBk2",
-    "node2" : "INTERNAL_vl_dVerticalBk2"
+    "node2" : "INTERNAL_vl_verticalBreaker"
   }, {
-    "node1" : "dF2",
-    "node2" : "INTERNAL_vl_dF1"
+    "node1" : "INTERNAL_vl_verticalBreaker",
+    "node2" : "verticalBreaker"
   }, {
     "node1" : "dF1",
-    "node2" : "INTERNAL_vl_dF1"
+    "node2" : "INTERNAL_vl_dF2"
   }, {
-    "node1" : "flatBreaker",
-    "node2" : "INTERNAL_vl_dFlatBk2"
+    "node1" : "INTERNAL_vl_dF2",
+    "node2" : "dF2"
+  }, {
+    "node1" : "BUSCO_flatDisconector",
+    "node2" : "INTERNAL_vl_flatDisconector"
+  }, {
+    "node1" : "INTERNAL_vl_flatDisconector",
+    "node2" : "flatDisconector"
   }, {
     "node1" : "dFlatBk2",
-    "node2" : "INTERNAL_vl_dFlatBk2"
+    "node2" : "INTERNAL_vl_flatBreaker"
   }, {
-    "node1" : "crossOverBreaker",
-    "node2" : "INTERNAL_vl_dCrossOverBk2"
+    "node1" : "INTERNAL_vl_flatBreaker",
+    "node2" : "flatBreaker"
   }, {
     "node1" : "dCrossOverBk2",
-    "node2" : "INTERNAL_vl_dCrossOverBk2"
+    "node2" : "INTERNAL_vl_crossOverBreaker"
+  }, {
+    "node1" : "INTERNAL_vl_crossOverBreaker",
+    "node2" : "crossOverBreaker"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestSldClassSubstation.svg
+++ b/single-line-diagram-core/src/test/resources/TestSldClassSubstation.svg
@@ -145,7 +145,7 @@
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_d1" transform="translate(111.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_b1" transform="translate(111.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_l" transform="translate(111.0,138.0)">
@@ -157,11 +157,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="l_N_LABEL" x="-5.0" y="-5.0">l</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d1_95_INTERNAL_95_vl1_95_d1">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d1_95_INTERNAL_95_vl1_95_b1">
                 <polyline points="115.0,252.0,115.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_d1">
-                <polyline points="115.0,192.0,115.0,222.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_b1_95_b1">
+                <polyline points="115.0,222.0,115.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_l">
                 <polyline points="115.0,172.0,115.0,142.0"/>
@@ -189,7 +189,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_d2" transform="translate(61.0,278.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_b2" transform="translate(61.0,278.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf_95_ONE" transform="translate(61.0,358.0)">
@@ -198,11 +198,11 @@
             <g class="sld-bottom-feeder sld-vl300to500-0" id="idtrf_95_ONE" transform="translate(65.0,424.0)">
                 <text class="sld-label" id="trf_ONE_S_LABEL" x="-5.0" y="5.0">trf</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d2_95_INTERNAL_95_vl1_95_d2">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d2_95_INTERNAL_95_vl1_95_b2">
                 <polyline points="65.0,252.0,65.0,282.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_d2">
-                <polyline points="65.0,312.0,65.0,282.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_b2_95_b2">
+                <polyline points="65.0,282.0,65.0,312.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_trf_95_ONE">
                 <polyline points="65.0,332.0,65.0,362.0"/>
@@ -237,7 +237,7 @@
             <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_d3" transform="translate(201.0,278.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_b3" transform="translate(201.0,278.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_g" transform="translate(201.0,358.0)">
@@ -249,11 +249,11 @@
                 <path d="M6,6 A 6 40 0 0 0 10,6"/>
                 <text class="sld-label" id="g_S_LABEL" x="-5.0" y="17.0">g</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_d3_95_INTERNAL_95_vl2_95_d3">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_d3_95_INTERNAL_95_vl2_95_b3">
                 <polyline points="205.0,252.0,205.0,282.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_b3_95_INTERNAL_95_vl2_95_d3">
-                <polyline points="205.0,312.0,205.0,282.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_b3_95_b3">
+                <polyline points="205.0,282.0,205.0,312.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_b3_95_INTERNAL_95_vl2_95_g">
                 <polyline points="205.0,332.0,205.0,362.0"/>
@@ -281,7 +281,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_d4" transform="translate(251.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_b4" transform="translate(251.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300-0" id="idINTERNAL_95_vl2_95_trf_95_TWO" transform="translate(251.0,138.0)">
@@ -290,11 +290,11 @@
             <g class="sld-top-feeder sld-vl180to300-0" id="idtrf_95_TWO" transform="translate(255.0,80.0)">
                 <text class="sld-label" id="trf_TWO_N_LABEL" x="-5.0" y="-5.0">trf</text>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_d4_95_INTERNAL_95_vl2_95_d4">
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_d4_95_INTERNAL_95_vl2_95_b4">
                 <polyline points="255.0,252.0,255.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_b4_95_INTERNAL_95_vl2_95_d4">
-                <polyline points="255.0,192.0,255.0,222.0"/>
+            <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_b4_95_b4">
+                <polyline points="255.0,222.0,255.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_b4_95_INTERNAL_95_vl2_95_trf_95_TWO">
                 <polyline points="255.0,172.0,255.0,142.0"/>

--- a/single-line-diagram-core/src/test/resources/TestSldClassSubstationMetadata.json
+++ b/single-line-diagram-core/src/test/resources/TestSldClassSubstationMetadata.json
@@ -573,6 +573,7 @@
     "feederInfosIntraMargin" : 10.0,
     "busInfoMargin" : 0.0,
     "busbarsAlignment" : "FIRST",
-    "feederInfoPrecision" : 0
+    "feederInfoPrecision" : 0,
+    "componentsOnBusbars" : [ "DISCONNECTOR" ]
   }
 }

--- a/single-line-diagram-core/src/test/resources/TestSldClassSubstationMetadata.json
+++ b/single-line-diagram-core/src/test/resources/TestSldClassSubstationMetadata.json
@@ -177,14 +177,14 @@
       "positionName" : "S_LABEL"
     } ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_d1",
+    "id" : "idINTERNAL_95_vl1_95_b1",
     "vid" : "vl1",
     "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_d2",
+    "id" : "idINTERNAL_95_vl1_95_b2",
     "vid" : "vl1",
     "componentType" : "NODE",
     "open" : false,
@@ -341,14 +341,14 @@
       "positionName" : "N_LABEL"
     } ]
   }, {
-    "id" : "idINTERNAL_95_vl2_95_d4",
+    "id" : "idINTERNAL_95_vl2_95_b4",
     "vid" : "vl2",
     "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl2_95_d3",
+    "id" : "idINTERNAL_95_vl2_95_b3",
     "vid" : "vl2",
     "componentType" : "NODE",
     "open" : false,
@@ -381,6 +381,12 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl2_95_d3_95_INTERNAL_95_vl2_95_b3",
+    "nodeId1" : "idd3",
+    "nodeId2" : "idINTERNAL_95_vl2_95_b3",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl2_95_bbs2_95_d4",
     "nodeId1" : "idbbs2",
     "nodeId2" : "idd4",
@@ -393,39 +399,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_d4_95_INTERNAL_95_vl2_95_d4",
-    "nodeId1" : "idd4",
-    "nodeId2" : "idINTERNAL_95_vl2_95_d4",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl2_95_INTERNAL_95_vl2_95_g_95_g",
     "nodeId1" : "idINTERNAL_95_vl2_95_g",
     "nodeId2" : "idg",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_d1_95_INTERNAL_95_vl1_95_d1",
-    "nodeId1" : "idd1",
-    "nodeId2" : "idINTERNAL_95_vl1_95_d1",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl2_95_b4_95_INTERNAL_95_vl2_95_d4",
-    "nodeId1" : "idb4",
-    "nodeId2" : "idINTERNAL_95_vl2_95_d4",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl2_95_INTERNAL_95_vl2_95_trf_95_TWO_95_trf_95_TWO",
     "nodeId1" : "idINTERNAL_95_vl2_95_trf_95_TWO",
     "nodeId2" : "idtrf_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_b1_95_INTERNAL_95_vl1_95_d1",
-    "nodeId1" : "idb1",
-    "nodeId2" : "idINTERNAL_95_vl1_95_d1",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -441,18 +423,6 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_d2_95_INTERNAL_95_vl1_95_d2",
-    "nodeId1" : "idd2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_d2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_b2_95_INTERNAL_95_vl1_95_d2",
-    "nodeId1" : "idb2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_d2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_INTERNAL_95_vl1_95_l_95_l",
     "nodeId1" : "idINTERNAL_95_vl1_95_l",
     "nodeId2" : "idl",
@@ -465,9 +435,21 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl1_95_d2_95_INTERNAL_95_vl1_95_b2",
+    "nodeId1" : "idd2",
+    "nodeId2" : "idINTERNAL_95_vl1_95_b2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_b2_95_INTERNAL_95_vl1_95_trf_95_ONE",
     "nodeId1" : "idb2",
     "nodeId2" : "idINTERNAL_95_vl1_95_trf_95_ONE",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_INTERNAL_95_vl2_95_b4_95_b4",
+    "nodeId1" : "idINTERNAL_95_vl2_95_b4",
+    "nodeId2" : "idb4",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -483,15 +465,33 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_d3_95_INTERNAL_95_vl2_95_d3",
-    "nodeId1" : "idd3",
-    "nodeId2" : "idINTERNAL_95_vl2_95_d3",
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_b2_95_b2",
+    "nodeId1" : "idINTERNAL_95_vl1_95_b2",
+    "nodeId2" : "idb2",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_b3_95_INTERNAL_95_vl2_95_d3",
-    "nodeId1" : "idb3",
-    "nodeId2" : "idINTERNAL_95_vl2_95_d3",
+    "id" : "_95_vl1_95_d1_95_INTERNAL_95_vl1_95_b1",
+    "nodeId1" : "idd1",
+    "nodeId2" : "idINTERNAL_95_vl1_95_b1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_b1_95_b1",
+    "nodeId1" : "idINTERNAL_95_vl1_95_b1",
+    "nodeId2" : "idb1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_d4_95_INTERNAL_95_vl2_95_b4",
+    "nodeId1" : "idd4",
+    "nodeId2" : "idINTERNAL_95_vl2_95_b4",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_INTERNAL_95_vl2_95_b3_95_b3",
+    "nodeId1" : "idINTERNAL_95_vl2_95_b3",
+    "nodeId2" : "idb3",
     "straight" : false,
     "snakeLine" : false
   } ],

--- a/single-line-diagram-core/src/test/resources/TestSldClassVl.svg
+++ b/single-line-diagram-core/src/test/resources/TestSldClassVl.svg
@@ -142,7 +142,7 @@
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_d1" transform="translate(111.0,218.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_b1" transform="translate(111.0,218.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_l" transform="translate(111.0,138.0)">
@@ -154,11 +154,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="l_N_LABEL" x="-5.0" y="-5.0">l</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d1_95_INTERNAL_95_vl1_95_d1">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d1_95_INTERNAL_95_vl1_95_b1">
                 <polyline points="115.0,252.0,115.0,222.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_d1">
-                <polyline points="115.0,192.0,115.0,222.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_b1_95_b1">
+                <polyline points="115.0,222.0,115.0,192.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b1_95_INTERNAL_95_vl1_95_l">
                 <polyline points="115.0,172.0,115.0,142.0"/>
@@ -186,7 +186,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_d2" transform="translate(61.0,278.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_b2" transform="translate(61.0,278.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_trf_95_ONE" transform="translate(61.0,358.0)">
@@ -197,11 +197,11 @@
                 <circle class="sld-vl180to300-0 sld-winding" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
                 <text class="sld-label" id="trf_ONE_S_LABEL" x="-5.0" y="20.0">trf</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d2_95_INTERNAL_95_vl1_95_d2">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d2_95_INTERNAL_95_vl1_95_b2">
                 <polyline points="65.0,252.0,65.0,282.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_d2">
-                <polyline points="65.0,312.0,65.0,282.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_b2_95_b2">
+                <polyline points="65.0,282.0,65.0,312.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b2_95_INTERNAL_95_vl1_95_trf_95_ONE">
                 <polyline points="65.0,332.0,65.0,362.0"/>

--- a/single-line-diagram-core/src/test/resources/TestSldClassVlMetadata.json
+++ b/single-line-diagram-core/src/test/resources/TestSldClassVlMetadata.json
@@ -336,6 +336,7 @@
     "feederInfosIntraMargin" : 10.0,
     "busInfoMargin" : 0.0,
     "busbarsAlignment" : "FIRST",
-    "feederInfoPrecision" : 0
+    "feederInfoPrecision" : 0,
+    "componentsOnBusbars" : [ "DISCONNECTOR" ]
   }
 }

--- a/single-line-diagram-core/src/test/resources/TestSldClassVlMetadata.json
+++ b/single-line-diagram-core/src/test/resources/TestSldClassVlMetadata.json
@@ -115,13 +115,6 @@
     "styleClass" : "sld-breaker"
   } ],
   "nodes" : [ {
-    "id" : "idINTERNAL_95_vl1_95_d1",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "idl",
     "vid" : "vl1",
     "componentType" : "LOAD",
@@ -134,7 +127,7 @@
       "positionName" : "N_LABEL"
     } ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_d2",
+    "id" : "idINTERNAL_95_vl1_95_b1",
     "vid" : "vl1",
     "componentType" : "NODE",
     "open" : false,
@@ -142,6 +135,13 @@
     "labels" : [ ]
   }, {
     "id" : "idINTERNAL_95_vl1_95_l",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_b2",
     "vid" : "vl1",
     "componentType" : "NODE",
     "open" : false,
@@ -224,9 +224,9 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_d1_95_INTERNAL_95_vl1_95_d1",
-    "nodeId1" : "idd1",
-    "nodeId2" : "idINTERNAL_95_vl1_95_d1",
+    "id" : "_95_vl1_95_d2_95_INTERNAL_95_vl1_95_b2",
+    "nodeId1" : "idd2",
+    "nodeId2" : "idINTERNAL_95_vl1_95_b2",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -242,9 +242,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_b1_95_INTERNAL_95_vl1_95_d1",
-    "nodeId1" : "idb1",
-    "nodeId2" : "idINTERNAL_95_vl1_95_d1",
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_b2_95_b2",
+    "nodeId1" : "idINTERNAL_95_vl1_95_b2",
+    "nodeId2" : "idb2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_d1_95_INTERNAL_95_vl1_95_b1",
+    "nodeId1" : "idd1",
+    "nodeId2" : "idINTERNAL_95_vl1_95_b1",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -254,15 +260,9 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_d2_95_INTERNAL_95_vl1_95_d2",
-    "nodeId1" : "idd2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_d2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_b2_95_INTERNAL_95_vl1_95_d2",
-    "nodeId1" : "idb2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_d2",
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_b1_95_b1",
+    "nodeId1" : "idINTERNAL_95_vl1_95_b1",
+    "nodeId2" : "idb1",
     "straight" : false,
     "snakeLine" : false
   }, {

--- a/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork1.json
+++ b/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork1.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -123,7 +123,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs", "d", "INTERNAL_vl_d" ]
+        "nodes" : [ "bbs", "d", "INTERNAL_vl_b" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -144,7 +144,7 @@
           "xSpan" : 50.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl_d", "b", "INTERNAL_vl_l" ]
+        "nodes" : [ "INTERNAL_vl_b", "b", "INTERNAL_vl_l" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -173,17 +173,17 @@
     "node1" : "bbs",
     "node2" : "d"
   }, {
+    "node1" : "d",
+    "node2" : "INTERNAL_vl_b"
+  }, {
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
+  }, {
     "node1" : "b",
     "node2" : "INTERNAL_vl_l"
   }, {
     "node1" : "INTERNAL_vl_l",
     "node2" : "l"
-  }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d"
-  }, {
-    "node1" : "d",
-    "node2" : "INTERNAL_vl_d"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork2.json
+++ b/single-line-diagram-core/src/test/resources/TestUnicityNodeIdNetWork2.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -123,7 +123,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs", "d", "INTERNAL_vl_d" ]
+        "nodes" : [ "bbs", "d", "INTERNAL_vl_b" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -144,7 +144,7 @@
           "xSpan" : 50.0,
           "ySpan" : 188.0
         },
-        "nodes" : [ "INTERNAL_vl_d", "b", "INTERNAL_vl_l" ]
+        "nodes" : [ "INTERNAL_vl_b", "b", "INTERNAL_vl_l" ]
       }, {
         "type" : "FEEDERPRIMARY",
         "cardinalities" : [ {
@@ -173,17 +173,17 @@
     "node1" : "bbs",
     "node2" : "d"
   }, {
+    "node1" : "d",
+    "node2" : "INTERNAL_vl_b"
+  }, {
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
+  }, {
     "node1" : "b",
     "node2" : "INTERNAL_vl_l"
   }, {
     "node1" : "INTERNAL_vl_l",
     "node2" : "l"
-  }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d"
-  }, {
-    "node1" : "d",
-    "node2" : "INTERNAL_vl_d"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
+++ b/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
@@ -1108,10 +1108,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_10">
-            <g class="sld-node sld-fictitious sld-vl70to120-0" id="idINTERNAL_95_AU_95_FX_95_ONE_95_1" transform="translate(511.0,304.0)">
+            <g class="sld-node sld-fictitious sld-vl70to120-0" id="idINTERNAL_95_AU_95_FX_95_ONE" transform="translate(511.0,304.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl70to120-0" id="idINTERNAL_95_AU_95_FX_95_ONE_95_2" transform="translate(511.0,574.0)">
+            <g class="sld-node sld-fictitious sld-vl70to120-0" id="idINTERNAL_95_AU_95_FX_95_ONE" transform="translate(511.0,574.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-two-wt sld-bottom-feeder" id="idFX_95_ONE" transform="translate(510.0,632.5)">
@@ -1119,13 +1119,13 @@
                 <circle class="sld-disconnected sld-winding" cx="5" cy="5" r="5" transform="rotate(180.0,5.0,7.5)"/>
                 <text class="sld-label" id="FX_ONE_NW" text-anchor="middle" x="4.0" y="-1.0">FY</text>
             </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_BUSCO_95_FX_95_ONE_95_INTERNAL_95_AU_95_FX_95_ONE_95_1">
+            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_BUSCO_95_FX_95_ONE_95_INTERNAL_95_AU_95_FX_95_ONE">
                 <polyline points="515.0,278.0,515.0,308.0"/>
             </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_FX_95_ONE_95_1_95_INTERNAL_95_AU_95_FX_95_ONE_95_2">
+            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_FX_95_ONE_95_INTERNAL_95_AU_95_FX_95_ONE">
                 <polyline points="515.0,308.0,515.0,578.0"/>
             </g>
-            <g class="sld-wire sld-vl70to120-0 sld-feeder-connected-disconnected" id="_95_AU_95_INTERNAL_95_AU_95_FX_95_ONE_95_2_95_FX_95_ONE">
+            <g class="sld-wire sld-vl70to120-0 sld-feeder-connected-disconnected" id="_95_AU_95_INTERNAL_95_AU_95_FX_95_ONE_95_FX_95_ONE">
                 <polyline points="515.0,578.0,515.0,632.0"/>
             </g>
             <g class="sld-arrow-q sld-in" id="idFX_95_ONE_ARROW_REACTIVE" transform="translate(510.0,607.0)">
@@ -1226,10 +1226,10 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_13">
-            <g class="sld-node sld-fictitious sld-vl70to120-1" id="idINTERNAL_95_AU_95_FR_95_ONE_95_1" transform="translate(661.0,219.0)">
+            <g class="sld-node sld-fictitious sld-vl70to120-1" id="idINTERNAL_95_AU_95_FR_95_ONE" transform="translate(661.0,219.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious sld-vl70to120-1" id="idINTERNAL_95_AU_95_FR_95_ONE_95_2" transform="translate(661.0,138.0)">
+            <g class="sld-node sld-fictitious sld-vl70to120-1" id="idINTERNAL_95_AU_95_FR_95_ONE" transform="translate(661.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-two-wt sld-top-feeder" id="idFR_95_ONE" transform="translate(660.0,72.5)">
@@ -1237,13 +1237,13 @@
                 <circle class="sld-disconnected sld-winding" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="FR_ONE_NW" text-anchor="middle" x="4.0" y="-1.0">FS</text>
             </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_BUSCO_95_FR_95_ONE_95_INTERNAL_95_AU_95_FR_95_ONE_95_1">
+            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_BUSCO_95_FR_95_ONE_95_INTERNAL_95_AU_95_FR_95_ONE">
                 <polyline points="665.0,253.0,665.0,223.0"/>
             </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_FR_95_ONE_95_1_95_INTERNAL_95_AU_95_FR_95_ONE_95_2">
+            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_FR_95_ONE_95_INTERNAL_95_AU_95_FR_95_ONE">
                 <polyline points="665.0,223.0,665.0,142.0"/>
             </g>
-            <g class="sld-wire sld-vl70to120-1 sld-feeder-connected-disconnected" id="_95_AU_95_INTERNAL_95_AU_95_FR_95_ONE_95_2_95_FR_95_ONE">
+            <g class="sld-wire sld-vl70to120-1 sld-feeder-connected-disconnected" id="_95_AU_95_INTERNAL_95_AU_95_FR_95_ONE_95_FR_95_ONE">
                 <polyline points="665.0,142.0,665.0,88.0"/>
             </g>
             <g class="sld-arrow-p sld-in" id="idFR_95_ONE_ARROW_ACTIVE" transform="translate(660.0,103.0)">

--- a/single-line-diagram-core/src/test/resources/feederInfoTest.svg
+++ b/single-line-diagram-core/src/test/resources/feederInfoTest.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg height="720.0" viewBox="0 0 280.0 720.0" width="280.0" xmlns="http://www.w3.org/2000/svg">
+<svg height="720.0" viewBox="0 0 330.0 720.0" width="330.0" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 /* ----------------------------------------------------------------------- */
 /* File: tautologies.css ------------------------------------------------- */
@@ -65,14 +65,15 @@
             <line x1="140.0" x2="140.0" y1="80.0" y2="640.0"/>
             <line x1="190.0" x2="190.0" y1="80.0" y2="640.0"/>
             <line x1="240.0" x2="240.0" y1="80.0" y2="640.0"/>
-            <line x1="40.0" x2="240.0" y1="330.0" y2="330.0"/>
-            <line x1="40.0" x2="240.0" y1="320.0" y2="320.0"/>
-            <line x1="40.0" x2="240.0" y1="142.0" y2="142.0"/>
-            <line x1="40.0" x2="240.0" y1="390.0" y2="390.0"/>
-            <line x1="40.0" x2="240.0" y1="400.0" y2="400.0"/>
-            <line x1="40.0" x2="240.0" y1="578.0" y2="578.0"/>
+            <line x1="290.0" x2="290.0" y1="80.0" y2="640.0"/>
+            <line x1="40.0" x2="290.0" y1="330.0" y2="330.0"/>
+            <line x1="40.0" x2="290.0" y1="320.0" y2="320.0"/>
+            <line x1="40.0" x2="290.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="290.0" y1="390.0" y2="390.0"/>
+            <line x1="40.0" x2="290.0" y1="400.0" y2="400.0"/>
+            <line x1="40.0" x2="290.0" y1="578.0" y2="578.0"/>
         </g>
-        <g class="sld-busbar-section" id="idbbs" transform="translate(152.5,360.0)">
+        <g class="sld-busbar-section" id="idbbs" transform="translate(202.5,360.0)">
             <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs_NW_LABEL" x="-5.0" y="-5.0">bbs</text>
         </g>
@@ -80,73 +81,103 @@
             <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
         </g>
-        <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(186.0,326.0)">
+        <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_0">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_bt" transform="translate(186.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_svc" transform="translate(161.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_bt" transform="translate(136.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-svc sld-top-feeder" id="idsvc" transform="translate(159.0,74.0)">
+            <g class="sld-wire" id="_95_vl_95_bbs_95_BUSCO_95_bt">
+                <polyline points="202.5,360.0,190.0,360.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_bt_95_bt">
+                <polyline points="190.0,360.0,175.0,360.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_bt_95_bt">
+                <polyline points="140.0,360.0,155.0,360.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_bbs2_95_BUSCO_95_bt">
+                <polyline points="127.5,360.0,140.0,360.0"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_bt" transform="translate(186.0,356.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idbt" transform="translate(155.0,350.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_bt" transform="translate(136.0,356.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+        </g>
+        <g class="sld-extern-cell" id="idEXTERN_32_1">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(236.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_svc" transform="translate(211.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-svc sld-top-feeder" id="idsvc" transform="translate(209.0,74.0)">
                 <path d="M 6,0 V 4.5 M 0,4.5 H 12 M 0,7.5 H 12 M 6,7.5 V 12"/>
                 <path d="M 0.2556,10.611 11.671,1.448 M 9.329,2.045 11.671,1.448 10.581,3.6046" style="fill:none;stroke:#0000ff;stroke-width:0.5;stroke-linejoin:miter"/>
                 <text class="sld-label" id="svc_N_LABEL" x="-5.0" y="-5.0">svc</text>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(211.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(261.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-vsc sld-top-feeder" id="idvsc" transform="translate(207.0,76.0)">
+            <g class="sld-vsc sld-top-feeder" id="idvsc" transform="translate(257.0,76.0)">
                 <text x="-5.3" y="6.6">AC / DC</text>
                 <text class="sld-label" id="vsc_N_LABEL" x="-5.0" y="-5.0">Converter1</text>
             </g>
             <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_vsc">
-                <polyline points="190.0,360.0,190.0,330.0"/>
+                <polyline points="240.0,360.0,240.0,330.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_vsc">
-                <polyline points="165.0,246.0,165.0,330.0,190.0,330.0"/>
+                <polyline points="215.0,246.0,215.0,330.0,240.0,330.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_INTERNAL_95_vl_95_vsc">
-                <polyline points="190.0,330.0,215.0,330.0,215.0,142.0"/>
+                <polyline points="240.0,330.0,265.0,330.0,265.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_svc">
-                <polyline points="165.0,226.0,165.0,142.0"/>
+                <polyline points="215.0,226.0,215.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_svc_95_svc">
-                <polyline points="165.0,142.0,165.0,86.0"/>
+                <polyline points="215.0,142.0,215.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(160.0,101.0)">
+            <g class="sld-arrow-p sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(160.0,121.0)">
+            <g class="sld-arrow-q sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
             </g>
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_vsc">
-                <polyline points="215.0,142.0,215.0,86.0"/>
+                <polyline points="265.0,142.0,265.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
+            <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(260.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
+            <g class="sld-arrow-q sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(260.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd" transform="translate(186.0,356.0)">
+            <g class="sld-disconnector sld-closed" id="idd" transform="translate(236.0,356.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idb" transform="translate(155.0,226.0)">
+            <g class="sld-breaker sld-closed" id="idb" transform="translate(205.0,226.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>
-        <g class="sld-extern-cell" id="idEXTERN_32_1">
+        <g class="sld-extern-cell" id="idEXTERN_32_2">
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b2" transform="translate(61.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
@@ -190,7 +221,7 @@
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>
-        <g class="sld-extern-cell" id="idEXTERN_32_2">
+        <g class="sld-extern-cell" id="idEXTERN_32_3">
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b3" transform="translate(111.0,386.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>

--- a/single-line-diagram-core/src/test/resources/feederInfoTest.svg
+++ b/single-line-diagram-core/src/test/resources/feederInfoTest.svg
@@ -81,7 +81,7 @@
             <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc_95_1" transform="translate(186.0,326.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(186.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_svc" transform="translate(161.0,138.0)">
@@ -92,20 +92,20 @@
                 <path d="M 0.2556,10.611 11.671,1.448 M 9.329,2.045 11.671,1.448 10.581,3.6046" style="fill:none;stroke:#0000ff;stroke-width:0.5;stroke-linejoin:miter"/>
                 <text class="sld-label" id="svc_N_LABEL" x="-5.0" y="-5.0">svc</text>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc_95_2" transform="translate(211.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(211.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-vsc sld-top-feeder" id="idvsc" transform="translate(207.0,76.0)">
                 <text x="-5.3" y="6.6">AC / DC</text>
                 <text class="sld-label" id="vsc_N_LABEL" x="-5.0" y="-5.0">Converter1</text>
             </g>
-            <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_vsc_95_1">
+            <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_vsc">
                 <polyline points="190.0,360.0,190.0,330.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_vsc_95_1">
+            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_vsc">
                 <polyline points="165.0,246.0,165.0,330.0,190.0,330.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_1_95_INTERNAL_95_vl_95_vsc_95_2">
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_INTERNAL_95_vl_95_vsc">
                 <polyline points="190.0,330.0,215.0,330.0,215.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_svc">
@@ -124,7 +124,7 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_2_95_vsc">
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_vsc">
                 <polyline points="215.0,142.0,215.0,86.0"/>
             </g>
             <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(210.0,101.0)">

--- a/single-line-diagram-core/src/test/resources/noComponentsOnBus.svg
+++ b/single-line-diagram-core/src/test/resources/noComponentsOnBus.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg height="720.0" viewBox="0 0 280.0 720.0" width="280.0" xmlns="http://www.w3.org/2000/svg">
+<svg height="720.0" viewBox="0 0 330.0 720.0" width="330.0" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 /* ----------------------------------------------------------------------- */
 /* File: tautologies.css ------------------------------------------------- */
@@ -65,14 +65,15 @@
             <line x1="140.0" x2="140.0" y1="80.0" y2="640.0"/>
             <line x1="190.0" x2="190.0" y1="80.0" y2="640.0"/>
             <line x1="240.0" x2="240.0" y1="80.0" y2="640.0"/>
-            <line x1="40.0" x2="240.0" y1="330.0" y2="330.0"/>
-            <line x1="40.0" x2="240.0" y1="320.0" y2="320.0"/>
-            <line x1="40.0" x2="240.0" y1="142.0" y2="142.0"/>
-            <line x1="40.0" x2="240.0" y1="390.0" y2="390.0"/>
-            <line x1="40.0" x2="240.0" y1="400.0" y2="400.0"/>
-            <line x1="40.0" x2="240.0" y1="578.0" y2="578.0"/>
+            <line x1="290.0" x2="290.0" y1="80.0" y2="640.0"/>
+            <line x1="40.0" x2="290.0" y1="330.0" y2="330.0"/>
+            <line x1="40.0" x2="290.0" y1="320.0" y2="320.0"/>
+            <line x1="40.0" x2="290.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="290.0" y1="390.0" y2="390.0"/>
+            <line x1="40.0" x2="290.0" y1="400.0" y2="400.0"/>
+            <line x1="40.0" x2="290.0" y1="578.0" y2="578.0"/>
         </g>
-        <g class="sld-busbar-section" id="idbbs" transform="translate(152.5,360.0)">
+        <g class="sld-busbar-section" id="idbbs" transform="translate(202.5,360.0)">
             <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs_NW_LABEL" x="-5.0" y="-5.0">bbs</text>
         </g>
@@ -80,73 +81,115 @@
             <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
         </g>
-        <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(186.0,326.0)">
+        <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_0">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_bt" transform="translate(186.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_svc" transform="translate(161.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_bt" transform="translate(136.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-svc sld-top-feeder" id="idsvc" transform="translate(159.0,74.0)">
+            <g class="sld-wire" id="_95_vl_95_bbs_95_BUSCO_95_bt">
+                <polyline points="202.5,360.0,190.0,360.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_bt_95_bt">
+                <polyline points="190.0,360.0,175.0,360.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_bt_95_bt">
+                <polyline points="140.0,360.0,155.0,360.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_bbs2_95_BUSCO_95_bt">
+                <polyline points="127.5,360.0,140.0,360.0"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_bt" transform="translate(186.0,356.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idbt" transform="translate(155.0,350.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_bt" transform="translate(136.0,356.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+        </g>
+        <g class="sld-extern-cell" id="idEXTERN_32_1">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_d" transform="translate(236.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc_95_fork" transform="translate(236.0,232.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_svc" transform="translate(211.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-svc sld-top-feeder" id="idsvc" transform="translate(209.0,74.0)">
                 <path d="M 6,0 V 4.5 M 0,4.5 H 12 M 0,7.5 H 12 M 6,7.5 V 12"/>
                 <path d="M 0.2556,10.611 11.671,1.448 M 9.329,2.045 11.671,1.448 10.581,3.6046" style="fill:none;stroke:#0000ff;stroke-width:0.5;stroke-linejoin:miter"/>
                 <text class="sld-label" id="svc_N_LABEL" x="-5.0" y="-5.0">svc</text>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(211.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(261.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-vsc sld-top-feeder" id="idvsc" transform="translate(207.0,76.0)">
+            <g class="sld-vsc sld-top-feeder" id="idvsc" transform="translate(257.0,76.0)">
                 <text x="-5.3" y="6.6">AC / DC</text>
                 <text class="sld-label" id="vsc_N_LABEL" x="-5.0" y="-5.0">Converter1</text>
             </g>
-            <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_vsc">
-                <polyline points="190.0,360.0,190.0,330.0"/>
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_d_95_INTERNAL_95_vl_95_d">
+                <polyline points="240.0,360.0,240.0,330.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_vsc">
-                <polyline points="165.0,246.0,165.0,330.0,190.0,330.0"/>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_d_95_d">
+                <polyline points="240.0,330.0,240.0,283.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_INTERNAL_95_vl_95_vsc">
-                <polyline points="190.0,330.0,215.0,330.0,215.0,142.0"/>
+            <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_vsc_95_fork">
+                <polyline points="240.0,283.0,240.0,236.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_vsc_95_fork">
+                <polyline points="215.0,199.0,215.0,236.0,240.0,236.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_fork_95_INTERNAL_95_vl_95_vsc">
+                <polyline points="240.0,236.0,265.0,236.0,265.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_svc">
-                <polyline points="165.0,226.0,165.0,142.0"/>
+                <polyline points="215.0,179.0,215.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_svc_95_svc">
-                <polyline points="165.0,142.0,165.0,86.0"/>
+                <polyline points="215.0,142.0,215.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(160.0,101.0)">
+            <g class="sld-arrow-p sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(160.0,121.0)">
+            <g class="sld-arrow-q sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
             </g>
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_vsc">
-                <polyline points="215.0,142.0,215.0,86.0"/>
+                <polyline points="265.0,142.0,265.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
+            <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(260.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
+            <g class="sld-arrow-q sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(260.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd" transform="translate(186.0,356.0)">
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_d" transform="translate(236.0,356.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-disconnector sld-closed" id="idd" transform="translate(236.0,279.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idb" transform="translate(155.0,226.0)">
+            <g class="sld-breaker sld-closed" id="idb" transform="translate(205.0,179.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>
-        <g class="sld-extern-cell" id="idEXTERN_32_1">
+        <g class="sld-extern-cell" id="idEXTERN_32_2">
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b2" transform="translate(61.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
@@ -190,7 +233,7 @@
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>
-        <g class="sld-extern-cell" id="idEXTERN_32_2">
+        <g class="sld-extern-cell" id="idEXTERN_32_3">
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b3" transform="translate(111.0,386.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
@@ -212,15 +255,15 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_dl1_95_dl1">
                 <polyline points="115.0,578.0,115.0,640.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,615.0)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
-                <text class="sld-label" x="15.0" y="5.0">100</text>
-            </g>
-            <g class="sld-arrow-q sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,595.0)">
+            <g class="sld-arrow-q sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,615.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
+            </g>
+            <g class="sld-arrow-p sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,595.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
             <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_b3" transform="translate(111.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>

--- a/single-line-diagram-core/src/test/resources/noComponentsOnBus.svg
+++ b/single-line-diagram-core/src/test/resources/noComponentsOnBus.svg
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg height="720.0" viewBox="0 0 280.0 720.0" width="280.0" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+/* ----------------------------------------------------------------------- */
+/* File: tautologies.css ------------------------------------------------- */
+.sld-out .sld-arrow-in {visibility: hidden}
+.sld-in .sld-arrow-out {visibility: hidden}
+.sld-closed .sld-sw-open {visibility: hidden}
+.sld-open .sld-sw-closed {visibility: hidden}
+.sld-hidden-node {visibility: hidden}
+.sld-top-feeder .sld-label {dominant-baseline: auto}
+.sld-bottom-feeder .sld-label {dominant-baseline: hanging}
+.sld-arrow-p .sld-label {dominant-baseline: middle}
+.sld-arrow-q .sld-label {dominant-baseline: middle}
+/* ----------------------------------------------------------------------- */
+/* File : components.css ------------------------------------------------- */
+/* Stroke black */
+.sld-disconnector {stroke-width: 3; stroke: black; fill: none}
+/* Stroke blue */
+.sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: white}
+/* Stroke --sld-vl-color with fallback black */
+.sld-bus-connection {fill: var(--sld-vl-color, black)}
+.sld-cell-shape-flat .sld-bus-connection {visibility: hidden}
+.sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
+/* Stroke --sld-vl-color with fallback red */
+.sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
+/* Stroke --sld-vl-color with fallback blue */
+.sld-load {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-three-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-winding {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-capacitor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-inductor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst-arrow {stroke: black; fill: none}
+.sld-svc {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-vsc {stroke: var(--sld-vl-color, blue); font-size: 7.43px; fill: none}
+/* Stroke none & fill: --sld-vl-color */
+.sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
+/* Stroke none & fill: black */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
+.sld-node {stroke: none; fill: black}
+.sld-flash {stroke: none; fill: black}
+.sld-lock {stroke: none; fill: black}
+/* Specific */
+.sld-grid {stroke: #003700; stroke-dasharray: 1,10}
+.sld-arrow-p {fill:black}
+.sld-arrow-q {fill:blue}
+.sld-frame {fill: var(--sld-background-color, transparent)}
+/* Stroke maroon for fictitious switch */
+.sld-breaker.sld-fictitious {stroke: maroon}
+.sld-disconnector.sld-fictitious {stroke: maroon}
+.sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
+
+]]></style>
+    <rect class="sld-frame" height="100%" width="100%"/>
+    <g>
+        <g class="sld-grid" id="GRID_vl">
+            <line x1="40.0" x2="40.0" y1="80.0" y2="640.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="640.0"/>
+            <line x1="140.0" x2="140.0" y1="80.0" y2="640.0"/>
+            <line x1="190.0" x2="190.0" y1="80.0" y2="640.0"/>
+            <line x1="240.0" x2="240.0" y1="80.0" y2="640.0"/>
+            <line x1="40.0" x2="240.0" y1="330.0" y2="330.0"/>
+            <line x1="40.0" x2="240.0" y1="320.0" y2="320.0"/>
+            <line x1="40.0" x2="240.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="240.0" y1="390.0" y2="390.0"/>
+            <line x1="40.0" x2="240.0" y1="400.0" y2="400.0"/>
+            <line x1="40.0" x2="240.0" y1="578.0" y2="578.0"/>
+        </g>
+        <g class="sld-busbar-section" id="idbbs" transform="translate(152.5,360.0)">
+            <line x1="0" x2="75.0" y1="0" y2="0"/>
+            <text class="sld-label" id="bbs_NW_LABEL" x="-5.0" y="-5.0">bbs</text>
+        </g>
+        <g class="sld-busbar-section" id="idbbs2" transform="translate(52.5,360.0)">
+            <line x1="0" x2="75.0" y1="0" y2="0"/>
+            <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
+        </g>
+        <g class="sld-extern-cell" id="idEXTERN_32_0">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(186.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_svc" transform="translate(161.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-svc sld-top-feeder" id="idsvc" transform="translate(159.0,74.0)">
+                <path d="M 6,0 V 4.5 M 0,4.5 H 12 M 0,7.5 H 12 M 6,7.5 V 12"/>
+                <path d="M 0.2556,10.611 11.671,1.448 M 9.329,2.045 11.671,1.448 10.581,3.6046" style="fill:none;stroke:#0000ff;stroke-width:0.5;stroke-linejoin:miter"/>
+                <text class="sld-label" id="svc_N_LABEL" x="-5.0" y="-5.0">svc</text>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(211.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-vsc sld-top-feeder" id="idvsc" transform="translate(207.0,76.0)">
+                <text x="-5.3" y="6.6">AC / DC</text>
+                <text class="sld-label" id="vsc_N_LABEL" x="-5.0" y="-5.0">Converter1</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_vsc">
+                <polyline points="190.0,360.0,190.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_vsc">
+                <polyline points="165.0,246.0,165.0,330.0,190.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_INTERNAL_95_vl_95_vsc">
+                <polyline points="190.0,330.0,215.0,330.0,215.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_svc">
+                <polyline points="165.0,226.0,165.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_svc_95_svc">
+                <polyline points="165.0,142.0,165.0,86.0"/>
+            </g>
+            <g class="sld-arrow-p sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(160.0,101.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">100</text>
+            </g>
+            <g class="sld-arrow-q sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(160.0,121.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">50</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_vsc">
+                <polyline points="215.0,142.0,215.0,86.0"/>
+            </g>
+            <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">100</text>
+            </g>
+            <g class="sld-arrow-q sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">50</text>
+            </g>
+            <g class="sld-disconnector sld-closed" id="idd" transform="translate(186.0,356.0)">
+                <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
+                <path class="sld-sw-open" d="M8,0 0,8"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idb" transform="translate(155.0,226.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+        </g>
+        <g class="sld-extern-cell" id="idEXTERN_32_1">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b2" transform="translate(61.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_C1" transform="translate(61.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-capacitor sld-top-feeder" id="idC1" transform="translate(59.0,74.0)">
+                <line x1="6" x2="6" y1="0" y2="4.5"/>
+                <line x1="0" x2="12" y1="4.5" y2="4.5"/>
+                <line x1="0" x2="12" y1="7.5" y2="7.5"/>
+                <line x1="6" x2="6" y1="7.5" y2="12"/>
+                <text class="sld-label" id="C1_N_LABEL" x="-5.0" y="-5.0">Filter 1</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_b2_95_INTERNAL_95_vl_95_b2">
+                <polyline points="65.0,360.0,65.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_b2_95_b2">
+                <polyline points="65.0,330.0,65.0,246.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b2_95_INTERNAL_95_vl_95_C1">
+                <polyline points="65.0,226.0,65.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_C1_95_C1">
+                <polyline points="65.0,142.0,65.0,86.0"/>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idC1_ARROW_ACTIVE" transform="translate(60.0,101.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idC1_ARROW_REACTIVE" transform="translate(60.0,121.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_b2" transform="translate(61.0,356.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idb2" transform="translate(55.0,226.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+        </g>
+        <g class="sld-extern-cell" id="idEXTERN_32_2">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b3" transform="translate(111.0,386.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_dl1" transform="translate(111.0,574.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-bottom-feeder" id="iddl1" transform="translate(115.0,640.0)">
+                <text class="sld-label" id="dl1_S_LABEL" x="-5.0" y="5.0">Dangling line 1</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_b3_95_INTERNAL_95_vl_95_b3">
+                <polyline points="115.0,360.0,115.0,390.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_b3_95_b3">
+                <polyline points="115.0,390.0,115.0,474.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b3_95_INTERNAL_95_vl_95_dl1">
+                <polyline points="115.0,494.0,115.0,578.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_dl1_95_dl1">
+                <polyline points="115.0,578.0,115.0,640.0"/>
+            </g>
+            <g class="sld-arrow-p sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,615.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">100</text>
+            </g>
+            <g class="sld-arrow-q sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,595.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">50</text>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_b3" transform="translate(111.0,356.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idb3" transform="translate(105.0,474.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_substation.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_substation.svg
@@ -114,7 +114,7 @@
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_d" transform="translate(76.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_b" transform="translate(76.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_l" transform="translate(76.0,168.0)">
@@ -126,11 +126,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="l_N_LABEL" x="-5.0" y="-5.0">l</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_d_95_INTERNAL_95_vl1_95_d">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_d_95_INTERNAL_95_vl1_95_b">
                 <polyline points="80.0,390.0,80.0,360.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_b_95_INTERNAL_95_vl1_95_d">
-                <polyline points="80.0,276.0,80.0,360.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_b_95_b">
+                <polyline points="80.0,360.0,80.0,276.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_b_95_INTERNAL_95_vl1_95_l">
                 <polyline points="80.0,256.0,80.0,172.0"/>
@@ -148,7 +148,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_d2WT_95_1" transform="translate(156.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_b2WT_95_1" transform="translate(156.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_2WT_95_ONE" transform="translate(156.0,168.0)">
@@ -157,11 +157,11 @@
             <g class="sld-top-feeder sld-vl300to500" id="id2WT_95_ONE" transform="translate(160.0,110.0)">
                 <text class="sld-label" id="2WT_ONE_N_LABEL" x="-5.0" y="-5.0">2WT_1</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_d2WT_95_1_95_INTERNAL_95_vl1_95_d2WT_95_1">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_d2WT_95_1_95_INTERNAL_95_vl1_95_b2WT_95_1">
                 <polyline points="160.0,390.0,160.0,360.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_b2WT_95_1_95_INTERNAL_95_vl1_95_d2WT_95_1">
-                <polyline points="160.0,276.0,160.0,360.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_b2WT_95_1_95_b2WT_95_1">
+                <polyline points="160.0,360.0,160.0,276.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_b2WT_95_1_95_INTERNAL_95_vl1_95_2WT_95_ONE">
                 <polyline points="160.0,256.0,160.0,172.0"/>
@@ -179,7 +179,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_d3WT_95_1" transform="translate(236.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_b3WT_95_1" transform="translate(236.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_vl1_95_3WT_95_ONE" transform="translate(236.0,168.0)">
@@ -188,11 +188,11 @@
             <g class="sld-top-feeder sld-vl300to500" id="id3WT_95_ONE" transform="translate(240.0,110.0)">
                 <text class="sld-label" id="3WT_ONE_N_LABEL" x="-5.0" y="-5.0">3WT_1</text>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_d3WT_95_1_95_INTERNAL_95_vl1_95_d3WT_95_1">
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_d3WT_95_1_95_INTERNAL_95_vl1_95_b3WT_95_1">
                 <polyline points="240.0,390.0,240.0,360.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_b3WT_95_1_95_INTERNAL_95_vl1_95_d3WT_95_1">
-                <polyline points="240.0,276.0,240.0,360.0"/>
+            <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_b3WT_95_1_95_b3WT_95_1">
+                <polyline points="240.0,360.0,240.0,276.0"/>
             </g>
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_b3WT_95_1_95_INTERNAL_95_vl1_95_3WT_95_ONE">
                 <polyline points="240.0,256.0,240.0,172.0"/>
@@ -217,7 +217,7 @@
             <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300" id="idINTERNAL_95_vl2_95_d2WT_95_2" transform="translate(356.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300" id="idINTERNAL_95_vl2_95_b2WT_95_2" transform="translate(356.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300" id="idINTERNAL_95_vl2_95_2WT_95_TWO" transform="translate(356.0,168.0)">
@@ -226,11 +226,11 @@
             <g class="sld-top-feeder sld-vl180to300" id="id2WT_95_TWO" transform="translate(360.0,110.0)">
                 <text class="sld-label" id="2WT_TWO_N_LABEL" x="-5.0" y="-5.0">2WT_2</text>
             </g>
-            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_d2WT_95_2_95_INTERNAL_95_vl2_95_d2WT_95_2">
+            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_d2WT_95_2_95_INTERNAL_95_vl2_95_b2WT_95_2">
                 <polyline points="360.0,390.0,360.0,360.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_b2WT_95_2_95_INTERNAL_95_vl2_95_d2WT_95_2">
-                <polyline points="360.0,276.0,360.0,360.0"/>
+            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_INTERNAL_95_vl2_95_b2WT_95_2_95_b2WT_95_2">
+                <polyline points="360.0,360.0,360.0,276.0"/>
             </g>
             <g class="sld-wire sld-vl180to300" id="_95_vl2_95_b2WT_95_2_95_INTERNAL_95_vl2_95_2WT_95_TWO">
                 <polyline points="360.0,256.0,360.0,172.0"/>
@@ -248,7 +248,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300" id="idINTERNAL_95_vl2_95_d3WT_95_2" transform="translate(436.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300" id="idINTERNAL_95_vl2_95_b3WT_95_2" transform="translate(436.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300" id="idINTERNAL_95_vl2_95_3WT_95_TWO" transform="translate(436.0,168.0)">
@@ -257,11 +257,11 @@
             <g class="sld-top-feeder sld-vl180to300" id="id3WT_95_TWO" transform="translate(440.0,110.0)">
                 <text class="sld-label" id="3WT_TWO_N_LABEL" x="-5.0" y="-5.0">3WT_2</text>
             </g>
-            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_d3WT_95_2_95_INTERNAL_95_vl2_95_d3WT_95_2">
+            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_d3WT_95_2_95_INTERNAL_95_vl2_95_b3WT_95_2">
                 <polyline points="440.0,390.0,440.0,360.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_b3WT_95_2_95_INTERNAL_95_vl2_95_d3WT_95_2">
-                <polyline points="440.0,276.0,440.0,360.0"/>
+            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_INTERNAL_95_vl2_95_b3WT_95_2_95_b3WT_95_2">
+                <polyline points="440.0,360.0,440.0,276.0"/>
             </g>
             <g class="sld-wire sld-vl180to300" id="_95_vl2_95_b3WT_95_2_95_INTERNAL_95_vl2_95_3WT_95_TWO">
                 <polyline points="440.0,256.0,440.0,172.0"/>
@@ -286,7 +286,7 @@
             <text class="sld-label" id="bbs3_NW_LABEL" x="-5.0" y="-5.0">bbs3</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl50to70" id="idINTERNAL_95_vl3_95_d3WT_95_3" transform="translate(556.0,356.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl50to70" id="idINTERNAL_95_vl3_95_b3WT_95_3" transform="translate(556.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl50to70" id="idINTERNAL_95_vl3_95_3WT_95_THREE" transform="translate(556.0,168.0)">
@@ -295,11 +295,11 @@
             <g class="sld-top-feeder sld-vl50to70" id="id3WT_95_THREE" transform="translate(560.0,110.0)">
                 <text class="sld-label" id="3WT_THREE_N_LABEL" x="-5.0" y="-5.0">3WT_3</text>
             </g>
-            <g class="sld-wire sld-vl50to70" id="_95_vl3_95_d3WT_95_3_95_INTERNAL_95_vl3_95_d3WT_95_3">
+            <g class="sld-wire sld-vl50to70" id="_95_vl3_95_d3WT_95_3_95_INTERNAL_95_vl3_95_b3WT_95_3">
                 <polyline points="560.0,390.0,560.0,360.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70" id="_95_vl3_95_b3WT_95_3_95_INTERNAL_95_vl3_95_d3WT_95_3">
-                <polyline points="560.0,276.0,560.0,360.0"/>
+            <g class="sld-wire sld-vl50to70" id="_95_vl3_95_INTERNAL_95_vl3_95_b3WT_95_3_95_b3WT_95_3">
+                <polyline points="560.0,360.0,560.0,276.0"/>
             </g>
             <g class="sld-wire sld-vl50to70" id="_95_vl3_95_b3WT_95_3_95_INTERNAL_95_vl3_95_3WT_95_THREE">
                 <polyline points="560.0,256.0,560.0,172.0"/>

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl2.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl2.svg
@@ -90,7 +90,7 @@
             <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300" id="idINTERNAL_95_vl2_95_d2WT_95_2" transform="translate(76.0,326.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300" id="idINTERNAL_95_vl2_95_b2WT_95_2" transform="translate(76.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300" id="idINTERNAL_95_vl2_95_2WT_95_TWO" transform="translate(76.0,138.0)">
@@ -101,11 +101,11 @@
                 <circle class="sld-vl300to500 sld-winding" cx="5" cy="5" r="5"/>
                 <text class="sld-label" id="2WT_TWO_N_LABEL" x="-5.0" y="-5.0">2WT_2</text>
             </g>
-            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_d2WT_95_2_95_INTERNAL_95_vl2_95_d2WT_95_2">
+            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_d2WT_95_2_95_INTERNAL_95_vl2_95_b2WT_95_2">
                 <polyline points="80.0,360.0,80.0,330.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_b2WT_95_2_95_INTERNAL_95_vl2_95_d2WT_95_2">
-                <polyline points="80.0,246.0,80.0,330.0"/>
+            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_INTERNAL_95_vl2_95_b2WT_95_2_95_b2WT_95_2">
+                <polyline points="80.0,330.0,80.0,246.0"/>
             </g>
             <g class="sld-wire sld-vl180to300" id="_95_vl2_95_b2WT_95_2_95_INTERNAL_95_vl2_95_2WT_95_TWO">
                 <polyline points="80.0,226.0,80.0,142.0"/>
@@ -123,7 +123,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300" id="idINTERNAL_95_vl2_95_d3WT_95_2" transform="translate(196.0,326.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl180to300" id="idINTERNAL_95_vl2_95_b3WT_95_2" transform="translate(196.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder sld-vl180to300" id="id3WT_95_ONE" transform="translate(160.0,80.0)">
@@ -132,11 +132,11 @@
             <g class="sld-top-feeder sld-vl180to300" id="id3WT_95_THREE" transform="translate(240.0,80.0)">
                 <text class="sld-label" id="3WT_THREE_N_LABEL" x="-5.0" y="-5.0">3WT_2</text>
             </g>
-            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_d3WT_95_2_95_INTERNAL_95_vl2_95_d3WT_95_2">
+            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_d3WT_95_2_95_INTERNAL_95_vl2_95_b3WT_95_2">
                 <polyline points="200.0,360.0,200.0,330.0"/>
             </g>
-            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_b3WT_95_2_95_INTERNAL_95_vl2_95_d3WT_95_2">
-                <polyline points="200.0,246.0,200.0,330.0"/>
+            <g class="sld-wire sld-vl180to300" id="_95_vl2_95_INTERNAL_95_vl2_95_b3WT_95_2_95_b3WT_95_2">
+                <polyline points="200.0,330.0,200.0,246.0"/>
             </g>
             <g class="sld-wire sld-vl180to300" id="_95_vl2_95_3WT_95_b3WT_95_2">
                 <polyline points="200.0,154.0,200.0,226.0"/>

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl3.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl3.svg
@@ -89,7 +89,7 @@
             <text class="sld-label" id="bbs3_NW_LABEL" x="-5.0" y="-5.0">bbs3</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-hidden-node sld-fictitious sld-vl50to70" id="idINTERNAL_95_vl3_95_d3WT_95_3" transform="translate(116.0,326.0)">
+            <g class="sld-node sld-hidden-node sld-fictitious sld-vl50to70" id="idINTERNAL_95_vl3_95_b3WT_95_3" transform="translate(116.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-top-feeder sld-vl50to70" id="id3WT_95_ONE" transform="translate(80.0,80.0)">
@@ -98,11 +98,11 @@
             <g class="sld-top-feeder sld-vl50to70" id="id3WT_95_TWO" transform="translate(160.0,80.0)">
                 <text class="sld-label" id="3WT_TWO_N_LABEL" x="-5.0" y="-5.0">3WT_3</text>
             </g>
-            <g class="sld-wire sld-vl50to70" id="_95_vl3_95_d3WT_95_3_95_INTERNAL_95_vl3_95_d3WT_95_3">
+            <g class="sld-wire sld-vl50to70" id="_95_vl3_95_d3WT_95_3_95_INTERNAL_95_vl3_95_b3WT_95_3">
                 <polyline points="120.0,360.0,120.0,330.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70" id="_95_vl3_95_b3WT_95_3_95_INTERNAL_95_vl3_95_d3WT_95_3">
-                <polyline points="120.0,246.0,120.0,330.0"/>
+            <g class="sld-wire sld-vl50to70" id="_95_vl3_95_INTERNAL_95_vl3_95_b3WT_95_3_95_b3WT_95_3">
+                <polyline points="120.0,330.0,120.0,246.0"/>
             </g>
             <g class="sld-wire sld-vl50to70" id="_95_vl3_95_3WT_95_b3WT_95_3">
                 <polyline points="120.0,154.0,120.0,226.0"/>

--- a/single-line-diagram-core/src/test/resources/orderConsistencyClust1.json
+++ b/single-line-diagram-core/src/test/resources/orderConsistencyClust1.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss1_0",
+    "id" : "BUSCO_ss1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 150.0,
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss1_1",
+    "id" : "BUSCO_ss1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 200.0,
@@ -26,7 +26,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss2_0",
+    "id" : "BUSCO_ss2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -35,7 +35,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss2_1",
+    "id" : "BUSCO_ss2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -94,7 +94,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_ss1_0",
+    "id" : "INTERNAL_vl1_ss1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -103,7 +103,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_ss1_1",
+    "id" : "INTERNAL_vl1_ss1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -112,7 +112,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_ss2_0",
+    "id" : "INTERNAL_vl1_ss2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -121,7 +121,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_ss2_1",
+    "id" : "INTERNAL_vl1_ss2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -417,7 +417,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs12", "BUSCO_ss1_1", "INTERNAL_vl1_ss1_1" ]
+        "nodes" : [ "bbs12", "BUSCO_ss1", "INTERNAL_vl1_ss1" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -438,7 +438,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl1_ss1_0", "ss1", "INTERNAL_vl1_ss1_1" ]
+        "nodes" : [ "INTERNAL_vl1_ss1", "ss1", "INTERNAL_vl1_ss1" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -459,7 +459,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs11", "BUSCO_ss1_0", "INTERNAL_vl1_ss1_0" ]
+        "nodes" : [ "bbs11", "BUSCO_ss1", "INTERNAL_vl1_ss1" ]
       } ]
     }
   }, {
@@ -505,7 +505,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs22", "BUSCO_ss2_1", "INTERNAL_vl1_ss2_1" ]
+        "nodes" : [ "bbs22", "BUSCO_ss2", "INTERNAL_vl1_ss2" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -526,7 +526,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl1_ss2_0", "ss2", "INTERNAL_vl1_ss2_1" ]
+        "nodes" : [ "INTERNAL_vl1_ss2", "ss2", "INTERNAL_vl1_ss2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -547,7 +547,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs21", "BUSCO_ss2_0", "INTERNAL_vl1_ss2_0" ]
+        "nodes" : [ "bbs21", "BUSCO_ss2", "INTERNAL_vl1_ss2" ]
       } ]
     }
   }, {
@@ -993,6 +993,42 @@
     "node1" : "INTERNAL_vl1_f2",
     "node2" : "b2"
   }, {
+    "node1" : "bbs11",
+    "node2" : "BUSCO_ss1"
+  }, {
+    "node1" : "bbs12",
+    "node2" : "BUSCO_ss1"
+  }, {
+    "node1" : "bbs21",
+    "node2" : "BUSCO_ss2"
+  }, {
+    "node1" : "bbs22",
+    "node2" : "BUSCO_ss2"
+  }, {
+    "node1" : "BUSCO_ss1",
+    "node2" : "INTERNAL_vl1_ss1"
+  }, {
+    "node1" : "INTERNAL_vl1_ss1",
+    "node2" : "ss1"
+  }, {
+    "node1" : "BUSCO_ss1",
+    "node2" : "INTERNAL_vl1_ss1"
+  }, {
+    "node1" : "INTERNAL_vl1_ss1",
+    "node2" : "ss1"
+  }, {
+    "node1" : "BUSCO_ss2",
+    "node2" : "INTERNAL_vl1_ss2"
+  }, {
+    "node1" : "INTERNAL_vl1_ss2",
+    "node2" : "ss2"
+  }, {
+    "node1" : "BUSCO_ss2",
+    "node2" : "INTERNAL_vl1_ss2"
+  }, {
+    "node1" : "INTERNAL_vl1_ss2",
+    "node2" : "ss2"
+  }, {
     "node1" : "b1",
     "node2" : "INTERNAL_vl1_l1"
   }, {
@@ -1010,42 +1046,6 @@
   }, {
     "node1" : "INTERNAL_vl1_l2",
     "node2" : "l2"
-  }, {
-    "node1" : "bbs11",
-    "node2" : "BUSCO_ss1_0"
-  }, {
-    "node1" : "BUSCO_ss1_0",
-    "node2" : "INTERNAL_vl1_ss1_0"
-  }, {
-    "node1" : "INTERNAL_vl1_ss1_0",
-    "node2" : "ss1"
-  }, {
-    "node1" : "bbs12",
-    "node2" : "BUSCO_ss1_1"
-  }, {
-    "node1" : "BUSCO_ss1_1",
-    "node2" : "INTERNAL_vl1_ss1_1"
-  }, {
-    "node1" : "INTERNAL_vl1_ss1_1",
-    "node2" : "ss1"
-  }, {
-    "node1" : "bbs21",
-    "node2" : "BUSCO_ss2_0"
-  }, {
-    "node1" : "BUSCO_ss2_0",
-    "node2" : "INTERNAL_vl1_ss2_0"
-  }, {
-    "node1" : "INTERNAL_vl1_ss2_0",
-    "node2" : "ss2"
-  }, {
-    "node1" : "bbs22",
-    "node2" : "BUSCO_ss2_1"
-  }, {
-    "node1" : "BUSCO_ss2_1",
-    "node2" : "INTERNAL_vl1_ss2_1"
-  }, {
-    "node1" : "INTERNAL_vl1_ss2_1",
-    "node2" : "ss2"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/orderConsistencyClust2.json
+++ b/single-line-diagram-core/src/test/resources/orderConsistencyClust2.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss1_0",
+    "id" : "BUSCO_ss1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss1_1",
+    "id" : "BUSCO_ss1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -26,7 +26,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss2_0",
+    "id" : "BUSCO_ss2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 150.0,
@@ -35,7 +35,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss2_1",
+    "id" : "BUSCO_ss2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 200.0,
@@ -94,7 +94,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_ss1_0",
+    "id" : "INTERNAL_vl2_ss1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -103,7 +103,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_ss1_1",
+    "id" : "INTERNAL_vl2_ss1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -112,7 +112,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_ss2_0",
+    "id" : "INTERNAL_vl2_ss2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -121,7 +121,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_ss2_1",
+    "id" : "INTERNAL_vl2_ss2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -417,7 +417,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs12", "BUSCO_ss1_1", "INTERNAL_vl2_ss1_1" ]
+        "nodes" : [ "bbs12", "BUSCO_ss1", "INTERNAL_vl2_ss1" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -438,7 +438,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl2_ss1_0", "ss1", "INTERNAL_vl2_ss1_1" ]
+        "nodes" : [ "INTERNAL_vl2_ss1", "ss1", "INTERNAL_vl2_ss1" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -459,7 +459,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs11", "BUSCO_ss1_0", "INTERNAL_vl2_ss1_0" ]
+        "nodes" : [ "bbs11", "BUSCO_ss1", "INTERNAL_vl2_ss1" ]
       } ]
     }
   }, {
@@ -505,7 +505,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs22", "BUSCO_ss2_1", "INTERNAL_vl2_ss2_1" ]
+        "nodes" : [ "bbs22", "BUSCO_ss2", "INTERNAL_vl2_ss2" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -526,7 +526,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl2_ss2_0", "ss2", "INTERNAL_vl2_ss2_1" ]
+        "nodes" : [ "INTERNAL_vl2_ss2", "ss2", "INTERNAL_vl2_ss2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -547,7 +547,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs21", "BUSCO_ss2_0", "INTERNAL_vl2_ss2_0" ]
+        "nodes" : [ "bbs21", "BUSCO_ss2", "INTERNAL_vl2_ss2" ]
       } ]
     }
   }, {
@@ -993,6 +993,42 @@
     "node1" : "INTERNAL_vl2_f2",
     "node2" : "b2"
   }, {
+    "node1" : "bbs11",
+    "node2" : "BUSCO_ss1"
+  }, {
+    "node1" : "bbs12",
+    "node2" : "BUSCO_ss1"
+  }, {
+    "node1" : "bbs21",
+    "node2" : "BUSCO_ss2"
+  }, {
+    "node1" : "bbs22",
+    "node2" : "BUSCO_ss2"
+  }, {
+    "node1" : "BUSCO_ss1",
+    "node2" : "INTERNAL_vl2_ss1"
+  }, {
+    "node1" : "INTERNAL_vl2_ss1",
+    "node2" : "ss1"
+  }, {
+    "node1" : "BUSCO_ss1",
+    "node2" : "INTERNAL_vl2_ss1"
+  }, {
+    "node1" : "INTERNAL_vl2_ss1",
+    "node2" : "ss1"
+  }, {
+    "node1" : "BUSCO_ss2",
+    "node2" : "INTERNAL_vl2_ss2"
+  }, {
+    "node1" : "INTERNAL_vl2_ss2",
+    "node2" : "ss2"
+  }, {
+    "node1" : "BUSCO_ss2",
+    "node2" : "INTERNAL_vl2_ss2"
+  }, {
+    "node1" : "INTERNAL_vl2_ss2",
+    "node2" : "ss2"
+  }, {
     "node1" : "b1",
     "node2" : "INTERNAL_vl2_l1"
   }, {
@@ -1010,42 +1046,6 @@
   }, {
     "node1" : "INTERNAL_vl2_l2",
     "node2" : "l2"
-  }, {
-    "node1" : "bbs11",
-    "node2" : "BUSCO_ss1_0"
-  }, {
-    "node1" : "BUSCO_ss1_0",
-    "node2" : "INTERNAL_vl2_ss1_0"
-  }, {
-    "node1" : "INTERNAL_vl2_ss1_0",
-    "node2" : "ss1"
-  }, {
-    "node1" : "bbs12",
-    "node2" : "BUSCO_ss1_1"
-  }, {
-    "node1" : "BUSCO_ss1_1",
-    "node2" : "INTERNAL_vl2_ss1_1"
-  }, {
-    "node1" : "INTERNAL_vl2_ss1_1",
-    "node2" : "ss1"
-  }, {
-    "node1" : "bbs21",
-    "node2" : "BUSCO_ss2_0"
-  }, {
-    "node1" : "BUSCO_ss2_0",
-    "node2" : "INTERNAL_vl2_ss2_0"
-  }, {
-    "node1" : "INTERNAL_vl2_ss2_0",
-    "node2" : "ss2"
-  }, {
-    "node1" : "bbs22",
-    "node2" : "BUSCO_ss2_1"
-  }, {
-    "node1" : "BUSCO_ss2_1",
-    "node2" : "INTERNAL_vl2_ss2_1"
-  }, {
-    "node1" : "INTERNAL_vl2_ss2_1",
-    "node2" : "ss2"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/orderConsistencyExt1.json
+++ b/single-line-diagram-core/src/test/resources/orderConsistencyExt1.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss1_0",
+    "id" : "BUSCO_ss1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 150.0,
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss1_1",
+    "id" : "BUSCO_ss1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 200.0,
@@ -26,7 +26,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss2_0",
+    "id" : "BUSCO_ss2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -35,7 +35,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss2_1",
+    "id" : "BUSCO_ss2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -92,7 +92,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_ss1_0",
+    "id" : "INTERNAL_vl1_ss1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -101,7 +101,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_ss1_1",
+    "id" : "INTERNAL_vl1_ss1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -110,7 +110,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_ss2_0",
+    "id" : "INTERNAL_vl1_ss2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -119,7 +119,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl1_ss2_1",
+    "id" : "INTERNAL_vl1_ss2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -412,7 +412,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs12", "BUSCO_ss1_1", "INTERNAL_vl1_ss1_1" ]
+        "nodes" : [ "bbs12", "BUSCO_ss1", "INTERNAL_vl1_ss1" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -433,7 +433,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl1_ss1_0", "ss1", "INTERNAL_vl1_ss1_1" ]
+        "nodes" : [ "INTERNAL_vl1_ss1", "ss1", "INTERNAL_vl1_ss1" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -454,7 +454,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs11", "BUSCO_ss1_0", "INTERNAL_vl1_ss1_0" ]
+        "nodes" : [ "bbs11", "BUSCO_ss1", "INTERNAL_vl1_ss1" ]
       } ]
     }
   }, {
@@ -501,7 +501,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs22", "BUSCO_ss2_1", "INTERNAL_vl1_ss2_1" ]
+        "nodes" : [ "bbs22", "BUSCO_ss2", "INTERNAL_vl1_ss2" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -522,7 +522,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl1_ss2_0", "ss2", "INTERNAL_vl1_ss2_1" ]
+        "nodes" : [ "INTERNAL_vl1_ss2", "ss2", "INTERNAL_vl1_ss2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -543,7 +543,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs21", "BUSCO_ss2_0", "INTERNAL_vl1_ss2_0" ]
+        "nodes" : [ "bbs21", "BUSCO_ss2", "INTERNAL_vl1_ss2" ]
       } ]
     }
   }, {
@@ -989,6 +989,42 @@
     "node1" : "INTERNAL_vl1_f2",
     "node2" : "b2"
   }, {
+    "node1" : "bbs11",
+    "node2" : "BUSCO_ss1"
+  }, {
+    "node1" : "bbs12",
+    "node2" : "BUSCO_ss1"
+  }, {
+    "node1" : "bbs21",
+    "node2" : "BUSCO_ss2"
+  }, {
+    "node1" : "bbs22",
+    "node2" : "BUSCO_ss2"
+  }, {
+    "node1" : "BUSCO_ss1",
+    "node2" : "INTERNAL_vl1_ss1"
+  }, {
+    "node1" : "INTERNAL_vl1_ss1",
+    "node2" : "ss1"
+  }, {
+    "node1" : "BUSCO_ss1",
+    "node2" : "INTERNAL_vl1_ss1"
+  }, {
+    "node1" : "INTERNAL_vl1_ss1",
+    "node2" : "ss1"
+  }, {
+    "node1" : "BUSCO_ss2",
+    "node2" : "INTERNAL_vl1_ss2"
+  }, {
+    "node1" : "INTERNAL_vl1_ss2",
+    "node2" : "ss2"
+  }, {
+    "node1" : "BUSCO_ss2",
+    "node2" : "INTERNAL_vl1_ss2"
+  }, {
+    "node1" : "INTERNAL_vl1_ss2",
+    "node2" : "ss2"
+  }, {
     "node1" : "b1",
     "node2" : "INTERNAL_vl1_l1"
   }, {
@@ -1006,42 +1042,6 @@
   }, {
     "node1" : "INTERNAL_vl1_l2",
     "node2" : "l2"
-  }, {
-    "node1" : "bbs11",
-    "node2" : "BUSCO_ss1_0"
-  }, {
-    "node1" : "BUSCO_ss1_0",
-    "node2" : "INTERNAL_vl1_ss1_0"
-  }, {
-    "node1" : "INTERNAL_vl1_ss1_0",
-    "node2" : "ss1"
-  }, {
-    "node1" : "bbs12",
-    "node2" : "BUSCO_ss1_1"
-  }, {
-    "node1" : "BUSCO_ss1_1",
-    "node2" : "INTERNAL_vl1_ss1_1"
-  }, {
-    "node1" : "INTERNAL_vl1_ss1_1",
-    "node2" : "ss1"
-  }, {
-    "node1" : "bbs21",
-    "node2" : "BUSCO_ss2_0"
-  }, {
-    "node1" : "BUSCO_ss2_0",
-    "node2" : "INTERNAL_vl1_ss2_0"
-  }, {
-    "node1" : "INTERNAL_vl1_ss2_0",
-    "node2" : "ss2"
-  }, {
-    "node1" : "bbs22",
-    "node2" : "BUSCO_ss2_1"
-  }, {
-    "node1" : "BUSCO_ss2_1",
-    "node2" : "INTERNAL_vl1_ss2_1"
-  }, {
-    "node1" : "INTERNAL_vl1_ss2_1",
-    "node2" : "ss2"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/orderConsistencyExt2.json
+++ b/single-line-diagram-core/src/test/resources/orderConsistencyExt2.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss1_0",
+    "id" : "BUSCO_ss1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 50.0,
@@ -17,7 +17,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss1_1",
+    "id" : "BUSCO_ss1",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 100.0,
@@ -26,7 +26,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss2_0",
+    "id" : "BUSCO_ss2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 150.0,
@@ -35,7 +35,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "BUSCO_ss2_1",
+    "id" : "BUSCO_ss2",
     "componentType" : "BUS_CONNECTION",
     "fictitious" : true,
     "x" : 200.0,
@@ -92,7 +92,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_ss1_0",
+    "id" : "INTERNAL_vl2_ss1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -101,7 +101,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_ss1_1",
+    "id" : "INTERNAL_vl2_ss1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 100.0,
@@ -110,7 +110,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_ss2_0",
+    "id" : "INTERNAL_vl2_ss2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 150.0,
@@ -119,7 +119,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl2_ss2_1",
+    "id" : "INTERNAL_vl2_ss2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 200.0,
@@ -412,7 +412,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs12", "BUSCO_ss1_1", "INTERNAL_vl2_ss1_1" ]
+        "nodes" : [ "bbs12", "BUSCO_ss1", "INTERNAL_vl2_ss1" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -433,7 +433,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl2_ss1_0", "ss1", "INTERNAL_vl2_ss1_1" ]
+        "nodes" : [ "INTERNAL_vl2_ss1", "ss1", "INTERNAL_vl2_ss1" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -454,7 +454,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs11", "BUSCO_ss1_0", "INTERNAL_vl2_ss1_0" ]
+        "nodes" : [ "bbs11", "BUSCO_ss1", "INTERNAL_vl2_ss1" ]
       } ]
     }
   }, {
@@ -501,7 +501,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs22", "BUSCO_ss2_1", "INTERNAL_vl2_ss2_1" ]
+        "nodes" : [ "bbs22", "BUSCO_ss2", "INTERNAL_vl2_ss2" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -522,7 +522,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl2_ss2_0", "ss2", "INTERNAL_vl2_ss2_1" ]
+        "nodes" : [ "INTERNAL_vl2_ss2", "ss2", "INTERNAL_vl2_ss2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -543,7 +543,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs21", "BUSCO_ss2_0", "INTERNAL_vl2_ss2_0" ]
+        "nodes" : [ "bbs21", "BUSCO_ss2", "INTERNAL_vl2_ss2" ]
       } ]
     }
   }, {
@@ -989,6 +989,42 @@
     "node1" : "INTERNAL_vl2_f2",
     "node2" : "b2"
   }, {
+    "node1" : "bbs11",
+    "node2" : "BUSCO_ss1"
+  }, {
+    "node1" : "bbs12",
+    "node2" : "BUSCO_ss1"
+  }, {
+    "node1" : "bbs21",
+    "node2" : "BUSCO_ss2"
+  }, {
+    "node1" : "bbs22",
+    "node2" : "BUSCO_ss2"
+  }, {
+    "node1" : "BUSCO_ss1",
+    "node2" : "INTERNAL_vl2_ss1"
+  }, {
+    "node1" : "INTERNAL_vl2_ss1",
+    "node2" : "ss1"
+  }, {
+    "node1" : "BUSCO_ss1",
+    "node2" : "INTERNAL_vl2_ss1"
+  }, {
+    "node1" : "INTERNAL_vl2_ss1",
+    "node2" : "ss1"
+  }, {
+    "node1" : "BUSCO_ss2",
+    "node2" : "INTERNAL_vl2_ss2"
+  }, {
+    "node1" : "INTERNAL_vl2_ss2",
+    "node2" : "ss2"
+  }, {
+    "node1" : "BUSCO_ss2",
+    "node2" : "INTERNAL_vl2_ss2"
+  }, {
+    "node1" : "INTERNAL_vl2_ss2",
+    "node2" : "ss2"
+  }, {
     "node1" : "b1",
     "node2" : "INTERNAL_vl2_l1"
   }, {
@@ -1006,42 +1042,6 @@
   }, {
     "node1" : "INTERNAL_vl2_l2",
     "node2" : "l2"
-  }, {
-    "node1" : "bbs11",
-    "node2" : "BUSCO_ss1_0"
-  }, {
-    "node1" : "BUSCO_ss1_0",
-    "node2" : "INTERNAL_vl2_ss1_0"
-  }, {
-    "node1" : "INTERNAL_vl2_ss1_0",
-    "node2" : "ss1"
-  }, {
-    "node1" : "bbs12",
-    "node2" : "BUSCO_ss1_1"
-  }, {
-    "node1" : "BUSCO_ss1_1",
-    "node2" : "INTERNAL_vl2_ss1_1"
-  }, {
-    "node1" : "INTERNAL_vl2_ss1_1",
-    "node2" : "ss1"
-  }, {
-    "node1" : "bbs21",
-    "node2" : "BUSCO_ss2_0"
-  }, {
-    "node1" : "BUSCO_ss2_0",
-    "node2" : "INTERNAL_vl2_ss2_0"
-  }, {
-    "node1" : "INTERNAL_vl2_ss2_0",
-    "node2" : "ss2"
-  }, {
-    "node1" : "bbs22",
-    "node2" : "BUSCO_ss2_1"
-  }, {
-    "node1" : "BUSCO_ss2_1",
-    "node2" : "INTERNAL_vl2_ss2_1"
-  }, {
-    "node1" : "INTERNAL_vl2_ss2_1",
-    "node2" : "ss2"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -2888,6 +2888,7 @@
     "feederInfosIntraMargin" : 10.0,
     "busInfoMargin" : 0.0,
     "busbarsAlignment" : "FIRST",
-    "feederInfoPrecision" : 0
+    "feederInfoPrecision" : 0,
+    "componentsOnBusbars" : [ "DISCONNECTOR" ]
   }
 }

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -217,22 +217,15 @@
       "positionName" : "S_LABEL"
     } ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_dline11_95_2",
+    "id" : "idINTERNAL_95_vl1_95_dtrct11",
     "vid" : "vl1",
     "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_dload2",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dload1",
-    "vid" : "vl1",
+    "id" : "idINTERNAL_95_vl2_95_bload3",
+    "vid" : "vl2",
     "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
@@ -261,22 +254,8 @@
     "equipmentId" : "dload3",
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_dgen1",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "idINTERNAL_95_vl3_95_load4",
     "vid" : "vl3",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dgen2",
-    "vid" : "vl1",
     "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
@@ -370,13 +349,6 @@
       "positionName" : "NW_LABEL"
     } ]
   }, {
-    "id" : "idINTERNAL_95_vl2_95_dload3",
-    "vid" : "vl2",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "idbbs6",
     "vid" : "vl2",
     "componentType" : "BUSBAR_SECTION",
@@ -447,13 +419,6 @@
     "equipmentId" : "dscpl1",
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl3_95_dtrf25",
-    "vid" : "vl3",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "iddscpl2",
     "vid" : "vl2",
     "componentType" : "DISCONNECTOR",
@@ -464,6 +429,13 @@
   }, {
     "id" : "idINTERNAL_95_vl2_95_trf8_95_TWO",
     "vid" : "vl2",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl3_95_bload4",
+    "vid" : "vl3",
     "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
@@ -581,41 +553,6 @@
     "vlabel" : false,
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_dsect12",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl3_95_dtrf38",
-    "vid" : "vl3",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dsect11",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl3_95_dtrf36",
-    "vid" : "vl3",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl3_95_dtrf37",
-    "vid" : "vl3",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "idddcpl1",
     "vid" : "vl2",
     "componentType" : "BREAKER",
@@ -696,6 +633,13 @@
     "equipmentId" : "dsect22",
     "labels" : [ ]
   }, {
+    "id" : "idINTERNAL_95_vl2_95_ddcpl1",
+    "vid" : "vl2",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
     "id" : "idtrf2_95_TWO",
     "vid" : "vl2",
     "nextVId" : "vl2",
@@ -763,13 +707,6 @@
     "vlabel" : true,
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_dsect21",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "LABEL_VL_vl3",
     "vid" : "vl3",
     "open" : false,
@@ -808,13 +745,6 @@
     "vlabel" : false,
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_dsect22",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "idbload3",
     "vid" : "vl2",
     "componentType" : "BREAKER",
@@ -839,27 +769,6 @@
     "equipmentId" : "bload1",
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl2_95_dtrf28",
-    "vid" : "vl2",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl2_95_dtrf26",
-    "vid" : "vl2",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl2_95_dtrf27",
-    "vid" : "vl2",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "idtrf8_95_THREE",
     "vid" : "vl3",
     "nextVId" : "vl3",
@@ -873,13 +782,6 @@
       "positionName" : "N_LABEL"
     } ]
   }, {
-    "id" : "idINTERNAL_95_vl2_95_dtrf24",
-    "vid" : "vl2",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "idINTERNAL_95_vl2_95_trf7_95_TWO",
     "vid" : "vl2",
     "componentType" : "NODE",
@@ -887,22 +789,22 @@
     "vlabel" : false,
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl2_95_dtrf22",
-    "vid" : "vl2",
+    "id" : "idINTERNAL_95_vl3_95_btrf25",
+    "vid" : "vl3",
     "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl2_95_dtrf23",
-    "vid" : "vl2",
+    "id" : "idINTERNAL_95_vl1_95_bgen1",
+    "vid" : "vl1",
     "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl2_95_dtrf21",
-    "vid" : "vl2",
+    "id" : "idINTERNAL_95_vl1_95_bgen2",
+    "vid" : "vl1",
     "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
@@ -950,12 +852,54 @@
       "positionName" : "N_LABEL"
     } ]
   }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf17",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf16",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf15",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf14",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
     "id" : "iddtrf38",
     "vid" : "vl3",
     "componentType" : "DISCONNECTOR",
     "open" : false,
     "vlabel" : false,
     "equipmentId" : "dtrf38",
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf13",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl2_95_btrf28",
+    "vid" : "vl2",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
     "labels" : [ ]
   }, {
     "id" : "iddtrf37",
@@ -966,12 +910,33 @@
     "equipmentId" : "dtrf37",
     "labels" : [ ]
   }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf12",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
     "id" : "iddtrf36",
     "vid" : "vl3",
     "componentType" : "DISCONNECTOR",
     "open" : false,
     "vlabel" : false,
     "equipmentId" : "dtrf36",
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf11",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl3_95_btrf38",
+    "vid" : "vl3",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
     "labels" : [ ]
   }, {
     "id" : "iddtrct21",
@@ -990,12 +955,33 @@
     "equipmentId" : "btrf18",
     "labels" : [ ]
   }, {
+    "id" : "idINTERNAL_95_vl3_95_btrf37",
+    "vid" : "vl3",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl3_95_btrf36",
+    "vid" : "vl3",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
     "id" : "idbtrf15",
     "vid" : "vl1",
     "componentType" : "BREAKER",
     "open" : false,
     "vlabel" : false,
     "equipmentId" : "btrf15",
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl2_95_btrf24",
+    "vid" : "vl2",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
     "labels" : [ ]
   }, {
     "id" : "idbtrf14",
@@ -1021,12 +1007,26 @@
     "equipmentId" : "btrf17",
     "labels" : [ ]
   }, {
+    "id" : "idINTERNAL_95_vl2_95_btrf26",
+    "vid" : "vl2",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
     "id" : "idbtrf16",
     "vid" : "vl1",
     "componentType" : "BREAKER",
     "open" : false,
     "vlabel" : false,
     "equipmentId" : "btrf16",
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl2_95_btrf27",
+    "vid" : "vl2",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
     "labels" : [ ]
   }, {
     "id" : "idbtrf11",
@@ -1037,6 +1037,13 @@
     "equipmentId" : "btrf11",
     "labels" : [ ]
   }, {
+    "id" : "idINTERNAL_95_vl2_95_btrf21",
+    "vid" : "vl2",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
     "id" : "idbtrf13",
     "vid" : "vl1",
     "componentType" : "BREAKER",
@@ -1045,12 +1052,33 @@
     "equipmentId" : "btrf13",
     "labels" : [ ]
   }, {
+    "id" : "idINTERNAL_95_vl2_95_btrf22",
+    "vid" : "vl2",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
     "id" : "idbtrf12",
     "vid" : "vl1",
     "componentType" : "BREAKER",
     "open" : false,
     "vlabel" : false,
     "equipmentId" : "btrf12",
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf18",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl2_95_btrf23",
+    "vid" : "vl2",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
     "labels" : [ ]
   }, {
     "id" : "idbgen1",
@@ -1159,55 +1187,6 @@
       "positionName" : "S_LABEL"
     } ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf13",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf12",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf15",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf14",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf17",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf16",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf18",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "idbtrf26",
     "vid" : "vl2",
     "componentType" : "BREAKER",
@@ -1269,13 +1248,6 @@
     "open" : false,
     "vlabel" : false,
     "equipmentId" : "btrf21",
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf11",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
     "labels" : [ ]
   }, {
     "id" : "idtrf1_95_ONE",
@@ -1406,13 +1378,6 @@
     "vlabel" : false,
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl2_95_dgen4",
-    "vid" : "vl2",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "iddgen4",
     "vid" : "vl2",
     "componentType" : "DISCONNECTOR",
@@ -1476,6 +1441,20 @@
     "equipmentId" : "trf8",
     "labels" : [ ]
   }, {
+    "id" : "idINTERNAL_95_vl1_95_bload2",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_bload1",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
     "id" : "idtrf8_95_TWO",
     "vid" : "vl2",
     "nextVId" : "vl2",
@@ -1526,8 +1505,8 @@
     "equipmentId" : "btrf38",
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl3_95_dload4",
-    "vid" : "vl3",
+    "id" : "idINTERNAL_95_vl2_95_bgen4",
+    "vid" : "vl2",
     "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
@@ -1602,15 +1581,15 @@
       "positionName" : "N_LABEL"
     } ]
   }, {
-    "id" : "idINTERNAL_95_vl2_95_dscpl1",
-    "vid" : "vl2",
+    "id" : "idINTERNAL_95_vl1_95_bline11_95_2",
+    "vid" : "vl1",
     "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl2_95_dscpl2",
-    "vid" : "vl2",
+    "id" : "idINTERNAL_95_vl1_95_dtrct21",
+    "vid" : "vl1",
     "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
@@ -1643,6 +1622,12 @@
     } ]
   } ],
   "wires" : [ {
+    "id" : "_95_vl2_95_INTERNAL_95_vl2_95_bload3_95_bload3",
+    "nodeId1" : "idINTERNAL_95_vl2_95_bload3",
+    "nodeId2" : "idbload3",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_trf8_95_ONE",
     "nodeId1" : "idbtrf18",
     "nodeId2" : "idINTERNAL_95_vl1_95_trf8_95_ONE",
@@ -1655,33 +1640,39 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_dtrf28_95_INTERNAL_95_vl2_95_dtrf28",
-    "nodeId1" : "iddtrf28",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf28",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_dtrf16",
-    "nodeId1" : "iddtrf16",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf16",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl2_95_INTERNAL_95_vl2_95_trf6_95_TWO_95_trf6_95_TWO",
     "nodeId1" : "idINTERNAL_95_vl2_95_trf6_95_TWO",
     "nodeId2" : "idtrf6_95_TWO",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_bbs3_95_dtrf17",
-    "nodeId1" : "idbbs3",
-    "nodeId2" : "iddtrf17",
+    "id" : "_95_vl3_95_dtrf25_95_INTERNAL_95_vl3_95_btrf25",
+    "nodeId1" : "iddtrf25",
+    "nodeId2" : "idINTERNAL_95_vl3_95_btrf25",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_dtrf27_95_INTERNAL_95_vl2_95_dtrf27",
-    "nodeId1" : "iddtrf27",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf27",
+    "id" : "_95_vl3_95_INTERNAL_95_vl3_95_btrf36_95_btrf36",
+    "nodeId1" : "idINTERNAL_95_vl3_95_btrf36",
+    "nodeId2" : "idbtrf36",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_INTERNAL_95_vl2_95_ddcpl1_95_ddcpl1",
+    "nodeId1" : "idINTERNAL_95_vl2_95_ddcpl1",
+    "nodeId2" : "idddcpl1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_dload4_95_INTERNAL_95_vl3_95_bload4",
+    "nodeId1" : "iddload4",
+    "nodeId2" : "idINTERNAL_95_vl3_95_bload4",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_bbs3_95_dtrf17",
+    "nodeId1" : "idbbs3",
+    "nodeId2" : "iddtrf17",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1697,12 +1688,6 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_dtrf15",
-    "nodeId1" : "iddtrf15",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf15",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_bbs1_95_dload1",
     "nodeId1" : "idbbs1",
     "nodeId2" : "iddload1",
@@ -1715,9 +1700,9 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl3_95_dtrf38_95_INTERNAL_95_vl3_95_dtrf38",
-    "nodeId1" : "iddtrf38",
-    "nodeId2" : "idINTERNAL_95_vl3_95_dtrf38",
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf16_95_btrf16",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf16",
+    "nodeId2" : "idbtrf16",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1733,15 +1718,9 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_bline11_95_2_95_INTERNAL_95_vl1_95_dline11_95_2",
-    "nodeId1" : "idbline11_95_2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dline11_95_2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl2_95_dtrf26_95_INTERNAL_95_vl2_95_dtrf26",
-    "nodeId1" : "iddtrf26",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf26",
+    "id" : "_95_vl3_95_INTERNAL_95_vl3_95_btrf37_95_btrf37",
+    "nodeId1" : "idINTERNAL_95_vl3_95_btrf37",
+    "nodeId2" : "idbtrf37",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1751,15 +1730,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_btrf21_95_INTERNAL_95_vl2_95_trf1_95_TWO",
-    "nodeId1" : "idbtrf21",
-    "nodeId2" : "idINTERNAL_95_vl2_95_trf1_95_TWO",
+    "id" : "_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_btrf18",
+    "nodeId1" : "iddtrf18",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf18",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_dload1",
-    "nodeId1" : "idbload1",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dload1",
+    "id" : "_95_vl2_95_btrf21_95_INTERNAL_95_vl2_95_trf1_95_TWO",
+    "nodeId1" : "idbtrf21",
+    "nodeId2" : "idINTERNAL_95_vl2_95_trf1_95_TWO",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1769,15 +1748,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl3_95_dtrf37_95_INTERNAL_95_vl3_95_dtrf37",
-    "nodeId1" : "iddtrf37",
-    "nodeId2" : "idINTERNAL_95_vl3_95_dtrf37",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl2_95_bbs6_95_dgen4",
     "nodeId1" : "idbbs6",
     "nodeId2" : "iddgen4",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_INTERNAL_95_vl2_95_btrf22_95_btrf22",
+    "nodeId1" : "idINTERNAL_95_vl2_95_btrf22",
+    "nodeId2" : "idbtrf22",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1787,27 +1766,9 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_btrf17_95_INTERNAL_95_vl1_95_dtrf17",
-    "nodeId1" : "idbtrf17",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf17",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl2_95_bgen4_95_INTERNAL_95_vl2_95_dgen4",
-    "nodeId1" : "idbgen4",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dgen4",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_dtrf13",
-    "nodeId1" : "iddtrf13",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf13",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_dtrf18",
-    "nodeId1" : "iddtrf18",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf18",
+    "id" : "_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_bload2",
+    "nodeId1" : "iddload2",
+    "nodeId2" : "idINTERNAL_95_vl1_95_bload2",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1823,21 +1784,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_dload3_95_INTERNAL_95_vl2_95_dload3",
-    "nodeId1" : "iddload3",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dload3",
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf17_95_btrf17",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf17",
+    "nodeId2" : "idbtrf17",
     "straight" : false,
     "snakeLine" : false
   }, {
     "id" : "_95_vl1_95_bbs3_95_dgen1",
     "nodeId1" : "idbbs3",
     "nodeId2" : "iddgen1",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl3_95_btrf25_95_INTERNAL_95_vl3_95_dtrf25",
-    "nodeId1" : "idbtrf25",
-    "nodeId2" : "idINTERNAL_95_vl3_95_dtrf25",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1859,17 +1814,17 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl2_95_dtrf27_95_INTERNAL_95_vl2_95_btrf27",
+    "nodeId1" : "iddtrf27",
+    "nodeId2" : "idINTERNAL_95_vl2_95_btrf27",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "idEDGE_95_trf1_95_TWO",
     "nodeId1" : "idtrf1_95_TWO",
     "nodeId2" : "idtrf1",
     "straight" : false,
     "snakeLine" : true
-  }, {
-    "id" : "_95_vl2_95_dtrf23_95_INTERNAL_95_vl2_95_dtrf23",
-    "nodeId1" : "iddtrf23",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf23",
-    "straight" : false,
-    "snakeLine" : false
   }, {
     "id" : "_95_vl1_95_INTERNAL_95_vl1_95_line1_95_ONE_95_line1_95_ONE",
     "nodeId1" : "idINTERNAL_95_vl1_95_line1_95_ONE",
@@ -1877,15 +1832,9 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_btrf27_95_INTERNAL_95_vl2_95_dtrf27",
-    "nodeId1" : "idbtrf27",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf27",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl3_95_dload4_95_INTERNAL_95_vl3_95_dload4",
-    "nodeId1" : "iddload4",
-    "nodeId2" : "idINTERNAL_95_vl3_95_dload4",
+    "id" : "_95_vl2_95_INTERNAL_95_vl2_95_btrf21_95_btrf21",
+    "nodeId1" : "idINTERNAL_95_vl2_95_btrf21",
+    "nodeId2" : "idbtrf21",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1943,21 +1892,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_dtrf22_95_INTERNAL_95_vl2_95_dtrf22",
-    "nodeId1" : "iddtrf22",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf22",
+    "id" : "_95_vl2_95_dtrf28_95_INTERNAL_95_vl2_95_btrf28",
+    "nodeId1" : "iddtrf28",
+    "nodeId2" : "idINTERNAL_95_vl2_95_btrf28",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_btrf26_95_INTERNAL_95_vl2_95_dtrf26",
-    "nodeId1" : "idbtrf26",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf26",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_dload2",
-    "nodeId1" : "idbload2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dload2",
+    "id" : "_95_vl2_95_INTERNAL_95_vl2_95_btrf24_95_btrf24",
+    "nodeId1" : "idINTERNAL_95_vl2_95_btrf24",
+    "nodeId2" : "idbtrf24",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1979,27 +1922,27 @@
     "straight" : false,
     "snakeLine" : true
   }, {
-    "id" : "_95_vl2_95_dscpl1_95_INTERNAL_95_vl2_95_dscpl1",
-    "nodeId1" : "iddscpl1",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dscpl1",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dsect21_95_INTERNAL_95_vl1_95_dsect21",
-    "nodeId1" : "iddsect21",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect21",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl2_95_INTERNAL_95_vl2_95_trf2_95_TWO_95_trf2_95_TWO",
     "nodeId1" : "idINTERNAL_95_vl2_95_trf2_95_TWO",
     "nodeId2" : "idtrf2_95_TWO",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl3_95_btrf37_95_INTERNAL_95_vl3_95_dtrf37",
-    "nodeId1" : "idbtrf37",
-    "nodeId2" : "idINTERNAL_95_vl3_95_dtrf37",
+    "id" : "_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_btrf17",
+    "nodeId1" : "iddtrf17",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf17",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl3_95_INTERNAL_95_vl3_95_btrf25_95_btrf25",
+    "nodeId1" : "idINTERNAL_95_vl3_95_btrf25",
+    "nodeId2" : "idbtrf25",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_bgen2",
+    "nodeId1" : "iddgen2",
+    "nodeId2" : "idINTERNAL_95_vl1_95_bgen2",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2009,15 +1952,15 @@
     "straight" : false,
     "snakeLine" : true
   }, {
-    "id" : "_95_vl1_95_dsect12_95_INTERNAL_95_vl1_95_dsect12",
-    "nodeId1" : "iddsect12",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect12",
+    "id" : "_95_vl2_95_dgen4_95_INTERNAL_95_vl2_95_bgen4",
+    "nodeId1" : "iddgen4",
+    "nodeId2" : "idINTERNAL_95_vl2_95_bgen4",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_dtrf13",
-    "nodeId1" : "idbtrf13",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf13",
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf11_95_btrf11",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf11",
+    "nodeId2" : "idbtrf11",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2026,12 +1969,6 @@
     "nodeId2" : "idtrf7",
     "straight" : false,
     "snakeLine" : true
-  }, {
-    "id" : "_95_vl1_95_dsect22_95_INTERNAL_95_vl1_95_dsect22",
-    "nodeId1" : "iddsect22",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect22",
-    "straight" : false,
-    "snakeLine" : false
   }, {
     "id" : "_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_gen1",
     "nodeId1" : "idbgen1",
@@ -2042,6 +1979,12 @@
     "id" : "_95_vl3_95_bload4_95_INTERNAL_95_vl3_95_load4",
     "nodeId1" : "idbload4",
     "nodeId2" : "idINTERNAL_95_vl3_95_load4",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_bline11_95_2_95_bline11_95_2",
+    "nodeId1" : "idINTERNAL_95_vl1_95_bline11_95_2",
+    "nodeId2" : "idbline11_95_2",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2060,6 +2003,12 @@
     "id" : "_95_vl2_95_INTERNAL_95_vl2_95_trf3_95_TWO_95_trf3_95_TWO",
     "nodeId1" : "idINTERNAL_95_vl2_95_trf3_95_TWO",
     "nodeId2" : "idtrf3_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_bgen2_95_bgen2",
+    "nodeId1" : "idINTERNAL_95_vl1_95_bgen2",
+    "nodeId2" : "idbgen2",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2087,9 +2036,9 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_bload3_95_INTERNAL_95_vl2_95_dload3",
-    "nodeId1" : "idbload3",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dload3",
+    "id" : "_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_bgen1",
+    "nodeId1" : "iddgen1",
+    "nodeId2" : "idINTERNAL_95_vl1_95_bgen1",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2099,21 +2048,21 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl2_95_INTERNAL_95_vl2_95_btrf27_95_btrf27",
+    "nodeId1" : "idINTERNAL_95_vl2_95_btrf27",
+    "nodeId2" : "idbtrf27",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl3_95_btrf37_95_INTERNAL_95_vl3_95_trf7_95_THREE",
     "nodeId1" : "idbtrf37",
     "nodeId2" : "idINTERNAL_95_vl3_95_trf7_95_THREE",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_dload1",
-    "nodeId1" : "iddload1",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dload1",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl3_95_dtrf36_95_INTERNAL_95_vl3_95_dtrf36",
-    "nodeId1" : "iddtrf36",
-    "nodeId2" : "idINTERNAL_95_vl3_95_dtrf36",
+    "id" : "_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_btrf14",
+    "nodeId1" : "iddtrf14",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf14",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2122,12 +2071,6 @@
     "nodeId2" : "idtrf5",
     "straight" : false,
     "snakeLine" : true
-  }, {
-    "id" : "_95_vl2_95_btrf23_95_INTERNAL_95_vl2_95_dtrf23",
-    "nodeId1" : "idbtrf23",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf23",
-    "straight" : false,
-    "snakeLine" : false
   }, {
     "id" : "_95_vl3_95_INTERNAL_95_vl3_95_trf7_95_THREE_95_trf7_95_THREE",
     "nodeId1" : "idINTERNAL_95_vl3_95_trf7_95_THREE",
@@ -2141,33 +2084,21 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl3_95_bload4_95_INTERNAL_95_vl3_95_dload4",
-    "nodeId1" : "idbload4",
-    "nodeId2" : "idINTERNAL_95_vl3_95_dload4",
+    "id" : "_95_vl2_95_dtrf21_95_INTERNAL_95_vl2_95_btrf21",
+    "nodeId1" : "iddtrf21",
+    "nodeId2" : "idINTERNAL_95_vl2_95_btrf21",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_dgen2",
-    "nodeId1" : "iddgen2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dgen2",
+    "id" : "_95_vl3_95_dtrf38_95_INTERNAL_95_vl3_95_btrf38",
+    "nodeId1" : "iddtrf38",
+    "nodeId2" : "idINTERNAL_95_vl3_95_btrf38",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_dtrf12",
-    "nodeId1" : "iddtrf12",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf12",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_btrf16_95_INTERNAL_95_vl1_95_dtrf16",
-    "nodeId1" : "idbtrf16",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf16",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl2_95_dgen4_95_INTERNAL_95_vl2_95_dgen4",
-    "nodeId1" : "iddgen4",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dgen4",
+    "id" : "_95_vl3_95_INTERNAL_95_vl3_95_btrf38_95_btrf38",
+    "nodeId1" : "idINTERNAL_95_vl3_95_btrf38",
+    "nodeId2" : "idbtrf38",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2177,9 +2108,9 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_btrf22_95_INTERNAL_95_vl2_95_dtrf22",
-    "nodeId1" : "idbtrf22",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf22",
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf13_95_btrf13",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf13",
+    "nodeId2" : "idbtrf13",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2201,15 +2132,33 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dsect11_95_INTERNAL_95_vl1_95_dsect11",
-    "nodeId1" : "iddsect11",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect11",
+    "id" : "_95_vl2_95_dtrf22_95_INTERNAL_95_vl2_95_btrf22",
+    "nodeId1" : "iddtrf22",
+    "nodeId2" : "idINTERNAL_95_vl2_95_btrf22",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_dgen1",
-    "nodeId1" : "iddgen1",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dgen1",
+    "id" : "_95_vl3_95_INTERNAL_95_vl3_95_bload4_95_bload4",
+    "nodeId1" : "idINTERNAL_95_vl3_95_bload4",
+    "nodeId2" : "idbload4",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_btrf11",
+    "nodeId1" : "iddtrf11",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf11",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_dscpl2_95_INTERNAL_95_vl2_95_ddcpl1",
+    "nodeId1" : "iddscpl2",
+    "nodeId2" : "idINTERNAL_95_vl2_95_ddcpl1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_bgen1_95_bgen1",
+    "nodeId1" : "idINTERNAL_95_vl1_95_bgen1",
+    "nodeId2" : "idbgen1",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2219,15 +2168,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_trf7_95_ONE_95_trf7_95_ONE",
-    "nodeId1" : "idINTERNAL_95_vl1_95_trf7_95_ONE",
-    "nodeId2" : "idtrf7_95_ONE",
+    "id" : "_95_vl2_95_dtrf23_95_INTERNAL_95_vl2_95_btrf23",
+    "nodeId1" : "iddtrf23",
+    "nodeId2" : "idINTERNAL_95_vl2_95_btrf23",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_btrf21_95_INTERNAL_95_vl2_95_dtrf21",
-    "nodeId1" : "idbtrf21",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf21",
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_trf7_95_ONE_95_trf7_95_ONE",
+    "nodeId1" : "idINTERNAL_95_vl1_95_trf7_95_ONE",
+    "nodeId2" : "idtrf7_95_ONE",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2237,21 +2186,21 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl2_95_INTERNAL_95_vl2_95_btrf26_95_btrf26",
+    "nodeId1" : "idINTERNAL_95_vl2_95_btrf26",
+    "nodeId2" : "idbtrf26",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "idEDGE_95_trf6_95_THREE",
     "nodeId1" : "idtrf6_95_THREE",
     "nodeId2" : "idtrf6",
     "straight" : false,
     "snakeLine" : true
   }, {
-    "id" : "_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect12",
-    "nodeId1" : "iddtrct11",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect12",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect11",
-    "nodeId1" : "iddtrct11",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect11",
+    "id" : "_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_btrf12",
+    "nodeId1" : "iddtrf12",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf12",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2261,51 +2210,51 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl2_95_dtrf24_95_INTERNAL_95_vl2_95_btrf24",
+    "nodeId1" : "iddtrf24",
+    "nodeId2" : "idINTERNAL_95_vl2_95_btrf24",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_dload3_95_INTERNAL_95_vl2_95_bload3",
+    "nodeId1" : "iddload3",
+    "nodeId2" : "idINTERNAL_95_vl2_95_bload3",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_INTERNAL_95_vl1_95_trf8_95_ONE_95_trf8_95_ONE",
     "nodeId1" : "idINTERNAL_95_vl1_95_trf8_95_ONE",
     "nodeId2" : "idtrf8_95_ONE",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_dload2",
-    "nodeId1" : "iddload2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dload2",
+    "id" : "_95_vl1_95_dsect22_95_INTERNAL_95_vl1_95_dtrct21",
+    "nodeId1" : "iddsect22",
+    "nodeId2" : "idINTERNAL_95_vl1_95_dtrct21",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl3_95_btrf36_95_INTERNAL_95_vl3_95_dtrf36",
-    "nodeId1" : "idbtrf36",
-    "nodeId2" : "idINTERNAL_95_vl3_95_dtrf36",
+    "id" : "_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_btrf13",
+    "nodeId1" : "iddtrf13",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf13",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dline11_95_2_95_INTERNAL_95_vl1_95_dline11_95_2",
-    "nodeId1" : "iddline11_95_2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dline11_95_2",
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf14_95_btrf14",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf14",
+    "nodeId2" : "idbtrf14",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_btrf24_95_INTERNAL_95_vl2_95_dtrf24",
-    "nodeId1" : "idbtrf24",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf24",
+    "id" : "_95_vl2_95_dscpl1_95_INTERNAL_95_vl2_95_ddcpl1",
+    "nodeId1" : "iddscpl1",
+    "nodeId2" : "idINTERNAL_95_vl2_95_ddcpl1",
     "straight" : false,
     "snakeLine" : false
   }, {
     "id" : "_95_vl2_95_btrf24_95_INTERNAL_95_vl2_95_trf4_95_TWO",
     "nodeId1" : "idbtrf24",
     "nodeId2" : "idINTERNAL_95_vl2_95_trf4_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_dgen2",
-    "nodeId1" : "idbgen2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dgen2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_dtrf12",
-    "nodeId1" : "idbtrf12",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf12",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2327,6 +2276,12 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl3_95_dtrf37_95_INTERNAL_95_vl3_95_btrf37",
+    "nodeId1" : "iddtrf37",
+    "nodeId2" : "idINTERNAL_95_vl3_95_btrf37",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_gen2",
     "nodeId1" : "idbgen2",
     "nodeId2" : "idINTERNAL_95_vl1_95_gen2",
@@ -2339,9 +2294,21 @@
     "straight" : false,
     "snakeLine" : true
   }, {
+    "id" : "_95_vl1_95_dline11_95_2_95_INTERNAL_95_vl1_95_bline11_95_2",
+    "nodeId1" : "iddline11_95_2",
+    "nodeId2" : "idINTERNAL_95_vl1_95_bline11_95_2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl2_95_dscpl2_95_bbs6",
     "nodeId1" : "iddscpl2",
     "nodeId2" : "idbbs6",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_INTERNAL_95_vl2_95_bgen4_95_bgen4",
+    "nodeId1" : "idINTERNAL_95_vl2_95_bgen4",
+    "nodeId2" : "idbgen4",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2351,9 +2318,21 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_bload2_95_bload2",
+    "nodeId1" : "idINTERNAL_95_vl1_95_bload2",
+    "nodeId2" : "idbload2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl2_95_btrf27_95_INTERNAL_95_vl2_95_trf7_95_TWO",
     "nodeId1" : "idbtrf27",
     "nodeId2" : "idINTERNAL_95_vl2_95_trf7_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_btrf15",
+    "nodeId1" : "iddtrf15",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf15",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2375,33 +2354,21 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl2_95_INTERNAL_95_vl2_95_btrf28_95_btrf28",
+    "nodeId1" : "idINTERNAL_95_vl2_95_btrf28",
+    "nodeId2" : "idbtrf28",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_INTERNAL_95_vl1_95_load2_95_load2",
     "nodeId1" : "idINTERNAL_95_vl1_95_load2",
     "nodeId2" : "idload2",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl3_95_dtrf25_95_INTERNAL_95_vl3_95_dtrf25",
-    "nodeId1" : "iddtrf25",
-    "nodeId2" : "idINTERNAL_95_vl3_95_dtrf25",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_dtrf11",
-    "nodeId1" : "iddtrf11",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf11",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_dtrf15",
-    "nodeId1" : "idbtrf15",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf15",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl2_95_dscpl2_95_INTERNAL_95_vl2_95_dscpl2",
-    "nodeId1" : "iddscpl2",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dscpl2",
+    "id" : "_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_btrf16",
+    "nodeId1" : "iddtrf16",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf16",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2429,15 +2396,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_trf1_95_ONE",
-    "nodeId1" : "idbtrf11",
-    "nodeId2" : "idINTERNAL_95_vl1_95_trf1_95_ONE",
+    "id" : "_95_vl1_95_dsect11_95_INTERNAL_95_vl1_95_dtrct11",
+    "nodeId1" : "iddsect11",
+    "nodeId2" : "idINTERNAL_95_vl1_95_dtrct11",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl3_95_btrf38_95_INTERNAL_95_vl3_95_dtrf38",
-    "nodeId1" : "idbtrf38",
-    "nodeId2" : "idINTERNAL_95_vl3_95_dtrf38",
+    "id" : "_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_trf1_95_ONE",
+    "nodeId1" : "idbtrf11",
+    "nodeId2" : "idINTERNAL_95_vl1_95_trf1_95_ONE",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2459,21 +2426,9 @@
     "straight" : false,
     "snakeLine" : true
   }, {
-    "id" : "_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect21",
-    "nodeId1" : "iddtrct21",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect21",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_INTERNAL_95_vl1_95_gen1_95_gen1",
     "nodeId1" : "idINTERNAL_95_vl1_95_gen1",
     "nodeId2" : "idgen1",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect22",
-    "nodeId1" : "iddtrct21",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect22",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2495,12 +2450,6 @@
     "straight" : false,
     "snakeLine" : true
   }, {
-    "id" : "_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_dtrf14",
-    "nodeId1" : "idbtrf14",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf14",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl2_95_bbs6_95_dtrf23",
     "nodeId1" : "idbbs6",
     "nodeId2" : "iddtrf23",
@@ -2519,6 +2468,12 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11",
+    "nodeId1" : "idINTERNAL_95_vl1_95_dtrct11",
+    "nodeId2" : "iddtrct11",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl2_95_bbs6_95_dtrf28",
     "nodeId1" : "idbbs6",
     "nodeId2" : "iddtrf28",
@@ -2531,21 +2486,9 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_dtrf21_95_INTERNAL_95_vl2_95_dtrf21",
-    "nodeId1" : "iddtrf21",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf21",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl3_95_btrf25_95_INTERNAL_95_vl3_95_trf5_95_TWO",
     "nodeId1" : "idbtrf25",
     "nodeId2" : "idINTERNAL_95_vl3_95_trf5_95_TWO",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_dtrf18",
-    "nodeId1" : "idbtrf18",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf18",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2555,27 +2498,33 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_ddcpl1_95_INTERNAL_95_vl2_95_dscpl1",
-    "nodeId1" : "idddcpl1",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dscpl1",
+    "id" : "_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_bload1",
+    "nodeId1" : "iddload1",
+    "nodeId2" : "idINTERNAL_95_vl1_95_bload1",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_ddcpl1_95_INTERNAL_95_vl2_95_dscpl2",
-    "nodeId1" : "idddcpl1",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dscpl2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_dtrf14",
-    "nodeId1" : "iddtrf14",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf14",
+    "id" : "_95_vl3_95_dtrf36_95_INTERNAL_95_vl3_95_btrf36",
+    "nodeId1" : "iddtrf36",
+    "nodeId2" : "idINTERNAL_95_vl3_95_btrf36",
     "straight" : false,
     "snakeLine" : false
   }, {
     "id" : "_95_vl2_95_btrf26_95_INTERNAL_95_vl2_95_trf6_95_TWO",
     "nodeId1" : "idbtrf26",
     "nodeId2" : "idINTERNAL_95_vl2_95_trf6_95_TWO",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_bload1_95_bload1",
+    "nodeId1" : "idINTERNAL_95_vl1_95_bload1",
+    "nodeId2" : "idbload1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf12_95_btrf12",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf12",
+    "nodeId2" : "idbtrf12",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2597,6 +2546,12 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf18_95_btrf18",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf18",
+    "nodeId2" : "idbtrf18",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl3_95_INTERNAL_95_vl3_95_trf6_95_THREE_95_trf6_95_THREE",
     "nodeId1" : "idINTERNAL_95_vl3_95_trf6_95_THREE",
     "nodeId2" : "idtrf6_95_THREE",
@@ -2615,9 +2570,15 @@
     "straight" : false,
     "snakeLine" : true
   }, {
-    "id" : "_95_vl2_95_btrf28_95_INTERNAL_95_vl2_95_dtrf28",
-    "nodeId1" : "idbtrf28",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf28",
+    "id" : "_95_vl1_95_dsect12_95_INTERNAL_95_vl1_95_dtrct11",
+    "nodeId1" : "iddsect12",
+    "nodeId2" : "idINTERNAL_95_vl1_95_dtrct11",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl2_95_INTERNAL_95_vl2_95_btrf23_95_btrf23",
+    "nodeId1" : "idINTERNAL_95_vl2_95_btrf23",
+    "nodeId2" : "idbtrf23",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2627,15 +2588,27 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl2_95_dtrf24_95_INTERNAL_95_vl2_95_dtrf24",
-    "nodeId1" : "iddtrf24",
-    "nodeId2" : "idINTERNAL_95_vl2_95_dtrf24",
+    "id" : "_95_vl2_95_dtrf26_95_INTERNAL_95_vl2_95_btrf26",
+    "nodeId1" : "iddtrf26",
+    "nodeId2" : "idINTERNAL_95_vl2_95_btrf26",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_dtrf11",
-    "nodeId1" : "idbtrf11",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf11",
+    "id" : "_95_vl1_95_dsect21_95_INTERNAL_95_vl1_95_dtrct21",
+    "nodeId1" : "iddsect21",
+    "nodeId2" : "idINTERNAL_95_vl1_95_dtrct21",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21",
+    "nodeId1" : "idINTERNAL_95_vl1_95_dtrct21",
+    "nodeId2" : "iddtrct21",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf15_95_btrf15",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf15",
+    "nodeId2" : "idbtrf15",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -2651,21 +2624,9 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_dtrf17",
-    "nodeId1" : "iddtrf17",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf17",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_bline11_95_2_95_INTERNAL_95_vl1_95_line1_95_ONE",
     "nodeId1" : "idbline11_95_2",
     "nodeId2" : "idINTERNAL_95_vl1_95_line1_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_dgen1",
-    "nodeId1" : "idbgen1",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dgen1",
     "straight" : false,
     "snakeLine" : false
   }, {

--- a/single-line-diagram-core/src/test/resources/switchesOnBus.svg
+++ b/single-line-diagram-core/src/test/resources/switchesOnBus.svg
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg height="720.0" viewBox="0 0 280.0 720.0" width="280.0" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+/* ----------------------------------------------------------------------- */
+/* File: tautologies.css ------------------------------------------------- */
+.sld-out .sld-arrow-in {visibility: hidden}
+.sld-in .sld-arrow-out {visibility: hidden}
+.sld-closed .sld-sw-open {visibility: hidden}
+.sld-open .sld-sw-closed {visibility: hidden}
+.sld-hidden-node {visibility: hidden}
+.sld-top-feeder .sld-label {dominant-baseline: auto}
+.sld-bottom-feeder .sld-label {dominant-baseline: hanging}
+.sld-arrow-p .sld-label {dominant-baseline: middle}
+.sld-arrow-q .sld-label {dominant-baseline: middle}
+/* ----------------------------------------------------------------------- */
+/* File : components.css ------------------------------------------------- */
+/* Stroke black */
+.sld-disconnector {stroke-width: 3; stroke: black; fill: none}
+/* Stroke blue */
+.sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: white}
+/* Stroke --sld-vl-color with fallback black */
+.sld-bus-connection {fill: var(--sld-vl-color, black)}
+.sld-cell-shape-flat .sld-bus-connection {visibility: hidden}
+.sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
+/* Stroke --sld-vl-color with fallback red */
+.sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
+/* Stroke --sld-vl-color with fallback blue */
+.sld-load {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-three-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-winding {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-capacitor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-inductor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst-arrow {stroke: black; fill: none}
+.sld-svc {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-vsc {stroke: var(--sld-vl-color, blue); font-size: 7.43px; fill: none}
+/* Stroke none & fill: --sld-vl-color */
+.sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
+/* Stroke none & fill: black */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
+.sld-node {stroke: none; fill: black}
+.sld-flash {stroke: none; fill: black}
+.sld-lock {stroke: none; fill: black}
+/* Specific */
+.sld-grid {stroke: #003700; stroke-dasharray: 1,10}
+.sld-arrow-p {fill:black}
+.sld-arrow-q {fill:blue}
+.sld-frame {fill: var(--sld-background-color, transparent)}
+/* Stroke maroon for fictitious switch */
+.sld-breaker.sld-fictitious {stroke: maroon}
+.sld-disconnector.sld-fictitious {stroke: maroon}
+.sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
+
+]]></style>
+    <rect class="sld-frame" height="100%" width="100%"/>
+    <g>
+        <g class="sld-grid" id="GRID_vl">
+            <line x1="40.0" x2="40.0" y1="80.0" y2="640.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="640.0"/>
+            <line x1="140.0" x2="140.0" y1="80.0" y2="640.0"/>
+            <line x1="190.0" x2="190.0" y1="80.0" y2="640.0"/>
+            <line x1="240.0" x2="240.0" y1="80.0" y2="640.0"/>
+            <line x1="40.0" x2="240.0" y1="330.0" y2="330.0"/>
+            <line x1="40.0" x2="240.0" y1="320.0" y2="320.0"/>
+            <line x1="40.0" x2="240.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="240.0" y1="390.0" y2="390.0"/>
+            <line x1="40.0" x2="240.0" y1="400.0" y2="400.0"/>
+            <line x1="40.0" x2="240.0" y1="578.0" y2="578.0"/>
+        </g>
+        <g class="sld-busbar-section" id="idbbs" transform="translate(152.5,360.0)">
+            <line x1="0" x2="75.0" y1="0" y2="0"/>
+            <text class="sld-label" id="bbs_NW_LABEL" x="-5.0" y="-5.0">bbs</text>
+        </g>
+        <g class="sld-busbar-section" id="idbbs2" transform="translate(52.5,360.0)">
+            <line x1="0" x2="75.0" y1="0" y2="0"/>
+            <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
+        </g>
+        <g class="sld-extern-cell" id="idEXTERN_32_0">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(186.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_svc" transform="translate(161.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-svc sld-top-feeder" id="idsvc" transform="translate(159.0,74.0)">
+                <path d="M 6,0 V 4.5 M 0,4.5 H 12 M 0,7.5 H 12 M 6,7.5 V 12"/>
+                <path d="M 0.2556,10.611 11.671,1.448 M 9.329,2.045 11.671,1.448 10.581,3.6046" style="fill:none;stroke:#0000ff;stroke-width:0.5;stroke-linejoin:miter"/>
+                <text class="sld-label" id="svc_N_LABEL" x="-5.0" y="-5.0">svc</text>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(211.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-vsc sld-top-feeder" id="idvsc" transform="translate(207.0,76.0)">
+                <text x="-5.3" y="6.6">AC / DC</text>
+                <text class="sld-label" id="vsc_N_LABEL" x="-5.0" y="-5.0">Converter1</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_vsc">
+                <polyline points="190.0,360.0,190.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_vsc">
+                <polyline points="165.0,246.0,165.0,330.0,190.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_INTERNAL_95_vl_95_vsc">
+                <polyline points="190.0,330.0,215.0,330.0,215.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_svc">
+                <polyline points="165.0,226.0,165.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_svc_95_svc">
+                <polyline points="165.0,142.0,165.0,86.0"/>
+            </g>
+            <g class="sld-arrow-p sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(160.0,101.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">100</text>
+            </g>
+            <g class="sld-arrow-q sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(160.0,121.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">50</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_vsc">
+                <polyline points="215.0,142.0,215.0,86.0"/>
+            </g>
+            <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">100</text>
+            </g>
+            <g class="sld-arrow-q sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">50</text>
+            </g>
+            <g class="sld-disconnector sld-closed" id="idd" transform="translate(186.0,356.0)">
+                <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
+                <path class="sld-sw-open" d="M8,0 0,8"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idb" transform="translate(155.0,226.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+        </g>
+        <g class="sld-extern-cell" id="idEXTERN_32_1">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b2" transform="translate(61.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_C1" transform="translate(61.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-capacitor sld-top-feeder" id="idC1" transform="translate(59.0,74.0)">
+                <line x1="6" x2="6" y1="0" y2="4.5"/>
+                <line x1="0" x2="12" y1="4.5" y2="4.5"/>
+                <line x1="0" x2="12" y1="7.5" y2="7.5"/>
+                <line x1="6" x2="6" y1="7.5" y2="12"/>
+                <text class="sld-label" id="C1_N_LABEL" x="-5.0" y="-5.0">Filter 1</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_b2_95_INTERNAL_95_vl_95_b2">
+                <polyline points="65.0,360.0,65.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_b2_95_b2">
+                <polyline points="65.0,330.0,65.0,246.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b2_95_INTERNAL_95_vl_95_C1">
+                <polyline points="65.0,226.0,65.0,142.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_C1_95_C1">
+                <polyline points="65.0,142.0,65.0,86.0"/>
+            </g>
+            <g class="sld-arrow-p sld-in" id="idC1_ARROW_ACTIVE" transform="translate(60.0,101.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idC1_ARROW_REACTIVE" transform="translate(60.0,121.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">-</text>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_b2" transform="translate(61.0,356.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idb2" transform="translate(55.0,226.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+        </g>
+        <g class="sld-extern-cell" id="idEXTERN_32_2">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b3" transform="translate(111.0,386.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_dl1" transform="translate(111.0,574.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-bottom-feeder" id="iddl1" transform="translate(115.0,640.0)">
+                <text class="sld-label" id="dl1_S_LABEL" x="-5.0" y="5.0">Dangling line 1</text>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_BUSCO_95_b3_95_INTERNAL_95_vl_95_b3">
+                <polyline points="115.0,360.0,115.0,390.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_b3_95_b3">
+                <polyline points="115.0,390.0,115.0,474.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b3_95_INTERNAL_95_vl_95_dl1">
+                <polyline points="115.0,494.0,115.0,578.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_dl1_95_dl1">
+                <polyline points="115.0,578.0,115.0,640.0"/>
+            </g>
+            <g class="sld-arrow-p sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,615.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">100</text>
+            </g>
+            <g class="sld-arrow-q sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,595.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">50</text>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_b3" transform="translate(111.0,356.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idb3" transform="translate(105.0,474.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/single-line-diagram-core/src/test/resources/switchesOnBus.svg
+++ b/single-line-diagram-core/src/test/resources/switchesOnBus.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg height="720.0" viewBox="0 0 280.0 720.0" width="280.0" xmlns="http://www.w3.org/2000/svg">
+<svg height="720.0" viewBox="0 0 330.0 720.0" width="330.0" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 /* ----------------------------------------------------------------------- */
 /* File: tautologies.css ------------------------------------------------- */
@@ -65,14 +65,15 @@
             <line x1="140.0" x2="140.0" y1="80.0" y2="640.0"/>
             <line x1="190.0" x2="190.0" y1="80.0" y2="640.0"/>
             <line x1="240.0" x2="240.0" y1="80.0" y2="640.0"/>
-            <line x1="40.0" x2="240.0" y1="330.0" y2="330.0"/>
-            <line x1="40.0" x2="240.0" y1="320.0" y2="320.0"/>
-            <line x1="40.0" x2="240.0" y1="142.0" y2="142.0"/>
-            <line x1="40.0" x2="240.0" y1="390.0" y2="390.0"/>
-            <line x1="40.0" x2="240.0" y1="400.0" y2="400.0"/>
-            <line x1="40.0" x2="240.0" y1="578.0" y2="578.0"/>
+            <line x1="290.0" x2="290.0" y1="80.0" y2="640.0"/>
+            <line x1="40.0" x2="290.0" y1="330.0" y2="330.0"/>
+            <line x1="40.0" x2="290.0" y1="320.0" y2="320.0"/>
+            <line x1="40.0" x2="290.0" y1="142.0" y2="142.0"/>
+            <line x1="40.0" x2="290.0" y1="390.0" y2="390.0"/>
+            <line x1="40.0" x2="290.0" y1="400.0" y2="400.0"/>
+            <line x1="40.0" x2="290.0" y1="578.0" y2="578.0"/>
         </g>
-        <g class="sld-busbar-section" id="idbbs" transform="translate(152.5,360.0)">
+        <g class="sld-busbar-section" id="idbbs" transform="translate(202.5,360.0)">
             <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs_NW_LABEL" x="-5.0" y="-5.0">bbs</text>
         </g>
@@ -80,74 +81,104 @@
             <line x1="0" x2="75.0" y1="0" y2="0"/>
             <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
         </g>
-        <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(186.0,326.0)">
+        <g class="sld-intern-cell sld-cell-shape-flat" id="idINTERN_32_0">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_bt" transform="translate(186.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_svc" transform="translate(161.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_bt" transform="translate(136.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-svc sld-top-feeder" id="idsvc" transform="translate(159.0,74.0)">
+            <g class="sld-wire" id="_95_vl_95_bbs_95_BUSCO_95_bt">
+                <polyline points="202.5,360.0,190.0,360.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_bt_95_bt">
+                <polyline points="190.0,360.0,175.0,360.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_bt_95_bt">
+                <polyline points="140.0,360.0,155.0,360.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_bbs2_95_BUSCO_95_bt">
+                <polyline points="127.5,360.0,140.0,360.0"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_bt" transform="translate(186.0,356.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idbt" transform="translate(155.0,350.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15" transform="rotate(90.0,10.0,10.0)"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15" transform="rotate(90.0,10.0,10.0)"/>
+            </g>
+            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_bt" transform="translate(136.0,356.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+        </g>
+        <g class="sld-extern-cell" id="idEXTERN_32_1">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(236.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_svc" transform="translate(211.0,138.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-svc sld-top-feeder" id="idsvc" transform="translate(209.0,74.0)">
                 <path d="M 6,0 V 4.5 M 0,4.5 H 12 M 0,7.5 H 12 M 6,7.5 V 12"/>
                 <path d="M 0.2556,10.611 11.671,1.448 M 9.329,2.045 11.671,1.448 10.581,3.6046" style="fill:none;stroke:#0000ff;stroke-width:0.5;stroke-linejoin:miter"/>
                 <text class="sld-label" id="svc_N_LABEL" x="-5.0" y="-5.0">svc</text>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(211.0,138.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_vsc" transform="translate(261.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-vsc sld-top-feeder" id="idvsc" transform="translate(207.0,76.0)">
+            <g class="sld-vsc sld-top-feeder" id="idvsc" transform="translate(257.0,76.0)">
                 <text x="-5.3" y="6.6">AC / DC</text>
                 <text class="sld-label" id="vsc_N_LABEL" x="-5.0" y="-5.0">Converter1</text>
             </g>
             <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_vsc">
-                <polyline points="190.0,360.0,190.0,330.0"/>
+                <polyline points="240.0,360.0,240.0,330.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_vsc">
-                <polyline points="165.0,246.0,165.0,330.0,190.0,330.0"/>
+                <polyline points="215.0,246.0,215.0,330.0,240.0,330.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_INTERNAL_95_vl_95_vsc">
-                <polyline points="190.0,330.0,215.0,330.0,215.0,142.0"/>
+                <polyline points="240.0,330.0,265.0,330.0,265.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_svc">
-                <polyline points="165.0,226.0,165.0,142.0"/>
+                <polyline points="215.0,226.0,215.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_svc_95_svc">
-                <polyline points="165.0,142.0,165.0,86.0"/>
+                <polyline points="215.0,142.0,215.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(160.0,101.0)">
+            <g class="sld-arrow-p sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(160.0,121.0)">
+            <g class="sld-arrow-q sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
             </g>
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_vsc">
-                <polyline points="215.0,142.0,215.0,86.0"/>
+                <polyline points="265.0,142.0,265.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
+            <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(260.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
+            <g class="sld-arrow-q sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(260.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
             </g>
-            <g class="sld-disconnector sld-closed" id="idd" transform="translate(186.0,356.0)">
+            <g class="sld-disconnector sld-closed" id="idd" transform="translate(236.0,356.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
                 <path class="sld-sw-open" d="M8,0 0,8"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idb" transform="translate(155.0,226.0)">
+            <g class="sld-breaker sld-closed" id="idb" transform="translate(205.0,226.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>
-        <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b2" transform="translate(61.0,326.0)">
+        <g class="sld-extern-cell" id="idEXTERN_32_2">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_C1" transform="translate(61.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_C1" transform="translate(61.0,138.0)">
@@ -160,14 +191,14 @@
                 <line x1="6" x2="6" y1="7.5" y2="12"/>
                 <text class="sld-label" id="C1_N_LABEL" x="-5.0" y="-5.0">Filter 1</text>
             </g>
-            <g class="sld-wire" id="_95_vl_95_BUSCO_95_b2_95_INTERNAL_95_vl_95_b2">
-                <polyline points="65.0,360.0,65.0,330.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_b2_95_b2">
-                <polyline points="65.0,330.0,65.0,246.0"/>
+            <g class="sld-wire" id="_95_vl_95_bbs2_95_b2">
+                <polyline points="65.0,360.0,65.0,350.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_b2_95_INTERNAL_95_vl_95_C1">
-                <polyline points="65.0,226.0,65.0,142.0"/>
+                <polyline points="65.0,350.0,65.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_C1_95_INTERNAL_95_vl_95_C1">
+                <polyline points="65.0,330.0,65.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_C1_95_C1">
                 <polyline points="65.0,142.0,65.0,86.0"/>
@@ -182,16 +213,13 @@
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-</text>
             </g>
-            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_b2" transform="translate(61.0,356.0)">
-                <circle cx="4" cy="4" r="4"/>
-            </g>
-            <g class="sld-breaker sld-closed" id="idb2" transform="translate(55.0,226.0)">
+            <g class="sld-breaker sld-closed" id="idb2" transform="translate(55.0,350.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
         </g>
-        <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b3" transform="translate(111.0,386.0)">
+        <g class="sld-extern-cell" id="idEXTERN_32_3">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_dl1" transform="translate(111.0,386.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_dl1" transform="translate(111.0,574.0)">
@@ -200,32 +228,29 @@
             <g class="sld-bottom-feeder" id="iddl1" transform="translate(115.0,640.0)">
                 <text class="sld-label" id="dl1_S_LABEL" x="-5.0" y="5.0">Dangling line 1</text>
             </g>
-            <g class="sld-wire" id="_95_vl_95_BUSCO_95_b3_95_INTERNAL_95_vl_95_b3">
-                <polyline points="115.0,360.0,115.0,390.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_b3_95_b3">
-                <polyline points="115.0,390.0,115.0,474.0"/>
+            <g class="sld-wire" id="_95_vl_95_bbs2_95_b3">
+                <polyline points="115.0,360.0,115.0,350.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_b3_95_INTERNAL_95_vl_95_dl1">
-                <polyline points="115.0,494.0,115.0,578.0"/>
+                <polyline points="115.0,370.0,115.0,390.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_dl1_95_INTERNAL_95_vl_95_dl1">
+                <polyline points="115.0,390.0,115.0,578.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_dl1_95_dl1">
                 <polyline points="115.0,578.0,115.0,640.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,615.0)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
-                <text class="sld-label" x="15.0" y="5.0">100</text>
-            </g>
-            <g class="sld-arrow-q sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,595.0)">
+            <g class="sld-arrow-q sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,615.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
             </g>
-            <g class="sld-bus-connection sld-fictitious" id="idBUSCO_95_b3" transform="translate(111.0,356.0)">
-                <circle cx="4" cy="4" r="4"/>
+            <g class="sld-arrow-p sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,595.0)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
+                <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-breaker sld-closed" id="idb3" transform="translate(105.0,474.0)">
+            <g class="sld-breaker sld-closed" id="idb3" transform="translate(105.0,350.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>

--- a/single-line-diagram-core/src/test/resources/testDoubleForkNode.json
+++ b/single-line-diagram-core/src/test/resources/testDoubleForkNode.json
@@ -1,0 +1,629 @@
+{
+  "voltageLevelInfos" : {
+    "id" : "vl1",
+    "name" : "vl1",
+    "nominalVoltage" : 380.0
+  },
+  "x" : 40.0,
+  "y" : 80.0,
+  "nodes" : [ {
+    "type" : "FICTITIOUS",
+    "id" : "BUSCO_bCD1",
+    "componentType" : "BUS_CONNECTION",
+    "fictitious" : true,
+    "x" : 75.0,
+    "y" : 305.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "BUSCO_bCD2",
+    "componentType" : "BUS_CONNECTION",
+    "fictitious" : true,
+    "x" : 25.0,
+    "y" : 280.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "BUSCO_bCD3",
+    "componentType" : "BUS_CONNECTION",
+    "fictitious" : true,
+    "x" : 125.0,
+    "y" : 280.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl1_bCD1",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 75.0,
+    "y" : 250.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl1_bCD2",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 25.0,
+    "y" : 250.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl1_bCD3",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 125.0,
+    "y" : 250.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl1_loadC",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 112.5,
+    "y" : 62.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl1_loadC_fork",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 75.0,
+    "y" : 156.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl1_loadD",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 37.5,
+    "y" : 62.0,
+    "open" : false
+  }, {
+    "type" : "SWITCH",
+    "id" : "bCD1",
+    "name" : "bCD1",
+    "equipmentId" : "bCD1",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 75.0,
+    "y" : 203.0,
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "SWITCH",
+    "id" : "bCD2",
+    "name" : "bCD2",
+    "equipmentId" : "bCD2",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 25.0,
+    "y" : 203.0,
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "SWITCH",
+    "id" : "bCD3",
+    "name" : "bCD3",
+    "equipmentId" : "bCD3",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 125.0,
+    "y" : 203.0,
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "SWITCH",
+    "id" : "bD1",
+    "name" : "bD1",
+    "equipmentId" : "bD1",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 37.5,
+    "y" : 109.0,
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "BUS",
+    "id" : "bbs13",
+    "name" : "bbs13",
+    "equipmentId" : "bbs13",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 12.5,
+    "y" : 280.0,
+    "open" : false,
+    "pxWidth" : 125.0,
+    "busbarIndex" : 1,
+    "sectionIndex" : 3,
+    "position" : {
+      "h" : 0,
+      "v" : 0,
+      "hSpan" : 6,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "BUS",
+    "id" : "bbs23",
+    "name" : "bbs23",
+    "equipmentId" : "bbs23",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 12.5,
+    "y" : 305.0,
+    "open" : false,
+    "pxWidth" : 125.0,
+    "busbarIndex" : 2,
+    "sectionIndex" : 3,
+    "position" : {
+      "h" : 0,
+      "v" : 1,
+      "hSpan" : 6,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "FEEDER",
+    "id" : "loadC",
+    "name" : "loadC",
+    "equipmentId" : "loadC",
+    "componentType" : "LOAD",
+    "fictitious" : false,
+    "x" : 112.5,
+    "y" : 0.0,
+    "open" : false,
+    "label" : "loadC",
+    "feederType" : "INJECTION",
+    "direction" : "TOP"
+  }, {
+    "type" : "FEEDER",
+    "id" : "loadD",
+    "name" : "loadD",
+    "equipmentId" : "loadD",
+    "componentType" : "LOAD",
+    "fictitious" : false,
+    "x" : 37.5,
+    "y" : 0.0,
+    "open" : false,
+    "label" : "loadD",
+    "feederType" : "INJECTION",
+    "direction" : "TOP"
+  } ],
+  "cells" : [ {
+    "type" : "EXTERN",
+    "number" : 0,
+    "direction" : "TOP",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 3
+      }, {
+        "END" : 2
+      } ],
+      "position" : {
+        "h" : 0,
+        "v" : 0,
+        "hSpan" : 6,
+        "vSpan" : 8,
+        "orientation" : "UP"
+      },
+      "coord" : {
+        "x" : 75.0,
+        "y" : 156.0,
+        "xSpan" : 150.0,
+        "ySpan" : 188.0
+      },
+      "subBlocks" : [ {
+        "type" : "BODYPARALLEL",
+        "cardinalities" : [ {
+          "START" : 3
+        }, {
+          "END" : 3
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 6,
+          "vSpan" : 4,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 203.0,
+          "xSpan" : 150.0,
+          "ySpan" : 94.0
+        },
+        "subBlocks" : [ {
+          "type" : "SERIAL",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 0,
+            "hSpan" : 2,
+            "vSpan" : 4,
+            "orientation" : "UP"
+          },
+          "coord" : {
+            "x" : 25.0,
+            "y" : 203.0,
+            "xSpan" : 50.0,
+            "ySpan" : 94.0
+          },
+          "subBlocks" : [ {
+            "type" : "LEGPRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 2,
+              "vSpan" : 0,
+              "orientation" : "UP"
+            },
+            "coord" : {
+              "x" : 25.0,
+              "y" : 250.0,
+              "xSpan" : 50.0,
+              "ySpan" : 0.0
+            },
+            "nodes" : [ "bbs13", "BUSCO_bCD2", "INTERNAL_vl1_bCD2" ]
+          }, {
+            "type" : "BODYPRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 2,
+              "vSpan" : 4,
+              "orientation" : "UP"
+            },
+            "coord" : {
+              "x" : 25.0,
+              "y" : 203.0,
+              "xSpan" : 50.0,
+              "ySpan" : 94.0
+            },
+            "nodes" : [ "INTERNAL_vl1_bCD2", "bCD2", "INTERNAL_vl1_loadC_fork" ]
+          } ]
+        }, {
+          "type" : "SERIAL",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 2,
+            "v" : 0,
+            "hSpan" : 2,
+            "vSpan" : 4,
+            "orientation" : "UP"
+          },
+          "coord" : {
+            "x" : 75.0,
+            "y" : 203.0,
+            "xSpan" : 50.0,
+            "ySpan" : 94.0
+          },
+          "subBlocks" : [ {
+            "type" : "LEGPRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 2,
+              "vSpan" : 0,
+              "orientation" : "UP"
+            },
+            "coord" : {
+              "x" : 75.0,
+              "y" : 250.0,
+              "xSpan" : 50.0,
+              "ySpan" : 0.0
+            },
+            "nodes" : [ "bbs23", "BUSCO_bCD1", "INTERNAL_vl1_bCD1" ]
+          }, {
+            "type" : "BODYPRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 2,
+              "vSpan" : 4,
+              "orientation" : "UP"
+            },
+            "coord" : {
+              "x" : 75.0,
+              "y" : 203.0,
+              "xSpan" : 50.0,
+              "ySpan" : 94.0
+            },
+            "nodes" : [ "INTERNAL_vl1_bCD1", "bCD1", "INTERNAL_vl1_loadC_fork" ]
+          } ]
+        }, {
+          "type" : "SERIAL",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 4,
+            "v" : 0,
+            "hSpan" : 2,
+            "vSpan" : 4,
+            "orientation" : "UP"
+          },
+          "coord" : {
+            "x" : 125.0,
+            "y" : 203.0,
+            "xSpan" : 50.0,
+            "ySpan" : 94.0
+          },
+          "subBlocks" : [ {
+            "type" : "LEGPRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 2,
+              "vSpan" : 0,
+              "orientation" : "UP"
+            },
+            "coord" : {
+              "x" : 125.0,
+              "y" : 250.0,
+              "xSpan" : 50.0,
+              "ySpan" : 0.0
+            },
+            "nodes" : [ "bbs13", "BUSCO_bCD3", "INTERNAL_vl1_bCD3" ]
+          }, {
+            "type" : "BODYPRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 2,
+              "vSpan" : 4,
+              "orientation" : "UP"
+            },
+            "coord" : {
+              "x" : 125.0,
+              "y" : 203.0,
+              "xSpan" : 50.0,
+              "ySpan" : 94.0
+            },
+            "nodes" : [ "INTERNAL_vl1_bCD3", "bCD3", "INTERNAL_vl1_loadC_fork" ]
+          } ]
+        } ]
+      }, {
+        "type" : "BODYPARALLEL",
+        "cardinalities" : [ {
+          "START" : 2
+        }, {
+          "END" : 2
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 4,
+          "hSpan" : 4,
+          "vSpan" : 4,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 109.0,
+          "xSpan" : 150.0,
+          "ySpan" : 94.0
+        },
+        "subBlocks" : [ {
+          "type" : "SERIAL",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 0,
+            "hSpan" : 2,
+            "vSpan" : 4,
+            "orientation" : "UP"
+          },
+          "coord" : {
+            "x" : 37.5,
+            "y" : 109.0,
+            "xSpan" : 75.0,
+            "ySpan" : 94.0
+          },
+          "subBlocks" : [ {
+            "type" : "BODYPRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 2,
+              "vSpan" : 4,
+              "orientation" : "UP"
+            },
+            "coord" : {
+              "x" : 37.5,
+              "y" : 109.0,
+              "xSpan" : 75.0,
+              "ySpan" : 94.0
+            },
+            "nodes" : [ "INTERNAL_vl1_loadC_fork", "bD1", "INTERNAL_vl1_loadD" ]
+          }, {
+            "type" : "FEEDERPRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 4,
+              "hSpan" : 2,
+              "vSpan" : 0,
+              "orientation" : "UP"
+            },
+            "coord" : {
+              "x" : 37.5,
+              "y" : 62.0,
+              "xSpan" : 75.0,
+              "ySpan" : 0.0
+            },
+            "nodes" : [ "INTERNAL_vl1_loadD", "loadD" ]
+          } ]
+        }, {
+          "type" : "SERIAL",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 2,
+            "v" : 0,
+            "hSpan" : 2,
+            "vSpan" : 2,
+            "orientation" : "UP"
+          },
+          "coord" : {
+            "x" : 112.5,
+            "y" : 109.0,
+            "xSpan" : 75.0,
+            "ySpan" : 94.0
+          },
+          "subBlocks" : [ {
+            "type" : "BODYPRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 0,
+              "hSpan" : 2,
+              "vSpan" : 2,
+              "orientation" : "UP"
+            },
+            "coord" : {
+              "x" : 112.5,
+              "y" : 109.0,
+              "xSpan" : 75.0,
+              "ySpan" : 94.0
+            },
+            "nodes" : [ "INTERNAL_vl1_loadC_fork", "INTERNAL_vl1_loadC" ]
+          }, {
+            "type" : "FEEDERPRIMARY",
+            "cardinalities" : [ {
+              "START" : 1
+            }, {
+              "END" : 1
+            } ],
+            "position" : {
+              "h" : 0,
+              "v" : 2,
+              "hSpan" : 2,
+              "vSpan" : 0,
+              "orientation" : "UP"
+            },
+            "coord" : {
+              "x" : 112.5,
+              "y" : 62.0,
+              "xSpan" : 75.0,
+              "ySpan" : 0.0
+            },
+            "nodes" : [ "INTERNAL_vl1_loadC", "loadC" ]
+          } ]
+        } ]
+      } ]
+    }
+  } ],
+  "edges" : [ {
+    "node1" : "bbs13",
+    "node2" : "BUSCO_bCD2"
+  }, {
+    "node1" : "bbs13",
+    "node2" : "BUSCO_bCD3"
+  }, {
+    "node1" : "bbs23",
+    "node2" : "BUSCO_bCD1"
+  }, {
+    "node1" : "BUSCO_bCD2",
+    "node2" : "INTERNAL_vl1_bCD2"
+  }, {
+    "node1" : "INTERNAL_vl1_bCD2",
+    "node2" : "bCD2"
+  }, {
+    "node1" : "BUSCO_bCD3",
+    "node2" : "INTERNAL_vl1_bCD3"
+  }, {
+    "node1" : "INTERNAL_vl1_bCD3",
+    "node2" : "bCD3"
+  }, {
+    "node1" : "BUSCO_bCD1",
+    "node2" : "INTERNAL_vl1_bCD1"
+  }, {
+    "node1" : "INTERNAL_vl1_bCD1",
+    "node2" : "bCD1"
+  }, {
+    "node1" : "bCD1",
+    "node2" : "INTERNAL_vl1_loadC_fork"
+  }, {
+    "node1" : "bCD2",
+    "node2" : "INTERNAL_vl1_loadC_fork"
+  }, {
+    "node1" : "bCD3",
+    "node2" : "INTERNAL_vl1_loadC_fork"
+  }, {
+    "node1" : "bD1",
+    "node2" : "INTERNAL_vl1_loadC_fork"
+  }, {
+    "node1" : "INTERNAL_vl1_loadC_fork",
+    "node2" : "INTERNAL_vl1_loadC"
+  }, {
+    "node1" : "INTERNAL_vl1_loadC",
+    "node2" : "loadC"
+  }, {
+    "node1" : "bD1",
+    "node2" : "INTERNAL_vl1_loadD"
+  }, {
+    "node1" : "INTERNAL_vl1_loadD",
+    "node2" : "loadD"
+  } ],
+  "multitermNodes" : [ ],
+  "twtEdges" : [ ],
+  "lineEdges" : [ ]
+}

--- a/single-line-diagram-core/src/test/resources/testLanesWithUnileg.json
+++ b/single-line-diagram-core/src/test/resources/testLanesWithUnileg.json
@@ -8,15 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_dF1",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 125.0,
-    "y" : 240.0,
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_db11",
+    "id" : "INTERNAL_vl_b1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 25.0,
@@ -24,7 +16,15 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_db12",
+    "id" : "INTERNAL_vl_b1",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 225.0,
+    "y" : 220.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl_b2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -33,20 +33,20 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_db31",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 225.0,
-    "y" : 220.0,
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_db32",
+    "id" : "INTERNAL_vl_b2",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 175.0,
     "y" : 345.0,
     "orientation" : "DOWN",
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl_dF2",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 125.0,
+    "y" : 240.0,
     "open" : false
   }, {
     "type" : "SWITCH",
@@ -260,7 +260,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs13", "db31", "INTERNAL_vl_db31" ]
+        "nodes" : [ "bbs13", "db31", "INTERNAL_vl_b1" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -281,7 +281,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_db11", "b1", "INTERNAL_vl_db31" ]
+        "nodes" : [ "INTERNAL_vl_b1", "b1", "INTERNAL_vl_b1" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -302,7 +302,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs11", "db11", "INTERNAL_vl_db11" ]
+        "nodes" : [ "bbs11", "db11", "INTERNAL_vl_b1" ]
       } ]
     }
   }, {
@@ -348,7 +348,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs13", "db32", "INTERNAL_vl_db32" ]
+        "nodes" : [ "bbs13", "db32", "INTERNAL_vl_b2" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -369,7 +369,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_db12", "b2", "INTERNAL_vl_db32" ]
+        "nodes" : [ "INTERNAL_vl_b2", "b2", "INTERNAL_vl_b2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -390,7 +390,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs11", "db12", "INTERNAL_vl_db12" ]
+        "nodes" : [ "bbs11", "db12", "INTERNAL_vl_b2" ]
       } ]
     }
   }, {
@@ -437,7 +437,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs12", "dF1", "INTERNAL_vl_dF1" ]
+        "nodes" : [ "bbs12", "dF1", "INTERNAL_vl_dF2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -458,7 +458,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs22", "dF2", "INTERNAL_vl_dF1" ]
+        "nodes" : [ "bbs22", "dF2", "INTERNAL_vl_dF2" ]
       } ]
     }
   } ],
@@ -481,35 +481,35 @@
     "node1" : "db32",
     "node2" : "bbs13"
   }, {
-    "node1" : "b1",
-    "node2" : "INTERNAL_vl_db11"
-  }, {
     "node1" : "db11",
-    "node2" : "INTERNAL_vl_db11"
+    "node2" : "INTERNAL_vl_b1"
   }, {
-    "node1" : "b2",
-    "node2" : "INTERNAL_vl_db12"
+    "node1" : "INTERNAL_vl_b1",
+    "node2" : "b1"
   }, {
     "node1" : "db12",
-    "node2" : "INTERNAL_vl_db12"
+    "node2" : "INTERNAL_vl_b2"
   }, {
-    "node1" : "dF2",
-    "node2" : "INTERNAL_vl_dF1"
+    "node1" : "INTERNAL_vl_b2",
+    "node2" : "b2"
   }, {
     "node1" : "dF1",
-    "node2" : "INTERNAL_vl_dF1"
+    "node2" : "INTERNAL_vl_dF2"
   }, {
-    "node1" : "b1",
-    "node2" : "INTERNAL_vl_db31"
+    "node1" : "INTERNAL_vl_dF2",
+    "node2" : "dF2"
   }, {
     "node1" : "db31",
-    "node2" : "INTERNAL_vl_db31"
+    "node2" : "INTERNAL_vl_b1"
   }, {
-    "node1" : "b2",
-    "node2" : "INTERNAL_vl_db32"
+    "node1" : "INTERNAL_vl_b1",
+    "node2" : "b1"
   }, {
     "node1" : "db32",
-    "node2" : "INTERNAL_vl_db32"
+    "node2" : "INTERNAL_vl_b2"
+  }, {
+    "node1" : "INTERNAL_vl_b2",
+    "node2" : "b2"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/testParallelFeedersOnBus.json
+++ b/single-line-diagram-core/src/test/resources/testParallelFeedersOnBus.json
@@ -16,7 +16,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_l1_1",
+    "id" : "INTERNAL_vl_l1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -24,7 +24,7 @@
     "open" : false
   }, {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_l1_2",
+    "id" : "INTERNAL_vl_l1",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 75.0,
@@ -139,7 +139,7 @@
           "xSpan" : 100.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs", "BUSCO_l1", "INTERNAL_vl_l1_1" ]
+        "nodes" : [ "bbs", "BUSCO_l1", "INTERNAL_vl_l1" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -200,7 +200,7 @@
               "xSpan" : 50.0,
               "ySpan" : 188.0
             },
-            "nodes" : [ "INTERNAL_vl_l1_1", "b", "INTERNAL_vl_l2" ]
+            "nodes" : [ "INTERNAL_vl_l1", "b", "INTERNAL_vl_l2" ]
           }, {
             "type" : "FEEDERPRIMARY",
             "cardinalities" : [ {
@@ -263,7 +263,7 @@
               "xSpan" : 50.0,
               "ySpan" : 188.0
             },
-            "nodes" : [ "INTERNAL_vl_l1_1", "INTERNAL_vl_l1_2" ]
+            "nodes" : [ "INTERNAL_vl_l1", "INTERNAL_vl_l1" ]
           }, {
             "type" : "FEEDERPRIMARY",
             "cardinalities" : [ {
@@ -284,7 +284,7 @@
               "xSpan" : 50.0,
               "ySpan" : 0.0
             },
-            "nodes" : [ "INTERNAL_vl_l1_2", "l1" ]
+            "nodes" : [ "INTERNAL_vl_l1", "l1" ]
           } ]
         } ]
       } ]
@@ -295,15 +295,15 @@
     "node2" : "BUSCO_l1"
   }, {
     "node1" : "b",
-    "node2" : "INTERNAL_vl_l1_1"
+    "node2" : "INTERNAL_vl_l1"
   }, {
     "node1" : "BUSCO_l1",
-    "node2" : "INTERNAL_vl_l1_1"
+    "node2" : "INTERNAL_vl_l1"
   }, {
-    "node1" : "INTERNAL_vl_l1_1",
-    "node2" : "INTERNAL_vl_l1_2"
+    "node1" : "INTERNAL_vl_l1",
+    "node2" : "INTERNAL_vl_l1"
   }, {
-    "node1" : "INTERNAL_vl_l1_2",
+    "node1" : "INTERNAL_vl_l1",
     "node2" : "l1"
   }, {
     "node1" : "b",

--- a/single-line-diagram-core/src/test/resources/testParallelFeedersOrders.json
+++ b/single-line-diagram-core/src/test/resources/testParallelFeedersOrders.json
@@ -8,7 +8,7 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_d",
+    "id" : "INTERNAL_vl_b",
     "componentType" : "NODE",
     "fictitious" : true,
     "x" : 50.0,
@@ -164,7 +164,7 @@
           "xSpan" : 100.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs", "d", "INTERNAL_vl_d" ]
+        "nodes" : [ "bbs", "d", "INTERNAL_vl_b" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -185,7 +185,7 @@
           "xSpan" : 100.0,
           "ySpan" : 94.0
         },
-        "nodes" : [ "INTERNAL_vl_d", "b", "INTERNAL_vl_f" ]
+        "nodes" : [ "INTERNAL_vl_b", "b", "INTERNAL_vl_f" ]
       }, {
         "type" : "BODYPARALLEL",
         "cardinalities" : [ {
@@ -346,6 +346,12 @@
     "node1" : "INTERNAL_vl_f",
     "node2" : "b2"
   }, {
+    "node1" : "d",
+    "node2" : "INTERNAL_vl_b"
+  }, {
+    "node1" : "INTERNAL_vl_b",
+    "node2" : "b"
+  }, {
     "node1" : "INTERNAL_vl_f",
     "node2" : "INTERNAL_vl_l1"
   }, {
@@ -357,12 +363,6 @@
   }, {
     "node1" : "INTERNAL_vl_l2",
     "node2" : "l2"
-  }, {
-    "node1" : "b",
-    "node2" : "INTERNAL_vl_d"
-  }, {
-    "node1" : "d",
-    "node2" : "INTERNAL_vl_d"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/testSerialBlocksInternCells.json
+++ b/single-line-diagram-core/src/test/resources/testSerialBlocksInternCells.json
@@ -8,6 +8,40 @@
   "y" : 80.0,
   "nodes" : [ {
     "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl_b11",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 100.0,
+    "y" : 280.0,
+    "orientation" : "RIGHT",
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl_b12",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 200.0,
+    "y" : 280.0,
+    "orientation" : "RIGHT",
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl_b21",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 25.0,
+    "y" : 240.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
+    "id" : "INTERNAL_vl_b22",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 225.0,
+    "y" : 240.0,
+    "open" : false
+  }, {
+    "type" : "FICTITIOUS",
     "id" : "INTERNAL_vl_f1",
     "componentType" : "NODE",
     "fictitious" : true,
@@ -23,40 +57,6 @@
     "x" : 75.0,
     "y" : 240.0,
     "orientation" : "RIGHT",
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_sd11",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 100.0,
-    "y" : 280.0,
-    "orientation" : "RIGHT",
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_sd12",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 200.0,
-    "y" : 280.0,
-    "orientation" : "RIGHT",
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_sd21",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 25.0,
-    "y" : 240.0,
-    "open" : false
-  }, {
-    "type" : "FICTITIOUS",
-    "id" : "INTERNAL_vl_sd22",
-    "componentType" : "NODE",
-    "fictitious" : true,
-    "x" : 225.0,
-    "y" : 240.0,
     "open" : false
   }, {
     "type" : "SWITCH",
@@ -273,7 +273,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs12", "sd12", "INTERNAL_vl_sd12" ]
+        "nodes" : [ "bbs12", "sd12", "INTERNAL_vl_b12" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -294,7 +294,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_f1", "b12", "INTERNAL_vl_sd12" ]
+        "nodes" : [ "INTERNAL_vl_f1", "b12", "INTERNAL_vl_b12" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -315,7 +315,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_sd11", "b11", "INTERNAL_vl_f1" ]
+        "nodes" : [ "INTERNAL_vl_b11", "b11", "INTERNAL_vl_f1" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -336,7 +336,7 @@
           "xSpan" : 0.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs11", "sd11", "INTERNAL_vl_sd11" ]
+        "nodes" : [ "bbs11", "sd11", "INTERNAL_vl_b11" ]
       } ]
     }
   }, {
@@ -382,7 +382,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs22", "sd22", "INTERNAL_vl_sd22" ]
+        "nodes" : [ "bbs22", "sd22", "INTERNAL_vl_b22" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -403,7 +403,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_f2", "b22", "INTERNAL_vl_sd22" ]
+        "nodes" : [ "INTERNAL_vl_f2", "b22", "INTERNAL_vl_b22" ]
       }, {
         "type" : "BODYPRIMARY",
         "cardinalities" : [ {
@@ -424,7 +424,7 @@
           "xSpan" : 50.0,
           "ySpan" : 40.0
         },
-        "nodes" : [ "INTERNAL_vl_sd21", "b21", "INTERNAL_vl_f2" ]
+        "nodes" : [ "INTERNAL_vl_b21", "b21", "INTERNAL_vl_f2" ]
       }, {
         "type" : "LEGPRIMARY",
         "cardinalities" : [ {
@@ -445,7 +445,7 @@
           "xSpan" : 50.0,
           "ySpan" : 0.0
         },
-        "nodes" : [ "bbs11", "sd21", "INTERNAL_vl_sd21" ]
+        "nodes" : [ "bbs11", "sd21", "INTERNAL_vl_b21" ]
       } ]
     }
   } ],
@@ -474,29 +474,29 @@
     "node1" : "bbs22",
     "node2" : "sd22"
   }, {
-    "node1" : "b11",
-    "node2" : "INTERNAL_vl_sd11"
-  }, {
     "node1" : "sd11",
-    "node2" : "INTERNAL_vl_sd11"
+    "node2" : "INTERNAL_vl_b11"
   }, {
-    "node1" : "b21",
-    "node2" : "INTERNAL_vl_sd21"
+    "node1" : "INTERNAL_vl_b11",
+    "node2" : "b11"
   }, {
     "node1" : "sd21",
-    "node2" : "INTERNAL_vl_sd21"
+    "node2" : "INTERNAL_vl_b21"
   }, {
-    "node1" : "b12",
-    "node2" : "INTERNAL_vl_sd12"
+    "node1" : "INTERNAL_vl_b21",
+    "node2" : "b21"
   }, {
     "node1" : "sd12",
-    "node2" : "INTERNAL_vl_sd12"
+    "node2" : "INTERNAL_vl_b12"
   }, {
-    "node1" : "b22",
-    "node2" : "INTERNAL_vl_sd22"
+    "node1" : "INTERNAL_vl_b12",
+    "node2" : "b12"
   }, {
     "node1" : "sd22",
-    "node2" : "INTERNAL_vl_sd22"
+    "node2" : "INTERNAL_vl_b22"
+  }, {
+    "node1" : "INTERNAL_vl_b22",
+    "node2" : "b22"
   } ],
   "multitermNodes" : [ ],
   "twtEdges" : [ ],

--- a/single-line-diagram-core/src/test/resources/topological_style_substation.svg
+++ b/single-line-diagram-core/src/test/resources/topological_style_substation.svg
@@ -178,7 +178,7 @@
             <text class="sld-label" id="bbs1_NW_LABEL" x="-5.0" y="-5.0">bbs1</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_d" transform="translate(61.0,356.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_b" transform="translate(61.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_l" transform="translate(61.0,168.0)">
@@ -190,11 +190,11 @@
                 <line x1="16" x2="0" y1="0" y2="9"/>
                 <text class="sld-label" id="l_N_LABEL" x="-5.0" y="-5.0">l</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d_95_INTERNAL_95_vl1_95_d">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d_95_INTERNAL_95_vl1_95_b">
                 <polyline points="65.0,390.0,65.0,360.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b_95_INTERNAL_95_vl1_95_d">
-                <polyline points="65.0,276.0,65.0,360.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_b_95_b">
+                <polyline points="65.0,360.0,65.0,276.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b_95_INTERNAL_95_vl1_95_l">
                 <polyline points="65.0,256.0,65.0,172.0"/>
@@ -222,7 +222,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_d2WT_95_1" transform="translate(111.0,356.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_b2WT_95_1" transform="translate(111.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_2WT_95_ONE" transform="translate(111.0,168.0)">
@@ -231,11 +231,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="id2WT_95_ONE" transform="translate(115.0,110.0)">
                 <text class="sld-label" id="2WT_ONE_N_LABEL" x="-5.0" y="-5.0">2WT_1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d2WT_95_1_95_INTERNAL_95_vl1_95_d2WT_95_1">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d2WT_95_1_95_INTERNAL_95_vl1_95_b2WT_95_1">
                 <polyline points="115.0,390.0,115.0,360.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b2WT_95_1_95_INTERNAL_95_vl1_95_d2WT_95_1">
-                <polyline points="115.0,276.0,115.0,360.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_b2WT_95_1_95_b2WT_95_1">
+                <polyline points="115.0,360.0,115.0,276.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b2WT_95_1_95_INTERNAL_95_vl1_95_2WT_95_ONE">
                 <polyline points="115.0,256.0,115.0,172.0"/>
@@ -263,7 +263,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_2">
-            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_d3WT_95_1" transform="translate(161.0,356.0)">
+            <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_b3WT_95_1" transform="translate(161.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_3WT_95_ONE" transform="translate(161.0,168.0)">
@@ -272,11 +272,11 @@
             <g class="sld-top-feeder sld-vl300to500-0" id="id3WT_95_ONE" transform="translate(165.0,110.0)">
                 <text class="sld-label" id="3WT_ONE_N_LABEL" x="-5.0" y="-5.0">3WT_1</text>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d3WT_95_1_95_INTERNAL_95_vl1_95_d3WT_95_1">
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_d3WT_95_1_95_INTERNAL_95_vl1_95_b3WT_95_1">
                 <polyline points="165.0,390.0,165.0,360.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b3WT_95_1_95_INTERNAL_95_vl1_95_d3WT_95_1">
-                <polyline points="165.0,276.0,165.0,360.0"/>
+            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_b3WT_95_1_95_b3WT_95_1">
+                <polyline points="165.0,360.0,165.0,276.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_b3WT_95_1_95_INTERNAL_95_vl1_95_3WT_95_ONE">
                 <polyline points="165.0,256.0,165.0,172.0"/>
@@ -311,7 +311,7 @@
             <text class="sld-label" id="bbs2_NW_LABEL" x="-5.0" y="-5.0">bbs2</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl2_95_d2WT_95_2" transform="translate(251.0,356.0)">
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl2_95_b2WT_95_2" transform="translate(251.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl2_95_2WT_95_TWO" transform="translate(251.0,168.0)">
@@ -320,11 +320,11 @@
             <g class="sld-top-feeder sld-disconnected" id="id2WT_95_TWO" transform="translate(255.0,110.0)">
                 <text class="sld-label" id="2WT_TWO_N_LABEL" x="-5.0" y="-5.0">2WT_2</text>
             </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl2_95_d2WT_95_2_95_INTERNAL_95_vl2_95_d2WT_95_2">
+            <g class="sld-wire sld-disconnected" id="_95_vl2_95_d2WT_95_2_95_INTERNAL_95_vl2_95_b2WT_95_2">
                 <polyline points="255.0,390.0,255.0,360.0"/>
             </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl2_95_b2WT_95_2_95_INTERNAL_95_vl2_95_d2WT_95_2">
-                <polyline points="255.0,276.0,255.0,360.0"/>
+            <g class="sld-wire sld-disconnected" id="_95_vl2_95_INTERNAL_95_vl2_95_b2WT_95_2_95_b2WT_95_2">
+                <polyline points="255.0,360.0,255.0,276.0"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl2_95_b2WT_95_2_95_INTERNAL_95_vl2_95_2WT_95_TWO">
                 <polyline points="255.0,256.0,255.0,172.0"/>
@@ -352,7 +352,7 @@
             </g>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_1">
-            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl2_95_d3WT_95_2" transform="translate(301.0,356.0)">
+            <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl2_95_b3WT_95_2" transform="translate(301.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl2_95_3WT_95_TWO" transform="translate(301.0,168.0)">
@@ -361,11 +361,11 @@
             <g class="sld-top-feeder sld-disconnected" id="id3WT_95_TWO" transform="translate(305.0,110.0)">
                 <text class="sld-label" id="3WT_TWO_N_LABEL" x="-5.0" y="-5.0">3WT_2</text>
             </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl2_95_d3WT_95_2_95_INTERNAL_95_vl2_95_d3WT_95_2">
+            <g class="sld-wire sld-disconnected" id="_95_vl2_95_d3WT_95_2_95_INTERNAL_95_vl2_95_b3WT_95_2">
                 <polyline points="305.0,390.0,305.0,360.0"/>
             </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl2_95_b3WT_95_2_95_INTERNAL_95_vl2_95_d3WT_95_2">
-                <polyline points="305.0,276.0,305.0,360.0"/>
+            <g class="sld-wire sld-disconnected" id="_95_vl2_95_INTERNAL_95_vl2_95_b3WT_95_2_95_b3WT_95_2">
+                <polyline points="305.0,360.0,305.0,276.0"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl2_95_b3WT_95_2_95_INTERNAL_95_vl2_95_3WT_95_TWO">
                 <polyline points="305.0,256.0,305.0,172.0"/>
@@ -400,7 +400,7 @@
             <text class="sld-label" id="bbs3_NW_LABEL" x="-5.0" y="-5.0">bbs3</text>
         </g>
         <g class="sld-extern-cell" id="idEXTERN_32_0">
-            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_d3WT_95_3" transform="translate(391.0,356.0)">
+            <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_b3WT_95_3" transform="translate(391.0,356.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl3_95_3WT_95_THREE" transform="translate(391.0,168.0)">
@@ -409,11 +409,11 @@
             <g class="sld-top-feeder sld-vl50to70-0" id="id3WT_95_THREE" transform="translate(395.0,110.0)">
                 <text class="sld-label" id="3WT_THREE_N_LABEL" x="-5.0" y="-5.0">3WT_3</text>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_d3WT_95_3_95_INTERNAL_95_vl3_95_d3WT_95_3">
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_d3WT_95_3_95_INTERNAL_95_vl3_95_b3WT_95_3">
                 <polyline points="395.0,390.0,395.0,360.0"/>
             </g>
-            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_b3WT_95_3_95_INTERNAL_95_vl3_95_d3WT_95_3">
-                <polyline points="395.0,276.0,395.0,360.0"/>
+            <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_b3WT_95_3_95_b3WT_95_3">
+                <polyline points="395.0,360.0,395.0,276.0"/>
             </g>
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_b3WT_95_3_95_INTERNAL_95_vl3_95_3WT_95_THREE">
                 <polyline points="395.0,256.0,395.0,172.0"/>

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -175,6 +175,27 @@
     "styleClass" : "sld-breaker"
   } ],
   "nodes" : [ {
+    "id" : "idINTERNAL_95_vl1_95_btrf17",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf16",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf15",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
     "id" : "idtrf7_95_THREE",
     "vid" : "vl1",
     "nextVId" : "vl3",
@@ -188,6 +209,41 @@
       "positionName" : "S_LABEL"
     } ]
   }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf14",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf13",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_dtrct11",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf12",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf11",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
     "id" : "iddtrct21",
     "vid" : "vl1",
     "componentType" : "BREAKER",
@@ -196,28 +252,7 @@
     "equipmentId" : "dtrct21",
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_dload2",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dload1",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "idINTERNAL_95_vl1_95_trf1_95_ONE",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dgen1",
     "vid" : "vl1",
     "componentType" : "NODE",
     "open" : false,
@@ -230,13 +265,6 @@
     "open" : false,
     "vlabel" : false,
     "equipmentId" : "btrf18",
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dgen2",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
     "labels" : [ ]
   }, {
     "id" : "iddload2",
@@ -339,6 +367,13 @@
     "equipmentId" : "btrf12",
     "labels" : [ ]
   }, {
+    "id" : "idINTERNAL_95_vl1_95_btrf18",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
     "id" : "idbbs4",
     "vid" : "vl1",
     "componentType" : "BUSBAR_SECTION",
@@ -423,55 +458,6 @@
       "positionName" : "NW_LABEL"
     } ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf13",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf12",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf15",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf14",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf17",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf16",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf18",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "iddtrf11",
     "vid" : "vl1",
     "componentType" : "DISCONNECTOR",
@@ -492,13 +478,6 @@
       "id" : "trf6_THREE_N_LABEL",
       "positionName" : "N_LABEL"
     } ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dtrf11",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
   }, {
     "id" : "idtrf1_95_ONE",
     "vid" : "vl1",
@@ -609,20 +588,6 @@
     "equipmentId" : "dtrf12",
     "labels" : [ ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_dsect12",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dsect11",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "idtrf6",
     "vid" : "vl1",
     "componentType" : "THREE_WINDINGS_TRANSFORMER",
@@ -661,6 +626,20 @@
     "open" : false,
     "vlabel" : false,
     "equipmentId" : "dgen2",
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_bload2",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_bload1",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
     "labels" : [ ]
   }, {
     "id" : "idtrf8_95_TWO",
@@ -764,22 +743,8 @@
       "positionName" : "N_LABEL"
     } ]
   }, {
-    "id" : "idINTERNAL_95_vl1_95_dsect21",
-    "vid" : "vl1",
-    "componentType" : "NODE",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
     "id" : "GRID_vl1",
     "vid" : "vl1",
-    "open" : false,
-    "vlabel" : false,
-    "labels" : [ ]
-  }, {
-    "id" : "idINTERNAL_95_vl1_95_dsect22",
-    "vid" : "vl1",
-    "componentType" : "NODE",
     "open" : false,
     "vlabel" : false,
     "labels" : [ ]
@@ -812,6 +777,27 @@
       "id" : "trf8_THREE_N_LABEL",
       "positionName" : "N_LABEL"
     } ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_dtrct21",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_bgen1",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
+  }, {
+    "id" : "idINTERNAL_95_vl1_95_bgen2",
+    "vid" : "vl1",
+    "componentType" : "NODE",
+    "open" : false,
+    "vlabel" : false,
+    "labels" : [ ]
   }, {
     "id" : "iddsect12",
     "vid" : "vl1",
@@ -856,6 +842,12 @@
     } ]
   } ],
   "wires" : [ {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf13_95_btrf13",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf13",
+    "nodeId2" : "idbtrf13",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_trf6_95_THREE_95_trf6",
     "nodeId1" : "idtrf6_95_THREE",
     "nodeId2" : "idtrf6",
@@ -868,21 +860,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dsect11_95_INTERNAL_95_vl1_95_dsect11",
-    "nodeId1" : "iddsect11",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect11",
+    "id" : "_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_btrf11",
+    "nodeId1" : "iddtrf11",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf11",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_dtrf16",
-    "nodeId1" : "iddtrf16",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf16",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_dgen1",
-    "nodeId1" : "iddgen1",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dgen1",
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_bgen1_95_bgen1",
+    "nodeId1" : "idINTERNAL_95_vl1_95_bgen1",
+    "nodeId2" : "idbgen1",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -904,12 +890,6 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_dtrf15",
-    "nodeId1" : "iddtrf15",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf15",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_trf6_95_TWO_95_trf6",
     "nodeId1" : "idtrf6_95_TWO",
     "nodeId2" : "idtrf6",
@@ -922,15 +902,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect12",
-    "nodeId1" : "iddtrct11",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect12",
+    "id" : "_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_btrf12",
+    "nodeId1" : "iddtrf12",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf12",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrct11_95_INTERNAL_95_vl1_95_dsect11",
-    "nodeId1" : "iddtrct11",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect11",
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf16_95_btrf16",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf16",
+    "nodeId2" : "idbtrf16",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -946,6 +926,12 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl1_95_dsect22_95_INTERNAL_95_vl1_95_dtrct21",
+    "nodeId1" : "iddsect22",
+    "nodeId2" : "idINTERNAL_95_vl1_95_dtrct21",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_btrf17_95_trf7",
     "nodeId1" : "idbtrf17",
     "nodeId2" : "idtrf7",
@@ -958,9 +944,21 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_bload1_95_INTERNAL_95_vl1_95_dload1",
-    "nodeId1" : "idbload1",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dload1",
+    "id" : "_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_btrf13",
+    "nodeId1" : "iddtrf13",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf13",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_btrf18",
+    "nodeId1" : "iddtrf18",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf18",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf14_95_btrf14",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf14",
+    "nodeId2" : "idbtrf14",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -970,33 +968,9 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_dload2",
-    "nodeId1" : "iddload2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dload2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_trf8_95_THREE_95_trf8",
     "nodeId1" : "idtrf8_95_THREE",
     "nodeId2" : "idtrf8",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_dgen2",
-    "nodeId1" : "idbgen2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dgen2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_btrf12_95_INTERNAL_95_vl1_95_dtrf12",
-    "nodeId1" : "idbtrf12",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf12",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_btrf17_95_INTERNAL_95_vl1_95_dtrf17",
-    "nodeId1" : "idbtrf17",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf17",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1006,27 +980,27 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrf13_95_INTERNAL_95_vl1_95_dtrf13",
-    "nodeId1" : "iddtrf13",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf13",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_bgen2_95_INTERNAL_95_vl1_95_gen2",
     "nodeId1" : "idbgen2",
     "nodeId2" : "idINTERNAL_95_vl1_95_gen2",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrf18_95_INTERNAL_95_vl1_95_dtrf18",
-    "nodeId1" : "iddtrf18",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf18",
+    "id" : "_95_vl1_95_dload2_95_INTERNAL_95_vl1_95_bload2",
+    "nodeId1" : "iddload2",
+    "nodeId2" : "idINTERNAL_95_vl1_95_bload2",
     "straight" : false,
     "snakeLine" : false
   }, {
     "id" : "_95_vl1_95_INTERNAL_95_vl1_95_load1_95_load1",
     "nodeId1" : "idINTERNAL_95_vl1_95_load1",
     "nodeId2" : "idload1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf17_95_btrf17",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf17",
+    "nodeId2" : "idbtrf17",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1042,9 +1016,21 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_bload2_95_bload2",
+    "nodeId1" : "idINTERNAL_95_vl1_95_bload2",
+    "nodeId2" : "idbload2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_bbs4_95_dtrf14",
     "nodeId1" : "idbbs4",
     "nodeId2" : "iddtrf14",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dtrf15_95_INTERNAL_95_vl1_95_btrf15",
+    "nodeId1" : "iddtrf15",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf15",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1072,21 +1058,21 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrf11_95_INTERNAL_95_vl1_95_dtrf11",
-    "nodeId1" : "iddtrf11",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf11",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_bbs1_95_dtrf15",
     "nodeId1" : "idbbs1",
     "nodeId2" : "iddtrf15",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_btrf15_95_INTERNAL_95_vl1_95_dtrf15",
-    "nodeId1" : "idbtrf15",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf15",
+    "id" : "_95_vl1_95_dtrf16_95_INTERNAL_95_vl1_95_btrf16",
+    "nodeId1" : "iddtrf16",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf16",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dsect11_95_INTERNAL_95_vl1_95_dtrct11",
+    "nodeId1" : "iddsect11",
+    "nodeId2" : "idINTERNAL_95_vl1_95_dtrct11",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1108,45 +1094,27 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect21",
-    "nodeId1" : "iddtrct21",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect21",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
     "id" : "_95_vl1_95_INTERNAL_95_vl1_95_gen1_95_gen1",
     "nodeId1" : "idINTERNAL_95_vl1_95_gen1",
     "nodeId2" : "idgen1",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrct21_95_INTERNAL_95_vl1_95_dsect22",
-    "nodeId1" : "iddtrct21",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect22",
+    "id" : "_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_btrf17",
+    "nodeId1" : "iddtrf17",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf17",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_bload2_95_INTERNAL_95_vl1_95_dload2",
-    "nodeId1" : "idbload2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dload2",
+    "id" : "_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_bgen2",
+    "nodeId1" : "iddgen2",
+    "nodeId2" : "idINTERNAL_95_vl1_95_bgen2",
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_btrf14_95_INTERNAL_95_vl1_95_dtrf14",
-    "nodeId1" : "idbtrf14",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf14",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dsect21_95_INTERNAL_95_vl1_95_dsect21",
-    "nodeId1" : "iddsect21",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect21",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dsect12_95_INTERNAL_95_vl1_95_dsect12",
-    "nodeId1" : "iddsect12",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect12",
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_dtrct11_95_dtrct11",
+    "nodeId1" : "idINTERNAL_95_vl1_95_dtrct11",
+    "nodeId2" : "iddtrct11",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1156,27 +1124,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf11_95_btrf11",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf11",
+    "nodeId2" : "idbtrf11",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_INTERNAL_95_vl1_95_trf3_95_ONE_95_trf3_95_ONE",
     "nodeId1" : "idINTERNAL_95_vl1_95_trf3_95_ONE",
     "nodeId2" : "idtrf3_95_ONE",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_btrf18_95_INTERNAL_95_vl1_95_dtrf18",
-    "nodeId1" : "idbtrf18",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf18",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_btrf13_95_INTERNAL_95_vl1_95_dtrf13",
-    "nodeId1" : "idbtrf13",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf13",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dsect22_95_INTERNAL_95_vl1_95_dsect22",
-    "nodeId1" : "iddsect22",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dsect22",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1186,9 +1142,27 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_dtrf14",
-    "nodeId1" : "iddtrf14",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf14",
+    "id" : "_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_bload1",
+    "nodeId1" : "iddload1",
+    "nodeId2" : "idINTERNAL_95_vl1_95_bload1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_bload1_95_bload1",
+    "nodeId1" : "idINTERNAL_95_vl1_95_bload1",
+    "nodeId2" : "idbload1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf12_95_btrf12",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf12",
+    "nodeId2" : "idbtrf12",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_bgen2_95_bgen2",
+    "nodeId1" : "idINTERNAL_95_vl1_95_bgen2",
+    "nodeId2" : "idbgen2",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1216,9 +1190,21 @@
     "straight" : false,
     "snakeLine" : false
   }, {
+    "id" : "_95_vl1_95_dgen1_95_INTERNAL_95_vl1_95_bgen1",
+    "nodeId1" : "iddgen1",
+    "nodeId2" : "idINTERNAL_95_vl1_95_bgen1",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
     "id" : "_95_vl1_95_dsect12_95_bbs2",
     "nodeId1" : "iddsect12",
     "nodeId2" : "idbbs2",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf18_95_btrf18",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf18",
+    "nodeId2" : "idbtrf18",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1240,9 +1226,15 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_dload1_95_INTERNAL_95_vl1_95_dload1",
-    "nodeId1" : "iddload1",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dload1",
+    "id" : "_95_vl1_95_dtrf14_95_INTERNAL_95_vl1_95_btrf14",
+    "nodeId1" : "iddtrf14",
+    "nodeId2" : "idINTERNAL_95_vl1_95_btrf14",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_dsect12_95_INTERNAL_95_vl1_95_dtrct11",
+    "nodeId1" : "iddsect12",
+    "nodeId2" : "idINTERNAL_95_vl1_95_dtrct11",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1258,9 +1250,21 @@
     "straight" : false,
     "snakeLine" : false
   }, {
-    "id" : "_95_vl1_95_btrf11_95_INTERNAL_95_vl1_95_dtrf11",
-    "nodeId1" : "idbtrf11",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf11",
+    "id" : "_95_vl1_95_dsect21_95_INTERNAL_95_vl1_95_dtrct21",
+    "nodeId1" : "iddsect21",
+    "nodeId2" : "idINTERNAL_95_vl1_95_dtrct21",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_dtrct21_95_dtrct21",
+    "nodeId1" : "idINTERNAL_95_vl1_95_dtrct21",
+    "nodeId2" : "iddtrct21",
+    "straight" : false,
+    "snakeLine" : false
+  }, {
+    "id" : "_95_vl1_95_INTERNAL_95_vl1_95_btrf15_95_btrf15",
+    "nodeId1" : "idINTERNAL_95_vl1_95_btrf15",
+    "nodeId2" : "idbtrf15",
     "straight" : false,
     "snakeLine" : false
   }, {
@@ -1273,36 +1277,6 @@
     "id" : "_95_vl1_95_trf8_95_TWO_95_trf8",
     "nodeId1" : "idtrf8_95_TWO",
     "nodeId2" : "idtrf8",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dgen2_95_INTERNAL_95_vl1_95_dgen2",
-    "nodeId1" : "iddgen2",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dgen2",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dtrf12_95_INTERNAL_95_vl1_95_dtrf12",
-    "nodeId1" : "iddtrf12",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf12",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_btrf16_95_INTERNAL_95_vl1_95_dtrf16",
-    "nodeId1" : "idbtrf16",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf16",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_dtrf17_95_INTERNAL_95_vl1_95_dtrf17",
-    "nodeId1" : "iddtrf17",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dtrf17",
-    "straight" : false,
-    "snakeLine" : false
-  }, {
-    "id" : "_95_vl1_95_bgen1_95_INTERNAL_95_vl1_95_dgen1",
-    "nodeId1" : "idbgen1",
-    "nodeId2" : "idINTERNAL_95_vl1_95_dgen1",
     "straight" : false,
     "snakeLine" : false
   } ],

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -1446,6 +1446,7 @@
     "feederInfosIntraMargin" : 10.0,
     "busInfoMargin" : 0.0,
     "busbarsAlignment" : "FIRST",
-    "feederInfoPrecision" : 0
+    "feederInfoPrecision" : 0,
+    "componentsOnBusbars" : [ "DISCONNECTOR" ]
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Feature (+ bug fix)


**What is the current behavior?**
All `SwitchNode` with `switchKind == DISCONNECTOR` are displayed on busbars


**What is the new behavior (if this is a feature change)?**
The equipments which are displayed on busbars can be chosen through `layoutParameters::setComponentsOnBusbars`, which takes a list of componentTypes.
By default it is the `DISCONNECTOR` componentType only.


**Does this PR introduce a breaking change or deprecate an API?**
No


**Other information**:
Code refactoring was needed which revealed some existing bugs. New unit tests were added for those.