### PR TITLE
Fix empty buses width

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockPositionner.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/BlockPositionner.java
@@ -59,14 +59,11 @@ class BlockPositionner {
             }
 
             hPos = placeCrossOverInternCells(hPos, ss.getInternCells(InternCell.Shape.CROSSOVER, Side.RIGHT), Side.RIGHT, nonFlatCellsToClose);
-            List<BusCell> verticalCells = new ArrayList<>();
-            verticalCells.addAll(ss.getVerticalInternCells());
-            verticalCells.addAll(ss.getExternCells());
-            verticalCells.sort(Comparator.comparingInt(bc -> bc.getOrder().orElse(-1)));
-            hPos = placeVerticalCells(hPos, verticalCells);
+            hPos = placeVerticalCells(hPos, getVerticalCells(ss));
             hPos = placeCrossOverInternCells(hPos, ss.getInternCells(InternCell.Shape.CROSSOVER, Side.LEFT), Side.LEFT, nonFlatCellsToClose);
             if (hPos == prevHPos) {
-                hPos++;
+                // Bus minimum width is one cell
+                hPos += 2; // A cell is 2 units wide
             }
             hSpace = placeFlatInternCells(hPos, ss.getInternCells(InternCell.Shape.FLAT, Side.LEFT)) - hPos;
             hPos += hSpace;
@@ -85,6 +82,14 @@ class BlockPositionner {
         }
 
         manageInternCellOverlaps(graph);
+    }
+
+    private static List<BusCell> getVerticalCells(Subsection ss) {
+        List<BusCell> verticalCells = new ArrayList<>();
+        verticalCells.addAll(ss.getVerticalInternCells());
+        verticalCells.addAll(ss.getExternCells());
+        verticalCells.sort(Comparator.comparingInt(bc -> bc.getOrder().orElse(-1)));
+        return verticalCells;
     }
 
     private List<BusNode> getBusNodesToClose(Subsection prevSS, Subsection ss) {

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/CreateNetworksUtil.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/CreateNetworksUtil.java
@@ -476,4 +476,24 @@ public final class CreateNetworksUtil {
         return network;
     }
 
+    public static Network createNetworkWithFlatSections() {
+        Network network = Network.create("TestSingleLineDiagramClass", "test");
+        Substation substation = createSubstation(network, "s", "s", Country.FR);
+        VoltageLevel vl = createVoltageLevel(substation, "vl1", "vl1", TopologyKind.NODE_BREAKER, 380, 10);
+        createBusBarSection(vl, "bbs11", "bbs11", 0, 1, 1);
+        createBusBarSection(vl, "bbs21", "bbs21", 1, 2, 1);
+        createBusBarSection(vl, "bbs12", "bbs12", 2, 1, 2);
+        createBusBarSection(vl, "bbs22", "bbs22", 3, 2, 2);
+        createBusBarSection(vl, "bbs13", "bbs13", 4, 1, 3);
+        createBusBarSection(vl, "bbs23", "bbs23", 5, 2, 3);
+        createSwitch(vl, "d112", "d112", SwitchKind.DISCONNECTOR, false, false, false, 0, 2);
+        createSwitch(vl, "d212", "d212", SwitchKind.DISCONNECTOR, false, false, false, 1, 3);
+        createSwitch(vl, "d123a", "d123a", SwitchKind.DISCONNECTOR, false, false, false, 2, 6);
+        createSwitch(vl, "b123", "b123", SwitchKind.BREAKER, false, false, false, 6, 7);
+        createSwitch(vl, "d123b", "d123b", SwitchKind.DISCONNECTOR, false, false, false, 7, 4);
+        createSwitch(vl, "d223a", "d223a", SwitchKind.DISCONNECTOR, false, false, false, 3, 8);
+        createSwitch(vl, "b223", "b223", SwitchKind.BREAKER, false, false, false, 8, 9);
+        createSwitch(vl, "d223b", "d223b", SwitchKind.DISCONNECTOR, false, false, false, 9, 5);
+        return network;
+    }
 }

