### PR TITLE
Fix missing busbar extension bug

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractPositionFinder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/AbstractPositionFinder.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.layout;
+
+import com.powsybl.sld.model.coordinate.Side;
+import com.powsybl.sld.model.graphs.VoltageLevelGraph;
+import com.powsybl.sld.model.nodes.BusNode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public abstract class AbstractPositionFinder implements PositionFinder {
+
+    public List<Subsection> buildLayout(VoltageLevelGraph graph, boolean handleShunt) {
+        if (graph.getNodes().isEmpty()) {
+            return new ArrayList<>();
+        }
+        Map<BusNode, Integer> busToNb = indexBusPosition(graph.getNodeBuses(), graph.getBusCells());
+        List<LegBusSet> legBusSets = LegBusSet.createLegBusSets(graph, busToNb, handleShunt);
+        LBSCluster lbsCluster = organizeLegBusSets(graph, legBusSets);
+        graph.setMaxBusPosition();
+        List<Subsection> subsections = Subsection.createSubsections(graph, lbsCluster, handleShunt);
+        organizeDirections(graph, subsections);
+        return subsections;
+    }
+
+    public void forceSameOrientationForShuntedCell(VoltageLevelGraph graph) {
+        graph.getShuntCellStream().forEach(sc -> sc.alignDirections(Side.LEFT));
+    }
+
+    public void organizeDirections(VoltageLevelGraph graph, List<Subsection> subsections) {
+        forceSameOrientationForShuntedCell(graph);
+    }
+}

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockOrganizer.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockOrganizer.java
@@ -114,22 +114,26 @@ public class BlockOrganizer {
      */
     private void determineStackableBlocks(VoltageLevelGraph graph) {
         LOGGER.info("Determining stackable Blocks");
-        graph.getBusCells().forEach(cell -> {
-            List<LegPrimaryBlock> blocks = cell.getLegPrimaryBlocks();
-            for (int i = 0; i < blocks.size(); i++) {
-                LegPrimaryBlock block1 = blocks.get(i);
-                if (block1.getNodes().size() == 3) {
-                    for (int j = i + 1; j < blocks.size(); j++) {
-                        LegPrimaryBlock block2 = blocks.get(j);
-                        if (block2.getNodes().size() == 3
-                                && block1.getExtremityNode(END).equals(block2.getExtremityNode(END))
-                                && !block1.getExtremityNode(START).equals(block2.getExtremityNode(START))) {
-                            block1.addStackableBlock(block2);
-                            block2.addStackableBlock(block1);
-                        }
+        graph.getBusCellStream()
+                .filter(cell -> !cell.getLegPrimaryBlocks().isEmpty())
+                .forEach(BlockOrganizer::determineStackableBlocks);
+    }
+
+    private static void determineStackableBlocks(BusCell cell) {
+        List<LegPrimaryBlock> blocks = cell.getLegPrimaryBlocks();
+        for (int i = 0; i < blocks.size(); i++) {
+            LegPrimaryBlock block1 = blocks.get(i);
+            if (block1.getNodes().size() == 3) {
+                for (int j = i + 1; j < blocks.size(); j++) {
+                    LegPrimaryBlock block2 = blocks.get(j);
+                    if (block2.getNodes().size() == 3
+                            && block1.getExtremityNode(END).equals(block2.getExtremityNode(END))
+                            && !block1.getExtremityNode(START).equals(block2.getExtremityNode(START))) {
+                        block1.addStackableBlock(block2);
+                        block2.addStackableBlock(block1);
                     }
                 }
             }
-        });
+        }
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionFinder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionFinder.java
@@ -7,11 +7,9 @@
 package com.powsybl.sld.layout;
 
 import com.powsybl.sld.model.cells.BusCell;
-import com.powsybl.sld.model.coordinate.Side;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import com.powsybl.sld.model.nodes.BusNode;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -31,24 +29,9 @@ public interface PositionFinder {
 
     LBSCluster organizeLegBusSets(VoltageLevelGraph graph, List<LegBusSet> legBusSets);
 
-    default List<Subsection> buildLayout(VoltageLevelGraph graph, boolean handleShunt) {
-        if (graph.getNodes().isEmpty()) {
-            return new ArrayList<>();
-        }
-        Map<BusNode, Integer> busToNb = indexBusPosition(graph.getNodeBuses(), graph.getBusCells());
-        List<LegBusSet> legBusSets = LegBusSet.createLegBusSets(graph, busToNb, handleShunt);
-        LBSCluster lbsCluster = organizeLegBusSets(graph, legBusSets);
-        graph.setMaxBusPosition();
-        List<Subsection> subsections = Subsection.createSubsections(graph, lbsCluster, handleShunt);
-        organizeDirections(graph, subsections);
-        return subsections;
-    }
+    List<Subsection> buildLayout(VoltageLevelGraph graph, boolean handleShunt);
 
-    default void forceSameOrientationForShuntedCell(VoltageLevelGraph graph) {
-        graph.getShuntCellStream().forEach(sc -> sc.alignDirections(Side.LEFT));
-    }
+    void forceSameOrientationForShuntedCell(VoltageLevelGraph graph);
 
-    default void organizeDirections(VoltageLevelGraph graph, List<Subsection> subsections) {
-        forceSameOrientationForShuntedCell(graph);
-    }
+    void organizeDirections(VoltageLevelGraph graph, List<Subsection> subsections);
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionFinder.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/PositionFinder.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.sld.layout;
 
+import com.powsybl.sld.model.cells.BusCell;
 import com.powsybl.sld.model.coordinate.Side;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
 import com.powsybl.sld.model.nodes.BusNode;
@@ -26,7 +27,7 @@ import java.util.Map;
  */
 public interface PositionFinder {
 
-    Map<BusNode, Integer> indexBusPosition(List<BusNode> busNodes);
+    Map<BusNode, Integer> indexBusPosition(List<BusNode> busNodes, List<BusCell> busCells);
 
     LBSCluster organizeLegBusSets(VoltageLevelGraph graph, List<LegBusSet> legBusSets);
 
@@ -34,7 +35,7 @@ public interface PositionFinder {
         if (graph.getNodes().isEmpty()) {
             return new ArrayList<>();
         }
-        Map<BusNode, Integer> busToNb = indexBusPosition(graph.getNodeBuses());
+        Map<BusNode, Integer> busToNb = indexBusPosition(graph.getNodeBuses(), graph.getBusCells());
         List<LegBusSet> legBusSets = LegBusSet.createLegBusSets(graph, busToNb, handleShunt);
         LBSCluster lbsCluster = organizeLegBusSets(graph, legBusSets);
         graph.setMaxBusPosition();

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/PositionByClustering.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/PositionByClustering.java
@@ -60,7 +60,7 @@ import static com.powsybl.sld.model.coordinate.Side.RIGHT;
 
 // WE ASSUME THAT IT IS POSSIBLE TO STACK ALL CELLS AND BE ABLE TO ORGANIZE THE VOLTAGELEVEL ACCORDINGLY
 
-public class PositionByClustering implements PositionFinder {
+public class PositionByClustering extends AbstractPositionFinder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PositionByClustering.class);
     private static final HBLaneManagerByClustering HBLMANAGER = new HBLaneManagerByClustering();

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/PositionByClustering.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionbyclustering/PositionByClustering.java
@@ -7,6 +7,7 @@
 package com.powsybl.sld.layout.positionbyclustering;
 
 import com.powsybl.sld.layout.*;
+import com.powsybl.sld.model.cells.BusCell;
 import com.powsybl.sld.model.cells.Cell;
 import com.powsybl.sld.model.cells.ExternCell;
 import com.powsybl.sld.model.cells.ShuntCell;
@@ -64,7 +65,8 @@ public class PositionByClustering implements PositionFinder {
     private static final Logger LOGGER = LoggerFactory.getLogger(PositionByClustering.class);
     private static final HBLaneManagerByClustering HBLMANAGER = new HBLaneManagerByClustering();
 
-    public Map<BusNode, Integer> indexBusPosition(List<BusNode> busNodes) {
+    @Override
+    public Map<BusNode, Integer> indexBusPosition(List<BusNode> busNodes, List<BusCell> busCells) {
         Map<BusNode, Integer> busToNb = new LinkedHashMap<>();
         int i = 1;
         for (BusNode n : busNodes.stream()

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionfromextension/PositionFromExtension.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/positionfromextension/PositionFromExtension.java
@@ -26,7 +26,7 @@ import static com.powsybl.sld.model.cells.Cell.CellType.EXTERN;
 /**
  * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
  */
-public class PositionFromExtension implements PositionFinder {
+public class PositionFromExtension extends AbstractPositionFinder {
     private static final Logger LOGGER = LoggerFactory.getLogger(PositionFromExtension.class);
     private static final Direction DEFAULTDIRECTION = Direction.TOP;
     private static final HorizontalBusLaneManager HBLMANAGER = new HBLaneManagerByExtension();
@@ -69,8 +69,8 @@ public class PositionFromExtension implements PositionFinder {
     }
 
     /**
-     * Replace position indices in given bus node with an appropriate value: either with new section index, or with the
-     * same section index as the first busNode which shares a BusCell with.
+     * Replace position indices in given bus node with an appropriate value: either with the same section index as the
+     * first busNode which shares a BusCell with, or if no such busNode with a new section index.
      * @param busNode bus node with a missing/incoherent position index/indices
      * @param busNodes all voltageLevelGraph bus nodes
      * @param busCells all voltageLevelGraph bus cells

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/VoltageLevelGraph.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/model/graphs/VoltageLevelGraph.java
@@ -289,12 +289,6 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
         setMaxVerticalBusPosition(Collections.max(v));
     }
 
-    public Stream<BusCell> getBusCells() {
-        return cells.stream()
-                .filter(cell -> cell instanceof BusCell && !((BusCell) cell).getLegPrimaryBlocks().isEmpty())
-                .map(BusCell.class::cast);
-    }
-
     public void insertBusConnections(Predicate<Node> nodesOnBus) {
         getNodeBuses().forEach(busNode -> insertBusConnections(busNode, nodesOnBus));
     }
@@ -510,6 +504,10 @@ public class VoltageLevelGraph extends AbstractBaseGraph {
 
     public Stream<BusCell> getBusCellStream() {
         return cells.stream().filter(BusCell.class::isInstance).map(BusCell.class::cast);
+    }
+
+    public List<BusCell> getBusCells() {
+        return getBusCellStream().collect(Collectors.toList());
     }
 
     public Stream<InternCell> getInternCellStream() {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseMissingBusbarPosition.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestCaseMissingBusbarPosition.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.iidm;
+
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.extensions.ConnectablePosition;
+import com.powsybl.sld.builders.NetworkGraphBuilder;
+import com.powsybl.sld.model.graphs.VoltageLevelGraph;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * <PRE>
+ * l
+ * |
+ * b
+ * |
+ * d
+ * |
+ * ------ bbs
+ * </PRE>
+ *
+ * @author Benoit Jeanson <benoit.jeanson at rte-france.com>
+ * @author Nicolas Duchene
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ */
+public class TestCaseMissingBusbarPosition extends AbstractTestCaseIidm {
+
+    @Before
+    public void setUp() {
+        network = Network.create("testCase1", "test");
+        graphBuilder = new NetworkGraphBuilder(network);
+        substation = createSubstation(network, "s", "s", Country.FR);
+        vl = createVoltageLevel(substation, "vl", "vl", TopologyKind.NODE_BREAKER, 380, 10);
+
+        vl.getNodeBreakerView().newBusbarSection().setId("bbs1").setName("bbs1").setNode(0).add(); // no position extension
+        createLoad(vl, "l", "l", "l", 0, ConnectablePosition.Direction.TOP, 2, 10, 10);
+        createSwitch(vl, "d1", "d1", SwitchKind.DISCONNECTOR, false, false, false, 0, 1);
+        createSwitch(vl, "b1", "b1", SwitchKind.BREAKER, false, false, false, 1, 2);
+
+        createBusBarSection(vl, "bbs2", "bbs2", 3, 1, 1);
+        createSwitch(vl, "d2", "d2", SwitchKind.DISCONNECTOR, false, false, false, 3, 4);
+        createSwitch(vl, "b2", "b2", SwitchKind.BREAKER, false, false, false, 4, 5);
+        createGenerator(vl, "g", "g", "generator", 2, ConnectablePosition.Direction.BOTTOM, 5, 0, 20, false, 10, 10);
+    }
+
+    @Test
+    public void busApartTest() {
+        // build graph
+        VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
+
+        // Run layout
+        voltageLevelGraphLayout(g);
+
+        // write Json and compare to reference
+        assertEquals(toString("/TestCaseMissingBusbarPositionBusApart.json"), toJson(g, "/TestCaseMissingBusbarPositionBusApart.json"));
+    }
+
+    @Test
+    public void busParallelTest() {
+        createSwitch(vl, "d2l", "d2l", SwitchKind.DISCONNECTOR, false, false, false, 3, 1);
+
+        // build graph
+        VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph(vl.getId());
+
+        // Run layout
+        voltageLevelGraphLayout(g);
+
+        // write Json and compare to reference
+        assertEquals(toString("/TestCaseMissingBusbarPositionBusParallel.json"), toJson(g, "/TestCaseMissingBusbarPositionBusParallel.json"));
+    }
+}

--- a/single-line-diagram-core/src/test/resources/TestCaseMissingBusbarPositionBusApart.json
+++ b/single-line-diagram-core/src/test/resources/TestCaseMissingBusbarPositionBusApart.json
@@ -1,0 +1,364 @@
+{
+  "voltageLevelInfos" : {
+    "id" : "vl",
+    "name" : "vl",
+    "nominalVoltage" : 380.0
+  },
+  "x" : 40.0,
+  "y" : 80.0,
+  "nodes" : [ {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl_b1",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 75.0,
+    "y" : 250.0
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl_b2",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 25.0,
+    "y" : 310.0,
+    "orientation" : "DOWN"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl_g",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 25.0,
+    "y" : 498.0,
+    "orientation" : "DOWN"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl_l",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 75.0,
+    "y" : 62.0
+  }, {
+    "type" : "SWITCH",
+    "id" : "b1",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 75.0,
+    "y" : 156.0,
+    "name" : "b1",
+    "equipmentId" : "b1",
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "SWITCH",
+    "id" : "b2",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 25.0,
+    "y" : 404.0,
+    "orientation" : "DOWN",
+    "name" : "b2",
+    "equipmentId" : "b2",
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "BUS",
+    "id" : "bbs1",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 62.5,
+    "y" : 280.0,
+    "name" : "bbs1",
+    "equipmentId" : "bbs1",
+    "pxWidth" : 25.0,
+    "busbarIndex" : 1,
+    "sectionIndex" : 2,
+    "position" : {
+      "h" : 2,
+      "v" : 0,
+      "hSpan" : 2,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "BUS",
+    "id" : "bbs2",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 12.5,
+    "y" : 280.0,
+    "name" : "bbs2",
+    "equipmentId" : "bbs2",
+    "pxWidth" : 25.0,
+    "busbarIndex" : 1,
+    "sectionIndex" : 1,
+    "position" : {
+      "h" : 0,
+      "v" : 0,
+      "hSpan" : 2,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "SWITCH",
+    "id" : "d1",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 75.0,
+    "y" : 280.0,
+    "name" : "d1",
+    "equipmentId" : "d1",
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d2",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 25.0,
+    "y" : 280.0,
+    "orientation" : "DOWN",
+    "name" : "d2",
+    "equipmentId" : "d2",
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "FEEDER",
+    "id" : "g",
+    "componentType" : "GENERATOR",
+    "fictitious" : false,
+    "x" : 25.0,
+    "y" : 560.0,
+    "orientation" : "DOWN",
+    "label" : "generator",
+    "name" : "g",
+    "equipmentId" : "g",
+    "feederType" : "INJECTION",
+    "order" : 2,
+    "direction" : "BOTTOM"
+  }, {
+    "type" : "FEEDER",
+    "id" : "l",
+    "componentType" : "LOAD",
+    "fictitious" : false,
+    "x" : 75.0,
+    "y" : 0.0,
+    "label" : "l",
+    "name" : "l",
+    "equipmentId" : "l",
+    "feederType" : "INJECTION",
+    "order" : 0,
+    "direction" : "TOP"
+  } ],
+  "cells" : [ {
+    "type" : "EXTERN",
+    "number" : 0,
+    "direction" : "TOP",
+    "order" : 0,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 2,
+        "v" : 0,
+        "hSpan" : 2,
+        "vSpan" : 4,
+        "orientation" : "UP"
+      },
+      "coord" : {
+        "x" : 75.0,
+        "y" : 156.0,
+        "xSpan" : 50.0,
+        "ySpan" : 188.0
+      },
+      "subBlocks" : [ {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 250.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs1", "d1", "INTERNAL_vl_b1" ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 4,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 156.0,
+          "xSpan" : 50.0,
+          "ySpan" : 188.0
+        },
+        "nodes" : [ "INTERNAL_vl_b1", "b1", "INTERNAL_vl_l" ]
+      }, {
+        "type" : "FEEDERPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 4,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 62.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "INTERNAL_vl_l", "l" ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 1,
+    "direction" : "BOTTOM",
+    "order" : 2,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 0,
+        "v" : 0,
+        "hSpan" : 2,
+        "vSpan" : 4,
+        "orientation" : "DOWN"
+      },
+      "coord" : {
+        "x" : 25.0,
+        "y" : 404.0,
+        "xSpan" : 50.0,
+        "ySpan" : 188.0
+      },
+      "subBlocks" : [ {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "DOWN"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 310.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs2", "d2", "INTERNAL_vl_b2" ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 4,
+          "orientation" : "DOWN"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 404.0,
+          "xSpan" : 50.0,
+          "ySpan" : 188.0
+        },
+        "nodes" : [ "INTERNAL_vl_b2", "b2", "INTERNAL_vl_g" ]
+      }, {
+        "type" : "FEEDERPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 4,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "DOWN"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 498.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "INTERNAL_vl_g", "g" ]
+      } ]
+    }
+  } ],
+  "edges" : [ {
+    "node1" : "bbs1",
+    "node2" : "d1"
+  }, {
+    "node1" : "bbs2",
+    "node2" : "d2"
+  }, {
+    "node1" : "d1",
+    "node2" : "INTERNAL_vl_b1"
+  }, {
+    "node1" : "INTERNAL_vl_b1",
+    "node2" : "b1"
+  }, {
+    "node1" : "d2",
+    "node2" : "INTERNAL_vl_b2"
+  }, {
+    "node1" : "INTERNAL_vl_b2",
+    "node2" : "b2"
+  }, {
+    "node1" : "b1",
+    "node2" : "INTERNAL_vl_l"
+  }, {
+    "node1" : "INTERNAL_vl_l",
+    "node2" : "l"
+  }, {
+    "node1" : "b2",
+    "node2" : "INTERNAL_vl_g"
+  }, {
+    "node1" : "INTERNAL_vl_g",
+    "node2" : "g"
+  } ],
+  "multitermNodes" : [ ],
+  "twtEdges" : [ ],
+  "lineEdges" : [ ]
+}

--- a/single-line-diagram-core/src/test/resources/TestCaseMissingBusbarPositionBusParallel.json
+++ b/single-line-diagram-core/src/test/resources/TestCaseMissingBusbarPositionBusParallel.json
@@ -1,0 +1,423 @@
+{
+  "voltageLevelInfos" : {
+    "id" : "vl",
+    "name" : "vl",
+    "nominalVoltage" : 380.0
+  },
+  "x" : 40.0,
+  "y" : 80.0,
+  "nodes" : [ {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl_1",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 25.0,
+    "y" : 250.0
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl_b2",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 75.0,
+    "y" : 335.0,
+    "orientation" : "DOWN"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl_g",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 75.0,
+    "y" : 523.0,
+    "orientation" : "DOWN"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl_l",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 25.0,
+    "y" : 62.0
+  }, {
+    "type" : "SWITCH",
+    "id" : "b1",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 25.0,
+    "y" : 156.0,
+    "name" : "b1",
+    "equipmentId" : "b1",
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "SWITCH",
+    "id" : "b2",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 75.0,
+    "y" : 429.0,
+    "orientation" : "DOWN",
+    "name" : "b2",
+    "equipmentId" : "b2",
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "BUS",
+    "id" : "bbs1",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 12.5,
+    "y" : 305.0,
+    "name" : "bbs1",
+    "equipmentId" : "bbs1",
+    "pxWidth" : 75.0,
+    "busbarIndex" : 2,
+    "sectionIndex" : 1,
+    "position" : {
+      "h" : 0,
+      "v" : 1,
+      "hSpan" : 4,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "BUS",
+    "id" : "bbs2",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 12.5,
+    "y" : 280.0,
+    "name" : "bbs2",
+    "equipmentId" : "bbs2",
+    "pxWidth" : 75.0,
+    "busbarIndex" : 1,
+    "sectionIndex" : 1,
+    "position" : {
+      "h" : 0,
+      "v" : 0,
+      "hSpan" : 4,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "SWITCH",
+    "id" : "d1",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 25.0,
+    "y" : 305.0,
+    "name" : "d1",
+    "equipmentId" : "d1",
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d2",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 75.0,
+    "y" : 280.0,
+    "orientation" : "DOWN",
+    "name" : "d2",
+    "equipmentId" : "d2",
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d2l",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 25.0,
+    "y" : 280.0,
+    "name" : "d2l",
+    "equipmentId" : "d2l",
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "FEEDER",
+    "id" : "g",
+    "componentType" : "GENERATOR",
+    "fictitious" : false,
+    "x" : 75.0,
+    "y" : 585.0,
+    "orientation" : "DOWN",
+    "label" : "generator",
+    "name" : "g",
+    "equipmentId" : "g",
+    "feederType" : "INJECTION",
+    "order" : 2,
+    "direction" : "BOTTOM"
+  }, {
+    "type" : "FEEDER",
+    "id" : "l",
+    "componentType" : "LOAD",
+    "fictitious" : false,
+    "x" : 25.0,
+    "y" : 0.0,
+    "label" : "l",
+    "name" : "l",
+    "equipmentId" : "l",
+    "feederType" : "INJECTION",
+    "order" : 0,
+    "direction" : "TOP"
+  } ],
+  "cells" : [ {
+    "type" : "EXTERN",
+    "number" : 0,
+    "direction" : "TOP",
+    "order" : 0,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 2
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 0,
+        "v" : 0,
+        "hSpan" : 2,
+        "vSpan" : 4,
+        "orientation" : "UP"
+      },
+      "coord" : {
+        "x" : 25.0,
+        "y" : 156.0,
+        "xSpan" : 50.0,
+        "ySpan" : 188.0
+      },
+      "subBlocks" : [ {
+        "type" : "LEGPARALLEL",
+        "cardinalities" : [ {
+          "START" : 2
+        }, {
+          "END" : 2
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 250.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "subBlocks" : [ {
+          "type" : "LEGPRIMARY",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 0,
+            "hSpan" : 2,
+            "vSpan" : 0,
+            "orientation" : "UP"
+          },
+          "coord" : {
+            "x" : 25.0,
+            "y" : 250.0,
+            "xSpan" : 50.0,
+            "ySpan" : 0.0
+          },
+          "nodes" : [ "bbs1", "d1", "INTERNAL_vl_1" ]
+        }, {
+          "type" : "LEGPRIMARY",
+          "cardinalities" : [ {
+            "START" : 1
+          }, {
+            "END" : 1
+          } ],
+          "position" : {
+            "h" : 0,
+            "v" : 0,
+            "hSpan" : 2,
+            "vSpan" : 0,
+            "orientation" : "UP"
+          },
+          "coord" : {
+            "x" : 25.0,
+            "y" : 250.0,
+            "xSpan" : 50.0,
+            "ySpan" : 0.0
+          },
+          "nodes" : [ "bbs2", "d2l", "INTERNAL_vl_1" ]
+        } ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 4,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 156.0,
+          "xSpan" : 50.0,
+          "ySpan" : 188.0
+        },
+        "nodes" : [ "INTERNAL_vl_1", "b1", "INTERNAL_vl_l" ]
+      }, {
+        "type" : "FEEDERPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 4,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "UP"
+        },
+        "coord" : {
+          "x" : 25.0,
+          "y" : 62.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "INTERNAL_vl_l", "l" ]
+      } ]
+    }
+  }, {
+    "type" : "EXTERN",
+    "number" : 1,
+    "direction" : "BOTTOM",
+    "order" : 2,
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : 2,
+        "v" : 0,
+        "hSpan" : 2,
+        "vSpan" : 4,
+        "orientation" : "DOWN"
+      },
+      "coord" : {
+        "x" : 75.0,
+        "y" : 429.0,
+        "xSpan" : 50.0,
+        "ySpan" : 188.0
+      },
+      "subBlocks" : [ {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "DOWN"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 335.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs2", "d2", "INTERNAL_vl_b2" ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 0,
+          "hSpan" : 2,
+          "vSpan" : 4,
+          "orientation" : "DOWN"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 429.0,
+          "xSpan" : 50.0,
+          "ySpan" : 188.0
+        },
+        "nodes" : [ "INTERNAL_vl_b2", "b2", "INTERNAL_vl_g" ]
+      }, {
+        "type" : "FEEDERPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 0,
+          "v" : 4,
+          "hSpan" : 2,
+          "vSpan" : 0,
+          "orientation" : "DOWN"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 523.0,
+          "xSpan" : 50.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "INTERNAL_vl_g", "g" ]
+      } ]
+    }
+  } ],
+  "edges" : [ {
+    "node1" : "bbs1",
+    "node2" : "d1"
+  }, {
+    "node1" : "d1",
+    "node2" : "INTERNAL_vl_1"
+  }, {
+    "node1" : "INTERNAL_vl_1",
+    "node2" : "b1"
+  }, {
+    "node1" : "bbs2",
+    "node2" : "d2"
+  }, {
+    "node1" : "bbs2",
+    "node2" : "d2l"
+  }, {
+    "node1" : "d2l",
+    "node2" : "INTERNAL_vl_1"
+  }, {
+    "node1" : "d2",
+    "node2" : "INTERNAL_vl_b2"
+  }, {
+    "node1" : "INTERNAL_vl_b2",
+    "node2" : "b2"
+  }, {
+    "node1" : "b1",
+    "node2" : "INTERNAL_vl_l"
+  }, {
+    "node1" : "INTERNAL_vl_l",
+    "node2" : "l"
+  }, {
+    "node1" : "b2",
+    "node2" : "INTERNAL_vl_g"
+  }, {
+    "node1" : "INTERNAL_vl_g",
+    "node2" : "g"
+  } ],
+  "multitermNodes" : [ ],
+  "twtEdges" : [ ],
+  "lineEdges" : [ ]
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
When a busbar position extension is missing and `PositionFromExtension` is used as `PositionFinder`, then `BlockOrganizer` fails with an `ArrayOutOfBoundException`.



**What is the new behavior (if this is a feature change)?**
When a busbar position extension is missing and `PositionFromExtension` is used as `PositionFinder`, then we replace the missing indices with appropriate values: either with the same section index as the first busNode which shares a BusCell with, or if none with a new section index.


**Does this PR introduce a breaking change or deprecate an API?** 
No