### PR TITLE
More CSS classes for discriminating text elements

### DIFF
--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/BasicStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/BasicStyleProvider.java
@@ -16,11 +16,7 @@ import com.powsybl.sld.model.cells.ShuntCell;
 import com.powsybl.sld.model.coordinate.Direction;
 import com.powsybl.sld.model.graphs.Graph;
 import com.powsybl.sld.model.graphs.VoltageLevelGraph;
-import com.powsybl.sld.model.nodes.BranchEdge;
-import com.powsybl.sld.model.nodes.Edge;
-import com.powsybl.sld.model.nodes.FeederNode;
-import com.powsybl.sld.model.nodes.Node;
-import com.powsybl.sld.model.nodes.SwitchNode;
+import com.powsybl.sld.model.nodes.*;
 
 import java.net.URL;
 import java.util.*;
@@ -144,5 +140,20 @@ public class BasicStyleProvider implements DiagramStyleProvider {
     @Override
     public List<String> getBusStyles(String busId, VoltageLevelGraph graph) {
         return Collections.singletonList(NODE_INFOS);
+    }
+
+    @Override
+    public Optional<String> getBusInfoStyle(BusInfo info) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<String> getFeederInfoStyles(FeederInfo info) {
+        List<String> styles = new ArrayList<>();
+        styles.add(FEEDER_INFO);
+        if (info instanceof DirectionalFeederInfo) {
+            styles.add(((DirectionalFeederInfo) info).getDirection() == DiagramLabelProvider.LabelDirection.OUT ? OUT_CLASS : IN_CLASS);
+        }
+        return styles;
     }
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DefaultSVGWriter.java
@@ -876,7 +876,7 @@ public class DefaultSVGWriter implements SVGWriter {
         // we draw the feeder info
         double rotationAngle = points.get(0).getY() > points.get(1).getY() ? 180 : 0;
         insertFeederInfoSVGIntoDocumentSVG(feederInfo, prefixId, g, rotationAngle);
-        styleProvider.getFeederInfoStyle(feederInfo).ifPresent(styles::add);
+        styles.addAll(styleProvider.getFeederInfoStyles(feederInfo));
 
         // we draw the right label only if present
         feederInfo.getRightLabel().ifPresent(s -> {
@@ -1171,7 +1171,7 @@ public class DefaultSVGWriter implements SVGWriter {
 
         labelV.setAttribute("x", String.valueOf(xShift - CIRCLE_RADIUS_NODE_INFOS_SIZE));
         labelV.setAttribute("y", String.valueOf(yShift + 2.5 * CIRCLE_RADIUS_NODE_INFOS_SIZE));
-        labelV.setAttribute(CLASS, LABEL_STYLE_CLASS);
+        labelV.setAttribute(CLASS, VOLTAGE);
         Text textV = g.getOwnerDocument().createTextNode(valueV);
         labelV.appendChild(textV);
         g.appendChild(labelV);
@@ -1183,7 +1183,7 @@ public class DefaultSVGWriter implements SVGWriter {
 
         labelAngle.setAttribute("x", String.valueOf(xShift - CIRCLE_RADIUS_NODE_INFOS_SIZE));
         labelAngle.setAttribute("y", String.valueOf(yShift + 4 * CIRCLE_RADIUS_NODE_INFOS_SIZE));
-        labelAngle.setAttribute(CLASS, LABEL_STYLE_CLASS);
+        labelAngle.setAttribute(CLASS, ANGLE);
         Text textAngle = g.getOwnerDocument().createTextNode(valueAngle);
         labelAngle.appendChild(textAngle);
         g.appendChild(labelAngle);
@@ -1192,19 +1192,23 @@ public class DefaultSVGWriter implements SVGWriter {
     private void drawNodesInfos(String prefixId, Element root, VoltageLevelGraph graph,
                                 GraphMetadata metadata, DiagramLabelProvider initProvider, DiagramStyleProvider styleProvider) {
 
+        Element nodesInfosNode = root.getOwnerDocument().createElement(GROUP);
+        root.appendChild(nodesInfosNode);
+        nodesInfosNode.setAttribute(CLASS, LEGEND);
+
         double xInitPos = layoutParameters.getDiagramPadding().getLeft() + CIRCLE_RADIUS_NODE_INFOS_SIZE;
         double yPos = graph.getY() - layoutParameters.getVoltageLevelPadding().getTop() + graph.getHeight() + CIRCLE_RADIUS_NODE_INFOS_SIZE;
 
         double xShift = graph.getX() + xInitPos;
         for (ElectricalNodeInfo node : initProvider.getElectricalNodesInfos(graph)) {
             String idNode = prefixId + "NODE_" + node.getBusId();
-            Element gNode = root.getOwnerDocument().createElement(GROUP);
+            Element gNode = nodesInfosNode.getOwnerDocument().createElement(GROUP);
             gNode.setAttribute("id", idNode);
 
             List<String> styles = styleProvider.getBusStyles(node.getBusId(), graph);
             drawNodeInfos(node, xShift, yPos, gNode, idNode, styles);
 
-            root.appendChild(gNode);
+            nodesInfosNode.appendChild(gNode);
 
             metadata.addElectricalNodeInfoMetadata(new GraphMetadata.ElectricalNodeInfoMetadata(idNode, node.getUserDefinedId()));
 

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DiagramStyleProvider.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DiagramStyleProvider.java
@@ -18,9 +18,6 @@ import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 
-import static com.powsybl.sld.svg.DiagramStyles.IN_CLASS;
-import static com.powsybl.sld.svg.DiagramStyles.OUT_CLASS;
-
 /**
  * @author Giovanni Ferrari <giovanni.ferrari at techrain.eu>
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
@@ -45,16 +42,9 @@ public interface DiagramStyleProvider {
 
     List<String> getBusStyles(String busId, VoltageLevelGraph graph);
 
-    default Optional<String> getBusInfoStyle(BusInfo info) {
-        return Optional.empty();
-    }
+    Optional<String> getBusInfoStyle(BusInfo info);
 
-    default Optional<String> getFeederInfoStyle(FeederInfo info) {
-        if (info instanceof DirectionalFeederInfo) {
-            return Optional.of(((DirectionalFeederInfo) info).getDirection() == DiagramLabelProvider.LabelDirection.OUT ? OUT_CLASS : IN_CLASS);
-        }
-        return Optional.empty();
-    }
+    List<String> getFeederInfoStyles(FeederInfo info);
 
     List<String> getCellStyles(Cell cell);
 }

--- a/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DiagramStyles.java
+++ b/single-line-diagram-core/src/main/java/com/powsybl/sld/svg/DiagramStyles.java
@@ -41,6 +41,11 @@ public final class DiagramStyles {
     public static final String INTERN_CELL = STYLE_PREFIX + "intern-cell";
     public static final String SHUNT_CELL = STYLE_PREFIX + "shunt-cell";
     public static final String CELL_SHAPE_PREFIX = STYLE_PREFIX + "cell-shape-";
+    public static final String LEGEND = STYLE_PREFIX + "legend";
+    public static final String VOLTAGE = STYLE_PREFIX + "voltage";
+    public static final String ANGLE = STYLE_PREFIX + "angle";
+    public static final String FEEDER_INFO = STYLE_PREFIX + "feeder-info";
+
     private static final String ID_PREFIX = "id";
 
     private DiagramStyles() {

--- a/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.css
+++ b/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.css
@@ -26,15 +26,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}

--- a/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.json
+++ b/single-line-diagram-core/src/main/resources/ConvergenceLibrary/components.json
@@ -375,7 +375,7 @@
       "fileName" : "arrow-down.svg",
       "styleClass" : "sld-arrow-in"
     } ],
-    "styleClass" : "sld-arrow-p"
+    "styleClass" : "sld-active-power"
   }, {
     "type" : "ARROW_REACTIVE",
     "size" : {
@@ -392,6 +392,6 @@
       "fileName" : "arrow-down.svg",
       "styleClass" : "sld-arrow-in"
     } ],
-    "styleClass" : "sld-arrow-q"
+    "styleClass" : "sld-reactive-power"
   } ]
 }

--- a/single-line-diagram-core/src/main/resources/tautologies.css
+++ b/single-line-diagram-core/src/main/resources/tautologies.css
@@ -7,5 +7,5 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}

--- a/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesBusBreaker.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: baseVoltages.css ------------------------------------------------ */
 .sld-vl300to500 {--sld-vl-color: #ff0000}
@@ -54,15 +54,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -144,12 +146,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_LD1_95_LD1">
                 <polyline points="165.0,142.0,165.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idLD1_ARROW_ACTIVE" transform="translate(160.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idLD1_ARROW_ACTIVE" transform="translate(160.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idLD1_ARROW_REACTIVE" transform="translate(160.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idLD1_ARROW_REACTIVE" transform="translate(160.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -180,12 +182,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_L11_95_ONE">
                 <polyline points="215.0,603.0,215.0,665.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL11_95_ONE_ARROW_REACTIVE" transform="translate(210.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL11_95_ONE_ARROW_REACTIVE" transform="translate(210.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL11_95_ONE_ARROW_ACTIVE" transform="translate(210.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL11_95_ONE_ARROW_ACTIVE" transform="translate(210.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -213,12 +215,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_T11_95_ONE">
                 <polyline points="265.0,142.0,265.0,80.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(260.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(260.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(260.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(260.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -246,12 +248,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_L12_95_ONE">
                 <polyline points="315.0,603.0,315.0,665.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL12_95_ONE_ARROW_REACTIVE" transform="translate(310.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL12_95_ONE_ARROW_REACTIVE" transform="translate(310.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL12_95_ONE_ARROW_ACTIVE" transform="translate(310.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL12_95_ONE_ARROW_ACTIVE" transform="translate(310.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -279,12 +281,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_VL1_95_T3_95_12_95_TWO_95_T3_95_12">
                 <polyline points="365.0,665.0,365.0,603.0,383.0,603.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_TWO_ARROW_REACTIVE" transform="translate(360.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_TWO_ARROW_REACTIVE" transform="translate(360.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_TWO_ARROW_ACTIVE" transform="translate(360.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_TWO_ARROW_ACTIVE" transform="translate(360.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -292,12 +294,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_VL1_95_T3_95_12_95_THREE_95_T3_95_12">
                 <polyline points="415.0,665.0,415.0,603.0,397.0,603.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(410.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(410.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(410.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(410.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -330,12 +332,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_G">
                 <polyline points="465.0,142.0,465.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idG_ARROW_ACTIVE" transform="translate(460.0,101.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idG_ARROW_ACTIVE" transform="translate(460.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idG_ARROW_REACTIVE" transform="translate(460.0,121.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idG_ARROW_REACTIVE" transform="translate(460.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -366,12 +368,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_L11_95_TWO">
                 <polyline points="515.0,603.0,515.0,665.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL11_95_TWO_ARROW_REACTIVE" transform="translate(510.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL11_95_TWO_ARROW_REACTIVE" transform="translate(510.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL11_95_TWO_ARROW_ACTIVE" transform="translate(510.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL11_95_TWO_ARROW_ACTIVE" transform="translate(510.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -399,12 +401,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_T11_95_TWO">
                 <polyline points="565.0,142.0,565.0,80.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(560.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(560.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(560.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(560.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -432,12 +434,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_T12_95_ONE">
                 <polyline points="615.0,603.0,615.0,657.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT12_95_ONE_ARROW_REACTIVE" transform="translate(610.0,632.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT12_95_ONE_ARROW_REACTIVE" transform="translate(610.0,632.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT12_95_ONE_ARROW_ACTIVE" transform="translate(610.0,612.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT12_95_ONE_ARROW_ACTIVE" transform="translate(610.0,612.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -467,12 +469,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_VL1_95_T3_95_12_95_ONE_95_T3_95_12">
                 <polyline points="665.0,665.0,665.0,603.0,683.0,603.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_ONE_ARROW_REACTIVE" transform="translate(660.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_ONE_ARROW_REACTIVE" transform="translate(660.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_ONE_ARROW_ACTIVE" transform="translate(660.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_ONE_ARROW_ACTIVE" transform="translate(660.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -480,12 +482,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_VL1_95_T3_95_12_95_THREE_95_T3_95_12">
                 <polyline points="715.0,665.0,715.0,603.0,697.0,603.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(710.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(710.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(710.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(710.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/InternalBranchesNodeBreaker.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -135,12 +137,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L1_95_L1">
                 <polyline points="165.0,172.0,165.0,114.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL1_ARROW_ACTIVE" transform="translate(160.0,129.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL1_ARROW_ACTIVE" transform="translate(160.0,129.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL1_ARROW_REACTIVE" transform="translate(160.0,149.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL1_ARROW_REACTIVE" transform="translate(160.0,149.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -179,12 +181,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_L11_95_ONE">
                 <polyline points="215.0,172.0,215.0,110.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL11_95_ONE_ARROW_ACTIVE" transform="translate(210.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL11_95_ONE_ARROW_ACTIVE" transform="translate(210.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL11_95_ONE_ARROW_REACTIVE" transform="translate(210.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL11_95_ONE_ARROW_REACTIVE" transform="translate(210.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -220,12 +222,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_L12_95_ONE">
                 <polyline points="265.0,172.0,265.0,110.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL12_95_ONE_ARROW_ACTIVE" transform="translate(260.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL12_95_ONE_ARROW_ACTIVE" transform="translate(260.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL12_95_ONE_ARROW_REACTIVE" transform="translate(260.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL12_95_ONE_ARROW_REACTIVE" transform="translate(260.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -261,12 +263,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_T11_95_ONE">
                 <polyline points="315.0,172.0,315.0,110.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(310.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(310.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">375</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(310.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(310.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">48</text>
@@ -302,12 +304,12 @@
             <g class="sld-wire" id="_95_VL1_95_T3_95_12_95_TWO_95_T3_95_12">
                 <polyline points="365.0,110.0,365.0,172.0,383.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_TWO_ARROW_ACTIVE" transform="translate(360.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_TWO_ARROW_ACTIVE" transform="translate(360.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_TWO_ARROW_REACTIVE" transform="translate(360.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_TWO_ARROW_REACTIVE" transform="translate(360.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -315,12 +317,12 @@
             <g class="sld-wire" id="_95_VL1_95_T3_95_12_95_THREE_95_T3_95_12">
                 <polyline points="415.0,110.0,415.0,172.0,397.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(410.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(410.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(410.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(410.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -361,12 +363,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_G">
                 <polyline points="465.0,172.0,465.0,116.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idG_ARROW_ACTIVE" transform="translate(460.0,131.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idG_ARROW_ACTIVE" transform="translate(460.0,131.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idG_ARROW_REACTIVE" transform="translate(460.0,151.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idG_ARROW_REACTIVE" transform="translate(460.0,151.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -405,12 +407,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_L11_95_TWO">
                 <polyline points="515.0,172.0,515.0,110.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL11_95_TWO_ARROW_ACTIVE" transform="translate(510.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL11_95_TWO_ARROW_ACTIVE" transform="translate(510.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL11_95_TWO_ARROW_REACTIVE" transform="translate(510.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL11_95_TWO_ARROW_REACTIVE" transform="translate(510.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -446,12 +448,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_T11_95_TWO">
                 <polyline points="565.0,172.0,565.0,110.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(560.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(560.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">375</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(560.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(560.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">48</text>
@@ -487,12 +489,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_T12_95_ONE">
                 <polyline points="615.0,172.0,615.0,118.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idT12_95_ONE_ARROW_ACTIVE" transform="translate(610.0,133.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idT12_95_ONE_ARROW_ACTIVE" transform="translate(610.0,133.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">375</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idT12_95_ONE_ARROW_REACTIVE" transform="translate(610.0,153.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idT12_95_ONE_ARROW_REACTIVE" transform="translate(610.0,153.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">48</text>
@@ -530,12 +532,12 @@
             <g class="sld-wire" id="_95_VL1_95_T3_95_12_95_ONE_95_T3_95_12">
                 <polyline points="665.0,110.0,665.0,172.0,683.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_ONE_ARROW_ACTIVE" transform="translate(660.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_ONE_ARROW_ACTIVE" transform="translate(660.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_ONE_ARROW_REACTIVE" transform="translate(660.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_ONE_ARROW_REACTIVE" transform="translate(660.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -543,12 +545,12 @@
             <g class="sld-wire" id="_95_VL1_95_T3_95_12_95_THREE_95_T3_95_12">
                 <polyline points="715.0,110.0,715.0,172.0,697.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(710.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(710.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(710.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(710.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusBusBreaker.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -130,12 +132,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_LD1_95_LD1">
                 <polyline points="165.0,142.0,165.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idLD1_ARROW_ACTIVE" transform="translate(160.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idLD1_ARROW_ACTIVE" transform="translate(160.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idLD1_ARROW_REACTIVE" transform="translate(160.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idLD1_ARROW_REACTIVE" transform="translate(160.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -166,12 +168,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_L11_95_ONE">
                 <polyline points="215.0,603.0,215.0,665.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL11_95_ONE_ARROW_REACTIVE" transform="translate(210.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL11_95_ONE_ARROW_REACTIVE" transform="translate(210.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL11_95_ONE_ARROW_ACTIVE" transform="translate(210.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL11_95_ONE_ARROW_ACTIVE" transform="translate(210.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -202,12 +204,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_T11_95_ONE">
                 <polyline points="265.0,142.0,265.0,80.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(260.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(260.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(260.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(260.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -238,12 +240,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_L12_95_ONE">
                 <polyline points="315.0,603.0,315.0,665.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL12_95_ONE_ARROW_REACTIVE" transform="translate(310.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL12_95_ONE_ARROW_REACTIVE" transform="translate(310.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL12_95_ONE_ARROW_ACTIVE" transform="translate(310.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL12_95_ONE_ARROW_ACTIVE" transform="translate(310.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -274,12 +276,12 @@
             <g class="sld-wire" id="_95_VL1_95_T3_95_12_95_TWO_95_T3_95_12">
                 <polyline points="365.0,665.0,365.0,603.0,383.0,603.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_TWO_ARROW_REACTIVE" transform="translate(360.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_TWO_ARROW_REACTIVE" transform="translate(360.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_TWO_ARROW_ACTIVE" transform="translate(360.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_TWO_ARROW_ACTIVE" transform="translate(360.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -287,12 +289,12 @@
             <g class="sld-wire" id="_95_VL1_95_T3_95_12_95_THREE_95_T3_95_12">
                 <polyline points="415.0,665.0,415.0,603.0,397.0,603.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(410.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(410.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(410.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(410.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -328,12 +330,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_G">
                 <polyline points="465.0,142.0,465.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idG_ARROW_ACTIVE" transform="translate(460.0,101.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idG_ARROW_ACTIVE" transform="translate(460.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idG_ARROW_REACTIVE" transform="translate(460.0,121.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idG_ARROW_REACTIVE" transform="translate(460.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -364,12 +366,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_L11_95_TWO">
                 <polyline points="515.0,603.0,515.0,665.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL11_95_TWO_ARROW_REACTIVE" transform="translate(510.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL11_95_TWO_ARROW_REACTIVE" transform="translate(510.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL11_95_TWO_ARROW_ACTIVE" transform="translate(510.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL11_95_TWO_ARROW_ACTIVE" transform="translate(510.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -400,12 +402,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_T11_95_TWO">
                 <polyline points="565.0,142.0,565.0,80.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(560.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(560.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(560.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(560.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -436,12 +438,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_T12_95_ONE">
                 <polyline points="615.0,603.0,615.0,657.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT12_95_ONE_ARROW_REACTIVE" transform="translate(610.0,632.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT12_95_ONE_ARROW_REACTIVE" transform="translate(610.0,632.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT12_95_ONE_ARROW_ACTIVE" transform="translate(610.0,612.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT12_95_ONE_ARROW_ACTIVE" transform="translate(610.0,612.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -474,12 +476,12 @@
             <g class="sld-wire" id="_95_VL1_95_T3_95_12_95_ONE_95_T3_95_12">
                 <polyline points="665.0,665.0,665.0,603.0,683.0,603.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_ONE_ARROW_REACTIVE" transform="translate(660.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_ONE_ARROW_REACTIVE" transform="translate(660.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_ONE_ARROW_ACTIVE" transform="translate(660.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_ONE_ARROW_ACTIVE" transform="translate(660.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -487,12 +489,12 @@
             <g class="sld-wire" id="_95_VL1_95_T3_95_12_95_THREE_95_T3_95_12">
                 <polyline points="715.0,665.0,715.0,603.0,697.0,603.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(710.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(710.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(710.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(710.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsBranchStatusNodeBreaker.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -149,12 +151,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L1_95_L1">
                 <polyline points="165.0,262.0,165.0,204.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL1_ARROW_ACTIVE" transform="translate(160.0,219.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL1_ARROW_ACTIVE" transform="translate(160.0,219.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL1_ARROW_REACTIVE" transform="translate(160.0,239.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL1_ARROW_REACTIVE" transform="translate(160.0,239.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -193,12 +195,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_L11_95_ONE">
                 <polyline points="215.0,262.0,215.0,200.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL11_95_ONE_ARROW_ACTIVE" transform="translate(210.0,215.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL11_95_ONE_ARROW_ACTIVE" transform="translate(210.0,215.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL11_95_ONE_ARROW_REACTIVE" transform="translate(210.0,235.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL11_95_ONE_ARROW_REACTIVE" transform="translate(210.0,235.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -237,12 +239,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_L12_95_ONE">
                 <polyline points="265.0,262.0,265.0,200.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL12_95_ONE_ARROW_ACTIVE" transform="translate(260.0,215.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL12_95_ONE_ARROW_ACTIVE" transform="translate(260.0,215.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL12_95_ONE_ARROW_REACTIVE" transform="translate(260.0,235.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL12_95_ONE_ARROW_REACTIVE" transform="translate(260.0,235.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -281,12 +283,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_T11_95_ONE">
                 <polyline points="315.0,262.0,315.0,200.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(310.0,215.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(310.0,215.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">375</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(310.0,235.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(310.0,235.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">48</text>
@@ -325,12 +327,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T3_95_12_95_ONE_95_T3_95_12_95_ONE">
                 <polyline points="365.0,262.0,365.0,200.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_ONE_ARROW_ACTIVE" transform="translate(360.0,215.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_ONE_ARROW_ACTIVE" transform="translate(360.0,215.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_ONE_ARROW_REACTIVE" transform="translate(360.0,235.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_ONE_ARROW_REACTIVE" transform="translate(360.0,235.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -369,12 +371,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_G">
                 <polyline points="415.0,262.0,415.0,206.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idG_ARROW_ACTIVE" transform="translate(410.0,221.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idG_ARROW_ACTIVE" transform="translate(410.0,221.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idG_ARROW_REACTIVE" transform="translate(410.0,241.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idG_ARROW_REACTIVE" transform="translate(410.0,241.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -413,12 +415,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_L11_95_TWO">
                 <polyline points="465.0,262.0,465.0,200.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL11_95_TWO_ARROW_ACTIVE" transform="translate(460.0,215.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL11_95_TWO_ARROW_ACTIVE" transform="translate(460.0,215.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL11_95_TWO_ARROW_REACTIVE" transform="translate(460.0,235.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL11_95_TWO_ARROW_REACTIVE" transform="translate(460.0,235.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -457,12 +459,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_T11_95_TWO">
                 <polyline points="515.0,262.0,515.0,200.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(510.0,215.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(510.0,215.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">375</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(510.0,235.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(510.0,235.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">48</text>
@@ -501,12 +503,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_T12_95_ONE">
                 <polyline points="565.0,262.0,565.0,200.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idT12_95_ONE_ARROW_ACTIVE" transform="translate(560.0,215.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idT12_95_ONE_ARROW_ACTIVE" transform="translate(560.0,215.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">375</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idT12_95_ONE_ARROW_REACTIVE" transform="translate(560.0,235.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idT12_95_ONE_ARROW_REACTIVE" transform="translate(560.0,235.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">48</text>
@@ -545,12 +547,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T3_95_12_95_TWO_95_T3_95_12_95_TWO">
                 <polyline points="615.0,262.0,615.0,200.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_TWO_ARROW_ACTIVE" transform="translate(610.0,215.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_TWO_ARROW_ACTIVE" transform="translate(610.0,215.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_TWO_ARROW_REACTIVE" transform="translate(610.0,235.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_TWO_ARROW_REACTIVE" transform="translate(610.0,235.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -609,12 +611,12 @@
             <g class="sld-wire" id="_95_VL2_95_INTERNAL_95_VL2_95_L2_95_L2">
                 <polyline points="705.0,262.0,705.0,204.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL2_ARROW_ACTIVE" transform="translate(700.0,219.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL2_ARROW_ACTIVE" transform="translate(700.0,219.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL2_ARROW_REACTIVE" transform="translate(700.0,239.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL2_ARROW_REACTIVE" transform="translate(700.0,239.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -653,12 +655,12 @@
             <g class="sld-wire" id="_95_VL2_95_INTERNAL_95_VL2_95_L12_95_TWO_95_L12_95_TWO">
                 <polyline points="755.0,262.0,755.0,200.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL12_95_TWO_ARROW_ACTIVE" transform="translate(750.0,215.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL12_95_TWO_ARROW_ACTIVE" transform="translate(750.0,215.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL12_95_TWO_ARROW_REACTIVE" transform="translate(750.0,235.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL12_95_TWO_ARROW_REACTIVE" transform="translate(750.0,235.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -697,12 +699,12 @@
             <g class="sld-wire" id="_95_VL2_95_INTERNAL_95_VL2_95_T12_95_TWO_95_T12_95_TWO">
                 <polyline points="805.0,262.0,805.0,200.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idT12_95_TWO_ARROW_ACTIVE" transform="translate(800.0,215.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idT12_95_TWO_ARROW_ACTIVE" transform="translate(800.0,215.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">375</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idT12_95_TWO_ARROW_REACTIVE" transform="translate(800.0,235.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idT12_95_TWO_ARROW_REACTIVE" transform="translate(800.0,235.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">48</text>
@@ -741,12 +743,12 @@
             <g class="sld-wire" id="_95_VL2_95_INTERNAL_95_VL2_95_T3_95_12_95_THREE_95_T3_95_12_95_THREE">
                 <polyline points="855.0,262.0,855.0,200.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(850.0,215.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(850.0,215.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(850.0,235.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(850.0,235.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
+++ b/single-line-diagram-core/src/test/resources/NodeDecoratorsSwitches.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -144,12 +146,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L1_95_L1">
                 <polyline points="165.0,172.0,165.0,114.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL1_ARROW_ACTIVE" transform="translate(160.0,129.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL1_ARROW_ACTIVE" transform="translate(160.0,129.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL1_ARROW_REACTIVE" transform="translate(160.0,149.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL1_ARROW_REACTIVE" transform="translate(160.0,149.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -194,12 +196,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_ONE_95_L11_95_ONE">
                 <polyline points="215.0,172.0,215.0,110.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL11_95_ONE_ARROW_ACTIVE" transform="translate(210.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL11_95_ONE_ARROW_ACTIVE" transform="translate(210.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL11_95_ONE_ARROW_REACTIVE" transform="translate(210.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL11_95_ONE_ARROW_REACTIVE" transform="translate(210.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -241,12 +243,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L12_95_ONE_95_L12_95_ONE">
                 <polyline points="265.0,172.0,265.0,110.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL12_95_ONE_ARROW_ACTIVE" transform="translate(260.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL12_95_ONE_ARROW_ACTIVE" transform="translate(260.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL12_95_ONE_ARROW_REACTIVE" transform="translate(260.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL12_95_ONE_ARROW_REACTIVE" transform="translate(260.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -288,12 +290,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_ONE_95_T11_95_ONE">
                 <polyline points="315.0,172.0,315.0,110.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(310.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(310.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">375</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(310.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(310.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">48</text>
@@ -335,12 +337,12 @@
             <g class="sld-wire" id="_95_VL1_95_T3_95_12_95_TWO_95_T3_95_12">
                 <polyline points="365.0,110.0,365.0,172.0,383.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_TWO_ARROW_ACTIVE" transform="translate(360.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_TWO_ARROW_ACTIVE" transform="translate(360.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_TWO_ARROW_REACTIVE" transform="translate(360.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_TWO_ARROW_REACTIVE" transform="translate(360.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -348,12 +350,12 @@
             <g class="sld-wire" id="_95_VL1_95_T3_95_12_95_THREE_95_T3_95_12">
                 <polyline points="415.0,110.0,415.0,172.0,397.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(410.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(410.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(410.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(410.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -400,12 +402,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_G_95_G">
                 <polyline points="465.0,172.0,465.0,116.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idG_ARROW_ACTIVE" transform="translate(460.0,131.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idG_ARROW_ACTIVE" transform="translate(460.0,131.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idG_ARROW_REACTIVE" transform="translate(460.0,151.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idG_ARROW_REACTIVE" transform="translate(460.0,151.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -450,12 +452,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_L11_95_TWO_95_L11_95_TWO">
                 <polyline points="515.0,172.0,515.0,110.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL11_95_TWO_ARROW_ACTIVE" transform="translate(510.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL11_95_TWO_ARROW_ACTIVE" transform="translate(510.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL11_95_TWO_ARROW_REACTIVE" transform="translate(510.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL11_95_TWO_ARROW_REACTIVE" transform="translate(510.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -497,12 +499,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T11_95_TWO_95_T11_95_TWO">
                 <polyline points="565.0,172.0,565.0,110.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(560.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(560.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">375</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(560.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(560.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">48</text>
@@ -544,12 +546,12 @@
             <g class="sld-wire" id="_95_VL1_95_INTERNAL_95_VL1_95_T12_95_ONE_95_T12_95_ONE">
                 <polyline points="615.0,172.0,615.0,118.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idT12_95_ONE_ARROW_ACTIVE" transform="translate(610.0,133.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idT12_95_ONE_ARROW_ACTIVE" transform="translate(610.0,133.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">375</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idT12_95_ONE_ARROW_REACTIVE" transform="translate(610.0,153.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idT12_95_ONE_ARROW_REACTIVE" transform="translate(610.0,153.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">48</text>
@@ -593,12 +595,12 @@
             <g class="sld-wire" id="_95_VL1_95_T3_95_12_95_ONE_95_T3_95_12">
                 <polyline points="665.0,110.0,665.0,172.0,683.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_ONE_ARROW_ACTIVE" transform="translate(660.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_ONE_ARROW_ACTIVE" transform="translate(660.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_ONE_ARROW_REACTIVE" transform="translate(660.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_ONE_ARROW_REACTIVE" transform="translate(660.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -606,12 +608,12 @@
             <g class="sld-wire" id="_95_VL1_95_T3_95_12_95_THREE_95_T3_95_12">
                 <polyline points="715.0,110.0,715.0,172.0,697.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(710.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_ACTIVE" transform="translate(710.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(710.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT3_95_12_95_THREE_ARROW_REACTIVE" transform="translate(710.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestCase1.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase1.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -86,13 +88,13 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_l_95_l">
                 <polyline points="65.0,142.0,65.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">tata</text>
                 <text class="sld-label" style="text-anchor:end" x="-5.0" y="5.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">tutu</text>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHFirst.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHFirst.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: topologicalBaseVoltages.css ------------------------------------- */
 .sld-disconnected {--sld-vl-color: #808080}
@@ -118,15 +118,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -290,12 +292,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_load1_95_INTERNAL_95_vl1_95_load1">
                 <polyline points="65.0,264.5,65.0,322.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload1_ARROW_ACTIVE" transform="translate(60.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload1_ARROW_ACTIVE" transform="translate(60.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload1_ARROW_REACTIVE" transform="translate(60.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload1_ARROW_REACTIVE" transform="translate(60.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -334,12 +336,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf1_95_ONE_95_trf1_95_ONE">
                 <polyline points="115.0,322.0,115.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf1_95_ONE_ARROW_ACTIVE" transform="translate(110.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf1_95_ONE_ARROW_ACTIVE" transform="translate(110.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf1_95_ONE_ARROW_REACTIVE" transform="translate(110.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf1_95_ONE_ARROW_REACTIVE" transform="translate(110.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -375,12 +377,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf5_95_ONE_95_trf5_95_ONE">
                 <polyline points="265.0,322.0,265.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf5_95_ONE_ARROW_ACTIVE" transform="translate(260.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf5_95_ONE_ARROW_ACTIVE" transform="translate(260.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf5_95_ONE_ARROW_REACTIVE" transform="translate(260.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf5_95_ONE_ARROW_REACTIVE" transform="translate(260.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -416,12 +418,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf6_95_ONE_95_trf6_95_ONE">
                 <polyline points="315.0,322.0,315.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_ONE_ARROW_ACTIVE" transform="translate(310.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_ONE_ARROW_ACTIVE" transform="translate(310.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_ONE_ARROW_REACTIVE" transform="translate(310.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_ONE_ARROW_REACTIVE" transform="translate(310.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -457,12 +459,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_line1_95_ONE_95_line1_95_ONE">
                 <polyline points="415.0,322.0,415.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idline1_95_ONE_ARROW_ACTIVE" transform="translate(410.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idline1_95_ONE_ARROW_ACTIVE" transform="translate(410.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idline1_95_ONE_ARROW_REACTIVE" transform="translate(410.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idline1_95_ONE_ARROW_REACTIVE" transform="translate(410.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -498,12 +500,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_load2_95_INTERNAL_95_vl1_95_load2">
                 <polyline points="515.0,264.5,515.0,322.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload2_ARROW_ACTIVE" transform="translate(510.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload2_ARROW_ACTIVE" transform="translate(510.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload2_ARROW_REACTIVE" transform="translate(510.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload2_ARROW_REACTIVE" transform="translate(510.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -542,12 +544,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf2_95_ONE_95_trf2_95_ONE">
                 <polyline points="665.0,322.0,665.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf2_95_ONE_ARROW_ACTIVE" transform="translate(660.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf2_95_ONE_ARROW_ACTIVE" transform="translate(660.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf2_95_ONE_ARROW_REACTIVE" transform="translate(660.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf2_95_ONE_ARROW_REACTIVE" transform="translate(660.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -583,12 +585,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf8_95_ONE_95_trf8_95_ONE">
                 <polyline points="565.0,322.0,565.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_ONE_ARROW_ACTIVE" transform="translate(560.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_ONE_ARROW_ACTIVE" transform="translate(560.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_ONE_ARROW_REACTIVE" transform="translate(560.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_ONE_ARROW_REACTIVE" transform="translate(560.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -624,12 +626,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_gen1_95_INTERNAL_95_vl1_95_gen1">
                 <polyline points="165.0,623.0,165.0,567.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen1_ARROW_REACTIVE" transform="translate(160.0,598.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen1_ARROW_REACTIVE" transform="translate(160.0,598.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen1_ARROW_ACTIVE" transform="translate(160.0,578.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen1_ARROW_ACTIVE" transform="translate(160.0,578.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -668,12 +670,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf3_95_ONE_95_trf3_95_ONE">
                 <polyline points="215.0,567.0,215.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf3_95_ONE_ARROW_REACTIVE" transform="translate(210.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf3_95_ONE_ARROW_REACTIVE" transform="translate(210.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf3_95_ONE_ARROW_ACTIVE" transform="translate(210.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf3_95_ONE_ARROW_ACTIVE" transform="translate(210.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -709,12 +711,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf7_95_ONE_95_trf7_95_ONE">
                 <polyline points="365.0,567.0,365.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_ONE_ARROW_REACTIVE" transform="translate(360.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_ONE_ARROW_REACTIVE" transform="translate(360.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_ONE_ARROW_ACTIVE" transform="translate(360.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_ONE_ARROW_ACTIVE" transform="translate(360.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -750,12 +752,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_gen2_95_INTERNAL_95_vl1_95_gen2">
                 <polyline points="715.0,623.0,715.0,567.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen2_ARROW_REACTIVE" transform="translate(710.0,598.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen2_ARROW_REACTIVE" transform="translate(710.0,598.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen2_ARROW_ACTIVE" transform="translate(710.0,578.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen2_ARROW_ACTIVE" transform="translate(710.0,578.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -794,12 +796,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf4_95_ONE_95_trf4_95_ONE">
                 <polyline points="615.0,567.0,615.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf4_95_ONE_ARROW_REACTIVE" transform="translate(610.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf4_95_ONE_ARROW_REACTIVE" transform="translate(610.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf4_95_ONE_ARROW_ACTIVE" transform="translate(610.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf4_95_ONE_ARROW_ACTIVE" transform="translate(610.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -878,12 +880,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_load3_95_INTERNAL_95_vl2_95_load3">
                 <polyline points="995.0,264.5,995.0,322.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload3_ARROW_ACTIVE" transform="translate(990.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload3_ARROW_ACTIVE" transform="translate(990.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload3_ARROW_REACTIVE" transform="translate(990.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload3_ARROW_REACTIVE" transform="translate(990.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -922,12 +924,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf1_95_TWO_95_trf1_95_TWO">
                 <polyline points="1045.0,322.0,1045.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf1_95_TWO_ARROW_ACTIVE" transform="translate(1040.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf1_95_TWO_ARROW_ACTIVE" transform="translate(1040.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf1_95_TWO_ARROW_REACTIVE" transform="translate(1040.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf1_95_TWO_ARROW_REACTIVE" transform="translate(1040.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -963,12 +965,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf4_95_TWO_95_trf4_95_TWO">
                 <polyline points="1145.0,322.0,1145.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf4_95_TWO_ARROW_ACTIVE" transform="translate(1140.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf4_95_TWO_ARROW_ACTIVE" transform="translate(1140.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf4_95_TWO_ARROW_REACTIVE" transform="translate(1140.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf4_95_TWO_ARROW_REACTIVE" transform="translate(1140.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1004,12 +1006,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf7_95_TWO_95_trf7_95_TWO">
                 <polyline points="1195.0,322.0,1195.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_TWO_ARROW_ACTIVE" transform="translate(1190.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_TWO_ARROW_ACTIVE" transform="translate(1190.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_TWO_ARROW_REACTIVE" transform="translate(1190.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_TWO_ARROW_REACTIVE" transform="translate(1190.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1045,12 +1047,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_gen4_95_INTERNAL_95_vl2_95_gen4">
                 <polyline points="1095.0,623.0,1095.0,567.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen4_ARROW_REACTIVE" transform="translate(1090.0,598.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen4_ARROW_REACTIVE" transform="translate(1090.0,598.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen4_ARROW_ACTIVE" transform="translate(1090.0,578.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen4_ARROW_ACTIVE" transform="translate(1090.0,578.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1089,12 +1091,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf2_95_TWO_95_trf2_95_TWO">
                 <polyline points="1345.0,567.0,1345.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf2_95_TWO_ARROW_REACTIVE" transform="translate(1340.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf2_95_TWO_ARROW_REACTIVE" transform="translate(1340.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf2_95_TWO_ARROW_ACTIVE" transform="translate(1340.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf2_95_TWO_ARROW_ACTIVE" transform="translate(1340.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1130,12 +1132,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf3_95_TWO_95_trf3_95_TWO">
                 <polyline points="1395.0,567.0,1395.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf3_95_TWO_ARROW_REACTIVE" transform="translate(1390.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf3_95_TWO_ARROW_REACTIVE" transform="translate(1390.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf3_95_TWO_ARROW_ACTIVE" transform="translate(1390.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf3_95_TWO_ARROW_ACTIVE" transform="translate(1390.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1171,12 +1173,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf6_95_TWO_95_trf6_95_TWO">
                 <polyline points="1245.0,322.0,1245.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_TWO_ARROW_ACTIVE" transform="translate(1240.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_TWO_ARROW_ACTIVE" transform="translate(1240.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_TWO_ARROW_REACTIVE" transform="translate(1240.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_TWO_ARROW_REACTIVE" transform="translate(1240.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1212,12 +1214,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf8_95_TWO_95_trf8_95_TWO">
                 <polyline points="1295.0,567.0,1295.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_TWO_ARROW_REACTIVE" transform="translate(1290.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_TWO_ARROW_REACTIVE" transform="translate(1290.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_TWO_ARROW_ACTIVE" transform="translate(1290.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_TWO_ARROW_ACTIVE" transform="translate(1290.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1260,12 +1262,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_load4_95_load4">
                 <polyline points="1545.0,322.0,1545.0,264.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload4_ARROW_ACTIVE" transform="translate(1540.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload4_ARROW_ACTIVE" transform="translate(1540.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload4_ARROW_REACTIVE" transform="translate(1540.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload4_ARROW_REACTIVE" transform="translate(1540.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1304,12 +1306,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf5_95_TWO_95_trf5_95_TWO">
                 <polyline points="1595.0,542.0,1595.0,604.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf5_95_TWO_ARROW_REACTIVE" transform="translate(1590.0,579.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf5_95_TWO_ARROW_REACTIVE" transform="translate(1590.0,579.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf5_95_TWO_ARROW_ACTIVE" transform="translate(1590.0,559.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf5_95_TWO_ARROW_ACTIVE" transform="translate(1590.0,559.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1345,12 +1347,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf6_95_THREE_95_trf6_95_THREE">
                 <polyline points="1645.0,322.0,1645.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_THREE_ARROW_ACTIVE" transform="translate(1640.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_THREE_ARROW_ACTIVE" transform="translate(1640.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_THREE_ARROW_REACTIVE" transform="translate(1640.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_THREE_ARROW_REACTIVE" transform="translate(1640.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1386,12 +1388,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf7_95_THREE_95_trf7_95_THREE">
                 <polyline points="1695.0,542.0,1695.0,604.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_THREE_ARROW_REACTIVE" transform="translate(1690.0,579.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_THREE_ARROW_REACTIVE" transform="translate(1690.0,579.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_THREE_ARROW_ACTIVE" transform="translate(1690.0,559.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_THREE_ARROW_ACTIVE" transform="translate(1690.0,559.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1427,12 +1429,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf8_95_THREE_95_trf8_95_THREE">
                 <polyline points="1745.0,322.0,1745.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_THREE_ARROW_ACTIVE" transform="translate(1740.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_THREE_ARROW_ACTIVE" transform="translate(1740.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_THREE_ARROW_REACTIVE" transform="translate(1740.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_THREE_ARROW_REACTIVE" transform="translate(1740.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHLast.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHLast.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: topologicalBaseVoltages.css ------------------------------------- */
 .sld-disconnected {--sld-vl-color: #808080}
@@ -118,15 +118,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -290,12 +292,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_load1_95_INTERNAL_95_vl1_95_load1">
                 <polyline points="65.0,264.5,65.0,322.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload1_ARROW_ACTIVE" transform="translate(60.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload1_ARROW_ACTIVE" transform="translate(60.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload1_ARROW_REACTIVE" transform="translate(60.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload1_ARROW_REACTIVE" transform="translate(60.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -334,12 +336,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf1_95_ONE_95_trf1_95_ONE">
                 <polyline points="115.0,322.0,115.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf1_95_ONE_ARROW_ACTIVE" transform="translate(110.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf1_95_ONE_ARROW_ACTIVE" transform="translate(110.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf1_95_ONE_ARROW_REACTIVE" transform="translate(110.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf1_95_ONE_ARROW_REACTIVE" transform="translate(110.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -375,12 +377,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf5_95_ONE_95_trf5_95_ONE">
                 <polyline points="265.0,322.0,265.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf5_95_ONE_ARROW_ACTIVE" transform="translate(260.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf5_95_ONE_ARROW_ACTIVE" transform="translate(260.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf5_95_ONE_ARROW_REACTIVE" transform="translate(260.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf5_95_ONE_ARROW_REACTIVE" transform="translate(260.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -416,12 +418,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf6_95_ONE_95_trf6_95_ONE">
                 <polyline points="315.0,322.0,315.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_ONE_ARROW_ACTIVE" transform="translate(310.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_ONE_ARROW_ACTIVE" transform="translate(310.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_ONE_ARROW_REACTIVE" transform="translate(310.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_ONE_ARROW_REACTIVE" transform="translate(310.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -457,12 +459,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_line1_95_ONE_95_line1_95_ONE">
                 <polyline points="415.0,322.0,415.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idline1_95_ONE_ARROW_ACTIVE" transform="translate(410.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idline1_95_ONE_ARROW_ACTIVE" transform="translate(410.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idline1_95_ONE_ARROW_REACTIVE" transform="translate(410.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idline1_95_ONE_ARROW_REACTIVE" transform="translate(410.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -498,12 +500,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_load2_95_INTERNAL_95_vl1_95_load2">
                 <polyline points="515.0,264.5,515.0,322.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload2_ARROW_ACTIVE" transform="translate(510.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload2_ARROW_ACTIVE" transform="translate(510.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload2_ARROW_REACTIVE" transform="translate(510.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload2_ARROW_REACTIVE" transform="translate(510.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -542,12 +544,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf2_95_ONE_95_trf2_95_ONE">
                 <polyline points="665.0,322.0,665.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf2_95_ONE_ARROW_ACTIVE" transform="translate(660.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf2_95_ONE_ARROW_ACTIVE" transform="translate(660.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf2_95_ONE_ARROW_REACTIVE" transform="translate(660.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf2_95_ONE_ARROW_REACTIVE" transform="translate(660.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -583,12 +585,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf8_95_ONE_95_trf8_95_ONE">
                 <polyline points="565.0,322.0,565.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_ONE_ARROW_ACTIVE" transform="translate(560.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_ONE_ARROW_ACTIVE" transform="translate(560.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_ONE_ARROW_REACTIVE" transform="translate(560.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_ONE_ARROW_REACTIVE" transform="translate(560.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -624,12 +626,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_gen1_95_INTERNAL_95_vl1_95_gen1">
                 <polyline points="165.0,623.0,165.0,567.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen1_ARROW_REACTIVE" transform="translate(160.0,598.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen1_ARROW_REACTIVE" transform="translate(160.0,598.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen1_ARROW_ACTIVE" transform="translate(160.0,578.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen1_ARROW_ACTIVE" transform="translate(160.0,578.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -668,12 +670,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf3_95_ONE_95_trf3_95_ONE">
                 <polyline points="215.0,567.0,215.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf3_95_ONE_ARROW_REACTIVE" transform="translate(210.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf3_95_ONE_ARROW_REACTIVE" transform="translate(210.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf3_95_ONE_ARROW_ACTIVE" transform="translate(210.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf3_95_ONE_ARROW_ACTIVE" transform="translate(210.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -709,12 +711,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf7_95_ONE_95_trf7_95_ONE">
                 <polyline points="365.0,567.0,365.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_ONE_ARROW_REACTIVE" transform="translate(360.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_ONE_ARROW_REACTIVE" transform="translate(360.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_ONE_ARROW_ACTIVE" transform="translate(360.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_ONE_ARROW_ACTIVE" transform="translate(360.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -750,12 +752,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_gen2_95_INTERNAL_95_vl1_95_gen2">
                 <polyline points="715.0,623.0,715.0,567.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen2_ARROW_REACTIVE" transform="translate(710.0,598.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen2_ARROW_REACTIVE" transform="translate(710.0,598.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen2_ARROW_ACTIVE" transform="translate(710.0,578.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen2_ARROW_ACTIVE" transform="translate(710.0,578.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -794,12 +796,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf4_95_ONE_95_trf4_95_ONE">
                 <polyline points="615.0,567.0,615.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf4_95_ONE_ARROW_REACTIVE" transform="translate(610.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf4_95_ONE_ARROW_REACTIVE" transform="translate(610.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf4_95_ONE_ARROW_ACTIVE" transform="translate(610.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf4_95_ONE_ARROW_ACTIVE" transform="translate(610.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -878,12 +880,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_load3_95_INTERNAL_95_vl2_95_load3">
                 <polyline points="995.0,264.5,995.0,322.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload3_ARROW_ACTIVE" transform="translate(990.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload3_ARROW_ACTIVE" transform="translate(990.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload3_ARROW_REACTIVE" transform="translate(990.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload3_ARROW_REACTIVE" transform="translate(990.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -922,12 +924,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf1_95_TWO_95_trf1_95_TWO">
                 <polyline points="1045.0,322.0,1045.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf1_95_TWO_ARROW_ACTIVE" transform="translate(1040.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf1_95_TWO_ARROW_ACTIVE" transform="translate(1040.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf1_95_TWO_ARROW_REACTIVE" transform="translate(1040.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf1_95_TWO_ARROW_REACTIVE" transform="translate(1040.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -963,12 +965,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf4_95_TWO_95_trf4_95_TWO">
                 <polyline points="1145.0,322.0,1145.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf4_95_TWO_ARROW_ACTIVE" transform="translate(1140.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf4_95_TWO_ARROW_ACTIVE" transform="translate(1140.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf4_95_TWO_ARROW_REACTIVE" transform="translate(1140.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf4_95_TWO_ARROW_REACTIVE" transform="translate(1140.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1004,12 +1006,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf7_95_TWO_95_trf7_95_TWO">
                 <polyline points="1195.0,322.0,1195.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_TWO_ARROW_ACTIVE" transform="translate(1190.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_TWO_ARROW_ACTIVE" transform="translate(1190.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_TWO_ARROW_REACTIVE" transform="translate(1190.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_TWO_ARROW_REACTIVE" transform="translate(1190.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1045,12 +1047,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_gen4_95_INTERNAL_95_vl2_95_gen4">
                 <polyline points="1095.0,623.0,1095.0,567.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen4_ARROW_REACTIVE" transform="translate(1090.0,598.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen4_ARROW_REACTIVE" transform="translate(1090.0,598.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen4_ARROW_ACTIVE" transform="translate(1090.0,578.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen4_ARROW_ACTIVE" transform="translate(1090.0,578.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1089,12 +1091,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf2_95_TWO_95_trf2_95_TWO">
                 <polyline points="1345.0,567.0,1345.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf2_95_TWO_ARROW_REACTIVE" transform="translate(1340.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf2_95_TWO_ARROW_REACTIVE" transform="translate(1340.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf2_95_TWO_ARROW_ACTIVE" transform="translate(1340.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf2_95_TWO_ARROW_ACTIVE" transform="translate(1340.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1130,12 +1132,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf3_95_TWO_95_trf3_95_TWO">
                 <polyline points="1395.0,567.0,1395.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf3_95_TWO_ARROW_REACTIVE" transform="translate(1390.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf3_95_TWO_ARROW_REACTIVE" transform="translate(1390.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf3_95_TWO_ARROW_ACTIVE" transform="translate(1390.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf3_95_TWO_ARROW_ACTIVE" transform="translate(1390.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1171,12 +1173,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf6_95_TWO_95_trf6_95_TWO">
                 <polyline points="1245.0,322.0,1245.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_TWO_ARROW_ACTIVE" transform="translate(1240.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_TWO_ARROW_ACTIVE" transform="translate(1240.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_TWO_ARROW_REACTIVE" transform="translate(1240.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_TWO_ARROW_REACTIVE" transform="translate(1240.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1212,12 +1214,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf8_95_TWO_95_trf8_95_TWO">
                 <polyline points="1295.0,567.0,1295.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_TWO_ARROW_REACTIVE" transform="translate(1290.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_TWO_ARROW_REACTIVE" transform="translate(1290.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_TWO_ARROW_ACTIVE" transform="translate(1290.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_TWO_ARROW_ACTIVE" transform="translate(1290.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1260,12 +1262,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_load4_95_load4">
                 <polyline points="1545.0,347.0,1545.0,289.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload4_ARROW_ACTIVE" transform="translate(1540.0,304.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload4_ARROW_ACTIVE" transform="translate(1540.0,304.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload4_ARROW_REACTIVE" transform="translate(1540.0,324.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload4_ARROW_REACTIVE" transform="translate(1540.0,324.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1304,12 +1306,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf5_95_TWO_95_trf5_95_TWO">
                 <polyline points="1595.0,567.0,1595.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf5_95_TWO_ARROW_REACTIVE" transform="translate(1590.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf5_95_TWO_ARROW_REACTIVE" transform="translate(1590.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf5_95_TWO_ARROW_ACTIVE" transform="translate(1590.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf5_95_TWO_ARROW_ACTIVE" transform="translate(1590.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1345,12 +1347,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf6_95_THREE_95_trf6_95_THREE">
                 <polyline points="1645.0,347.0,1645.0,285.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_THREE_ARROW_ACTIVE" transform="translate(1640.0,300.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_THREE_ARROW_ACTIVE" transform="translate(1640.0,300.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_THREE_ARROW_REACTIVE" transform="translate(1640.0,320.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_THREE_ARROW_REACTIVE" transform="translate(1640.0,320.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1386,12 +1388,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf7_95_THREE_95_trf7_95_THREE">
                 <polyline points="1695.0,567.0,1695.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_THREE_ARROW_REACTIVE" transform="translate(1690.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_THREE_ARROW_REACTIVE" transform="translate(1690.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_THREE_ARROW_ACTIVE" transform="translate(1690.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_THREE_ARROW_ACTIVE" transform="translate(1690.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1427,12 +1429,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf8_95_THREE_95_trf8_95_THREE">
                 <polyline points="1745.0,347.0,1745.0,285.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_THREE_ARROW_ACTIVE" transform="translate(1740.0,300.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_THREE_ARROW_ACTIVE" transform="translate(1740.0,300.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_THREE_ARROW_REACTIVE" transform="translate(1740.0,320.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_THREE_ARROW_REACTIVE" transform="translate(1740.0,320.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHMiddle.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHMiddle.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: topologicalBaseVoltages.css ------------------------------------- */
 .sld-disconnected {--sld-vl-color: #808080}
@@ -118,15 +118,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -290,12 +292,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_load1_95_INTERNAL_95_vl1_95_load1">
                 <polyline points="65.0,264.5,65.0,322.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload1_ARROW_ACTIVE" transform="translate(60.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload1_ARROW_ACTIVE" transform="translate(60.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload1_ARROW_REACTIVE" transform="translate(60.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload1_ARROW_REACTIVE" transform="translate(60.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -334,12 +336,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf1_95_ONE_95_trf1_95_ONE">
                 <polyline points="115.0,322.0,115.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf1_95_ONE_ARROW_ACTIVE" transform="translate(110.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf1_95_ONE_ARROW_ACTIVE" transform="translate(110.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf1_95_ONE_ARROW_REACTIVE" transform="translate(110.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf1_95_ONE_ARROW_REACTIVE" transform="translate(110.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -375,12 +377,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf5_95_ONE_95_trf5_95_ONE">
                 <polyline points="265.0,322.0,265.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf5_95_ONE_ARROW_ACTIVE" transform="translate(260.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf5_95_ONE_ARROW_ACTIVE" transform="translate(260.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf5_95_ONE_ARROW_REACTIVE" transform="translate(260.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf5_95_ONE_ARROW_REACTIVE" transform="translate(260.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -416,12 +418,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf6_95_ONE_95_trf6_95_ONE">
                 <polyline points="315.0,322.0,315.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_ONE_ARROW_ACTIVE" transform="translate(310.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_ONE_ARROW_ACTIVE" transform="translate(310.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_ONE_ARROW_REACTIVE" transform="translate(310.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_ONE_ARROW_REACTIVE" transform="translate(310.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -457,12 +459,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_line1_95_ONE_95_line1_95_ONE">
                 <polyline points="415.0,322.0,415.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idline1_95_ONE_ARROW_ACTIVE" transform="translate(410.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idline1_95_ONE_ARROW_ACTIVE" transform="translate(410.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idline1_95_ONE_ARROW_REACTIVE" transform="translate(410.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idline1_95_ONE_ARROW_REACTIVE" transform="translate(410.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -498,12 +500,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_load2_95_INTERNAL_95_vl1_95_load2">
                 <polyline points="515.0,264.5,515.0,322.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload2_ARROW_ACTIVE" transform="translate(510.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload2_ARROW_ACTIVE" transform="translate(510.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload2_ARROW_REACTIVE" transform="translate(510.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload2_ARROW_REACTIVE" transform="translate(510.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -542,12 +544,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf2_95_ONE_95_trf2_95_ONE">
                 <polyline points="665.0,322.0,665.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf2_95_ONE_ARROW_ACTIVE" transform="translate(660.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf2_95_ONE_ARROW_ACTIVE" transform="translate(660.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf2_95_ONE_ARROW_REACTIVE" transform="translate(660.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf2_95_ONE_ARROW_REACTIVE" transform="translate(660.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -583,12 +585,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf8_95_ONE_95_trf8_95_ONE">
                 <polyline points="565.0,322.0,565.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_ONE_ARROW_ACTIVE" transform="translate(560.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_ONE_ARROW_ACTIVE" transform="translate(560.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_ONE_ARROW_REACTIVE" transform="translate(560.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_ONE_ARROW_REACTIVE" transform="translate(560.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -624,12 +626,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_gen1_95_INTERNAL_95_vl1_95_gen1">
                 <polyline points="165.0,623.0,165.0,567.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen1_ARROW_REACTIVE" transform="translate(160.0,598.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen1_ARROW_REACTIVE" transform="translate(160.0,598.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen1_ARROW_ACTIVE" transform="translate(160.0,578.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen1_ARROW_ACTIVE" transform="translate(160.0,578.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -668,12 +670,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf3_95_ONE_95_trf3_95_ONE">
                 <polyline points="215.0,567.0,215.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf3_95_ONE_ARROW_REACTIVE" transform="translate(210.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf3_95_ONE_ARROW_REACTIVE" transform="translate(210.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf3_95_ONE_ARROW_ACTIVE" transform="translate(210.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf3_95_ONE_ARROW_ACTIVE" transform="translate(210.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -709,12 +711,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf7_95_ONE_95_trf7_95_ONE">
                 <polyline points="365.0,567.0,365.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_ONE_ARROW_REACTIVE" transform="translate(360.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_ONE_ARROW_REACTIVE" transform="translate(360.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_ONE_ARROW_ACTIVE" transform="translate(360.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_ONE_ARROW_ACTIVE" transform="translate(360.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -750,12 +752,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_gen2_95_INTERNAL_95_vl1_95_gen2">
                 <polyline points="715.0,623.0,715.0,567.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen2_ARROW_REACTIVE" transform="translate(710.0,598.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen2_ARROW_REACTIVE" transform="translate(710.0,598.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen2_ARROW_ACTIVE" transform="translate(710.0,578.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen2_ARROW_ACTIVE" transform="translate(710.0,578.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -794,12 +796,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf4_95_ONE_95_trf4_95_ONE">
                 <polyline points="615.0,567.0,615.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf4_95_ONE_ARROW_REACTIVE" transform="translate(610.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf4_95_ONE_ARROW_REACTIVE" transform="translate(610.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf4_95_ONE_ARROW_ACTIVE" transform="translate(610.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf4_95_ONE_ARROW_ACTIVE" transform="translate(610.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -878,12 +880,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_load3_95_INTERNAL_95_vl2_95_load3">
                 <polyline points="995.0,264.5,995.0,322.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload3_ARROW_ACTIVE" transform="translate(990.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload3_ARROW_ACTIVE" transform="translate(990.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload3_ARROW_REACTIVE" transform="translate(990.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload3_ARROW_REACTIVE" transform="translate(990.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -922,12 +924,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf1_95_TWO_95_trf1_95_TWO">
                 <polyline points="1045.0,322.0,1045.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf1_95_TWO_ARROW_ACTIVE" transform="translate(1040.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf1_95_TWO_ARROW_ACTIVE" transform="translate(1040.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf1_95_TWO_ARROW_REACTIVE" transform="translate(1040.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf1_95_TWO_ARROW_REACTIVE" transform="translate(1040.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -963,12 +965,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf4_95_TWO_95_trf4_95_TWO">
                 <polyline points="1145.0,322.0,1145.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf4_95_TWO_ARROW_ACTIVE" transform="translate(1140.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf4_95_TWO_ARROW_ACTIVE" transform="translate(1140.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf4_95_TWO_ARROW_REACTIVE" transform="translate(1140.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf4_95_TWO_ARROW_REACTIVE" transform="translate(1140.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1004,12 +1006,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf7_95_TWO_95_trf7_95_TWO">
                 <polyline points="1195.0,322.0,1195.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_TWO_ARROW_ACTIVE" transform="translate(1190.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_TWO_ARROW_ACTIVE" transform="translate(1190.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_TWO_ARROW_REACTIVE" transform="translate(1190.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_TWO_ARROW_REACTIVE" transform="translate(1190.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1045,12 +1047,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_gen4_95_INTERNAL_95_vl2_95_gen4">
                 <polyline points="1095.0,623.0,1095.0,567.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen4_ARROW_REACTIVE" transform="translate(1090.0,598.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen4_ARROW_REACTIVE" transform="translate(1090.0,598.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen4_ARROW_ACTIVE" transform="translate(1090.0,578.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen4_ARROW_ACTIVE" transform="translate(1090.0,578.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1089,12 +1091,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf2_95_TWO_95_trf2_95_TWO">
                 <polyline points="1345.0,567.0,1345.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf2_95_TWO_ARROW_REACTIVE" transform="translate(1340.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf2_95_TWO_ARROW_REACTIVE" transform="translate(1340.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf2_95_TWO_ARROW_ACTIVE" transform="translate(1340.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf2_95_TWO_ARROW_ACTIVE" transform="translate(1340.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1130,12 +1132,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf3_95_TWO_95_trf3_95_TWO">
                 <polyline points="1395.0,567.0,1395.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf3_95_TWO_ARROW_REACTIVE" transform="translate(1390.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf3_95_TWO_ARROW_REACTIVE" transform="translate(1390.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf3_95_TWO_ARROW_ACTIVE" transform="translate(1390.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf3_95_TWO_ARROW_ACTIVE" transform="translate(1390.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1171,12 +1173,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf6_95_TWO_95_trf6_95_TWO">
                 <polyline points="1245.0,322.0,1245.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_TWO_ARROW_ACTIVE" transform="translate(1240.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_TWO_ARROW_ACTIVE" transform="translate(1240.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_TWO_ARROW_REACTIVE" transform="translate(1240.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_TWO_ARROW_REACTIVE" transform="translate(1240.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1212,12 +1214,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf8_95_TWO_95_trf8_95_TWO">
                 <polyline points="1295.0,567.0,1295.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_TWO_ARROW_REACTIVE" transform="translate(1290.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_TWO_ARROW_REACTIVE" transform="translate(1290.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_TWO_ARROW_ACTIVE" transform="translate(1290.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_TWO_ARROW_ACTIVE" transform="translate(1290.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1260,12 +1262,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_load4_95_load4">
                 <polyline points="1545.0,334.5,1545.0,277.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload4_ARROW_ACTIVE" transform="translate(1540.0,292.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload4_ARROW_ACTIVE" transform="translate(1540.0,292.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload4_ARROW_REACTIVE" transform="translate(1540.0,312.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload4_ARROW_REACTIVE" transform="translate(1540.0,312.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1304,12 +1306,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf5_95_TWO_95_trf5_95_TWO">
                 <polyline points="1595.0,554.5,1595.0,616.5"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf5_95_TWO_ARROW_REACTIVE" transform="translate(1590.0,591.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf5_95_TWO_ARROW_REACTIVE" transform="translate(1590.0,591.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf5_95_TWO_ARROW_ACTIVE" transform="translate(1590.0,571.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf5_95_TWO_ARROW_ACTIVE" transform="translate(1590.0,571.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1345,12 +1347,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf6_95_THREE_95_trf6_95_THREE">
                 <polyline points="1645.0,334.5,1645.0,272.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_THREE_ARROW_ACTIVE" transform="translate(1640.0,287.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_THREE_ARROW_ACTIVE" transform="translate(1640.0,287.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_THREE_ARROW_REACTIVE" transform="translate(1640.0,307.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_THREE_ARROW_REACTIVE" transform="translate(1640.0,307.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1386,12 +1388,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf7_95_THREE_95_trf7_95_THREE">
                 <polyline points="1695.0,554.5,1695.0,616.5"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_THREE_ARROW_REACTIVE" transform="translate(1690.0,591.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_THREE_ARROW_REACTIVE" transform="translate(1690.0,591.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_THREE_ARROW_ACTIVE" transform="translate(1690.0,571.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_THREE_ARROW_ACTIVE" transform="translate(1690.0,571.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1427,12 +1429,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf8_95_THREE_95_trf8_95_THREE">
                 <polyline points="1745.0,334.5,1745.0,272.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_THREE_ARROW_ACTIVE" transform="translate(1740.0,287.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_THREE_ARROW_ACTIVE" transform="translate(1740.0,287.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_THREE_ARROW_REACTIVE" transform="translate(1740.0,307.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_THREE_ARROW_REACTIVE" transform="translate(1740.0,307.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHNone.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase11SubstationGraphHNone.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: topologicalBaseVoltages.css ------------------------------------- */
 .sld-disconnected {--sld-vl-color: #808080}
@@ -118,15 +118,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -290,12 +292,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_load1_95_INTERNAL_95_vl1_95_load1">
                 <polyline points="65.0,264.5,65.0,322.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload1_ARROW_ACTIVE" transform="translate(60.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload1_ARROW_ACTIVE" transform="translate(60.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload1_ARROW_REACTIVE" transform="translate(60.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload1_ARROW_REACTIVE" transform="translate(60.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -334,12 +336,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf1_95_ONE_95_trf1_95_ONE">
                 <polyline points="115.0,322.0,115.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf1_95_ONE_ARROW_ACTIVE" transform="translate(110.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf1_95_ONE_ARROW_ACTIVE" transform="translate(110.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf1_95_ONE_ARROW_REACTIVE" transform="translate(110.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf1_95_ONE_ARROW_REACTIVE" transform="translate(110.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -375,12 +377,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf5_95_ONE_95_trf5_95_ONE">
                 <polyline points="265.0,322.0,265.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf5_95_ONE_ARROW_ACTIVE" transform="translate(260.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf5_95_ONE_ARROW_ACTIVE" transform="translate(260.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf5_95_ONE_ARROW_REACTIVE" transform="translate(260.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf5_95_ONE_ARROW_REACTIVE" transform="translate(260.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -416,12 +418,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf6_95_ONE_95_trf6_95_ONE">
                 <polyline points="315.0,322.0,315.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_ONE_ARROW_ACTIVE" transform="translate(310.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_ONE_ARROW_ACTIVE" transform="translate(310.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_ONE_ARROW_REACTIVE" transform="translate(310.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_ONE_ARROW_REACTIVE" transform="translate(310.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -457,12 +459,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_line1_95_ONE_95_line1_95_ONE">
                 <polyline points="415.0,322.0,415.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idline1_95_ONE_ARROW_ACTIVE" transform="translate(410.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idline1_95_ONE_ARROW_ACTIVE" transform="translate(410.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idline1_95_ONE_ARROW_REACTIVE" transform="translate(410.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idline1_95_ONE_ARROW_REACTIVE" transform="translate(410.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -498,12 +500,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_load2_95_INTERNAL_95_vl1_95_load2">
                 <polyline points="515.0,264.5,515.0,322.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload2_ARROW_ACTIVE" transform="translate(510.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload2_ARROW_ACTIVE" transform="translate(510.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload2_ARROW_REACTIVE" transform="translate(510.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload2_ARROW_REACTIVE" transform="translate(510.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -542,12 +544,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf2_95_ONE_95_trf2_95_ONE">
                 <polyline points="665.0,322.0,665.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf2_95_ONE_ARROW_ACTIVE" transform="translate(660.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf2_95_ONE_ARROW_ACTIVE" transform="translate(660.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf2_95_ONE_ARROW_REACTIVE" transform="translate(660.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf2_95_ONE_ARROW_REACTIVE" transform="translate(660.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -583,12 +585,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf8_95_ONE_95_trf8_95_ONE">
                 <polyline points="565.0,322.0,565.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_ONE_ARROW_ACTIVE" transform="translate(560.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_ONE_ARROW_ACTIVE" transform="translate(560.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_ONE_ARROW_REACTIVE" transform="translate(560.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_ONE_ARROW_REACTIVE" transform="translate(560.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -624,12 +626,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_gen1_95_INTERNAL_95_vl1_95_gen1">
                 <polyline points="165.0,623.0,165.0,567.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen1_ARROW_REACTIVE" transform="translate(160.0,598.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen1_ARROW_REACTIVE" transform="translate(160.0,598.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen1_ARROW_ACTIVE" transform="translate(160.0,578.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen1_ARROW_ACTIVE" transform="translate(160.0,578.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -668,12 +670,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf3_95_ONE_95_trf3_95_ONE">
                 <polyline points="215.0,567.0,215.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf3_95_ONE_ARROW_REACTIVE" transform="translate(210.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf3_95_ONE_ARROW_REACTIVE" transform="translate(210.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf3_95_ONE_ARROW_ACTIVE" transform="translate(210.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf3_95_ONE_ARROW_ACTIVE" transform="translate(210.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -709,12 +711,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf7_95_ONE_95_trf7_95_ONE">
                 <polyline points="365.0,567.0,365.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_ONE_ARROW_REACTIVE" transform="translate(360.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_ONE_ARROW_REACTIVE" transform="translate(360.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_ONE_ARROW_ACTIVE" transform="translate(360.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_ONE_ARROW_ACTIVE" transform="translate(360.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -750,12 +752,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_gen2_95_INTERNAL_95_vl1_95_gen2">
                 <polyline points="715.0,623.0,715.0,567.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen2_ARROW_REACTIVE" transform="translate(710.0,598.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen2_ARROW_REACTIVE" transform="translate(710.0,598.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen2_ARROW_ACTIVE" transform="translate(710.0,578.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen2_ARROW_ACTIVE" transform="translate(710.0,578.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -794,12 +796,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf4_95_ONE_95_trf4_95_ONE">
                 <polyline points="615.0,567.0,615.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf4_95_ONE_ARROW_REACTIVE" transform="translate(610.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf4_95_ONE_ARROW_REACTIVE" transform="translate(610.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf4_95_ONE_ARROW_ACTIVE" transform="translate(610.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf4_95_ONE_ARROW_ACTIVE" transform="translate(610.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -878,12 +880,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_load3_95_INTERNAL_95_vl2_95_load3">
                 <polyline points="995.0,264.5,995.0,322.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload3_ARROW_ACTIVE" transform="translate(990.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload3_ARROW_ACTIVE" transform="translate(990.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload3_ARROW_REACTIVE" transform="translate(990.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload3_ARROW_REACTIVE" transform="translate(990.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -922,12 +924,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf1_95_TWO_95_trf1_95_TWO">
                 <polyline points="1045.0,322.0,1045.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf1_95_TWO_ARROW_ACTIVE" transform="translate(1040.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf1_95_TWO_ARROW_ACTIVE" transform="translate(1040.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf1_95_TWO_ARROW_REACTIVE" transform="translate(1040.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf1_95_TWO_ARROW_REACTIVE" transform="translate(1040.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -963,12 +965,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf4_95_TWO_95_trf4_95_TWO">
                 <polyline points="1145.0,322.0,1145.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf4_95_TWO_ARROW_ACTIVE" transform="translate(1140.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf4_95_TWO_ARROW_ACTIVE" transform="translate(1140.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf4_95_TWO_ARROW_REACTIVE" transform="translate(1140.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf4_95_TWO_ARROW_REACTIVE" transform="translate(1140.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1004,12 +1006,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf7_95_TWO_95_trf7_95_TWO">
                 <polyline points="1195.0,322.0,1195.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_TWO_ARROW_ACTIVE" transform="translate(1190.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_TWO_ARROW_ACTIVE" transform="translate(1190.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_TWO_ARROW_REACTIVE" transform="translate(1190.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_TWO_ARROW_REACTIVE" transform="translate(1190.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1045,12 +1047,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_gen4_95_INTERNAL_95_vl2_95_gen4">
                 <polyline points="1095.0,623.0,1095.0,567.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen4_ARROW_REACTIVE" transform="translate(1090.0,598.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen4_ARROW_REACTIVE" transform="translate(1090.0,598.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen4_ARROW_ACTIVE" transform="translate(1090.0,578.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen4_ARROW_ACTIVE" transform="translate(1090.0,578.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1089,12 +1091,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf2_95_TWO_95_trf2_95_TWO">
                 <polyline points="1345.0,567.0,1345.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf2_95_TWO_ARROW_REACTIVE" transform="translate(1340.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf2_95_TWO_ARROW_REACTIVE" transform="translate(1340.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf2_95_TWO_ARROW_ACTIVE" transform="translate(1340.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf2_95_TWO_ARROW_ACTIVE" transform="translate(1340.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1130,12 +1132,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf3_95_TWO_95_trf3_95_TWO">
                 <polyline points="1395.0,567.0,1395.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf3_95_TWO_ARROW_REACTIVE" transform="translate(1390.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf3_95_TWO_ARROW_REACTIVE" transform="translate(1390.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf3_95_TWO_ARROW_ACTIVE" transform="translate(1390.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf3_95_TWO_ARROW_ACTIVE" transform="translate(1390.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1171,12 +1173,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf6_95_TWO_95_trf6_95_TWO">
                 <polyline points="1245.0,322.0,1245.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_TWO_ARROW_ACTIVE" transform="translate(1240.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_TWO_ARROW_ACTIVE" transform="translate(1240.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_TWO_ARROW_REACTIVE" transform="translate(1240.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_TWO_ARROW_REACTIVE" transform="translate(1240.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1212,12 +1214,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf8_95_TWO_95_trf8_95_TWO">
                 <polyline points="1295.0,567.0,1295.0,629.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_TWO_ARROW_REACTIVE" transform="translate(1290.0,604.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_TWO_ARROW_REACTIVE" transform="translate(1290.0,604.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_TWO_ARROW_ACTIVE" transform="translate(1290.0,584.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_TWO_ARROW_ACTIVE" transform="translate(1290.0,584.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1260,12 +1262,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_load4_95_load4">
                 <polyline points="1545.0,322.0,1545.0,264.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload4_ARROW_ACTIVE" transform="translate(1540.0,279.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload4_ARROW_ACTIVE" transform="translate(1540.0,279.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload4_ARROW_REACTIVE" transform="translate(1540.0,299.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload4_ARROW_REACTIVE" transform="translate(1540.0,299.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1304,12 +1306,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf5_95_TWO_95_trf5_95_TWO">
                 <polyline points="1595.0,542.0,1595.0,604.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf5_95_TWO_ARROW_REACTIVE" transform="translate(1590.0,579.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf5_95_TWO_ARROW_REACTIVE" transform="translate(1590.0,579.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf5_95_TWO_ARROW_ACTIVE" transform="translate(1590.0,559.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf5_95_TWO_ARROW_ACTIVE" transform="translate(1590.0,559.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1345,12 +1347,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf6_95_THREE_95_trf6_95_THREE">
                 <polyline points="1645.0,322.0,1645.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_THREE_ARROW_ACTIVE" transform="translate(1640.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_THREE_ARROW_ACTIVE" transform="translate(1640.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_THREE_ARROW_REACTIVE" transform="translate(1640.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_THREE_ARROW_REACTIVE" transform="translate(1640.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1386,12 +1388,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf7_95_THREE_95_trf7_95_THREE">
                 <polyline points="1695.0,542.0,1695.0,604.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_THREE_ARROW_REACTIVE" transform="translate(1690.0,579.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_THREE_ARROW_REACTIVE" transform="translate(1690.0,579.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_THREE_ARROW_ACTIVE" transform="translate(1690.0,559.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_THREE_ARROW_ACTIVE" transform="translate(1690.0,559.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1427,12 +1429,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_INTERNAL_95_vl3_95_trf8_95_THREE_95_trf8_95_THREE">
                 <polyline points="1745.0,322.0,1745.0,260.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_THREE_ARROW_ACTIVE" transform="translate(1740.0,275.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_THREE_ARROW_ACTIVE" transform="translate(1740.0,275.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_THREE_ARROW_REACTIVE" transform="translate(1740.0,295.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_THREE_ARROW_REACTIVE" transform="translate(1740.0,295.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosNominalVoltage.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: baseVoltages.css ------------------------------------------------ */
 .sld-vl300to500 {--sld-vl-color: #ff0000}
@@ -54,15 +54,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -191,12 +193,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_load1_95_INTERNAL_95_vl1_95_load1">
                 <polyline points="80.0,84.5,80.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload1_ARROW_ACTIVE" transform="translate(75.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload1_ARROW_ACTIVE" transform="translate(75.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload1_ARROW_REACTIVE" transform="translate(75.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload1_ARROW_REACTIVE" transform="translate(75.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -235,12 +237,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_trf1_95_ONE_95_trf1_95_ONE">
                 <polyline points="160.0,142.0,160.0,88.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf1_95_ONE_ARROW_ACTIVE" transform="translate(155.0,103.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf1_95_ONE_ARROW_ACTIVE" transform="translate(155.0,103.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf1_95_ONE_ARROW_REACTIVE" transform="translate(155.0,123.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf1_95_ONE_ARROW_REACTIVE" transform="translate(155.0,123.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -278,12 +280,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_trf5_95_ONE_95_trf5_95_ONE">
                 <polyline points="400.0,142.0,400.0,88.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf5_95_ONE_ARROW_ACTIVE" transform="translate(395.0,103.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf5_95_ONE_ARROW_ACTIVE" transform="translate(395.0,103.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf5_95_ONE_ARROW_REACTIVE" transform="translate(395.0,123.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf5_95_ONE_ARROW_REACTIVE" transform="translate(395.0,123.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -321,12 +323,12 @@
             <g class="sld-wire sld-vl180to300" id="_95_vl1_95_trf6_95_TWO_95_trf6">
                 <polyline points="480.0,80.0,480.0,142.0,513.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_TWO_ARROW_ACTIVE" transform="translate(475.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_TWO_ARROW_ACTIVE" transform="translate(475.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_TWO_ARROW_REACTIVE" transform="translate(475.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_TWO_ARROW_REACTIVE" transform="translate(475.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -334,12 +336,12 @@
             <g class="sld-wire sld-vl50to70" id="_95_vl1_95_trf6_95_THREE_95_trf6">
                 <polyline points="560.0,80.0,560.0,142.0,527.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_THREE_ARROW_ACTIVE" transform="translate(555.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_THREE_ARROW_ACTIVE" transform="translate(555.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_THREE_ARROW_REACTIVE" transform="translate(555.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_THREE_ARROW_REACTIVE" transform="translate(555.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -380,12 +382,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_load2_95_INTERNAL_95_vl1_95_load2">
                 <polyline points="880.0,84.5,880.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload2_ARROW_ACTIVE" transform="translate(875.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload2_ARROW_ACTIVE" transform="translate(875.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload2_ARROW_REACTIVE" transform="translate(875.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload2_ARROW_REACTIVE" transform="translate(875.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -424,12 +426,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_trf2_95_ONE_95_trf2_95_ONE">
                 <polyline points="1200.0,142.0,1200.0,88.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf2_95_ONE_ARROW_ACTIVE" transform="translate(1195.0,103.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf2_95_ONE_ARROW_ACTIVE" transform="translate(1195.0,103.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf2_95_ONE_ARROW_REACTIVE" transform="translate(1195.0,123.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf2_95_ONE_ARROW_REACTIVE" transform="translate(1195.0,123.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -467,12 +469,12 @@
             <g class="sld-wire sld-vl180to300" id="_95_vl1_95_trf8_95_TWO_95_trf8">
                 <polyline points="960.0,80.0,960.0,142.0,993.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_TWO_ARROW_ACTIVE" transform="translate(955.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_TWO_ARROW_ACTIVE" transform="translate(955.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_TWO_ARROW_REACTIVE" transform="translate(955.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_TWO_ARROW_REACTIVE" transform="translate(955.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -480,12 +482,12 @@
             <g class="sld-wire sld-vl50to70" id="_95_vl1_95_trf8_95_THREE_95_trf8">
                 <polyline points="1040.0,80.0,1040.0,142.0,1007.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_THREE_ARROW_ACTIVE" transform="translate(1035.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_THREE_ARROW_ACTIVE" transform="translate(1035.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_THREE_ARROW_REACTIVE" transform="translate(1035.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_THREE_ARROW_REACTIVE" transform="translate(1035.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -526,12 +528,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_gen1_95_INTERNAL_95_vl1_95_gen1">
                 <polyline points="240.0,443.0,240.0,387.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen1_ARROW_REACTIVE" transform="translate(235.0,418.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen1_ARROW_REACTIVE" transform="translate(235.0,418.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen1_ARROW_ACTIVE" transform="translate(235.0,398.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen1_ARROW_ACTIVE" transform="translate(235.0,398.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -570,12 +572,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_trf3_95_ONE_95_trf3_95_ONE">
                 <polyline points="320.0,387.0,320.0,441.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf3_95_ONE_ARROW_REACTIVE" transform="translate(315.0,416.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf3_95_ONE_ARROW_REACTIVE" transform="translate(315.0,416.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf3_95_ONE_ARROW_ACTIVE" transform="translate(315.0,396.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf3_95_ONE_ARROW_ACTIVE" transform="translate(315.0,396.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -613,12 +615,12 @@
             <g class="sld-wire sld-vl180to300" id="_95_vl1_95_trf7_95_TWO_95_trf7">
                 <polyline points="640.0,449.0,640.0,387.0,673.0,387.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_TWO_ARROW_REACTIVE" transform="translate(635.0,424.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_TWO_ARROW_REACTIVE" transform="translate(635.0,424.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_TWO_ARROW_ACTIVE" transform="translate(635.0,404.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_TWO_ARROW_ACTIVE" transform="translate(635.0,404.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -626,12 +628,12 @@
             <g class="sld-wire sld-vl50to70" id="_95_vl1_95_trf7_95_THREE_95_trf7">
                 <polyline points="720.0,449.0,720.0,387.0,687.0,387.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_THREE_ARROW_REACTIVE" transform="translate(715.0,424.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_THREE_ARROW_REACTIVE" transform="translate(715.0,424.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_THREE_ARROW_ACTIVE" transform="translate(715.0,404.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_THREE_ARROW_ACTIVE" transform="translate(715.0,404.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -672,12 +674,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_gen2_95_INTERNAL_95_vl1_95_gen2">
                 <polyline points="1280.0,443.0,1280.0,387.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen2_ARROW_REACTIVE" transform="translate(1275.0,418.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen2_ARROW_REACTIVE" transform="translate(1275.0,418.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen2_ARROW_ACTIVE" transform="translate(1275.0,398.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen2_ARROW_ACTIVE" transform="translate(1275.0,398.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -716,12 +718,12 @@
             <g class="sld-wire sld-vl300to500" id="_95_vl1_95_INTERNAL_95_vl1_95_trf4_95_ONE_95_trf4_95_ONE">
                 <polyline points="1120.0,387.0,1120.0,441.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf4_95_ONE_ARROW_REACTIVE" transform="translate(1115.0,416.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf4_95_ONE_ARROW_REACTIVE" transform="translate(1115.0,416.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf4_95_ONE_ARROW_ACTIVE" transform="translate(1115.0,396.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf4_95_ONE_ARROW_ACTIVE" transform="translate(1115.0,396.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -746,15 +748,17 @@
                 <text class="sld-label" id="trf4_ONE_S_LABEL" x="-5.0" y="20.0">trf4</text>
             </g>
         </g>
-        <g id="NODE_vl1_0">
-            <circle class="sld-vl300to500 sld-node-infos" cx="70.0" cy="519.0" id="NODE_vl1_0_circle" r="10" stroke-width="10"/>
-            <text class="sld-label" id="NODE_vl1_0_v" x="60.0" y="544.0">392.0 kV</text>
-            <text class="sld-label" id="NODE_vl1_0_angle" x="60.0" y="559.0">-2.3°</text>
-        </g>
-        <g id="NODE_vl1_2">
-            <circle class="sld-vl300to500 sld-node-infos" cx="140.0" cy="519.0" id="NODE_vl1_2_circle" r="10" stroke-width="10"/>
-            <text class="sld-label" id="NODE_vl1_2_v" x="130.0" y="544.0">403.0 kV</text>
-            <text class="sld-label" id="NODE_vl1_2_angle" x="130.0" y="559.0">-1.7°</text>
+        <g class="sld-legend">
+            <g id="NODE_vl1_0">
+                <circle class="sld-vl300to500 sld-node-infos" cx="70.0" cy="519.0" id="NODE_vl1_0_circle" r="10" stroke-width="10"/>
+                <text class="sld-voltage" id="NODE_vl1_0_v" x="60.0" y="544.0">392.0 kV</text>
+                <text class="sld-angle" id="NODE_vl1_0_angle" x="60.0" y="559.0">-2.3°</text>
+            </g>
+            <g id="NODE_vl1_2">
+                <circle class="sld-vl300to500 sld-node-infos" cx="140.0" cy="519.0" id="NODE_vl1_2_circle" r="10" stroke-width="10"/>
+                <text class="sld-voltage" id="NODE_vl1_2_v" x="130.0" y="544.0">403.0 kV</text>
+                <text class="sld-angle" id="NODE_vl1_2_angle" x="130.0" y="559.0">-1.7°</text>
+            </g>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase12GraphWithNodesInfosTopological.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: topologicalBaseVoltages.css ------------------------------------- */
 .sld-disconnected {--sld-vl-color: #808080}
@@ -118,15 +118,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -255,12 +257,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_load1_95_INTERNAL_95_vl1_95_load1">
                 <polyline points="80.0,84.5,80.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload1_ARROW_ACTIVE" transform="translate(75.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload1_ARROW_ACTIVE" transform="translate(75.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload1_ARROW_REACTIVE" transform="translate(75.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload1_ARROW_REACTIVE" transform="translate(75.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -299,12 +301,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf1_95_ONE_95_trf1_95_ONE">
                 <polyline points="160.0,142.0,160.0,88.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf1_95_ONE_ARROW_ACTIVE" transform="translate(155.0,103.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf1_95_ONE_ARROW_ACTIVE" transform="translate(155.0,103.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf1_95_ONE_ARROW_REACTIVE" transform="translate(155.0,123.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf1_95_ONE_ARROW_REACTIVE" transform="translate(155.0,123.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -342,12 +344,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf5_95_ONE_95_trf5_95_ONE">
                 <polyline points="400.0,142.0,400.0,88.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf5_95_ONE_ARROW_ACTIVE" transform="translate(395.0,103.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf5_95_ONE_ARROW_ACTIVE" transform="translate(395.0,103.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf5_95_ONE_ARROW_REACTIVE" transform="translate(395.0,123.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf5_95_ONE_ARROW_REACTIVE" transform="translate(395.0,123.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -385,12 +387,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl1_95_trf6_95_TWO_95_trf6">
                 <polyline points="480.0,80.0,480.0,142.0,513.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_TWO_ARROW_ACTIVE" transform="translate(475.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_TWO_ARROW_ACTIVE" transform="translate(475.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_TWO_ARROW_REACTIVE" transform="translate(475.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_TWO_ARROW_REACTIVE" transform="translate(475.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -398,12 +400,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl1_95_trf6_95_THREE_95_trf6">
                 <polyline points="560.0,80.0,560.0,142.0,527.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf6_95_THREE_ARROW_ACTIVE" transform="translate(555.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf6_95_THREE_ARROW_ACTIVE" transform="translate(555.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf6_95_THREE_ARROW_REACTIVE" transform="translate(555.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf6_95_THREE_ARROW_REACTIVE" transform="translate(555.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -444,12 +446,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_load2_95_INTERNAL_95_vl1_95_load2">
                 <polyline points="880.0,84.5,880.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idload2_ARROW_ACTIVE" transform="translate(875.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idload2_ARROW_ACTIVE" transform="translate(875.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idload2_ARROW_REACTIVE" transform="translate(875.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idload2_ARROW_REACTIVE" transform="translate(875.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -488,12 +490,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf2_95_ONE_95_trf2_95_ONE">
                 <polyline points="1200.0,142.0,1200.0,88.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf2_95_ONE_ARROW_ACTIVE" transform="translate(1195.0,103.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf2_95_ONE_ARROW_ACTIVE" transform="translate(1195.0,103.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf2_95_ONE_ARROW_REACTIVE" transform="translate(1195.0,123.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf2_95_ONE_ARROW_REACTIVE" transform="translate(1195.0,123.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -531,12 +533,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl1_95_trf8_95_TWO_95_trf8">
                 <polyline points="960.0,80.0,960.0,142.0,993.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_TWO_ARROW_ACTIVE" transform="translate(955.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_TWO_ARROW_ACTIVE" transform="translate(955.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_TWO_ARROW_REACTIVE" transform="translate(955.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_TWO_ARROW_REACTIVE" transform="translate(955.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -544,12 +546,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl1_95_trf8_95_THREE_95_trf8">
                 <polyline points="1040.0,80.0,1040.0,142.0,1007.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf8_95_THREE_ARROW_ACTIVE" transform="translate(1035.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf8_95_THREE_ARROW_ACTIVE" transform="translate(1035.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf8_95_THREE_ARROW_REACTIVE" transform="translate(1035.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf8_95_THREE_ARROW_REACTIVE" transform="translate(1035.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -590,12 +592,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_gen1_95_INTERNAL_95_vl1_95_gen1">
                 <polyline points="240.0,443.0,240.0,387.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen1_ARROW_REACTIVE" transform="translate(235.0,418.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen1_ARROW_REACTIVE" transform="translate(235.0,418.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen1_ARROW_ACTIVE" transform="translate(235.0,398.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen1_ARROW_ACTIVE" transform="translate(235.0,398.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -634,12 +636,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf3_95_ONE_95_trf3_95_ONE">
                 <polyline points="320.0,387.0,320.0,441.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf3_95_ONE_ARROW_REACTIVE" transform="translate(315.0,416.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf3_95_ONE_ARROW_REACTIVE" transform="translate(315.0,416.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf3_95_ONE_ARROW_ACTIVE" transform="translate(315.0,396.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf3_95_ONE_ARROW_ACTIVE" transform="translate(315.0,396.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -677,12 +679,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl1_95_trf7_95_TWO_95_trf7">
                 <polyline points="640.0,449.0,640.0,387.0,673.0,387.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_TWO_ARROW_REACTIVE" transform="translate(635.0,424.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_TWO_ARROW_REACTIVE" transform="translate(635.0,424.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_TWO_ARROW_ACTIVE" transform="translate(635.0,404.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_TWO_ARROW_ACTIVE" transform="translate(635.0,404.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -690,12 +692,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl1_95_trf7_95_THREE_95_trf7">
                 <polyline points="720.0,449.0,720.0,387.0,687.0,387.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf7_95_THREE_ARROW_REACTIVE" transform="translate(715.0,424.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf7_95_THREE_ARROW_REACTIVE" transform="translate(715.0,424.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf7_95_THREE_ARROW_ACTIVE" transform="translate(715.0,404.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf7_95_THREE_ARROW_ACTIVE" transform="translate(715.0,404.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -736,12 +738,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_gen2_95_INTERNAL_95_vl1_95_gen2">
                 <polyline points="1280.0,443.0,1280.0,387.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idgen2_ARROW_REACTIVE" transform="translate(1275.0,418.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idgen2_ARROW_REACTIVE" transform="translate(1275.0,418.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idgen2_ARROW_ACTIVE" transform="translate(1275.0,398.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idgen2_ARROW_ACTIVE" transform="translate(1275.0,398.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -780,12 +782,12 @@
             <g class="sld-wire sld-vl300to500-1" id="_95_vl1_95_INTERNAL_95_vl1_95_trf4_95_ONE_95_trf4_95_ONE">
                 <polyline points="1120.0,387.0,1120.0,441.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf4_95_ONE_ARROW_REACTIVE" transform="translate(1115.0,416.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf4_95_ONE_ARROW_REACTIVE" transform="translate(1115.0,416.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf4_95_ONE_ARROW_ACTIVE" transform="translate(1115.0,396.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf4_95_ONE_ARROW_ACTIVE" transform="translate(1115.0,396.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -810,15 +812,17 @@
                 <text class="sld-label" id="trf4_ONE_S_LABEL" x="-5.0" y="20.0">trf4</text>
             </g>
         </g>
-        <g id="NODE_vl1_0">
-            <circle class="sld-vl300to500-0 sld-node-infos" cx="70.0" cy="519.0" id="NODE_vl1_0_circle" r="10" stroke-width="10"/>
-            <text class="sld-label" id="NODE_vl1_0_v" x="60.0" y="544.0">392.0 kV</text>
-            <text class="sld-label" id="NODE_vl1_0_angle" x="60.0" y="559.0">-2.3°</text>
-        </g>
-        <g id="NODE_vl1_2">
-            <circle class="sld-vl300to500-1 sld-node-infos" cx="140.0" cy="519.0" id="NODE_vl1_2_circle" r="10" stroke-width="10"/>
-            <text class="sld-label" id="NODE_vl1_2_v" x="130.0" y="544.0">403.0 kV</text>
-            <text class="sld-label" id="NODE_vl1_2_angle" x="130.0" y="559.0">-1.7°</text>
+        <g class="sld-legend">
+            <g id="NODE_vl1_0">
+                <circle class="sld-vl300to500-0 sld-node-infos" cx="70.0" cy="519.0" id="NODE_vl1_0_circle" r="10" stroke-width="10"/>
+                <text class="sld-voltage" id="NODE_vl1_0_v" x="60.0" y="544.0">392.0 kV</text>
+                <text class="sld-angle" id="NODE_vl1_0_angle" x="60.0" y="559.0">-2.3°</text>
+            </g>
+            <g id="NODE_vl1_2">
+                <circle class="sld-vl300to500-1 sld-node-infos" cx="140.0" cy="519.0" id="NODE_vl1_2_circle" r="10" stroke-width="10"/>
+                <text class="sld-voltage" id="NODE_vl1_2_v" x="130.0" y="544.0">403.0 kV</text>
+                <text class="sld-angle" id="NODE_vl1_2_angle" x="130.0" y="559.0">-1.7°</text>
+            </g>
         </g>
     </g>
 </svg>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicator.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -129,12 +131,12 @@
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadA_95_loadA">
                 <polyline points="115.0,142.0,115.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadA_ARROW_ACTIVE" transform="translate(110.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idloadA_ARROW_ACTIVE" transform="translate(110.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadA_ARROW_REACTIVE" transform="translate(110.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idloadA_ARROW_REACTIVE" transform="translate(110.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -180,12 +182,12 @@
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadB_95_loadB">
                 <polyline points="165.0,142.0,165.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadB_ARROW_ACTIVE" transform="translate(160.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idloadB_ARROW_ACTIVE" transform="translate(160.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadB_ARROW_REACTIVE" transform="translate(160.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idloadB_ARROW_REACTIVE" transform="translate(160.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -285,12 +287,12 @@
             <g class="sld-wire" id="_95_vl1_95_loadD_95_INTERNAL_95_vl1_95_loadD">
                 <polyline points="277.5,84.5,277.5,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadD_ARROW_ACTIVE" transform="translate(272.5,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idloadD_ARROW_ACTIVE" transform="translate(272.5,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadD_ARROW_REACTIVE" transform="translate(272.5,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idloadD_ARROW_REACTIVE" transform="translate(272.5,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -298,12 +300,12 @@
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
                 <polyline points="352.5,142.0,352.5,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(347.5,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(347.5,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(347.5,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(347.5,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithVoltageIndicatorTopological.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: topologicalBaseVoltages.css ------------------------------------- */
 .sld-disconnected {--sld-vl-color: #808080}
@@ -118,15 +118,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -219,12 +221,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadA_95_loadA">
                 <polyline points="115.0,142.0,115.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadA_ARROW_ACTIVE" transform="translate(110.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idloadA_ARROW_ACTIVE" transform="translate(110.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadA_ARROW_REACTIVE" transform="translate(110.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idloadA_ARROW_REACTIVE" transform="translate(110.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -270,12 +272,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadB_95_loadB">
                 <polyline points="215.0,142.0,215.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadB_ARROW_ACTIVE" transform="translate(210.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idloadB_ARROW_ACTIVE" transform="translate(210.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadB_ARROW_REACTIVE" transform="translate(210.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idloadB_ARROW_REACTIVE" transform="translate(210.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -375,12 +377,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_loadD_95_INTERNAL_95_vl1_95_loadD">
                 <polyline points="377.5,84.5,377.5,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadD_ARROW_ACTIVE" transform="translate(372.5,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idloadD_ARROW_ACTIVE" transform="translate(372.5,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadD_ARROW_REACTIVE" transform="translate(372.5,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idloadD_ARROW_REACTIVE" transform="translate(372.5,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -388,12 +390,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
                 <polyline points="452.5,142.0,452.5,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(447.5,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(447.5,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(447.5,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(447.5,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
+++ b/single-line-diagram-core/src/test/resources/TestCase15GraphWithoutVoltageIndicator.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -113,12 +115,12 @@
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadA_95_loadA">
                 <polyline points="65.0,142.0,65.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadA_ARROW_ACTIVE" transform="translate(60.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idloadA_ARROW_ACTIVE" transform="translate(60.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadA_ARROW_REACTIVE" transform="translate(60.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idloadA_ARROW_REACTIVE" transform="translate(60.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -164,12 +166,12 @@
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadB_95_loadB">
                 <polyline points="115.0,142.0,115.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadB_ARROW_ACTIVE" transform="translate(110.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idloadB_ARROW_ACTIVE" transform="translate(110.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadB_ARROW_REACTIVE" transform="translate(110.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idloadB_ARROW_REACTIVE" transform="translate(110.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -269,12 +271,12 @@
             <g class="sld-wire" id="_95_vl1_95_loadD_95_INTERNAL_95_vl1_95_loadD">
                 <polyline points="227.5,84.5,227.5,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadD_ARROW_ACTIVE" transform="translate(222.5,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idloadD_ARROW_ACTIVE" transform="translate(222.5,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadD_ARROW_REACTIVE" transform="translate(222.5,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idloadD_ARROW_REACTIVE" transform="translate(222.5,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -282,12 +284,12 @@
             <g class="sld-wire" id="_95_vl1_95_INTERNAL_95_vl1_95_loadC_95_loadC">
                 <polyline points="302.5,142.0,302.5,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(297.5,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idloadC_ARROW_ACTIVE" transform="translate(297.5,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(297.5,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idloadC_ARROW_REACTIVE" transform="translate(297.5,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseComplexCoupling.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}

--- a/single-line-diagram-core/src/test/resources/TestCaseFictitiousBus.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseFictitiousBus.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -84,12 +86,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_L1_95_ONE">
                 <polyline points="65.0,142.0,65.0,80.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL1_95_ONE_ARROW_ACTIVE" transform="translate(60.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL1_95_ONE_ARROW_ACTIVE" transform="translate(60.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL1_95_ONE_ARROW_REACTIVE" transform="translate(60.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL1_95_ONE_ARROW_REACTIVE" transform="translate(60.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -117,12 +119,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_L2_95_ONE">
                 <polyline points="115.0,578.0,115.0,640.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL2_95_ONE_ARROW_REACTIVE" transform="translate(110.0,615.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL2_95_ONE_ARROW_REACTIVE" transform="translate(110.0,615.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL2_95_ONE_ARROW_ACTIVE" transform="translate(110.0,595.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL2_95_ONE_ARROW_ACTIVE" transform="translate(110.0,595.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -150,12 +152,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_L3_95_ONE">
                 <polyline points="165.0,142.0,165.0,80.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL3_95_ONE_ARROW_ACTIVE" transform="translate(160.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL3_95_ONE_ARROW_ACTIVE" transform="translate(160.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL3_95_ONE_ARROW_REACTIVE" transform="translate(160.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL3_95_ONE_ARROW_REACTIVE" transform="translate(160.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestCaseFictitiousBusTopological.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseFictitiousBusTopological.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: topologicalBaseVoltages.css ------------------------------------- */
 .sld-disconnected {--sld-vl-color: #808080}
@@ -118,15 +118,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -162,12 +164,12 @@
             <g class="sld-wire sld-vl50to70-0 sld-feeder-connected-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_L1_95_ONE_95_L1_95_ONE">
                 <polyline points="65.0,142.0,65.0,80.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL1_95_ONE_ARROW_ACTIVE" transform="translate(60.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL1_95_ONE_ARROW_ACTIVE" transform="translate(60.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL1_95_ONE_ARROW_REACTIVE" transform="translate(60.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL1_95_ONE_ARROW_REACTIVE" transform="translate(60.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -195,12 +197,12 @@
             <g class="sld-wire sld-vl50to70-0 sld-feeder-connected-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_L2_95_ONE_95_L2_95_ONE">
                 <polyline points="115.0,578.0,115.0,640.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL2_95_ONE_ARROW_REACTIVE" transform="translate(110.0,615.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL2_95_ONE_ARROW_REACTIVE" transform="translate(110.0,615.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL2_95_ONE_ARROW_ACTIVE" transform="translate(110.0,595.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL2_95_ONE_ARROW_ACTIVE" transform="translate(110.0,595.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -228,12 +230,12 @@
             <g class="sld-wire sld-vl50to70-0 sld-feeder-connected-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_L3_95_ONE_95_L3_95_ONE">
                 <polyline points="165.0,142.0,165.0,80.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idL3_95_ONE_ARROW_ACTIVE" transform="translate(160.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idL3_95_ONE_ARROW_ACTIVE" transform="translate(160.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idL3_95_ONE_ARROW_REACTIVE" transform="translate(160.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idL3_95_ONE_ARROW_REACTIVE" transform="translate(160.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
+++ b/single-line-diagram-core/src/test/resources/TestCaseLoadBreakSwitch.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: topologicalBaseVoltages.css ------------------------------------- */
 .sld-disconnected {--sld-vl-color: #808080}
@@ -118,15 +118,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -203,12 +205,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl_95_INTERNAL_95_vl_95_G_95_G">
                 <polyline points="265.0,142.0,265.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idG_ARROW_ACTIVE" transform="translate(260.0,101.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idG_ARROW_ACTIVE" transform="translate(260.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idG_ARROW_REACTIVE" transform="translate(260.0,121.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idG_ARROW_REACTIVE" transform="translate(260.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -246,12 +248,12 @@
             <g class="sld-wire sld-disconnected sld-feeder-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_T11_95_ONE_95_T11_95_ONE">
                 <polyline points="165.0,142.0,165.0,80.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(160.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT11_95_ONE_ARROW_ACTIVE" transform="translate(160.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(160.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT11_95_ONE_ARROW_REACTIVE" transform="translate(160.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -289,12 +291,12 @@
             <g class="sld-wire sld-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_l_95_l">
                 <polyline points="315.0,603.0,315.0,660.5"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(310.0,635.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idl_ARROW_REACTIVE" transform="translate(310.0,635.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idl_ARROW_ACTIVE" transform="translate(310.0,615.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idl_ARROW_ACTIVE" transform="translate(310.0,615.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -371,12 +373,12 @@
             <g class="sld-wire sld-disconnected sld-feeder-disconnected" id="_95_vl_95_INTERNAL_95_vl_95_T11_95_TWO_95_T11_95_TWO">
                 <polyline points="215.0,603.0,215.0,665.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(210.0,640.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idT11_95_TWO_ARROW_REACTIVE" transform="translate(210.0,640.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(210.0,620.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idT11_95_TWO_ARROW_ACTIVE" transform="translate(210.0,620.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestFeederInfos.svg
+++ b/single-line-diagram-core/src/test/resources/TestFeederInfos.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -86,27 +88,27 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_l_95_l">
                 <polyline points="65.0,192.0,65.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">1,000.968</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,114.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,114.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,129.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,129.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">3000</text>
             </g>
-            <g class="sld-arrow-p sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,144.5)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,144.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">40</text>
             </g>
-            <g class="sld-arrow-p sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,159.5)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,159.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>

--- a/single-line-diagram-core/src/test/resources/TestFeederInfos.svg
+++ b/single-line-diagram-core/src/test/resources/TestFeederInfos.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg height="720.0" viewBox="0 0 130.0 720.0" width="130.0" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+/* ----------------------------------------------------------------------- */
+/* File: tautologies.css ------------------------------------------------- */
+.sld-out .sld-arrow-in {visibility: hidden}
+.sld-in .sld-arrow-out {visibility: hidden}
+.sld-closed .sld-sw-open {visibility: hidden}
+.sld-open .sld-sw-closed {visibility: hidden}
+.sld-hidden-node {visibility: hidden}
+.sld-top-feeder .sld-label {dominant-baseline: auto}
+.sld-bottom-feeder .sld-label {dominant-baseline: hanging}
+.sld-arrow-p .sld-label {dominant-baseline: middle}
+.sld-arrow-q .sld-label {dominant-baseline: middle}
+/* ----------------------------------------------------------------------- */
+/* File : components.css ------------------------------------------------- */
+/* Stroke black */
+.sld-disconnector {stroke-width: 3; stroke: black; fill: none}
+/* Stroke blue */
+.sld-breaker {stroke-width: 2; stroke: blue; fill:white}
+.sld-load-break-switch {stroke: blue; fill: white}
+/* Stroke --sld-vl-color with fallback black */
+.sld-bus-connection {fill: var(--sld-vl-color, black)}
+.sld-cell-shape-flat .sld-bus-connection {visibility: hidden}
+.sld-busbar-section {stroke: var(--sld-vl-color, black); stroke-width: 3; fill: none}
+/* Stroke --sld-vl-color with fallback red */
+.sld-wire {stroke: var(--sld-vl-color, #c80000); fill: none}
+/* Stroke --sld-vl-color with fallback blue */
+.sld-load {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-generator {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-two-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-three-wt {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-winding {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-capacitor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-inductor {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-pst-arrow {stroke: black; fill: none}
+.sld-svc {stroke: var(--sld-vl-color, blue); fill: none}
+.sld-vsc {stroke: var(--sld-vl-color, blue); font-size: 7.43px; fill: none}
+/* Stroke none & fill: --sld-vl-color */
+.sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
+/* Stroke none & fill: black */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
+.sld-node {stroke: none; fill: black}
+.sld-flash {stroke: none; fill: black}
+.sld-lock {stroke: none; fill: black}
+/* Specific */
+.sld-grid {stroke: #003700; stroke-dasharray: 1,10}
+.sld-arrow-p {fill:black}
+.sld-arrow-q {fill:blue}
+.sld-frame {fill: var(--sld-background-color, transparent)}
+/* Stroke maroon for fictitious switch */
+.sld-breaker.sld-fictitious {stroke: maroon}
+.sld-disconnector.sld-fictitious {stroke: maroon}
+.sld-load-break-switch.sld-fictitious {stroke: maroon}
+.sld-busbar-section.sld-fictitious {stroke: var(--sld-vl-color, #c80000); stroke-width: 1}
+
+]]></style>
+    <rect class="sld-frame" height="100%" width="100%"/>
+    <g>
+        <g class="sld-grid" id="GRID_vl">
+            <line x1="40.0" x2="40.0" y1="80.0" y2="640.0"/>
+            <line x1="90.0" x2="90.0" y1="80.0" y2="640.0"/>
+            <line x1="40.0" x2="90.0" y1="330.0" y2="330.0"/>
+            <line x1="40.0" x2="90.0" y1="320.0" y2="320.0"/>
+            <line x1="40.0" x2="90.0" y1="192.0" y2="192.0"/>
+            <line x1="40.0" x2="90.0" y1="390.0" y2="390.0"/>
+            <line x1="40.0" x2="90.0" y1="400.0" y2="400.0"/>
+            <line x1="40.0" x2="90.0" y1="528.0" y2="528.0"/>
+        </g>
+        <g class="sld-busbar-section" id="idbbs" transform="translate(52.5,360.0)">
+            <line x1="0" x2="25.0" y1="0" y2="0"/>
+            <text class="sld-label" id="bbs_NW_LABEL" x="-5.0" y="-5.0">bbs</text>
+        </g>
+        <g class="sld-extern-cell" id="idEXTERN_32_0">
+            <g class="sld-wire" id="_95_vl_95_d_95_INTERNAL_95_vl_95_b">
+                <polyline points="65.0,360.0,65.0,330.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_b_95_b">
+                <polyline points="65.0,330.0,65.0,271.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_l">
+                <polyline points="65.0,251.0,65.0,192.0"/>
+            </g>
+            <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_l_95_l">
+                <polyline points="65.0,192.0,65.0,84.5"/>
+            </g>
+            <g class="sld-arrow-p sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,99.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">1,000.968</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,114.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">—</text>
+            </g>
+            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,129.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">3000</text>
+            </g>
+            <g class="sld-arrow-p sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,144.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">40</text>
+            </g>
+            <g class="sld-arrow-p sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,159.5)">
+                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
+                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
+                <text class="sld-label" x="15.0" y="5.0">50</text>
+            </g>
+            <g class="sld-disconnector sld-closed" id="idd" transform="translate(61.0,356.0)">
+                <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
+                <path class="sld-sw-open" d="M8,0 0,8"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b" transform="translate(61.0,326.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-breaker sld-closed" id="idb" transform="translate(55.0,251.0)">
+                <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
+                <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
+            </g>
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_l" transform="translate(61.0,188.0)">
+                <circle cx="4" cy="4" r="4"/>
+            </g>
+            <g class="sld-load sld-top-feeder" id="idl" transform="translate(57.0,75.5)">
+                <rect height="9" width="16"/>
+                <line x1="0" x2="16" y1="0" y2="9"/>
+                <line x1="16" x2="0" y1="0" y2="9"/>
+                <text class="sld-label" id="l_N_LABEL" x="-5.0" y="-5.0">l</text>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/single-line-diagram-core/src/test/resources/TestFeederOnBus.svg
+++ b/single-line-diagram-core/src/test/resources/TestFeederOnBus.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -80,13 +82,13 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_line_95_ONE_95_line_95_ONE">
                 <polyline points="65.0,142.0,65.0,80.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idline_95_ONE_ARROW_ACTIVE" transform="translate(60.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idline_95_ONE_ARROW_ACTIVE" transform="translate(60.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">tata</text>
                 <text class="sld-label" style="text-anchor:end" x="-5.0" y="5.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idline_95_ONE_ARROW_REACTIVE" transform="translate(60.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idline_95_ONE_ARROW_REACTIVE" transform="translate(60.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">tutu</text>

--- a/single-line-diagram-core/src/test/resources/TestFeederOnBusDisconnector.svg
+++ b/single-line-diagram-core/src/test/resources/TestFeederOnBusDisconnector.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -80,13 +82,13 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_line_95_ONE_95_line_95_ONE">
                 <polyline points="65.0,190.0,65.0,252.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idline_95_ONE_ARROW_ACTIVE" transform="translate(60.0,227.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idline_95_ONE_ARROW_ACTIVE" transform="translate(60.0,227.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">tata</text>
                 <text class="sld-label" style="text-anchor:end" x="-5.0" y="5.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idline_95_ONE_ARROW_REACTIVE" transform="translate(60.0,207.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idline_95_ONE_ARROW_REACTIVE" transform="translate(60.0,207.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">tutu</text>

--- a/single-line-diagram-core/src/test/resources/TestFormattingFeederInfos.svg
+++ b/single-line-diagram-core/src/test/resources/TestFormattingFeederInfos.svg
@@ -64,10 +64,10 @@
             <line x1="90.0" x2="90.0" y1="80.0" y2="640.0"/>
             <line x1="40.0" x2="90.0" y1="330.0" y2="330.0"/>
             <line x1="40.0" x2="90.0" y1="320.0" y2="320.0"/>
-            <line x1="40.0" x2="90.0" y1="192.0" y2="192.0"/>
+            <line x1="40.0" x2="90.0" y1="142.0" y2="142.0"/>
             <line x1="40.0" x2="90.0" y1="390.0" y2="390.0"/>
             <line x1="40.0" x2="90.0" y1="400.0" y2="400.0"/>
-            <line x1="40.0" x2="90.0" y1="528.0" y2="528.0"/>
+            <line x1="40.0" x2="90.0" y1="578.0" y2="578.0"/>
         </g>
         <g class="sld-busbar-section" id="idbbs" transform="translate(52.5,360.0)">
             <line x1="0" x2="25.0" y1="0" y2="0"/>
@@ -78,38 +78,23 @@
                 <polyline points="65.0,360.0,65.0,330.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_b_95_b">
-                <polyline points="65.0,330.0,65.0,271.0"/>
+                <polyline points="65.0,330.0,65.0,246.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_b_95_INTERNAL_95_vl_95_l">
-                <polyline points="65.0,251.0,65.0,192.0"/>
+                <polyline points="65.0,226.0,65.0,142.0"/>
             </g>
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_l_95_l">
-                <polyline points="65.0,192.0,65.0,84.5"/>
+                <polyline points="65.0,142.0,65.0,84.5"/>
             </g>
             <g class="sld-arrow-p sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">10.968</text>
+                <text class="sld-label" x="15.0" y="5.0">1 200,3</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,114.5)">
+            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">—</text>
-            </g>
-            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,129.5)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">30</text>
-            </g>
-            <g class="sld-arrow-p sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,144.5)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">40</text>
-            </g>
-            <g class="sld-arrow-p sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,159.5)">
-                <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
-                <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
-                <text class="sld-label" x="15.0" y="5.0">50</text>
+                <text class="sld-label" x="15.0" y="5.0">-1,0</text>
             </g>
             <g class="sld-disconnector sld-closed" id="idd" transform="translate(61.0,356.0)">
                 <path class="sld-sw-closed" d="M0,0 8,8 M8,0 0,8"/>
@@ -118,11 +103,11 @@
             <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_b" transform="translate(61.0,326.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
-            <g class="sld-breaker sld-closed" id="idb" transform="translate(55.0,251.0)">
+            <g class="sld-breaker sld-closed" id="idb" transform="translate(55.0,226.0)">
                 <path class="sld-sw-closed" d="M1,1 V19 H19 V1z M10,5 V15"/>
                 <path class="sld-sw-open" d="M1,1 V19 H19 V1z M5,10 H15"/>
             </g>
-            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_l" transform="translate(61.0,188.0)">
+            <g class="sld-node sld-fictitious" id="idINTERNAL_95_vl_95_l" transform="translate(61.0,138.0)">
                 <circle cx="4" cy="4" r="4"/>
             </g>
             <g class="sld-load sld-top-feeder" id="idl" transform="translate(57.0,75.5)">

--- a/single-line-diagram-core/src/test/resources/TestFormattingFeederInfos.svg
+++ b/single-line-diagram-core/src/test/resources/TestFormattingFeederInfos.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -86,12 +88,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_l_95_l">
                 <polyline points="65.0,142.0,65.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">1 200,3</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-1,0</text>

--- a/single-line-diagram-core/src/test/resources/TestPacman.svg
+++ b/single-line-diagram-core/src/test/resources/TestPacman.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -93,13 +95,13 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_l_95_l">
                 <polyline points="65.0,142.0,65.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idl_ARROW_ACTIVE" transform="translate(60.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">tata</text>
                 <text class="sld-label" style="text-anchor:end" x="-5.0" y="5.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">tutu</text>

--- a/single-line-diagram-core/src/test/resources/TestSldClassSubstation.svg
+++ b/single-line-diagram-core/src/test/resources/TestSldClassSubstation.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: topologicalBaseVoltages.css ------------------------------------- */
 .sld-disconnected {--sld-vl-color: #808080}
@@ -118,15 +118,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -157,12 +159,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_l_95_l">
                 <polyline points="115.0,142.0,115.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idl_ARROW_ACTIVE" transform="translate(110.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idl_ARROW_ACTIVE" transform="translate(110.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(110.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idl_ARROW_REACTIVE" transform="translate(110.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -201,12 +203,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf_95_ONE_95_trf_95_ONE">
                 <polyline points="65.0,362.0,65.0,424.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf_95_ONE_ARROW_REACTIVE" transform="translate(60.0,399.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf_95_ONE_ARROW_REACTIVE" transform="translate(60.0,399.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf_95_ONE_ARROW_ACTIVE" transform="translate(60.0,379.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf_95_ONE_ARROW_ACTIVE" transform="translate(60.0,379.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -249,12 +251,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_g_95_g">
                 <polyline points="205.0,362.0,205.0,418.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idg_ARROW_REACTIVE" transform="translate(200.0,393.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idg_ARROW_REACTIVE" transform="translate(200.0,393.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idg_ARROW_ACTIVE" transform="translate(200.0,373.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idg_ARROW_ACTIVE" transform="translate(200.0,373.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -293,12 +295,12 @@
             <g class="sld-wire sld-vl180to300-0" id="_95_vl2_95_INTERNAL_95_vl2_95_trf_95_TWO_95_trf_95_TWO">
                 <polyline points="255.0,142.0,255.0,80.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf_95_TWO_ARROW_ACTIVE" transform="translate(250.0,95.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf_95_TWO_ARROW_ACTIVE" transform="translate(250.0,95.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf_95_TWO_ARROW_REACTIVE" transform="translate(250.0,115.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf_95_TWO_ARROW_REACTIVE" transform="translate(250.0,115.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestSldClassSubstationMetadata.json
+++ b/single-line-diagram-core/src/test/resources/TestSldClassSubstationMetadata.json
@@ -40,7 +40,7 @@
       "LEFT" : "ROTATION",
       "RIGHT" : "ROTATION"
     },
-    "styleClass" : "sld-arrow-q"
+    "styleClass" : "sld-reactive-power"
   }, {
     "type" : "ARROW_ACTIVE",
     "size" : {
@@ -51,7 +51,7 @@
       "LEFT" : "ROTATION",
       "RIGHT" : "ROTATION"
     },
-    "styleClass" : "sld-arrow-p"
+    "styleClass" : "sld-active-power"
   }, {
     "type" : "LOAD",
     "anchorPoints" : [ {

--- a/single-line-diagram-core/src/test/resources/TestSldClassVl.svg
+++ b/single-line-diagram-core/src/test/resources/TestSldClassVl.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: topologicalBaseVoltages.css ------------------------------------- */
 .sld-disconnected {--sld-vl-color: #808080}
@@ -118,15 +118,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -154,12 +156,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_l_95_l">
                 <polyline points="115.0,142.0,115.0,84.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idl_ARROW_ACTIVE" transform="translate(110.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idl_ARROW_ACTIVE" transform="translate(110.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(110.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idl_ARROW_REACTIVE" transform="translate(110.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -198,12 +200,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_trf_95_ONE_95_trf_95_ONE">
                 <polyline points="65.0,362.0,65.0,416.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idtrf_95_ONE_ARROW_REACTIVE" transform="translate(60.0,391.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idtrf_95_ONE_ARROW_REACTIVE" transform="translate(60.0,391.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idtrf_95_ONE_ARROW_ACTIVE" transform="translate(60.0,371.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idtrf_95_ONE_ARROW_ACTIVE" transform="translate(60.0,371.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/TestSldClassVlMetadata.json
+++ b/single-line-diagram-core/src/test/resources/TestSldClassVlMetadata.json
@@ -16,7 +16,7 @@
       "LEFT" : "ROTATION",
       "RIGHT" : "ROTATION"
     },
-    "styleClass" : "sld-arrow-q"
+    "styleClass" : "sld-reactive-power"
   }, {
     "type" : "ARROW_ACTIVE",
     "size" : {
@@ -27,7 +27,7 @@
       "LEFT" : "ROTATION",
       "RIGHT" : "ROTATION"
     },
-    "styleClass" : "sld-arrow-p"
+    "styleClass" : "sld-active-power"
   }, {
     "type" : "LOAD",
     "anchorPoints" : [ {

--- a/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
+++ b/single-line-diagram-core/src/test/resources/consecutive_shunts.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: topologicalBaseVoltages.css ------------------------------------- */
 .sld-disconnected {--sld-vl-color: #808080}
@@ -118,15 +118,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -585,12 +587,12 @@
             <g class="sld-wire sld-vl70to120-0 sld-feeder-connected-disconnected" id="_95_AU_95_FT_95_ONE_95_INTERNAL_95_AU_95_FT_95_ONE">
                 <polyline points="165.0,632.0,165.0,578.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idFT_95_ONE_ARROW_REACTIVE" transform="translate(160.0,607.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idFT_95_ONE_ARROW_REACTIVE" transform="translate(160.0,607.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idFT_95_ONE_ARROW_ACTIVE" transform="translate(160.0,587.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idFT_95_ONE_ARROW_ACTIVE" transform="translate(160.0,587.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
@@ -962,12 +964,12 @@
             <g class="sld-wire sld-vl70to120-0" id="_95_AU_95_FP_95_INTERNAL_95_AU_95_FP">
                 <polyline points="515.0,84.5,515.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idFP_ARROW_ACTIVE" transform="translate(510.0,99.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idFP_ARROW_ACTIVE" transform="translate(510.0,99.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idFP_ARROW_REACTIVE" transform="translate(510.0,119.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idFP_ARROW_REACTIVE" transform="translate(510.0,119.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
@@ -1003,12 +1005,12 @@
             <g class="sld-wire sld-vl70to120-0 sld-feeder-connected-disconnected" id="_95_AU_95_INTERNAL_95_AU_95_FX_95_ONE_95_FX_95_ONE">
                 <polyline points="565.0,578.0,565.0,632.0"/>
             </g>
-            <g class="sld-arrow-q sld-in" id="idFX_95_ONE_ARROW_REACTIVE" transform="translate(560.0,607.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idFX_95_ONE_ARROW_REACTIVE" transform="translate(560.0,607.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-p sld-in" id="idFX_95_ONE_ARROW_ACTIVE" transform="translate(560.0,587.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idFX_95_ONE_ARROW_ACTIVE" transform="translate(560.0,587.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">0</text>
@@ -1041,12 +1043,12 @@
             <g class="sld-wire sld-vl70to120-1 sld-feeder-connected-disconnected" id="_95_AU_95_FV_95_ONE_95_INTERNAL_95_AU_95_FV_95_ONE">
                 <polyline points="1065.0,88.0,1065.0,142.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idFV_95_ONE_ARROW_ACTIVE" transform="translate(1060.0,103.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idFV_95_ONE_ARROW_ACTIVE" transform="translate(1060.0,103.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idFV_95_ONE_ARROW_REACTIVE" transform="translate(1060.0,123.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idFV_95_ONE_ARROW_REACTIVE" transform="translate(1060.0,123.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -1121,12 +1123,12 @@
             <g class="sld-wire sld-vl70to120-1 sld-feeder-connected-disconnected" id="_95_AU_95_INTERNAL_95_AU_95_FR_95_ONE_95_FR_95_ONE">
                 <polyline points="765.0,142.0,765.0,88.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idFR_95_ONE_ARROW_ACTIVE" transform="translate(760.0,103.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idFR_95_ONE_ARROW_ACTIVE" transform="translate(760.0,103.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">-0</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idFR_95_ONE_ARROW_REACTIVE" transform="translate(760.0,123.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idFR_95_ONE_ARROW_REACTIVE" transform="translate(760.0,123.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/feederInfoTest.svg
+++ b/single-line-diagram-core/src/test/resources/feederInfoTest.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -127,12 +129,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_svc_95_svc">
                 <polyline points="215.0,142.0,215.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
@@ -140,12 +142,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_vsc">
                 <polyline points="265.0,142.0,265.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(260.0,101.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(260.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(260.0,121.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(260.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
@@ -190,12 +192,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_C1_95_C1">
                 <polyline points="65.0,142.0,65.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idC1_ARROW_ACTIVE" transform="translate(60.0,101.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idC1_ARROW_ACTIVE" transform="translate(60.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idC1_ARROW_REACTIVE" transform="translate(60.0,121.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idC1_ARROW_REACTIVE" transform="translate(60.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -234,12 +236,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_dl1_95_dl1">
                 <polyline points="115.0,578.0,115.0,640.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,615.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,615.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,595.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,595.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>

--- a/single-line-diagram-core/src/test/resources/label_on_all_nodes.svg
+++ b/single-line-diagram-core/src/test/resources/label_on_all_nodes.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}

--- a/single-line-diagram-core/src/test/resources/noComponentsOnBus.svg
+++ b/single-line-diagram-core/src/test/resources/noComponentsOnBus.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -133,12 +135,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_svc_95_svc">
                 <polyline points="215.0,142.0,215.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
@@ -146,12 +148,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_vsc">
                 <polyline points="265.0,142.0,265.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(260.0,101.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(260.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(260.0,121.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(260.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
@@ -202,12 +204,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_C1_95_C1">
                 <polyline points="65.0,142.0,65.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idC1_ARROW_ACTIVE" transform="translate(60.0,101.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idC1_ARROW_ACTIVE" transform="translate(60.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idC1_ARROW_REACTIVE" transform="translate(60.0,121.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idC1_ARROW_REACTIVE" transform="translate(60.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -246,12 +248,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_dl1_95_dl1">
                 <polyline points="115.0,578.0,115.0,640.0"/>
             </g>
-            <g class="sld-arrow-q sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,615.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,615.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
             </g>
-            <g class="sld-arrow-p sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,595.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,595.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_substation.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_substation.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: baseVoltages.css ------------------------------------------------ */
 .sld-vl300to500 {--sld-vl-color: #ff0000}
@@ -54,15 +54,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl2.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl2.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: baseVoltages.css ------------------------------------------------ */
 .sld-vl300to500 {--sld-vl-color: #ff0000}
@@ -54,15 +54,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}

--- a/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl3.svg
+++ b/single-line-diagram-core/src/test/resources/nominal_voltage_style_vl3.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: baseVoltages.css ------------------------------------------------ */
 .sld-vl300to500 {--sld-vl-color: #ff0000}
@@ -54,15 +54,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}

--- a/single-line-diagram-core/src/test/resources/substDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/substDiag_metadata.json
@@ -40,7 +40,7 @@
       "LEFT" : "ROTATION",
       "RIGHT" : "ROTATION"
     },
-    "styleClass" : "sld-arrow-q"
+    "styleClass" : "sld-reactive-power"
   }, {
     "type" : "ARROW_ACTIVE",
     "size" : {
@@ -51,7 +51,7 @@
       "LEFT" : "ROTATION",
       "RIGHT" : "ROTATION"
     },
-    "styleClass" : "sld-arrow-p"
+    "styleClass" : "sld-active-power"
   }, {
     "type" : "LOAD",
     "anchorPoints" : [ {

--- a/single-line-diagram-core/src/test/resources/substation.svg
+++ b/single-line-diagram-core/src/test/resources/substation.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: baseVoltages.css ------------------------------------------------ */
 .sld-vl300to500 {--sld-vl-color: #ff0000}
@@ -54,15 +54,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -99,12 +101,12 @@
         <g class="sld-wire sld-vl300to500" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
             <polyline points="80.0,124.5,80.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,139.5)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,139.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,159.5)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,159.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -115,12 +117,12 @@
         <g class="sld-wire sld-vl300to500" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="120.0,540.0,120.0,450.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,515.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,515.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,495.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,495.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -131,12 +133,12 @@
         <g class="sld-wire sld-vl300to500" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2">
             <polyline points="440.0,120.0,440.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(435.0,135.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(435.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(435.0,155.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(435.0,155.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -202,12 +204,12 @@
         <g class="sld-wire sld-vl180to300" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1">
             <polyline points="640.0,126.0,640.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_gen1_ARROW_ACTIVE" transform="translate(635.0,141.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_gen1_ARROW_ACTIVE" transform="translate(635.0,141.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_gen1_ARROW_REACTIVE" transform="translate(635.0,161.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_gen1_ARROW_REACTIVE" transform="translate(635.0,161.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -218,12 +220,12 @@
         <g class="sld-wire sld-vl180to300" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1">
             <polyline points="690.0,540.0,690.0,450.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_trf1_ARROW_REACTIVE" transform="translate(685.0,515.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_trf1_ARROW_REACTIVE" transform="translate(685.0,515.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_trf1_ARROW_ACTIVE" transform="translate(685.0,495.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_trf1_ARROW_ACTIVE" transform="translate(685.0,495.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -234,12 +236,12 @@
         <g class="sld-wire sld-vl180to300" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2">
             <polyline points="750.0,120.0,750.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_trf2_95_one_ARROW_ACTIVE" transform="translate(745.0,135.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_trf2_95_one_ARROW_ACTIVE" transform="translate(745.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_trf2_95_one_ARROW_REACTIVE" transform="translate(745.0,155.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_trf2_95_one_ARROW_REACTIVE" transform="translate(745.0,155.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -293,12 +295,12 @@
         <g class="sld-wire sld-vl50to70" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1">
             <polyline points="930.0,126.0,930.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl3_95_capa1_ARROW_ACTIVE" transform="translate(925.0,141.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl3_95_capa1_ARROW_ACTIVE" transform="translate(925.0,141.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl3_95_capa1_ARROW_REACTIVE" transform="translate(925.0,161.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl3_95_capa1_ARROW_REACTIVE" transform="translate(925.0,161.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -309,12 +311,12 @@
         <g class="sld-wire sld-vl50to70" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2">
             <polyline points="1040.0,120.0,1040.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl3_95_trf2_95_one_ARROW_ACTIVE" transform="translate(1035.0,135.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl3_95_trf2_95_one_ARROW_ACTIVE" transform="translate(1035.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl3_95_trf2_95_one_ARROW_REACTIVE" transform="translate(1035.0,155.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl3_95_trf2_95_one_ARROW_REACTIVE" transform="translate(1035.0,155.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
+++ b/single-line-diagram-core/src/test/resources/substation_feeder_arrow_symmetry.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -85,12 +87,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
             <polyline points="80.0,124.5,80.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,139.5)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,139.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,159.5)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,159.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -101,12 +103,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="120.0,540.0,120.0,450.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,515.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,515.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,495.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,495.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -117,12 +119,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2">
             <polyline points="440.0,120.0,440.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(435.0,135.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(435.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(435.0,155.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(435.0,155.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -188,12 +190,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1">
             <polyline points="640.0,126.0,640.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_gen1_ARROW_ACTIVE" transform="translate(635.0,141.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_gen1_ARROW_ACTIVE" transform="translate(635.0,141.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_gen1_ARROW_REACTIVE" transform="translate(635.0,161.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_gen1_ARROW_REACTIVE" transform="translate(635.0,161.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -204,12 +206,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1">
             <polyline points="690.0,540.0,690.0,450.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_trf1_ARROW_ACTIVE" transform="translate(685.0,515.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_trf1_ARROW_ACTIVE" transform="translate(685.0,515.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_trf1_ARROW_REACTIVE" transform="translate(685.0,495.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_trf1_ARROW_REACTIVE" transform="translate(685.0,495.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -220,12 +222,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2">
             <polyline points="750.0,120.0,750.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_trf2_95_one_ARROW_ACTIVE" transform="translate(745.0,135.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_trf2_95_one_ARROW_ACTIVE" transform="translate(745.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_trf2_95_one_ARROW_REACTIVE" transform="translate(745.0,155.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_trf2_95_one_ARROW_REACTIVE" transform="translate(745.0,155.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -279,12 +281,12 @@
         <g class="sld-wire" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1">
             <polyline points="930.0,126.0,930.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl3_95_capa1_ARROW_ACTIVE" transform="translate(925.0,141.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl3_95_capa1_ARROW_ACTIVE" transform="translate(925.0,141.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl3_95_capa1_ARROW_REACTIVE" transform="translate(925.0,161.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl3_95_capa1_ARROW_REACTIVE" transform="translate(925.0,161.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -295,12 +297,12 @@
         <g class="sld-wire" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2">
             <polyline points="1040.0,120.0,1040.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl3_95_trf2_95_one_ARROW_ACTIVE" transform="translate(1035.0,135.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl3_95_trf2_95_one_ARROW_ACTIVE" transform="translate(1035.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl3_95_trf2_95_one_ARROW_REACTIVE" transform="translate(1035.0,155.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl3_95_trf2_95_one_ARROW_REACTIVE" transform="translate(1035.0,155.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
+++ b/single-line-diagram-core/src/test/resources/substation_no_feeder_values.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}

--- a/single-line-diagram-core/src/test/resources/substation_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/substation_optimized.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -154,12 +156,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
             <polyline points="80.0,124.5,80.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,139.5)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,139.5)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,159.5)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,159.5)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -170,12 +172,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="120.0,540.0,120.0,450.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,515.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,515.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN" transform="rotate(180.0,5.0,5.0)"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,495.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,495.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN" transform="rotate(180.0,5.0,5.0)"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -186,12 +188,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_btrf2">
             <polyline points="440.0,120.0,440.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(435.0,135.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(435.0,135.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(435.0,155.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(435.0,155.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -255,12 +257,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1">
             <polyline points="640.0,126.0,640.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_gen1_ARROW_ACTIVE" transform="translate(635.0,141.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_gen1_ARROW_ACTIVE" transform="translate(635.0,141.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_gen1_ARROW_REACTIVE" transform="translate(635.0,161.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_gen1_ARROW_REACTIVE" transform="translate(635.0,161.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -271,12 +273,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1">
             <polyline points="690.0,540.0,690.0,450.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_trf1_ARROW_REACTIVE" transform="translate(685.0,515.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_trf1_ARROW_REACTIVE" transform="translate(685.0,515.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN" transform="rotate(180.0,5.0,5.0)"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_trf1_ARROW_ACTIVE" transform="translate(685.0,495.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_trf1_ARROW_ACTIVE" transform="translate(685.0,495.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN" transform="rotate(180.0,5.0,5.0)"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -287,12 +289,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_btrf2">
             <polyline points="750.0,120.0,750.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_trf2_95_one_ARROW_ACTIVE" transform="translate(745.0,135.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_trf2_95_one_ARROW_ACTIVE" transform="translate(745.0,135.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_trf2_95_one_ARROW_REACTIVE" transform="translate(745.0,155.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_trf2_95_one_ARROW_REACTIVE" transform="translate(745.0,155.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -344,12 +346,12 @@
         <g class="sld-wire" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1">
             <polyline points="930.0,126.0,930.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl3_95_capa1_ARROW_ACTIVE" transform="translate(925.0,141.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl3_95_capa1_ARROW_ACTIVE" transform="translate(925.0,141.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl3_95_capa1_ARROW_REACTIVE" transform="translate(925.0,161.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl3_95_capa1_ARROW_REACTIVE" transform="translate(925.0,161.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -360,12 +362,12 @@
         <g class="sld-wire" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_btrf2">
             <polyline points="1040.0,120.0,1040.0,210.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl3_95_trf2_95_one_ARROW_ACTIVE" transform="translate(1035.0,135.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl3_95_trf2_95_one_ARROW_ACTIVE" transform="translate(1035.0,135.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl3_95_trf2_95_one_ARROW_REACTIVE" transform="translate(1035.0,155.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl3_95_trf2_95_one_ARROW_REACTIVE" transform="translate(1035.0,155.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/switchesOnBus.svg
+++ b/single-line-diagram-core/src/test/resources/switchesOnBus.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -127,12 +129,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_svc_95_svc">
                 <polyline points="215.0,142.0,215.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idsvc_ARROW_ACTIVE" transform="translate(210.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idsvc_ARROW_REACTIVE" transform="translate(210.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
@@ -140,12 +142,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_vsc_95_vsc">
                 <polyline points="265.0,142.0,265.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(260.0,101.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="idvsc_ARROW_ACTIVE" transform="translate(260.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>
             </g>
-            <g class="sld-arrow-q sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(260.0,121.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="idvsc_ARROW_REACTIVE" transform="translate(260.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
@@ -190,12 +192,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_C1_95_C1">
                 <polyline points="65.0,142.0,65.0,86.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idC1_ARROW_ACTIVE" transform="translate(60.0,101.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idC1_ARROW_ACTIVE" transform="translate(60.0,101.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idC1_ARROW_REACTIVE" transform="translate(60.0,121.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idC1_ARROW_REACTIVE" transform="translate(60.0,121.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -231,12 +233,12 @@
             <g class="sld-wire" id="_95_vl_95_INTERNAL_95_vl_95_dl1_95_dl1">
                 <polyline points="115.0,578.0,115.0,640.0"/>
             </g>
-            <g class="sld-arrow-q sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,615.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-out" id="iddl1_ARROW_REACTIVE" transform="translate(110.0,615.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">50</text>
             </g>
-            <g class="sld-arrow-p sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,595.0)">
+            <g class="sld-active-power sld-feeder-info sld-out" id="iddl1_ARROW_ACTIVE" transform="translate(110.0,595.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
                 <text class="sld-label" x="15.0" y="5.0">100</text>

--- a/single-line-diagram-core/src/test/resources/topological_style_substation.svg
+++ b/single-line-diagram-core/src/test/resources/topological_style_substation.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: topologicalBaseVoltages.css ------------------------------------- */
 .sld-disconnected {--sld-vl-color: #808080}
@@ -118,15 +118,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -190,12 +192,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_INTERNAL_95_vl1_95_l_95_l">
                 <polyline points="65.0,172.0,65.0,114.5"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="idl_ARROW_ACTIVE" transform="translate(60.0,129.5)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="idl_ARROW_ACTIVE" transform="translate(60.0,129.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,149.5)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="idl_ARROW_REACTIVE" transform="translate(60.0,149.5)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -234,12 +236,12 @@
             <g class="sld-wire sld-vl300to500-0 sld-feeder-connected-disconnected" id="_95_vl1_95_2WT_95_ONE_95_INTERNAL_95_vl1_95_2WT_95_ONE">
                 <polyline points="115.0,110.0,115.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="id2WT_95_ONE_ARROW_ACTIVE" transform="translate(110.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="id2WT_95_ONE_ARROW_ACTIVE" transform="translate(110.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="id2WT_95_ONE_ARROW_REACTIVE" transform="translate(110.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="id2WT_95_ONE_ARROW_REACTIVE" transform="translate(110.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -275,12 +277,12 @@
             <g class="sld-wire sld-vl300to500-0" id="_95_vl1_95_3WT_95_ONE_95_INTERNAL_95_vl1_95_3WT_95_ONE">
                 <polyline points="165.0,110.0,165.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="id3WT_95_ONE_ARROW_ACTIVE" transform="translate(160.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="id3WT_95_ONE_ARROW_ACTIVE" transform="translate(160.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="id3WT_95_ONE_ARROW_REACTIVE" transform="translate(160.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="id3WT_95_ONE_ARROW_REACTIVE" transform="translate(160.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -323,12 +325,12 @@
             <g class="sld-wire sld-disconnected sld-feeder-disconnected-connected" id="_95_vl2_95_2WT_95_TWO_95_INTERNAL_95_vl2_95_2WT_95_TWO">
                 <polyline points="255.0,110.0,255.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="id2WT_95_TWO_ARROW_ACTIVE" transform="translate(250.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="id2WT_95_TWO_ARROW_ACTIVE" transform="translate(250.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="id2WT_95_TWO_ARROW_REACTIVE" transform="translate(250.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="id2WT_95_TWO_ARROW_REACTIVE" transform="translate(250.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -364,12 +366,12 @@
             <g class="sld-wire sld-disconnected sld-feeder-disconnected" id="_95_vl2_95_3WT_95_TWO_95_INTERNAL_95_vl2_95_3WT_95_TWO">
                 <polyline points="305.0,110.0,305.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="id3WT_95_TWO_ARROW_ACTIVE" transform="translate(300.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="id3WT_95_TWO_ARROW_ACTIVE" transform="translate(300.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="id3WT_95_TWO_ARROW_REACTIVE" transform="translate(300.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="id3WT_95_TWO_ARROW_REACTIVE" transform="translate(300.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
@@ -412,12 +414,12 @@
             <g class="sld-wire sld-vl50to70-0" id="_95_vl3_95_3WT_95_THREE_95_INTERNAL_95_vl3_95_3WT_95_THREE">
                 <polyline points="395.0,110.0,395.0,172.0"/>
             </g>
-            <g class="sld-arrow-p sld-in" id="id3WT_95_THREE_ARROW_ACTIVE" transform="translate(390.0,125.0)">
+            <g class="sld-active-power sld-feeder-info sld-in" id="id3WT_95_THREE_ARROW_ACTIVE" transform="translate(390.0,125.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>
             </g>
-            <g class="sld-arrow-q sld-in" id="id3WT_95_THREE_ARROW_REACTIVE" transform="translate(390.0,145.0)">
+            <g class="sld-reactive-power sld-feeder-info sld-in" id="id3WT_95_THREE_ARROW_REACTIVE" transform="translate(390.0,145.0)">
                 <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
                 <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
                 <text class="sld-label" x="15.0" y="5.0">—</text>

--- a/single-line-diagram-core/src/test/resources/vl1.svg
+++ b/single-line-diagram-core/src/test/resources/vl1.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -82,12 +84,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
             <polyline points="80.0,104.5,80.0,190.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -98,12 +100,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="120.0,512.0,120.0,430.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -114,12 +116,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="400.0,100.0,400.0,160.0,433.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(395.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(395.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(395.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(395.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -127,12 +129,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="480.0,100.0,480.0,160.0,447.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="translate(475.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="translate(475.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="translate(475.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="translate(475.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/vl1_external_css.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_external_css.svg
@@ -26,12 +26,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
             <polyline points="80.0,104.5,80.0,190.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -42,12 +42,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="120.0,512.0,120.0,430.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -58,12 +58,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="400.0,100.0,400.0,160.0,433.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(395.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(395.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(395.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(395.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -71,12 +71,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="480.0,100.0,480.0,160.0,447.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="translate(475.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="translate(475.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="translate(475.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="translate(475.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/vl1_external_css_no_import.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_external_css_no_import.svg
@@ -25,12 +25,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
             <polyline points="80.0,104.5,80.0,190.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -41,12 +41,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="120.0,512.0,120.0,430.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -57,12 +57,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="400.0,100.0,400.0,160.0,433.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(395.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(395.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(395.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(395.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -70,12 +70,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="480.0,100.0,480.0,160.0,447.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="translate(475.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="translate(475.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="translate(475.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="translate(475.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/vl1_multiline_tooltip.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_multiline_tooltip.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}

--- a/single-line-diagram-core/src/test/resources/vl1_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_optimized.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -140,12 +142,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
             <polyline points="80.0,104.5,80.0,190.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -156,12 +158,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="120.0,512.0,120.0,430.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN" transform="rotate(180.0,5.0,5.0)"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN" transform="rotate(180.0,5.0,5.0)"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -172,12 +174,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="400.0,100.0,400.0,160.0,433.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(395.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(395.0,115.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(395.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(395.0,135.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -185,12 +187,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="480.0,100.0,480.0,160.0,447.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="translate(475.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="translate(475.0,115.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="translate(475.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="translate(475.0,135.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_straightWires.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -82,12 +84,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
             <polyline points="80.0,104.5,80.0,190.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -98,12 +100,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="120.0,512.0,120.0,430.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -114,12 +116,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="400.0,100.0,433.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="matrix(0.8762,-0.4819,0.4819,0.8762,402.8477,115.5528)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="matrix(0.8762,-0.4819,0.4819,0.8762,402.8477,115.5528)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="matrix(0.8762,-0.4819,0.4819,0.8762,412.4861,133.0772)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="matrix(0.8762,-0.4819,0.4819,0.8762,412.4861,133.0772)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -127,12 +129,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="480.0,100.0,447.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="matrix(0.8762,0.4819,-0.4819,0.8762,468.3901,110.7336)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="matrix(0.8762,0.4819,-0.4819,0.8762,468.3901,110.7336)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="matrix(0.8762,0.4819,-0.4819,0.8762,458.7518,128.258)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="matrix(0.8762,0.4819,-0.4819,0.8762,458.7518,128.258)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/vl1_tooltip.svg
+++ b/single-line-diagram-core/src/test/resources/vl1_tooltip.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -82,12 +84,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
             <polyline points="80.0,104.5,80.0,190.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -98,12 +100,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="120.0,512.0,120.0,430.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -114,12 +116,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="400.0,100.0,400.0,160.0,433.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(395.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(395.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(395.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(395.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -127,12 +129,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="480.0,100.0,480.0,160.0,447.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="translate(475.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="translate(475.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="translate(475.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="translate(475.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/vl2.svg
+++ b/single-line-diagram-core/src/test/resources/vl2.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -66,12 +68,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1">
             <polyline points="90.0,106.0,90.0,190.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_gen1_ARROW_ACTIVE" transform="translate(85.0,121.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_gen1_ARROW_ACTIVE" transform="translate(85.0,121.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_gen1_ARROW_REACTIVE" transform="translate(85.0,141.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_gen1_ARROW_REACTIVE" transform="translate(85.0,141.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -82,12 +84,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1">
             <polyline points="140.0,512.0,140.0,430.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_trf1_ARROW_REACTIVE" transform="translate(135.0,487.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_trf1_ARROW_REACTIVE" transform="translate(135.0,487.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_trf1_ARROW_ACTIVE" transform="translate(135.0,467.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_trf1_ARROW_ACTIVE" transform="translate(135.0,467.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -98,12 +100,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_trf2">
             <polyline points="170.0,100.0,170.0,160.0,193.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_trf2_95_one_ARROW_ACTIVE" transform="translate(165.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_trf2_95_one_ARROW_ACTIVE" transform="translate(165.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_trf2_95_one_ARROW_REACTIVE" transform="translate(165.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_trf2_95_one_ARROW_REACTIVE" transform="translate(165.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -111,12 +113,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_trf2_95_two_95_vl2_95_trf2">
             <polyline points="230.0,100.0,230.0,160.0,207.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_trf2_95_two_ARROW_ACTIVE" transform="translate(225.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_trf2_95_two_ARROW_ACTIVE" transform="translate(225.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_trf2_95_two_ARROW_REACTIVE" transform="translate(225.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_trf2_95_two_ARROW_REACTIVE" transform="translate(225.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/vl2_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl2_optimized.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -124,12 +126,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_gen1_95_vl2_95_bgen1">
             <polyline points="90.0,106.0,90.0,190.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_gen1_ARROW_ACTIVE" transform="translate(85.0,121.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_gen1_ARROW_ACTIVE" transform="translate(85.0,121.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_gen1_ARROW_REACTIVE" transform="translate(85.0,141.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_gen1_ARROW_REACTIVE" transform="translate(85.0,141.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -140,12 +142,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_trf1_95_vl2_95_btrf1">
             <polyline points="140.0,512.0,140.0,430.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_trf1_ARROW_REACTIVE" transform="translate(135.0,487.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_trf1_ARROW_REACTIVE" transform="translate(135.0,487.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN" transform="rotate(180.0,5.0,5.0)"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_trf1_ARROW_ACTIVE" transform="translate(135.0,467.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_trf1_ARROW_ACTIVE" transform="translate(135.0,467.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN" transform="rotate(180.0,5.0,5.0)"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -156,12 +158,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_trf2_95_one_95_vl2_95_trf2">
             <polyline points="170.0,100.0,170.0,160.0,193.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_trf2_95_one_ARROW_ACTIVE" transform="translate(165.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_trf2_95_one_ARROW_ACTIVE" transform="translate(165.0,115.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_trf2_95_one_ARROW_REACTIVE" transform="translate(165.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_trf2_95_one_ARROW_REACTIVE" transform="translate(165.0,135.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -169,12 +171,12 @@
         <g class="sld-wire" id="_95_vl2_95_vl2_95_trf2_95_two_95_vl2_95_trf2">
             <polyline points="230.0,100.0,230.0,160.0,207.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl2_95_trf2_95_two_ARROW_ACTIVE" transform="translate(225.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl2_95_trf2_95_two_ARROW_ACTIVE" transform="translate(225.0,115.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl2_95_trf2_95_two_ARROW_REACTIVE" transform="translate(225.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl2_95_trf2_95_two_ARROW_REACTIVE" transform="translate(225.0,135.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/vl3.svg
+++ b/single-line-diagram-core/src/test/resources/vl3.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -66,12 +68,12 @@
         <g class="sld-wire" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1">
             <polyline points="80.0,106.0,80.0,190.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl3_95_capa1_ARROW_ACTIVE" transform="translate(75.0,121.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl3_95_capa1_ARROW_ACTIVE" transform="translate(75.0,121.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl3_95_capa1_ARROW_REACTIVE" transform="translate(75.0,141.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl3_95_capa1_ARROW_REACTIVE" transform="translate(75.0,141.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -82,12 +84,12 @@
         <g class="sld-wire" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_trf2">
             <polyline points="150.0,100.0,150.0,160.0,183.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl3_95_trf2_95_one_ARROW_ACTIVE" transform="translate(145.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl3_95_trf2_95_one_ARROW_ACTIVE" transform="translate(145.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl3_95_trf2_95_one_ARROW_REACTIVE" transform="translate(145.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl3_95_trf2_95_one_ARROW_REACTIVE" transform="translate(145.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -95,12 +97,12 @@
         <g class="sld-wire" id="_95_vl3_95_vl3_95_trf2_95_two_95_vl3_95_trf2">
             <polyline points="230.0,100.0,230.0,160.0,197.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl3_95_trf2_95_two_ARROW_ACTIVE" transform="translate(225.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl3_95_trf2_95_two_ARROW_ACTIVE" transform="translate(225.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl3_95_trf2_95_two_ARROW_REACTIVE" transform="translate(225.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl3_95_trf2_95_two_ARROW_REACTIVE" transform="translate(225.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/vl3_optimized.svg
+++ b/single-line-diagram-core/src/test/resources/vl3_optimized.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -117,12 +119,12 @@
         <g class="sld-wire" id="_95_vl3_95_vl3_95_capa1_95_vl3_95_bcapa1">
             <polyline points="80.0,106.0,80.0,190.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl3_95_capa1_ARROW_ACTIVE" transform="translate(75.0,121.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl3_95_capa1_ARROW_ACTIVE" transform="translate(75.0,121.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl3_95_capa1_ARROW_REACTIVE" transform="translate(75.0,141.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl3_95_capa1_ARROW_REACTIVE" transform="translate(75.0,141.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -133,12 +135,12 @@
         <g class="sld-wire" id="_95_vl3_95_vl3_95_trf2_95_one_95_vl3_95_trf2">
             <polyline points="150.0,100.0,150.0,160.0,183.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl3_95_trf2_95_one_ARROW_ACTIVE" transform="translate(145.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl3_95_trf2_95_one_ARROW_ACTIVE" transform="translate(145.0,115.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl3_95_trf2_95_one_ARROW_REACTIVE" transform="translate(145.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl3_95_trf2_95_one_ARROW_REACTIVE" transform="translate(145.0,135.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -146,12 +148,12 @@
         <g class="sld-wire" id="_95_vl3_95_vl3_95_trf2_95_two_95_vl3_95_trf2">
             <polyline points="230.0,100.0,230.0,160.0,197.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl3_95_trf2_95_two_ARROW_ACTIVE" transform="translate(225.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl3_95_trf2_95_two_ARROW_ACTIVE" transform="translate(225.0,115.0)">
             <use class="sld-arrow-in" href="#ARROW_ACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_ACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl3_95_trf2_95_two_ARROW_REACTIVE" transform="translate(225.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl3_95_trf2_95_two_ARROW_REACTIVE" transform="translate(225.0,135.0)">
             <use class="sld-arrow-in" href="#ARROW_REACTIVE-DOWN"/>
             <use class="sld-arrow-out" href="#ARROW_REACTIVE-UP"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
+++ b/single-line-diagram-core/src/test/resources/vlDiag_metadata.json
@@ -40,7 +40,7 @@
       "LEFT" : "ROTATION",
       "RIGHT" : "ROTATION"
     },
-    "styleClass" : "sld-arrow-q"
+    "styleClass" : "sld-reactive-power"
   }, {
     "type" : "ARROW_ACTIVE",
     "size" : {
@@ -51,7 +51,7 @@
       "LEFT" : "ROTATION",
       "RIGHT" : "ROTATION"
     },
-    "styleClass" : "sld-arrow-p"
+    "styleClass" : "sld-active-power"
   }, {
     "type" : "LOAD",
     "anchorPoints" : [ {

--- a/single-line-diagram-core/src/test/resources/with_frame_background.svg
+++ b/single-line-diagram-core/src/test/resources/with_frame_background.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File: baseVoltages.css ------------------------------------------------ */
 .sld-vl300to500 {--sld-vl-color: #ff0000}
@@ -57,15 +57,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -99,12 +101,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_load1_95_vl1_95_bload1">
             <polyline points="80.0,104.5,80.0,190.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_load1_ARROW_ACTIVE" transform="translate(75.0,119.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_load1_ARROW_REACTIVE" transform="translate(75.0,139.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -115,12 +117,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf1_95_vl1_95_btrf1">
             <polyline points="120.0,512.0,120.0,430.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf1_ARROW_REACTIVE" transform="translate(115.0,487.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf1_ARROW_ACTIVE" transform="translate(115.0,467.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -131,12 +133,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_one_95_vl1_95_trf2">
             <polyline points="400.0,100.0,400.0,160.0,433.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(395.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_one_ARROW_ACTIVE" transform="translate(395.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(395.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_one_ARROW_REACTIVE" transform="translate(395.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
@@ -144,12 +146,12 @@
         <g class="sld-wire" id="_95_vl1_95_vl1_95_trf2_95_two_95_vl1_95_trf2">
             <polyline points="480.0,100.0,480.0,160.0,447.0,160.0"/>
         </g>
-        <g class="sld-arrow-p sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="translate(475.0,115.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idvl1_95_trf2_95_two_ARROW_ACTIVE" transform="translate(475.0,115.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
         </g>
-        <g class="sld-arrow-q sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="translate(475.0,135.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idvl1_95_trf2_95_two_ARROW_REACTIVE" transform="translate(475.0,135.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>

--- a/single-line-diagram-core/src/test/resources/zone.svg
+++ b/single-line-diagram-core/src/test/resources/zone.svg
@@ -10,8 +10,8 @@
 .sld-hidden-node {visibility: hidden}
 .sld-top-feeder .sld-label {dominant-baseline: auto}
 .sld-bottom-feeder .sld-label {dominant-baseline: hanging}
-.sld-arrow-p .sld-label {dominant-baseline: middle}
-.sld-arrow-q .sld-label {dominant-baseline: middle}
+.sld-active-power .sld-label {dominant-baseline: middle}
+.sld-reactive-power .sld-label {dominant-baseline: middle}
 /* ----------------------------------------------------------------------- */
 /* File : components.css ------------------------------------------------- */
 /* Stroke black */
@@ -40,15 +40,17 @@
 /* Stroke none & fill: --sld-vl-color */
 .sld-node-infos {stroke: none; fill: var(--sld-vl-color, black)}
 /* Stroke none & fill: black */
-.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
-.sld-graph-label {stroke: none; fill: black; font: 12px "Verdana"}
 .sld-node {stroke: none; fill: black}
 .sld-flash {stroke: none; fill: black}
 .sld-lock {stroke: none; fill: black}
+/* Fonts */
+.sld-label {stroke: none; fill: black; font: 8px "Verdana"}
+.sld-angle, .sld-voltage {font: 10px "Verdana"}
+.sld-graph-label {font: 12px "Verdana"}
 /* Specific */
 .sld-grid {stroke: #003700; stroke-dasharray: 1,10}
-.sld-arrow-p {fill:black}
-.sld-arrow-q {fill:blue}
+.sld-feeder-info.sld-active-power {fill:black}
+.sld-feeder-info.sld-reactive-power {fill:blue}
 .sld-frame {fill: var(--sld-background-color, transparent)}
 /* Stroke maroon for fictitious switch */
 .sld-breaker.sld-fictitious {stroke: maroon}
@@ -69,12 +71,12 @@
         <g class="sld-wire" id="_95_VoltageLevel11_95_Bus11_95_Load">
             <polyline points="90.0,200.0,90.0,54.5"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idLoad_ARROW_REACTIVE" transform="translate(85.0,69.5)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idLoad_ARROW_REACTIVE" transform="translate(85.0,69.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idLoad_ARROW_ACTIVE" transform="translate(85.0,89.5)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idLoad_ARROW_ACTIVE" transform="translate(85.0,89.5)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -82,12 +84,12 @@
         <g class="sld-wire" id="_95_VoltageLevel11_95_Bus11_95_Transformer_95_ONE">
             <polyline points="90.0,200.0,90.0,300.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idTransformer_95_ONE_ARROW_REACTIVE" transform="translate(85.0,275.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idTransformer_95_ONE_ARROW_REACTIVE" transform="translate(85.0,275.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idTransformer_95_ONE_ARROW_ACTIVE" transform="translate(85.0,255.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idTransformer_95_ONE_ARROW_ACTIVE" transform="translate(85.0,255.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -111,12 +113,12 @@
         <g class="sld-wire" id="_95_VoltageLevel12_95_Bus12_95_Transformer_95_TWO">
             <polyline points="90.0,500.0,90.0,400.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idTransformer_95_TWO_ARROW_REACTIVE" transform="translate(85.0,415.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idTransformer_95_TWO_ARROW_REACTIVE" transform="translate(85.0,415.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idTransformer_95_TWO_ARROW_ACTIVE" transform="translate(85.0,435.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idTransformer_95_TWO_ARROW_ACTIVE" transform="translate(85.0,435.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -124,12 +126,12 @@
         <g class="sld-wire" id="_95_VoltageLevel12_95_Bus12_95_Line_95_ONE">
             <polyline points="90.0,500.0,90.0,650.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idLine_95_ONE_ARROW_REACTIVE" transform="translate(85.0,625.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idLine_95_ONE_ARROW_REACTIVE" transform="translate(85.0,625.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idLine_95_ONE_ARROW_ACTIVE" transform="translate(85.0,605.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idLine_95_ONE_ARROW_ACTIVE" transform="translate(85.0,605.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -160,12 +162,12 @@
         <g class="sld-wire" id="_95_VoltageLevel21_95_Bus21_95_Generator">
             <polyline points="190.0,1100.0,190.0,1244.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idGenerator_ARROW_REACTIVE" transform="translate(185.0,1219.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idGenerator_ARROW_REACTIVE" transform="translate(185.0,1219.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idGenerator_ARROW_ACTIVE" transform="translate(185.0,1199.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idGenerator_ARROW_ACTIVE" transform="translate(185.0,1199.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10" transform="rotate(180.0,5.0,5.0)"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10" transform="rotate(180.0,5.0,5.0)"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>
@@ -173,12 +175,12 @@
         <g class="sld-wire" id="_95_VoltageLevel21_95_Bus21_95_Line_95_TWO">
             <polyline points="190.0,1100.0,190.0,950.0"/>
         </g>
-        <g class="sld-arrow-q sld-in" id="idLine_95_TWO_ARROW_REACTIVE" transform="translate(185.0,965.0)">
+        <g class="sld-reactive-power sld-feeder-info sld-in" id="idLine_95_TWO_ARROW_REACTIVE" transform="translate(185.0,965.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">20</text>
         </g>
-        <g class="sld-arrow-p sld-out" id="idLine_95_TWO_ARROW_ACTIVE" transform="translate(185.0,985.0)">
+        <g class="sld-active-power sld-feeder-info sld-out" id="idLine_95_TWO_ARROW_ACTIVE" transform="translate(185.0,985.0)">
             <polygon class="sld-arrow-in" points="0,0 10,0 5,10"/>
             <polygon class="sld-arrow-out" points="5,0 10,10 0,10"/>
             <text class="sld-label" x="15.0" y="5.0">10</text>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** 
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Text elements cannot be easily discriminated.


**What is the new behavior (if this is a feature change)?**
Text elements can be more easily discriminated with the new added classes `sld-legend`, `sld-active-power`, `sld-reactive-power`, `sld-feeder-info`, `sld-voltage`, `sld-angle`


**Does this PR introduce a breaking change or deprecate an API?** yes
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*