### PR TITLE
Fix compatibility with Jackson 2.21.x versions

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/LayoutParameters.java
@@ -53,7 +53,6 @@ public class LayoutParameters {
     @JsonIgnore
     private Map<String, ComponentSize> componentsSize;
 
-    @JsonCreator
     public LayoutParameters() {
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When using Jackson 2.21.x versions, 250+ unit tests fail with the following error:
```
java.io.UncheckedIOException: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Conflicting property-based creators: already had explicit creator [constructor for `com.powsybl.sld.layout.LayoutParameters` (0 args), annotations: {interface com.fasterxml.jackson.annotation.JsonCreator=@com.fasterxml.jackson.annotation.JsonCreator(mode=DEFAULT)}, encountered another: [constructor for `com.powsybl.sld.layout.LayoutParameters` (22 args), annotations: {interface com.fasterxml.jackson.annotation.JsonCreator=@com.fasterxml.jackson.annotation.JsonCreator(mode=DEFAULT)} (through reference chain: com.powsybl.sld.svg.GraphMetadata["layoutParams"])
```

**What is the new behavior (if this is a feature change)?**
The unit tests work.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
To solve GHSA-72hv-8253-57qq, `powsybl-core` needs to bump its Jackson version to `2.21.1` (see powsybl/powsybl-core#3799).
