### PR TITLE
Fix two-winding transformers static definition in style provider

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentTypeName.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/library/ComponentTypeName.java
@@ -33,10 +33,6 @@ public final class ComponentTypeName {
     public static final String PHASE_SHIFT_TRANSFORMER = "PHASE_SHIFT_TRANSFORMER";
     public static final String PHASE_SHIFT_TRANSFORMER_LEG = "PHASE_SHIFT_TRANSFORMER_LEG";
 
-    public static boolean is2WTtransformer(String componentName) {
-        return TWO_WINDINGS_TRANSFORMER.equals(componentName) || PHASE_SHIFT_TRANSFORMER.equals(componentName);
-    }
-
     private ComponentTypeName() {
         throw new AssertionError();
     }

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
@@ -199,7 +199,7 @@
             <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L11_95_ONE" transform="translate(211.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-bottom-feeder sld-vl300to500" id="idL11_95_ONE" transform="translate(215.0,665.0)">
+            <g class="sld-bottom-feeder" id="idL11_95_ONE" transform="translate(215.0,665.0)">
                 <text class="sld-label" id="L11_ONE_S_LABEL" x="-5.0" y="5.0">L11</text>
             </g>
         </g>
@@ -265,7 +265,7 @@
             <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L12_95_ONE" transform="translate(311.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-bottom-feeder sld-vl300to500" id="idL12_95_ONE" transform="translate(315.0,665.0)">
+            <g class="sld-bottom-feeder" id="idL12_95_ONE" transform="translate(315.0,665.0)">
                 <text class="sld-label" id="L12_ONE_S_LABEL" x="-5.0" y="5.0">L12</text>
             </g>
         </g>
@@ -385,7 +385,7 @@
             <g class="sld-node sld-fictitious sld-vl300to500" id="idINTERNAL_95_VL1_95_L11_95_TWO" transform="translate(511.0,599.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-bottom-feeder sld-vl300to500" id="idL11_95_TWO" transform="translate(515.0,665.0)">
+            <g class="sld-bottom-feeder" id="idL11_95_TWO" transform="translate(515.0,665.0)">
                 <text class="sld-label" id="L11_TWO_S_LABEL" x="-5.0" y="5.0">L11</text>
             </g>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHFirst.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHFirst.svg
@@ -481,7 +481,7 @@
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_line1_95_ONE" transform="translate(411.0,318.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-top-feeder sld-vl300to500-0" id="idline1_95_ONE" transform="translate(415.0,260.0)">
+            <g class="sld-top-feeder" id="idline1_95_ONE" transform="translate(415.0,260.0)">
                 <text class="sld-label" id="line1_ONE_N_LABEL" x="-5.0" y="-5.0">line1</text>
             </g>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHLast.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHLast.svg
@@ -481,7 +481,7 @@
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_line1_95_ONE" transform="translate(411.0,318.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-top-feeder sld-vl300to500-0" id="idline1_95_ONE" transform="translate(415.0,260.0)">
+            <g class="sld-top-feeder" id="idline1_95_ONE" transform="translate(415.0,260.0)">
                 <text class="sld-label" id="line1_ONE_N_LABEL" x="-5.0" y="-5.0">line1</text>
             </g>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHMiddle.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHMiddle.svg
@@ -481,7 +481,7 @@
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_line1_95_ONE" transform="translate(411.0,318.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-top-feeder sld-vl300to500-0" id="idline1_95_ONE" transform="translate(415.0,260.0)">
+            <g class="sld-top-feeder" id="idline1_95_ONE" transform="translate(415.0,260.0)">
                 <text class="sld-label" id="line1_ONE_N_LABEL" x="-5.0" y="-5.0">line1</text>
             </g>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHNone.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHNone.svg
@@ -481,7 +481,7 @@
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_line1_95_ONE" transform="translate(411.0,318.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-top-feeder sld-vl300to500-0" id="idline1_95_ONE" transform="translate(415.0,260.0)">
+            <g class="sld-top-feeder" id="idline1_95_ONE" transform="translate(415.0,260.0)">
                 <text class="sld-label" id="line1_ONE_N_LABEL" x="-5.0" y="-5.0">line1</text>
             </g>
         </g>

--- a/single-line-diagram-core/src/test/resources/TestCaseFictitiousBusTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseFictitiousBusTopological.svg
@@ -181,7 +181,7 @@
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L1_95_ONE" transform="translate(61.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-top-feeder sld-vl50to70-0" id="idL1_95_ONE" transform="translate(65.0,80.0)">
+            <g class="sld-top-feeder" id="idL1_95_ONE" transform="translate(65.0,80.0)">
                 <text class="sld-label" id="L1_ONE_N_LABEL" x="-5.0" y="-5.0">L1</text>
             </g>
         </g>
@@ -214,7 +214,7 @@
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L2_95_ONE" transform="translate(111.0,574.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-bottom-feeder sld-vl50to70-0" id="idL2_95_ONE" transform="translate(115.0,640.0)">
+            <g class="sld-bottom-feeder" id="idL2_95_ONE" transform="translate(115.0,640.0)">
                 <text class="sld-label" id="L2_ONE_S_LABEL" x="-5.0" y="5.0">L2</text>
             </g>
         </g>
@@ -247,7 +247,7 @@
             <g class="sld-node sld-fictitious sld-vl50to70-0" id="idINTERNAL_95_vl_95_L3_95_ONE" transform="translate(161.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-top-feeder sld-vl50to70-0" id="idL3_95_ONE" transform="translate(165.0,80.0)">
+            <g class="sld-top-feeder" id="idL3_95_ONE" transform="translate(165.0,80.0)">
                 <text class="sld-label" id="L3_ONE_N_LABEL" x="-5.0" y="-5.0">L3</text>
             </g>
         </g>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
In the default StyleProvider implementation, the 2-winding transformers are detected to put the appropriate voltage level style:
- no voltage level style on the component itself
- voltage level style for each winding subcomponent 

This detection is based on 2-winding transformers component name with the use of a static method, which leaves no space for the custom 2-winding transformers.


**What is the new behavior (if this is a feature change)?**
In the default StyleProvider implementation, the detection of 2-winding transformers and more generally the nodes connecting two voltage levels is now based on the FeederNode::getFeeder instance. Besides, this detection can be overridden as the corresponding `AbstractBaseVoltageDiagramStyleProvider::isNodeConnectingVoltageLevels` visibility is `protected`.


**Does this PR introduce a breaking change or deprecate an API?**
No