### PR TITLE
Draw all edges once only

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -273,9 +273,11 @@ public class DefaultSVGWriter implements SVGWriter {
         g.setAttribute("id", cellId);
         g.setAttribute(CLASS, String.join(" ", styleProvider.getCellStyles(cell)));
 
-        List<Node> nodesToDraw = cell.getNodes().stream().filter(n -> !(n instanceof BusNode)).collect(Collectors.toList());
-        Collection<Edge> edgesToDraw = new LinkedHashSet<>();
-        nodesToDraw.forEach(n -> edgesToDraw.addAll(n.getAdjacentEdges()));
+        List<Node> cellNodes = cell.getNodes();
+        List<Node> nodesToDraw = cellNodes.stream().filter(n -> !(n instanceof BusNode)).collect(Collectors.toList());
+        Collection<Edge> edgesToDraw = nodesToDraw.stream().flatMap(n -> n.getAdjacentEdges().stream())
+                .filter(e -> cellNodes.contains(e.getNode1()) && cellNodes.contains(e.getNode2()))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         drawEdges(prefixId, g, graph, metadata, initProvider, styleProvider, edgesToDraw);
         drawNodes(prefixId, g, graph, graph.getCoord(), metadata, initProvider, styleProvider, nodesToDraw);

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
@@ -174,9 +174,6 @@
             <g class="sld-wire" id="_95_vl1_95_dB2_95_INTERNAL_95_vl1_95_5">
                 <polyline points="165.0,280.0,165.0,250.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="165.0,250.0,190.0,250.0,190.0,223.0"/>
-            </g>
             <g class="sld-wire" id="_95_vl1_95_bB_95_INTERNAL_95_vl1_95_loadB">
                 <polyline points="165.0,186.0,165.0,142.0"/>
             </g>
@@ -219,15 +216,6 @@
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_2">
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_bB">
-                <polyline points="165.0,250.0,165.0,206.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_dB1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,305.0,165.0,250.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_dB2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="165.0,280.0,165.0,250.0"/>
-            </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
                 <polyline points="165.0,250.0,190.0,250.0,190.0,223.0"/>
             </g>
@@ -239,21 +227,6 @@
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2_95_INTERNAL_95_vl1_95_loadC_95_fork">
                 <polyline points="240.0,223.0,240.0,196.0,315.0,196.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_bCD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="265.0,213.0,265.0,196.0,315.0,196.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_bCD2_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="315.0,213.0,315.0,196.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_bCD3_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="365.0,213.0,365.0,196.0,315.0,196.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_bD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="277.5,179.0,277.5,196.0,315.0,196.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="315.0,196.0,352.5,196.0,352.5,142.0"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(161.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
@@ -287,9 +260,6 @@
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
                 <polyline points="315.0,196.0,352.5,196.0,352.5,142.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="240.0,223.0,240.0,196.0,315.0,196.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_bCD1_95_bCD1">
                 <polyline points="265.0,250.0,265.0,233.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
@@ -264,9 +264,6 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dB2_95_INTERNAL_95_vl1_95_5">
                 <polyline points="215.0,280.0,215.0,250.0"/>
             </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="215.0,250.0,240.0,250.0,240.0,223.0"/>
-            </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bB_95_INTERNAL_95_vl1_95_loadB">
                 <polyline points="215.0,186.0,215.0,142.0"/>
             </g>
@@ -309,15 +306,6 @@
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_2">
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_bB">
-                <polyline points="215.0,250.0,215.0,206.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dB1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="215.0,305.0,215.0,250.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_dB2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="215.0,280.0,215.0,250.0"/>
-            </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
                 <polyline points="215.0,250.0,240.0,250.0,240.0,223.0"/>
             </g>
@@ -329,21 +317,6 @@
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2_95_INTERNAL_95_vl1_95_loadC_95_fork">
                 <polyline points="340.0,223.0,340.0,196.0,415.0,196.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bCD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="365.0,213.0,365.0,196.0,415.0,196.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bCD2_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="415.0,213.0,415.0,196.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bCD3_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="465.0,213.0,465.0,196.0,415.0,196.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_bD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="377.5,179.0,377.5,196.0,415.0,196.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="415.0,196.0,452.5,196.0,452.5,142.0"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl300to500-0" id="idINTERNAL_95_vl1_95_5" transform="translate(211.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
@@ -377,9 +350,6 @@
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
                 <polyline points="415.0,196.0,452.5,196.0,452.5,142.0"/>
-            </g>
-            <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="340.0,223.0,340.0,196.0,415.0,196.0"/>
             </g>
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_bCD1_95_bCD1">
                 <polyline points="365.0,250.0,365.0,233.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
@@ -158,9 +158,6 @@
             <g class="sld-wire" id="_95_vl1_95_dB2_95_INTERNAL_95_vl1_95_5">
                 <polyline points="115.0,280.0,115.0,250.0"/>
             </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
-                <polyline points="115.0,250.0,140.0,250.0,140.0,223.0"/>
-            </g>
             <g class="sld-wire" id="_95_vl1_95_bB_95_INTERNAL_95_vl1_95_loadB">
                 <polyline points="115.0,186.0,115.0,142.0"/>
             </g>
@@ -203,15 +200,6 @@
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_2">
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_bB">
-                <polyline points="115.0,250.0,115.0,206.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_dB1_95_INTERNAL_95_vl1_95_5">
-                <polyline points="115.0,305.0,115.0,250.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_dB2_95_INTERNAL_95_vl1_95_5">
-                <polyline points="115.0,280.0,115.0,250.0"/>
-            </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_5_95_INTERNAL_95_vl1_95_Shunt_32_2_46_1">
                 <polyline points="115.0,250.0,140.0,250.0,140.0,223.0"/>
             </g>
@@ -223,21 +211,6 @@
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2_95_INTERNAL_95_vl1_95_loadC_95_fork">
                 <polyline points="190.0,223.0,190.0,196.0,265.0,196.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_bCD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="215.0,213.0,215.0,196.0,265.0,196.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_bCD2_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="265.0,213.0,265.0,196.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_bCD3_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="315.0,213.0,315.0,196.0,265.0,196.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_bD1_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="227.5,179.0,227.5,196.0,265.0,196.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
-                <polyline points="265.0,196.0,302.5,196.0,302.5,142.0"/>
             </g>
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl1_95_5" transform="translate(111.0,246.0)">
                 <circle cx="4" cy="4" r="4"/>
@@ -271,9 +244,6 @@
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_fork_95_INTERNAL_95_vl1_95_loadC">
                 <polyline points="265.0,196.0,302.5,196.0,302.5,142.0"/>
-            </g>
-            <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_Shunt_32_2_46_2_95_INTERNAL_95_vl1_95_loadC_95_fork">
-                <polyline points="190.0,223.0,190.0,196.0,265.0,196.0"/>
             </g>
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_bCD1_95_bCD1">
                 <polyline points="215.0,250.0,215.0,233.0"/>

--- a/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
@@ -280,9 +280,6 @@
             <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_fork_95_INTERNAL_95_vl_95_l">
                 <polyline points="315.0,540.3333333333333,315.0,603.0"/>
             </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_Shunt_32_4_46_1_95_INTERNAL_95_vl_95_l_95_fork">
-                <polyline points="290.0,524.6666666666666,290.0,540.3333333333333,315.0,540.3333333333333"/>
-            </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_b_95_b">
                 <polyline points="315.0,415.0,315.0,472.6666666666667"/>
             </g>
@@ -326,12 +323,6 @@
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_4">
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_b3_95_INTERNAL_95_vl_95_5">
-                <polyline points="215.0,467.0,215.0,509.0"/>
-            </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_5_95_b4">
-                <polyline points="215.0,509.0,215.0,551.0"/>
-            </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_5_95_INTERNAL_95_vl_95_Shunt_32_4_46_2">
                 <polyline points="215.0,509.0,240.0,509.0,240.0,524.6666666666666"/>
             </g>
@@ -343,12 +334,6 @@
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_Shunt_32_4_46_1_95_INTERNAL_95_vl_95_l_95_fork">
                 <polyline points="290.0,524.6666666666666,290.0,540.3333333333333,315.0,540.3333333333333"/>
-            </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_b_95_INTERNAL_95_vl_95_l_95_fork">
-                <polyline points="315.0,482.6666666666667,315.0,540.3333333333333"/>
-            </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_fork_95_INTERNAL_95_vl_95_l">
-                <polyline points="315.0,540.3333333333333,315.0,603.0"/>
             </g>
             <g class="sld-node sld-fictitious sld-disconnected" id="idINTERNAL_95_vl_95_5" transform="translate(211.0,505.0)">
                 <circle cx="4" cy="4" r="4"/>
@@ -373,9 +358,6 @@
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_5_95_b4">
                 <polyline points="215.0,509.0,215.0,551.0"/>
-            </g>
-            <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_5_95_INTERNAL_95_vl_95_Shunt_32_4_46_2">
-                <polyline points="215.0,509.0,240.0,509.0,240.0,524.6666666666666"/>
             </g>
             <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_b3_95_b3">
                 <polyline points="215.0,415.0,215.0,457.0"/>

--- a/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
+++ b/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
@@ -198,12 +198,6 @@
             <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_EH_95_INTERNAL_95_AU_95_19">
                 <polyline points="815.0,395.1428571428571,815.0,423.71428571428567,790.0,423.71428571428567"/>
             </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_1_46_1_95_INTERNAL_95_AU_95_19">
-                <polyline points="740.0,433.35714285714283,740.0,423.71428571428567,790.0,423.71428571428567"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_2_46_1_95_INTERNAL_95_AU_95_19">
-                <polyline points="740.0,410.85714285714283,740.0,423.71428571428567,790.0,423.71428571428567"/>
-            </g>
             <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_BL_95_BL">
                 <polyline points="765.0,308.0,765.0,355.85714285714283"/>
             </g>
@@ -286,20 +280,8 @@
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_1">
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_CT_95_INTERNAL_95_AU_95_5">
-                <polyline points="590.0,419.25,590.0,443.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_DZ_95_INTERNAL_95_AU_95_5">
-                <polyline points="565.0,466.75,565.0,443.0,590.0,443.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_FH_95_INTERNAL_95_AU_95_5">
-                <polyline points="615.0,466.75,615.0,443.0,590.0,443.0"/>
-            </g>
             <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_1_46_2_95_INTERNAL_95_AU_95_5">
                 <polyline points="640.0,433.35714285714283,640.0,443.0,590.0,443.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_4_46_1_95_INTERNAL_95_AU_95_5">
-                <polyline points="540.0,402.5,540.0,443.0,590.0,443.0"/>
             </g>
             <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_BX_95_INTERNAL_95_AU_95_Shunt_32_1_46_2">
                 <polyline points="655.0,433.35714285714283,640.0,433.35714285714283"/>
@@ -315,18 +297,6 @@
             </g>
             <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_1_46_1_95_INTERNAL_95_AU_95_19">
                 <polyline points="740.0,433.35714285714283,740.0,423.71428571428567,790.0,423.71428571428567"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_BL_95_INTERNAL_95_AU_95_19">
-                <polyline points="765.0,375.85714285714283,765.0,423.71428571428567,790.0,423.71428571428567"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_BN_95_INTERNAL_95_AU_95_19">
-                <polyline points="790.0,452.2857142857142,790.0,423.71428571428567"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_EH_95_INTERNAL_95_AU_95_19">
-                <polyline points="815.0,395.1428571428571,815.0,423.71428571428567,790.0,423.71428571428567"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_2_46_1_95_INTERNAL_95_AU_95_19">
-                <polyline points="740.0,410.85714285714283,740.0,423.71428571428567,790.0,423.71428571428567"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl70to120-1" id="idINTERNAL_95_AU_95_5" transform="translate(586.0,439.0)">
                 <circle cx="4" cy="4" r="4"/>
@@ -359,20 +329,8 @@
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_2">
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_DP_95_INTERNAL_95_AU_95_43">
-                <polyline points="115.0,433.0,115.0,398.0,140.0,398.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_EX_95_INTERNAL_95_AU_95_43">
-                <polyline points="140.0,363.0,140.0,398.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_FF_95_INTERNAL_95_AU_95_43">
-                <polyline points="165.0,433.0,165.0,398.0,140.0,398.0"/>
-            </g>
             <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_2_46_2_95_INTERNAL_95_AU_95_43">
                 <polyline points="190.0,410.85714285714283,190.0,398.0,140.0,398.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_6_46_1_95_INTERNAL_95_AU_95_43">
-                <polyline points="190.0,434.0,190.0,398.0,140.0,398.0"/>
             </g>
             <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_FN_95_INTERNAL_95_AU_95_Shunt_32_2_46_2">
                 <polyline points="317.5,410.85714285714283,190.0,410.85714285714283"/>
@@ -388,18 +346,6 @@
             </g>
             <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_2_46_1_95_INTERNAL_95_AU_95_19">
                 <polyline points="740.0,410.85714285714283,740.0,423.71428571428567,790.0,423.71428571428567"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_BL_95_INTERNAL_95_AU_95_19">
-                <polyline points="765.0,375.85714285714283,765.0,423.71428571428567,790.0,423.71428571428567"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_BN_95_INTERNAL_95_AU_95_19">
-                <polyline points="790.0,452.2857142857142,790.0,423.71428571428567"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_EH_95_INTERNAL_95_AU_95_19">
-                <polyline points="815.0,395.1428571428571,815.0,423.71428571428567,790.0,423.71428571428567"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_1_46_1_95_INTERNAL_95_AU_95_19">
-                <polyline points="740.0,433.35714285714283,740.0,423.71428571428567,790.0,423.71428571428567"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl70to120-0" id="idINTERNAL_95_AU_95_43" transform="translate(136.0,394.0)">
                 <circle cx="4" cy="4" r="4"/>
@@ -440,12 +386,6 @@
             </g>
             <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_FH_95_INTERNAL_95_AU_95_5">
                 <polyline points="615.0,466.75,615.0,443.0,590.0,443.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_1_46_2_95_INTERNAL_95_AU_95_5">
-                <polyline points="640.0,433.35714285714283,640.0,443.0,590.0,443.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_4_46_1_95_INTERNAL_95_AU_95_5">
-                <polyline points="540.0,402.5,540.0,443.0,590.0,443.0"/>
             </g>
             <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_BJ_95_CT">
                 <polyline points="590.0,385.5,590.0,399.25"/>
@@ -554,12 +494,6 @@
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_4">
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_BZ_95_INTERNAL_95_AU_95_50">
-                <polyline points="327.5,345.0,327.5,362.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_DL_95_INTERNAL_95_AU_95_50">
-                <polyline points="327.5,379.0,327.5,362.0"/>
-            </g>
             <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_4_46_2_95_INTERNAL_95_AU_95_50">
                 <polyline points="440.0,402.5,440.0,362.0,327.5,362.0"/>
             </g>
@@ -577,18 +511,6 @@
             </g>
             <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_4_46_1_95_INTERNAL_95_AU_95_5">
                 <polyline points="540.0,402.5,540.0,443.0,590.0,443.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_CT_95_INTERNAL_95_AU_95_5">
-                <polyline points="590.0,419.25,590.0,443.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_DZ_95_INTERNAL_95_AU_95_5">
-                <polyline points="565.0,466.75,565.0,443.0,590.0,443.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_FH_95_INTERNAL_95_AU_95_5">
-                <polyline points="615.0,466.75,615.0,443.0,590.0,443.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-1" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_1_46_2_95_INTERNAL_95_AU_95_5">
-                <polyline points="640.0,433.35714285714283,640.0,443.0,590.0,443.0"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl70to120-0" id="idINTERNAL_95_AU_95_50" transform="translate(323.5,358.0)">
                 <circle cx="4" cy="4" r="4"/>
@@ -629,12 +551,6 @@
             </g>
             <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_FF_95_INTERNAL_95_AU_95_43">
                 <polyline points="165.0,433.0,165.0,398.0,140.0,398.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_2_46_2_95_INTERNAL_95_AU_95_43">
-                <polyline points="190.0,410.85714285714283,190.0,398.0,140.0,398.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_6_46_1_95_INTERNAL_95_AU_95_43">
-                <polyline points="190.0,434.0,190.0,398.0,140.0,398.0"/>
             </g>
             <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_DP_95_ET">
                 <polyline points="115.0,453.0,115.0,478.0"/>
@@ -738,18 +654,6 @@
             </g>
         </g>
         <g class="sld-shunt-cell" id="idSHUNT_32_6">
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_DP_95_INTERNAL_95_AU_95_43">
-                <polyline points="115.0,433.0,115.0,398.0,140.0,398.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_EX_95_INTERNAL_95_AU_95_43">
-                <polyline points="140.0,363.0,140.0,398.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_FF_95_INTERNAL_95_AU_95_43">
-                <polyline points="165.0,433.0,165.0,398.0,140.0,398.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_2_46_2_95_INTERNAL_95_AU_95_43">
-                <polyline points="190.0,410.85714285714283,190.0,398.0,140.0,398.0"/>
-            </g>
             <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_6_46_1_95_INTERNAL_95_AU_95_43">
                 <polyline points="190.0,434.0,190.0,398.0,140.0,398.0"/>
             </g>
@@ -767,21 +671,6 @@
             </g>
             <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_6_46_2_95_INTERNAL_95_AU_95_45">
                 <polyline points="290.0,434.0,290.0,470.0,365.0,470.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_BT_95_INTERNAL_95_AU_95_45">
-                <polyline points="315.0,487.0,315.0,470.0,365.0,470.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_CB_95_INTERNAL_95_AU_95_45">
-                <polyline points="365.0,487.0,365.0,470.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_CN_95_INTERNAL_95_AU_95_45">
-                <polyline points="402.5,439.5,402.5,470.0,365.0,470.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_CR_95_INTERNAL_95_AU_95_45">
-                <polyline points="415.0,487.0,415.0,470.0,365.0,470.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_DN_95_INTERNAL_95_AU_95_45">
-                <polyline points="327.5,453.0,327.5,470.0,365.0,470.0"/>
             </g>
             <g class="sld-node sld-fictitious sld-vl70to120-0" id="idINTERNAL_95_AU_95_43" transform="translate(136.0,394.0)">
                 <circle cx="4" cy="4" r="4"/>
@@ -820,9 +709,6 @@
             <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_DL_95_INTERNAL_95_AU_95_50">
                 <polyline points="327.5,379.0,327.5,362.0"/>
             </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_4_46_2_95_INTERNAL_95_AU_95_50">
-                <polyline points="440.0,402.5,440.0,362.0,327.5,362.0"/>
-            </g>
             <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_BZ_95_BZ">
                 <polyline points="327.5,308.0,327.5,325.0"/>
             </g>
@@ -849,9 +735,6 @@
             </g>
             <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_CR_95_INTERNAL_95_AU_95_45">
                 <polyline points="415.0,487.0,415.0,470.0,365.0,470.0"/>
-            </g>
-            <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_INTERNAL_95_AU_95_Shunt_32_6_46_2_95_INTERNAL_95_AU_95_45">
-                <polyline points="290.0,434.0,290.0,470.0,365.0,470.0"/>
             </g>
             <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_BT_95_ED">
                 <polyline points="315.0,507.0,315.0,514.0"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?** 
Bug fix



**What is the current behavior?**
When drawing cell bay all neighbouring edges are drawn, leading to some edges being drawn twice



**What is the new behavior (if this is a feature change)?**
When drawing cell bay only inside edges are drawn


**Does this PR introduce a breaking change or deprecate an API?**
No