### PR TITLE
Manage a `VoltageLevelFilter` in `GeographicalLayoutFactory`to optimize Node position computation

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/layout/GeographicalLayoutFactory.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/layout/GeographicalLayoutFactory.java
@@ -12,6 +12,7 @@ import com.powsybl.iidm.network.Substation;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.iidm.network.extensions.Coordinate;
 import com.powsybl.iidm.network.extensions.SubstationPosition;
+import com.powsybl.nad.build.iidm.VoltageLevelFilter;
 import com.powsybl.nad.model.Point;
 import org.jgrapht.alg.util.Pair;
 import org.slf4j.Logger;
@@ -21,6 +22,7 @@ import org.slf4j.event.Level;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Sophie Frasnedo {@literal <sophie.frasnedo at rte-france.com>}
@@ -37,14 +39,29 @@ public class GeographicalLayoutFactory extends FixedLayoutFactory implements Lay
     }
 
     public GeographicalLayoutFactory(Network network, int scalingFactor, double radiusFactor, LayoutFactory layoutFactory) {
-        super(getFixedNodePosition(network, scalingFactor, radiusFactor), layoutFactory);
+        super(getFixedNodePosition(network, scalingFactor, radiusFactor, null), layoutFactory);
     }
 
-    private static Map<String, Point> getFixedNodePosition(Network network, int scalingFactor, double radiusFactor) {
-        Map<String, Point> fixedNodePositionMap = new HashMap<>();
-        network.getSubstationStream().forEach(substation -> fillPositionMap(substation, fixedNodePositionMap, scalingFactor, radiusFactor));
+    public GeographicalLayoutFactory(Network network, int scalingFactor, double radiusFactor, VoltageLevelFilter voltageLevelFilter, LayoutFactory layoutFactory) {
+        super(getFixedNodePosition(network, scalingFactor, radiusFactor, voltageLevelFilter), layoutFactory);
+    }
 
-        int voltageLevelCount = network.getVoltageLevelCount();
+    private static Map<String, Point> getFixedNodePosition(Network network, int scalingFactor, double radiusFactor, VoltageLevelFilter voltageLevelFilter) {
+        Map<String, Point> fixedNodePositionMap = new HashMap<>();
+        List<Substation> substationsToProcess;
+        int voltageLevelCount = 0;
+        if (voltageLevelFilter != null) {
+            substationsToProcess = voltageLevelFilter.voltageLevels().stream()
+                    .map(VoltageLevel::getNullableSubstation)
+                    .filter(Objects::nonNull)
+                    .toList();
+            voltageLevelCount = voltageLevelFilter.getNbVoltageLevels();
+        } else {
+            substationsToProcess = network.getSubstationStream().toList();
+            voltageLevelCount = network.getVoltageLevelCount();
+        }
+        substationsToProcess.forEach(substation -> fillPositionMap(substation, fixedNodePositionMap, scalingFactor, radiusFactor));
+
         int missingPositions = voltageLevelCount - fixedNodePositionMap.size();
         double missingPositionsRatio = (double) missingPositions / voltageLevelCount;
         LOGGER.atLevel(missingPositionsRatio > 0.3 ? Level.WARN : Level.INFO)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Add an optional `VoltageLevelFilter` parameter to the `GeographicalLayoutFactory` constructor to avoid a large value for `missingPositions` which implies a long computation of missing positions on large networks when we need only some positions for a portion of the total voltageLevels.


**What is the new behavior (if this is a feature change)?**
Now, position computation is implemented considering the given VoltageLevelFilter


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
No migration needed.
Add a VoltageLeveFilter to the constructor to optimize position computation for large networks