--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestFlatSection.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/iidm/TestFlatSection.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.iidm;
+
+import com.powsybl.sld.builders.NetworkGraphBuilder;
+import com.powsybl.sld.model.graphs.VoltageLevelGraph;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class TestFlatSection extends AbstractTestCaseIidm {
+
+    @Before
+    public void setUp() throws IOException {
+        network = CreateNetworksUtil.createNetworkWithFlatSections();
+        graphBuilder = new NetworkGraphBuilder(network);
+        layoutParameters.setAdaptCellHeightToContent(true);
+    }
+
+    @Test
+    public void test() {
+        // build graph
+        VoltageLevelGraph g = graphBuilder.buildVoltageLevelGraph("vl1");
+
+        // Run layout
+        voltageLevelGraphLayout(g);
+
+        // write SVG and compare to reference
+        assertEquals(toString("/testFlatSections.json"), toJson(g, "/testFlatSections.json"));
+    }
+}

--- a/single-line-diagram-core/src/test/resources/TestUndefinedBlockExternCell.json
+++ b/single-line-diagram-core/src/test/resources/TestUndefinedBlockExternCell.json
@@ -50,13 +50,13 @@
     "y" : 280.0,
     "name" : "bbs",
     "equipmentId" : "bbs",
-    "pxWidth" : 0.0,
+    "pxWidth" : 25.0,
     "busbarIndex" : 1,
     "sectionIndex" : 1,
     "position" : {
       "h" : 0,
       "v" : 0,
-      "hSpan" : 1,
+      "hSpan" : 2,
       "vSpan" : 0
     }
   }, {

--- a/single-line-diagram-core/src/test/resources/testFlatSections.json
+++ b/single-line-diagram-core/src/test/resources/testFlatSections.json
@@ -1,0 +1,743 @@
+{
+  "voltageLevelInfos" : {
+    "id" : "vl1",
+    "name" : "vl1",
+    "nominalVoltage" : 380.0
+  },
+  "x" : 40.0,
+  "y" : 80.0,
+  "nodes" : [ {
+    "type" : "INTERNAL",
+    "id" : "BUSCO_d112",
+    "componentType" : "BUS_CONNECTION",
+    "fictitious" : true,
+    "x" : 50.0,
+    "y" : 0.0,
+    "orientation" : "RIGHT"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "BUSCO_d112",
+    "componentType" : "BUS_CONNECTION",
+    "fictitious" : true,
+    "x" : 100.0,
+    "y" : 0.0,
+    "orientation" : "RIGHT"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "BUSCO_d212",
+    "componentType" : "BUS_CONNECTION",
+    "fictitious" : true,
+    "x" : 50.0,
+    "y" : 25.0,
+    "orientation" : "RIGHT"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "BUSCO_d212",
+    "componentType" : "BUS_CONNECTION",
+    "fictitious" : true,
+    "x" : 100.0,
+    "y" : 25.0,
+    "orientation" : "RIGHT"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl1_b123",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 150.0,
+    "y" : 0.0,
+    "orientation" : "RIGHT"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl1_b123",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 200.0,
+    "y" : 0.0,
+    "orientation" : "RIGHT"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl1_b223",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 150.0,
+    "y" : 25.0,
+    "orientation" : "RIGHT"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl1_b223",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 200.0,
+    "y" : 25.0,
+    "orientation" : "RIGHT"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl1_d112",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 50.0,
+    "y" : 0.0,
+    "orientation" : "RIGHT"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl1_d112",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 100.0,
+    "y" : 0.0,
+    "orientation" : "RIGHT"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl1_d212",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 50.0,
+    "y" : 25.0,
+    "orientation" : "RIGHT"
+  }, {
+    "type" : "INTERNAL",
+    "id" : "INTERNAL_vl1_d212",
+    "componentType" : "NODE",
+    "fictitious" : true,
+    "x" : 100.0,
+    "y" : 25.0,
+    "orientation" : "RIGHT"
+  }, {
+    "type" : "SWITCH",
+    "id" : "b123",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 175.0,
+    "y" : 0.0,
+    "orientation" : "RIGHT",
+    "name" : "b123",
+    "equipmentId" : "b123",
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "SWITCH",
+    "id" : "b223",
+    "componentType" : "BREAKER",
+    "fictitious" : false,
+    "x" : 175.0,
+    "y" : 25.0,
+    "orientation" : "RIGHT",
+    "name" : "b223",
+    "equipmentId" : "b223",
+    "open" : false,
+    "kind" : "BREAKER"
+  }, {
+    "type" : "BUS",
+    "id" : "bbs11",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 12.5,
+    "y" : 0.0,
+    "name" : "bbs11",
+    "equipmentId" : "bbs11",
+    "pxWidth" : 25.0,
+    "busbarIndex" : 1,
+    "sectionIndex" : 1,
+    "position" : {
+      "h" : 0,
+      "v" : 0,
+      "hSpan" : 2,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "BUS",
+    "id" : "bbs12",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 112.5,
+    "y" : 0.0,
+    "name" : "bbs12",
+    "equipmentId" : "bbs12",
+    "pxWidth" : 25.0,
+    "busbarIndex" : 1,
+    "sectionIndex" : 2,
+    "position" : {
+      "h" : 4,
+      "v" : 0,
+      "hSpan" : 2,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "BUS",
+    "id" : "bbs13",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 212.5,
+    "y" : 0.0,
+    "name" : "bbs13",
+    "equipmentId" : "bbs13",
+    "pxWidth" : 25.0,
+    "busbarIndex" : 1,
+    "sectionIndex" : 3,
+    "position" : {
+      "h" : 8,
+      "v" : 0,
+      "hSpan" : 2,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "BUS",
+    "id" : "bbs21",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 12.5,
+    "y" : 25.0,
+    "name" : "bbs21",
+    "equipmentId" : "bbs21",
+    "pxWidth" : 25.0,
+    "busbarIndex" : 2,
+    "sectionIndex" : 1,
+    "position" : {
+      "h" : 0,
+      "v" : 1,
+      "hSpan" : 2,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "BUS",
+    "id" : "bbs22",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 112.5,
+    "y" : 25.0,
+    "name" : "bbs22",
+    "equipmentId" : "bbs22",
+    "pxWidth" : 25.0,
+    "busbarIndex" : 2,
+    "sectionIndex" : 2,
+    "position" : {
+      "h" : 4,
+      "v" : 1,
+      "hSpan" : 2,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "BUS",
+    "id" : "bbs23",
+    "componentType" : "BUSBAR_SECTION",
+    "fictitious" : false,
+    "x" : 212.5,
+    "y" : 25.0,
+    "name" : "bbs23",
+    "equipmentId" : "bbs23",
+    "pxWidth" : 25.0,
+    "busbarIndex" : 2,
+    "sectionIndex" : 3,
+    "position" : {
+      "h" : 8,
+      "v" : 1,
+      "hSpan" : 2,
+      "vSpan" : 0
+    }
+  }, {
+    "type" : "SWITCH",
+    "id" : "d112",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 75.0,
+    "y" : 0.0,
+    "orientation" : "RIGHT",
+    "name" : "d112",
+    "equipmentId" : "d112",
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d123a",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 150.0,
+    "y" : 0.0,
+    "orientation" : "RIGHT",
+    "name" : "d123a",
+    "equipmentId" : "d123a",
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d123b",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 200.0,
+    "y" : 0.0,
+    "orientation" : "RIGHT",
+    "name" : "d123b",
+    "equipmentId" : "d123b",
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d212",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 75.0,
+    "y" : 25.0,
+    "orientation" : "RIGHT",
+    "name" : "d212",
+    "equipmentId" : "d212",
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d223a",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 150.0,
+    "y" : 25.0,
+    "orientation" : "RIGHT",
+    "name" : "d223a",
+    "equipmentId" : "d223a",
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  }, {
+    "type" : "SWITCH",
+    "id" : "d223b",
+    "componentType" : "DISCONNECTOR",
+    "fictitious" : false,
+    "x" : 200.0,
+    "y" : 25.0,
+    "orientation" : "RIGHT",
+    "name" : "d223b",
+    "equipmentId" : "d223b",
+    "open" : false,
+    "kind" : "DISCONNECTOR"
+  } ],
+  "cells" : [ {
+    "type" : "INTERN",
+    "number" : 0,
+    "direction" : "MIDDLE",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0,
+        "orientation" : "RIGHT"
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 4,
+          "v" : -1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 100.0,
+          "y" : -50.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs12", "BUSCO_d112", "INTERNAL_vl1_d112" ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 2,
+          "v" : 1,
+          "hSpan" : 2,
+          "vSpan" : 2,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 0.0,
+          "xSpan" : 50.0,
+          "ySpan" : 40.0
+        },
+        "nodes" : [ "INTERNAL_vl1_d112", "d112", "INTERNAL_vl1_d112" ]
+      }, {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 2,
+          "v" : -1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 50.0,
+          "y" : -50.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs11", "BUSCO_d112", "INTERNAL_vl1_d112" ]
+      } ]
+    }
+  }, {
+    "type" : "INTERN",
+    "number" : 1,
+    "direction" : "MIDDLE",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0,
+        "orientation" : "RIGHT"
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 4,
+          "v" : -1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 100.0,
+          "y" : -50.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs22", "BUSCO_d212", "INTERNAL_vl1_d212" ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 2,
+          "v" : 2,
+          "hSpan" : 2,
+          "vSpan" : 2,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 75.0,
+          "y" : 25.0,
+          "xSpan" : 50.0,
+          "ySpan" : 40.0
+        },
+        "nodes" : [ "INTERNAL_vl1_d212", "d212", "INTERNAL_vl1_d212" ]
+      }, {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 2,
+          "v" : -1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 50.0,
+          "y" : -50.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs21", "BUSCO_d212", "INTERNAL_vl1_d212" ]
+      } ]
+    }
+  }, {
+    "type" : "INTERN",
+    "number" : 2,
+    "direction" : "MIDDLE",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0,
+        "orientation" : "RIGHT"
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 8,
+          "v" : -1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 200.0,
+          "y" : -50.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs13", "d123b", "INTERNAL_vl1_b123" ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 6,
+          "v" : 1,
+          "hSpan" : 2,
+          "vSpan" : 2,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 175.0,
+          "y" : 0.0,
+          "xSpan" : 50.0,
+          "ySpan" : 40.0
+        },
+        "nodes" : [ "INTERNAL_vl1_b123", "b123", "INTERNAL_vl1_b123" ]
+      }, {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 6,
+          "v" : -1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 150.0,
+          "y" : -50.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs12", "d123a", "INTERNAL_vl1_b123" ]
+      } ]
+    }
+  }, {
+    "type" : "INTERN",
+    "number" : 3,
+    "direction" : "MIDDLE",
+    "rootBlock" : {
+      "type" : "SERIAL",
+      "cardinalities" : [ {
+        "START" : 1
+      }, {
+        "END" : 1
+      } ],
+      "position" : {
+        "h" : -1,
+        "v" : -1,
+        "hSpan" : 0,
+        "vSpan" : 0,
+        "orientation" : "RIGHT"
+      },
+      "coord" : {
+        "x" : -1.0,
+        "y" : -1.0,
+        "xSpan" : 0.0,
+        "ySpan" : 0.0
+      },
+      "subBlocks" : [ {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 8,
+          "v" : -1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 200.0,
+          "y" : -50.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs23", "d223b", "INTERNAL_vl1_b223" ]
+      }, {
+        "type" : "BODYPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 6,
+          "v" : 2,
+          "hSpan" : 2,
+          "vSpan" : 2,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 175.0,
+          "y" : 25.0,
+          "xSpan" : 50.0,
+          "ySpan" : 40.0
+        },
+        "nodes" : [ "INTERNAL_vl1_b223", "b223", "INTERNAL_vl1_b223" ]
+      }, {
+        "type" : "LEGPRIMARY",
+        "cardinalities" : [ {
+          "START" : 1
+        }, {
+          "END" : 1
+        } ],
+        "position" : {
+          "h" : 6,
+          "v" : -1,
+          "hSpan" : 0,
+          "vSpan" : 0,
+          "orientation" : "RIGHT"
+        },
+        "coord" : {
+          "x" : 150.0,
+          "y" : -50.0,
+          "xSpan" : 0.0,
+          "ySpan" : 0.0
+        },
+        "nodes" : [ "bbs22", "d223a", "INTERNAL_vl1_b223" ]
+      } ]
+    }
+  } ],
+  "edges" : [ {
+    "node1" : "bbs12",
+    "node2" : "d123a"
+  }, {
+    "node1" : "d123b",
+    "node2" : "bbs13"
+  }, {
+    "node1" : "bbs22",
+    "node2" : "d223a"
+  }, {
+    "node1" : "d223b",
+    "node2" : "bbs23"
+  }, {
+    "node1" : "bbs11",
+    "node2" : "BUSCO_d112"
+  }, {
+    "node1" : "bbs21",
+    "node2" : "BUSCO_d212"
+  }, {
+    "node1" : "BUSCO_d112",
+    "node2" : "bbs12"
+  }, {
+    "node1" : "BUSCO_d212",
+    "node2" : "bbs22"
+  }, {
+    "node1" : "BUSCO_d112",
+    "node2" : "INTERNAL_vl1_d112"
+  }, {
+    "node1" : "INTERNAL_vl1_d112",
+    "node2" : "d112"
+  }, {
+    "node1" : "BUSCO_d212",
+    "node2" : "INTERNAL_vl1_d212"
+  }, {
+    "node1" : "INTERNAL_vl1_d212",
+    "node2" : "d212"
+  }, {
+    "node1" : "d123a",
+    "node2" : "INTERNAL_vl1_b123"
+  }, {
+    "node1" : "INTERNAL_vl1_b123",
+    "node2" : "b123"
+  }, {
+    "node1" : "d112",
+    "node2" : "INTERNAL_vl1_d112"
+  }, {
+    "node1" : "INTERNAL_vl1_d112",
+    "node2" : "BUSCO_d112"
+  }, {
+    "node1" : "d223a",
+    "node2" : "INTERNAL_vl1_b223"
+  }, {
+    "node1" : "INTERNAL_vl1_b223",
+    "node2" : "b223"
+  }, {
+    "node1" : "d212",
+    "node2" : "INTERNAL_vl1_d212"
+  }, {
+    "node1" : "INTERNAL_vl1_d212",
+    "node2" : "BUSCO_d212"
+  }, {
+    "node1" : "b123",
+    "node2" : "INTERNAL_vl1_b123"
+  }, {
+    "node1" : "INTERNAL_vl1_b123",
+    "node2" : "d123b"
+  }, {
+    "node1" : "b223",
+    "node2" : "INTERNAL_vl1_b223"
+  }, {
+    "node1" : "INTERNAL_vl1_b223",
+    "node2" : "d223b"
+  } ],
+  "multitermNodes" : [ ],
+  "twtEdges" : [ ],
+  "lineEdges" : [ ]
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** 
Bug fix



**What is the current behavior?** 
Buses with no feeders nor couplers have a zero width:
![bug](https://user-images.githubusercontent.com/66690739/192553801-4da9a37b-7b11-42ea-a545-2e84fcc6150b.png)



**What is the new behavior (if this is a feature change)?**
Buses with no feeders nor couplers have a width of one cell:
![fix](https://user-images.githubusercontent.com/66690739/192553878-8a29e019-d560-4076-a8c2-7f181846d1a4.png)



**Does this PR introduce a breaking change or deprecate an API?**
No