### PR TITLE
[NAD] Add network name to metadata output

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/NetworkAreaDiagram.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/NetworkAreaDiagram.java
@@ -77,7 +77,7 @@ public final class NetworkAreaDiagram {
         Graph graph = getLayoutResult(network, param, voltageLevelFilter);
         NetworkGraphBuilder.applyStyle(graph, styleProvider);
         createSvgWriter(param).writeSvg(graph, svgFile);
-        createMetadata(graph, param).writeJson(getMetadataPath(svgFile));
+        createMetadata(graph, param, network).writeJson(getMetadataPath(svgFile));
     }
 
     public static void draw(Network network, Writer writer, Writer metadataWriter, NadParameters param, Predicate<VoltageLevel> voltageLevelFilter) {
@@ -90,11 +90,13 @@ public final class NetworkAreaDiagram {
         Graph graph = getLayoutResult(network, param, voltageLevelFilter);
         NetworkGraphBuilder.applyStyle(graph, styleProvider);
         createSvgWriter(param).writeSvg(graph, writer);
-        createMetadata(graph, param).writeJson(metadataWriter);
+        createMetadata(graph, param, network).writeJson(metadataWriter);
     }
 
-    private static DiagramMetadata createMetadata(Graph graph, NadParameters param) {
-        return new DiagramMetadata(param.getLayoutParameters(), param.getSvgParameters()).addMetadata(graph);
+    private static DiagramMetadata createMetadata(Graph graph, NadParameters param, Network network) {
+        return new DiagramMetadata(param.getLayoutParameters(), param.getSvgParameters())
+                .setNetworkName(network.getNameOrId())
+                .addMetadata(graph);
     }
 
     private static Graph getLayoutResult(Network network, NadParameters param, Predicate<VoltageLevel> voltageLevelFilter) {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
@@ -76,6 +76,17 @@ public class DiagramMetadata extends AbstractMetadata {
         this.networkName = networkName;
     }
 
+    public DiagramMetadata(LayoutParameters layoutParameters,
+                           SvgParameters svgParameters,
+                           List<BusNodeMetadata> busNodesMetadata,
+                           List<NodeMetadata> nodesMetadata,
+                           List<InjectionMetadata> injectionsMetadata,
+                           List<EdgeMetadata> edgesMetadata,
+                           List<TextNodeMetadata> textNodesMetadata) {
+        this(layoutParameters, svgParameters, busNodesMetadata, nodesMetadata, injectionsMetadata, edgesMetadata,
+                textNodesMetadata, null);
+    }
+
     @JsonProperty("busNodes")
     public List<BusNodeMetadata> getBusNodesMetadata() {
         return busNodesMetadata;

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
@@ -40,6 +40,7 @@ public class DiagramMetadata extends AbstractMetadata {
         THREEWT, BOUNDARY;
     }
 
+    private String networkName;
     private final LayoutParameters layoutParameters;
     private final SvgParameters svgParameters;
     private final List<BusNodeMetadata> busNodesMetadata = new ArrayList<>();
@@ -63,7 +64,8 @@ public class DiagramMetadata extends AbstractMetadata {
                            @JsonProperty("nodes") List<NodeMetadata> nodesMetadata,
                            @JsonProperty("injections") List<InjectionMetadata> injectionsMetadata,
                            @JsonProperty("edges") List<EdgeMetadata> edgesMetadata,
-                           @JsonProperty("textNodes") List<TextNodeMetadata> textNodesMetadata) {
+                           @JsonProperty("textNodes") List<TextNodeMetadata> textNodesMetadata,
+                           @JsonProperty("networkName") String networkName) {
         this.layoutParameters = Objects.requireNonNull(layoutParameters);
         this.svgParameters = Objects.requireNonNull(svgParameters);
         this.busNodesMetadata.addAll(busNodesMetadata);
@@ -71,6 +73,7 @@ public class DiagramMetadata extends AbstractMetadata {
         this.injectionsMetadata.addAll(injectionsMetadata);
         this.edgesMetadata.addAll(edgesMetadata);
         this.textNodesMetadata.addAll(textNodesMetadata);
+        this.networkName = networkName;
     }
 
     @JsonProperty("busNodes")
@@ -106,6 +109,17 @@ public class DiagramMetadata extends AbstractMetadata {
     @JsonProperty("svgParameters")
     public SvgParameters getSvgParameters() {
         return svgParameters;
+    }
+
+    @JsonProperty("networkName")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getNetworkName() {
+        return networkName;
+    }
+
+    public DiagramMetadata setNetworkName(String networkName) {
+        this.networkName = networkName;
+        return this;
     }
 
     public DiagramMetadata addMetadata(Graph graph) {


### PR DESCRIPTION
## Summary

Adds the network name to the NAD (Network Area Diagram) metadata JSON output.

- Adds a `networkName` field to `DiagramMetadata`, populated via `Network.getNameOrId()`
- The field is omitted from the JSON when `null` (backward compatible)
- Downstream tools like powsybl-network-viewer can use this field to name exported SVG/PNG files

Closes #801
