### PR TITLE
Use jspecify `NonNull` annotation instead of javax.annotations `Nonnull`

### DIFF
--- a/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/position/clustering/Link.java
+++ b/single-line-diagram/single-line-diagram-core/src/main/java/com/powsybl/sld/layout/position/clustering/Link.java
@@ -12,13 +12,13 @@ import com.powsybl.sld.model.cells.ShuntCell;
 import com.powsybl.sld.model.coordinate.Side;
 import com.powsybl.sld.model.nodes.BusNode;
 
-import javax.annotation.Nonnull;
 import java.util.EnumMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.NonNull;
 
 /**
  * A link is define between two VBSClusterSides (having the same implementation).
@@ -174,7 +174,7 @@ class Link implements Comparable<Link> {
     }
 
     @Override
-    public int compareTo(@Nonnull Link oLink) {
+    public int compareTo(@NonNull Link oLink) {
         for (LinkCategory category : LinkCategory.values()) {
             if (oLink.getLinkCategoryWeight(category) > getLinkCategoryWeight(category)) {
                 return -1;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Quality


**What is the current behavior?**
<!-- You can also link to an open issue here -->
powsybl-diagram uses the `Nonnull` annotation from `javax.annotation`.


**What is the new behavior (if this is a feature change)?**
powsybl-diagram uses the `NonNull` annotation from `jspecify`.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

This PR is needed as an adaption to powsybl/powsybl-core#3599
