### PR TITLE
Add powsybl-diagram version number to metadata output

### DIFF
--- a/diagram-util/src/main/java/com/powsybl/diagram/metadata/AbstractMetadata.java
+++ b/diagram-util/src/main/java/com/powsybl/diagram/metadata/AbstractMetadata.java
@@ -15,13 +15,35 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 
+import java.util.ServiceLoader;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.commons.json.JsonUtil;
+import com.powsybl.tools.Version;
 
 /**
  * @author Massimo Ferraro {@literal <massimo.ferraro@soft.it>}
  */
+@JsonPropertyOrder(value = {"diagramVersion"}, alphabetic = false)
 public abstract class AbstractMetadata {
+
+    private static final String DIAGRAM_VERSION = resolveDiagramVersion();
+
+    private static String resolveDiagramVersion() {
+        for (Version v : ServiceLoader.load(Version.class)) {
+            if ("powsybl-diagram".equals(v.getRepositoryName())) {
+                return v.getMavenProjectVersion();
+            }
+        }
+        return null;
+    }
+
+    @JsonProperty("diagramVersion")
+    public String getDiagramVersion() {
+        return DIAGRAM_VERSION;
+    }
 
     public void writeJson(Path file) {
         Objects.requireNonNull(file);

--- a/diagram-util/src/main/java/com/powsybl/diagram/metadata/AbstractMetadata.java
+++ b/diagram-util/src/main/java/com/powsybl/diagram/metadata/AbstractMetadata.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 
 import java.util.ServiceLoader;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,6 +42,7 @@ public abstract class AbstractMetadata {
     }
 
     @JsonProperty("diagramVersion")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getDiagramVersion() {
         return DIAGRAM_VERSION;
     }


### PR DESCRIPTION
## Summary
Add the `powsybl-diagram` version number to the metadata JSON output.

A new top-level `diagramVersion` field is now included in the metadata JSON for both SLD (`GraphMetadata`) and NAD (`DiagramMetadata`) diagrams. The version is resolved at startup via `ServiceLoader` from the `PowsyblDiagramVersion` SPI provider.

Example output:
```json
{
  "diagramVersion" : "5.4.0-SNAPSHOT",
  ...
}
```

## Changes
- `AbstractMetadata`: added `getDiagramVersion()` method with `@JsonProperty("diagramVersion")` annotation, and `@JsonPropertyOrder` to ensure it appears first in the JSON output.

## Note
Golden test JSON files may need updating to include the new `diagramVersion` field. Happy to update them if needed.

Closes #802
