### PR TITLE
Fix shunt compensator component type

### DIFF
--- a/single-line-diagram-core/src/test/java/com/powsybl/sld/builders/NetworkGraphBuilderTest.java
+++ b/single-line-diagram-core/src/test/java/com/powsybl/sld/builders/NetworkGraphBuilderTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.sld.builders;
+
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class NetworkGraphBuilderTest {
+
+    @Test
+    public void isCapacitorTest() {
+        Network network = EurostagTutorialExample1Factory.create();
+        VoltageLevel vlload = network.getVoltageLevel("VLLOAD");
+        ShuntCompensator sc = vlload.newShuntCompensator()
+                .setId("SC")
+                .setConnectableBus("NLOAD")
+                .newLinearModel()
+                .setBPerSection(0.05)
+                .setMaximumSectionCount(1)
+                .add()
+                .setSectionCount(0)
+                .add();
+        assertTrue(NetworkGraphBuilder.isCapacitor(sc));
+        sc.getModel(ShuntCompensatorLinearModel.class).setBPerSection(-0.03);
+        assertFalse(NetworkGraphBuilder.isCapacitor(sc));
+        ShuntCompensator sc2 = vlload.newShuntCompensator()
+                .setId("SC2")
+                .setConnectableBus("NLOAD")
+                .newNonLinearModel()
+                .beginSection()
+                .setB(0.05)
+                .endSection()
+                .beginSection()
+                .setB(-0.02)
+                .endSection()
+                .add()
+                .setSectionCount(0)
+                .add();
+        assertTrue(NetworkGraphBuilder.isCapacitor(sc2));
+        sc2.getModel(ShuntCompensatorNonLinearModel.class).getAllSections().get(1).setB(-0.07);
+        assertFalse(NetworkGraphBuilder.isCapacitor(sc2));
+    }
+}


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Conductor or inductor symbol is made on current susceptance so dependent of the activated sections. In addition when no section is activated, a conductor is drawn.


**What is the new behavior (if this is a feature change)?**
The conductor or inductor choice is done only on structural data.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
