### PR TITLE
Remove mock on sld test

### DIFF
--- a/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/LayoutToCgmesDlExporterToolTest.java
+++ b/single-line-diagram/single-line-diagram-cgmes/single-line-diagram-cgmes-layout/src/test/java/com/powsybl/sld/cgmes/layout/LayoutToCgmesDlExporterToolTest.java
@@ -33,7 +33,11 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
+ * Note: this class does not use a mock because it had some strange interaction with other tests, where it would greatly
+ * increase the time it would take for some other tests to finish (making it so that running all tests would take 5 minutes instead of 30s)
+ * The problem was also that this behaviour depends on the order in which tests pass (so sometimes the issue would appear, sometimes not)
  * @author Thomas Adam {@literal <tadam at silicom.fr>}
+ * @author Nathan Dissoubray {@literal <nathan.dissoubrat at rte-france.com>}
  */
 class LayoutToCgmesDlExporterToolTest extends AbstractToolTest {
 
@@ -116,6 +120,8 @@ class LayoutToCgmesDlExporterToolTest extends AbstractToolTest {
         options.addOption("output-dir", true, "output-dir");
         options.addOption("voltage-level-layout", true, "voltage level layout");
 
+        //the options use single dash because add option uses single dash by default when passing just opt (and not longOpt), like -i for short and --input for long
+        //except here we only gave input so that defaults to short option, thus the -input instead of --input
         CommandLine commandLine = defaultParser.parse(
             options,
             new String[] {

--- a/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/SingleLineDiagramToolTest.java
+++ b/single-line-diagram/single-line-diagram-core/src/test/java/com/powsybl/sld/SingleLineDiagramToolTest.java
@@ -129,6 +129,8 @@ class SingleLineDiagramToolTest extends AbstractToolTest {
         options.addOption("output-dir", true, "output-dir");
         options.addOption("ids", true, "ids");
 
+        //the options use single dash because add option uses single dash by default when passing just opt (and not longOpt), like -i for short and --input for long
+        //except here we only gave input so that defaults to short option, thus the -input instead of --input
         CommandLine commandLine = defaultParser.parse(
             options,
             new String[] {


### PR DESCRIPTION
It caused some other tests to stall sometimes, making it take way longer to finish.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix an issue where tests that used mock features of Mockito would make other tests take longer to run. This depends on the order the tests are ran, so sometimes this behavior would appear, sometimes not.

**What is the current behavior?**
<!-- You can also link to an open issue here -->

Replaced the mock by concrete implementations. The tests take the same time to finish individually and when launched in group.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
