### PR TITLE
Add voltage-level class to edge info metadata

### DIFF
--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/DiagramMetadata.java
@@ -1,4 +1,4 @@
-/**
+ /**
  * Copyright (c) 2022, RTE (http://www.rte-france.com/)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.nad.svg.metadata;
-
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.commons.PowsyblException;
@@ -31,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Thomas Adam {@literal <tadam at silicom.fr>}
@@ -136,7 +136,7 @@ public class DiagramMetadata extends AbstractMetadata {
                                         injection.getComponentType(),
                                         busNode.getSvgId(),
                                         vlNode.getSvgId(),
-                                        injection.getSvgEdgeInfo().map(DiagramMetadata::createEdgeInfoMetadata).orElse(null),
+                                        injection.getSvgEdgeInfo().map(sei -> createEdgeInfoMetadata(sei, vlNode.getStyleClasses())).orElse(null),
                                         injection.getStyleClasses(),
                                         injection.getStyle()
                                 )))));
@@ -151,9 +151,9 @@ public class DiagramMetadata extends AbstractMetadata {
                 null,
                 !edge.isVisible(BranchEdge.Side.ONE),
                 !edge.isVisible(BranchEdge.Side.TWO),
-                edge.getSvgEdgeInfo(BranchEdge.Side.ONE).map(DiagramMetadata::createEdgeInfoMetadata).orElse(null),
-                edge.getSvgEdgeInfo(BranchEdge.Side.TWO).map(DiagramMetadata::createEdgeInfoMetadata).orElse(null),
-                edge.getSvgEdgeInfoMiddle().map(DiagramMetadata::createEdgeInfoMetadata).orElse(null),
+                edge.getSvgEdgeInfo(BranchEdge.Side.ONE).map(sei -> createEdgeInfoMetadata(sei, graph.getVoltageLevelNode1(edge).getStyleClasses())).orElse(null),
+                edge.getSvgEdgeInfo(BranchEdge.Side.TWO).map(sei -> createEdgeInfoMetadata(sei, graph.getVoltageLevelNode2(edge).getStyleClasses())).orElse(null),
+                edge.getSvgEdgeInfoMiddle().map(sei -> createEdgeInfoMetadata(sei, getMiddleEdgeInfoClasses(graph, edge))).orElse(null),
                 edge.getEdgeStyleInfo(BranchEdge.Side.ONE).styleClasses(),
                 edge.getEdgeStyleInfo(BranchEdge.Side.TWO).styleClasses(),
                 edge.getEdgeStyleInfo(BranchEdge.Side.ONE).style(),
@@ -172,7 +172,7 @@ public class DiagramMetadata extends AbstractMetadata {
                     edge.getSide().name(),
                     !edge.isVisible(),
                     false,
-                    edge.getSvgEdgeInfo().map(DiagramMetadata::createEdgeInfoMetadata).orElse(null),
+                    edge.getSvgEdgeInfo().map(sei -> createEdgeInfoMetadata(sei, graph.getVoltageLevelNode(edge).getStyleClasses())).orElse(null),
                     null,
                     null,
                     edge.getEdgeStyleInfo().styleClasses(),
@@ -242,7 +242,19 @@ public class DiagramMetadata extends AbstractMetadata {
         }
     }
 
-    private static EdgeInfoMetadata createEdgeInfoMetadata(SvgEdgeInfo svgEdgeInfo) {
+    /**
+     * Voltage-level classes for a branch's middle edge info: it belongs to no single side, so we use
+     * both ends' classes (deduplicated).
+     */
+    private static List<String> getMiddleEdgeInfoClasses(Graph graph, BranchEdge edge) {
+        return Stream.concat(
+                        graph.getVoltageLevelNode1(edge).getStyleClasses().stream(),
+                        graph.getVoltageLevelNode2(edge).getStyleClasses().stream())
+                .distinct()
+                .toList();
+    }
+
+    private static EdgeInfoMetadata createEdgeInfoMetadata(SvgEdgeInfo svgEdgeInfo, List<String> classes) {
         EdgeInfo edgeInfo = svgEdgeInfo.edgeInfo();
         return new EdgeInfoMetadata(svgEdgeInfo.svgId(),
                 edgeInfo.getInfoTypeA(),
@@ -252,7 +264,8 @@ public class DiagramMetadata extends AbstractMetadata {
                 edgeInfo.getDirectionB().map(Enum::name).orElse(null),
                 edgeInfo.getLabelA().orElse(null),
                 edgeInfo.getLabelB().orElse(null),
-                edgeInfo.getComponentType().orElse(null));
+                edgeInfo.getComponentType().orElse(null),
+                classes);
     }
 
     private String getPrefixedId(String id) {

--- a/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/EdgeInfoMetadata.java
+++ b/network-area-diagram/src/main/java/com/powsybl/nad/svg/metadata/EdgeInfoMetadata.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 /**
  * @author Florian Dupuy {@literal <florian.dupuy at rte-france.com>}
  */
@@ -25,6 +27,7 @@ public class EdgeInfoMetadata {
     private final String labelA;
     private final String labelB;
     private final String componentType;
+    private final List<String> classes;
 
     @JsonCreator
     public EdgeInfoMetadata(@JsonProperty("svgId") String svgId,
@@ -35,7 +38,8 @@ public class EdgeInfoMetadata {
                             @JsonProperty("directionB") String directionB,
                             @JsonProperty("labelA") String labelA,
                             @JsonProperty("labelB") String labelB,
-                            @JsonProperty("componentType") String componentType) {
+                            @JsonProperty("componentType") String componentType,
+                            @JsonProperty("classes") List<String> classes) {
         this.svgId = svgId;
         this.infoTypeA = infoTypeA;
         this.infoTypeB = infoTypeB;
@@ -53,6 +57,7 @@ public class EdgeInfoMetadata {
         this.labelA = labelA;
         this.labelB = labelB;
         this.componentType = componentType;
+        this.classes = classes;
     }
 
     @JsonProperty("svgId")
@@ -98,5 +103,11 @@ public class EdgeInfoMetadata {
     @JsonProperty("componentType")
     public String getComponentType() {
         return componentType;
+    }
+
+    @JsonProperty("classes")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<String> getClasses() {
+        return classes;
     }
 }

--- a/network-area-diagram/src/test/java/com/powsybl/nad/svg/DiagramMetadataTest.java
+++ b/network-area-diagram/src/test/java/com/powsybl/nad/svg/DiagramMetadataTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,6 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  * @author Thomas Adam {@literal <tadam at silicom.fr>}
@@ -184,6 +186,39 @@ class DiagramMetadataTest extends AbstractTest {
         line.getTerminal1().getBusBreakerView().getBus().setV(400.0);
         line.getTerminal2().getBusBreakerView().getBus().setV(410.0);
         roundTrip(network, "/edge_info_metadata.json", new LayoutParameters().setInjectionsAdded(true));
+    }
+
+    @Test
+    void testEdgeInfoMiddleMergesBothSidesVoltageLevelClasses() {
+        // A line connecting two voltage levels of different base-voltage bands: the middle edge info
+        // must carry the (deduplicated) voltage-level classes of both ends.
+        Network network = Networks.createTwoVoltageLevels();
+        network.getVoltageLevel("vl2").setNominalV(225); // vl1 stays at 400 kV -> different class than vl2
+        labelProvider = new DefaultLabelProvider.Builder()
+                .setInfoMiddleSide1(EdgeInfoEnum.NAME)
+                .setInfoMiddleSide2(EdgeInfoEnum.EMPTY)
+                .build(network, getSvgParameters());
+
+        DiagramMetadata metadata = roundTrip(network, "/edge_info_middle_merged_classes_metadata.json",
+                new LayoutParameters().setInjectionsAdded(true));
+
+        var lineEdge = metadata.getEdgesMetadata().stream()
+                .filter(e -> e.getEdgeInfoMiddle() != null)
+                .findFirst().orElseThrow();
+        List<String> node1Classes = nodeClasses(metadata, lineEdge.getNode1SvgId());
+        List<String> node2Classes = nodeClasses(metadata, lineEdge.getNode2SvgId());
+
+        // Sanity check: the two sides really carry different voltage-level classes
+        assertNotEquals(node1Classes, node2Classes);
+
+        List<String> expected = Stream.concat(node1Classes.stream(), node2Classes.stream()).distinct().toList();
+        assertEquals(expected, lineEdge.getEdgeInfoMiddle().getClasses());
+    }
+
+    private static List<String> nodeClasses(DiagramMetadata metadata, String nodeSvgId) {
+        return metadata.getNodesMetadata().stream()
+                .filter(n -> n.getSvgId().equals(nodeSvgId))
+                .findFirst().orElseThrow().getClasses();
     }
 
     @Test

--- a/network-area-diagram/src/test/resources/edge_info_metadata.json
+++ b/network-area-diagram/src/test/resources/edge_info_metadata.json
@@ -132,7 +132,8 @@
       "infoTypeB" : "Current",
       "direction" : "OUT",
       "labelA" : "1,400",
-      "labelB" : "2,102"
+      "labelB" : "2,102",
+      "classes" : [ "nad-vl300to500" ]
     },
     "edgeInfo2" : {
       "svgId" : "11",
@@ -140,12 +141,14 @@
       "infoTypeB" : "Current",
       "direction" : "OUT",
       "labelA" : "1,410",
-      "labelB" : "2,068"
+      "labelB" : "2,068",
+      "classes" : [ "nad-vl300to500" ]
     },
     "edgeInfoMiddle" : {
       "svgId" : "12",
       "infoTypeA" : "Name",
-      "labelA" : "l1"
+      "labelA" : "l1",
+      "classes" : [ "nad-vl300to500" ]
     },
     "classes1" : [ "nad-vl300to500" ],
     "classes2" : [ "nad-vl300to500" ]

--- a/network-area-diagram/src/test/resources/edge_info_middle_merged_classes_metadata.json
+++ b/network-area-diagram/src/test/resources/edge_info_middle_merged_classes_metadata.json
@@ -8,7 +8,7 @@
     "maxSteps" : 1000,
     "timeoutSeconds" : 15.0,
     "textNodeEdgeConnectionYShift" : 25.0,
-    "injectionsAdded" : false,
+    "injectionsAdded" : true,
     "scaleFactor" : 1.0
   },
   "svgParameters" : {
@@ -18,7 +18,7 @@
       "right" : 200.0,
       "bottom" : 200.0
     },
-    "insertNameDesc" : false,
+    "insertNameDesc" : true,
     "svgWidthAndHeightAdded" : true,
     "cssLocation" : "INSERTED_IN_SVG",
     "sizeConstraint" : "FIXED_WIDTH",
@@ -39,7 +39,7 @@
     "loopDistance" : 120.0,
     "loopEdgesAperture" : 60.0,
     "loopControlDistance" : 40.0,
-    "edgeInfoAlongEdge" : false,
+    "edgeInfoAlongEdge" : true,
     "interAnnulusSpace" : 5.0,
     "svgPrefix" : "",
     "arrowPathIn" : "M-10 -10 H10 L0 10z",
@@ -62,125 +62,101 @@
     "doubleArrowShiftFactorText" : 1.8
   },
   "busNodes" : [ {
-    "svgId" : "3",
-    "equipmentId" : "vl_0",
+    "svgId" : "4",
+    "equipmentId" : "vl1_0",
     "nbNeighbours" : 0,
     "index" : 0,
     "vlNode" : "0",
-    "legend" : " kV / °"
+    "legend" : " kV / °",
+    "classes" : [ "nad-bus-0" ]
   }, {
-    "svgId" : "7",
+    "svgId" : "8",
     "equipmentId" : "vl2_0",
     "nbNeighbours" : 0,
     "index" : 0,
-    "vlNode" : "4",
-    "legend" : " kV / °"
+    "vlNode" : "5",
+    "legend" : " kV / °",
+    "classes" : [ "nad-bus-0" ]
   }, {
-    "svgId" : "9",
+    "svgId" : "12",
     "equipmentId" : "dl1",
     "nbNeighbours" : 0,
     "index" : 0,
-    "vlNode" : "8"
+    "vlNode" : "11",
+    "classes" : [ "nad-bus-0" ]
   } ],
   "nodes" : [ {
     "svgId" : "0",
-    "equipmentId" : "vl",
-    "x" : -94.84,
-    "y" : -119.74,
+    "equipmentId" : "vl1",
+    "x" : -56.06,
+    "y" : -318.7,
     "legendSvgId" : "1",
     "legendEdgeSvgId" : "2",
-    "legendHeader" : [ "vl" ],
+    "legendHeader" : [ "Voltage level 1" ],
     "classes" : [ "nad-vl300to500" ]
   }, {
-    "svgId" : "4",
+    "svgId" : "5",
     "equipmentId" : "vl2",
-    "x" : -432.32,
-    "y" : 17.46,
-    "legendSvgId" : "5",
-    "legendEdgeSvgId" : "6",
-    "legendHeader" : [ "vl2" ],
-    "classes" : [ "nad-vl300to500" ]
+    "x" : -230.42,
+    "y" : 1.18,
+    "legendSvgId" : "6",
+    "legendEdgeSvgId" : "7",
+    "legendHeader" : [ "Voltage level 2" ],
+    "classes" : [ "nad-vl180to300" ]
   }, {
-    "svgId" : "8",
+    "svgId" : "11",
     "equipmentId" : "dl1",
-    "x" : 194.24,
-    "y" : 101.91,
+    "x" : -49.12,
+    "y" : 317.14,
     "type" : "BOUNDARY",
-    "classes" : [ "nad-boundary-node", "nad-vl300to500" ]
+    "classes" : [ "nad-boundary-node", "nad-vl180to300" ]
+  } ],
+  "injections" : [ {
+    "svgId" : "3",
+    "equipmentId" : "g1",
+    "componentType" : "GENERATOR",
+    "busNodeId" : "4",
+    "vlNodeId" : "0"
   } ],
   "edges" : [ {
-    "svgId" : "10",
-    "equipmentId" : "dl1",
+    "svgId" : "9",
+    "equipmentId" : "l1",
     "node1" : "0",
-    "node2" : "8",
-    "busNode1" : "3",
-    "busNode2" : "9",
-    "type" : "BoundaryLineEdge",
-    "edgeInfo1" : {
-      "svgId" : "11",
-      "infoTypeA" : "ReactivePower",
-      "infoTypeB" : "ActivePower",
-      "directionA" : "OUT",
-      "directionB" : "OUT",
-      "labelA" : "50",
-      "labelB" : "100",
-      "classes" : [ "nad-vl300to500" ]
-    },
-    "classes1" : [ "nad-vl300to500" ],
-    "classes2" : [ "nad-vl300to500" ]
-  }, {
-    "svgId" : "12",
-    "equipmentId" : "hvdc",
-    "node1" : "0",
-    "node2" : "4",
-    "busNode1" : "3",
-    "busNode2" : "7",
-    "type" : "HvdcLineVscEdge",
-    "edgeInfo1" : {
-      "svgId" : "13",
-      "infoTypeA" : "ReactivePower",
-      "infoTypeB" : "ActivePower",
-      "directionA" : "OUT",
-      "directionB" : "OUT",
-      "labelA" : "50",
-      "labelB" : "100",
-      "classes" : [ "nad-vl300to500" ]
-    },
-    "edgeInfo2" : {
-      "svgId" : "14",
-      "infoTypeA" : "ReactivePower",
-      "infoTypeB" : "ActivePower",
-      "directionA" : "OUT",
-      "directionB" : "OUT",
-      "labelA" : "75",
-      "labelB" : "300",
-      "classes" : [ "nad-vl300to500" ]
-    },
+    "node2" : "5",
+    "busNode1" : "4",
+    "busNode2" : "8",
+    "type" : "LineEdge",
     "edgeInfoMiddle" : {
-      "svgId" : "15",
-      "infoTypeA" : "ReactivePower",
-      "infoTypeB" : "ActivePower",
-      "directionA" : "OUT",
-      "directionB" : "OUT",
-      "labelA" : "50",
-      "labelB" : "100",
-      "classes" : [ "nad-vl300to500" ]
+      "svgId" : "10",
+      "infoTypeA" : "Name",
+      "labelA" : "l1",
+      "classes" : [ "nad-vl300to500", "nad-vl180to300" ]
     },
     "classes1" : [ "nad-vl300to500" ],
-    "classes2" : [ "nad-vl300to500" ]
+    "classes2" : [ "nad-vl180to300" ]
+  }, {
+    "svgId" : "13",
+    "equipmentId" : "dl1",
+    "node1" : "5",
+    "node2" : "11",
+    "busNode1" : "8",
+    "busNode2" : "12",
+    "type" : "BoundaryLineEdge",
+    "classes1" : [ "nad-vl180to300" ],
+    "classes2" : [ "nad-vl180to300" ]
   } ],
   "textNodes" : [ {
     "svgId" : "1",
-    "equipmentId" : "vl",
+    "equipmentId" : "vl1",
     "vlNode" : "0",
     "shiftX" : 100.0,
     "shiftY" : -40.0,
     "connectionShiftX" : 100.0,
     "connectionShiftY" : -15.0
   }, {
-    "svgId" : "5",
+    "svgId" : "6",
     "equipmentId" : "vl2",
-    "vlNode" : "4",
+    "vlNode" : "5",
     "shiftX" : 100.0,
     "shiftY" : -40.0,
     "connectionShiftX" : 100.0,

--- a/network-area-diagram/src/test/resources/nad-double-arrows-with-middle-label_metadata.json
+++ b/network-area-diagram/src/test/resources/nad-double-arrows-with-middle-label_metadata.json
@@ -123,7 +123,8 @@
       "directionA" : "OUT",
       "directionB" : "OUT",
       "labelA" : "50",
-      "labelB" : "100"
+      "labelB" : "100",
+      "classes" : [ "nad-vl300to500" ]
     },
     "classes1" : [ "nad-vl300to500" ],
     "classes2" : [ "nad-vl300to500" ]
@@ -142,7 +143,8 @@
       "directionA" : "OUT",
       "directionB" : "OUT",
       "labelA" : "50",
-      "labelB" : "100"
+      "labelB" : "100",
+      "classes" : [ "nad-vl300to500" ]
     },
     "edgeInfo2" : {
       "svgId" : "14",
@@ -151,12 +153,14 @@
       "directionA" : "OUT",
       "directionB" : "OUT",
       "labelA" : "75",
-      "labelB" : "300"
+      "labelB" : "300",
+      "classes" : [ "nad-vl300to500" ]
     },
     "edgeInfoMiddle" : {
       "svgId" : "15",
       "infoTypeA" : "Name",
-      "labelA" : "Converter1"
+      "labelA" : "Converter1",
+      "classes" : [ "nad-vl300to500" ]
     },
     "classes1" : [ "nad-vl300to500" ],
     "classes2" : [ "nad-vl300to500" ]

--- a/network-area-diagram/src/test/resources/nad-double-arrows-with-middle-values_metadata.json
+++ b/network-area-diagram/src/test/resources/nad-double-arrows-with-middle-values_metadata.json
@@ -123,7 +123,8 @@
       "directionA" : "OUT",
       "directionB" : "OUT",
       "labelA" : "50",
-      "labelB" : "100"
+      "labelB" : "100",
+      "classes" : [ "nad-vl300to500" ]
     },
     "classes1" : [ "nad-vl300to500" ],
     "classes2" : [ "nad-vl300to500" ]
@@ -142,7 +143,8 @@
       "directionA" : "OUT",
       "directionB" : "OUT",
       "labelA" : "50",
-      "labelB" : "100"
+      "labelB" : "100",
+      "classes" : [ "nad-vl300to500" ]
     },
     "edgeInfo2" : {
       "svgId" : "14",
@@ -151,7 +153,8 @@
       "directionA" : "OUT",
       "directionB" : "OUT",
       "labelA" : "75",
-      "labelB" : "300"
+      "labelB" : "300",
+      "classes" : [ "nad-vl300to500" ]
     },
     "edgeInfoMiddle" : {
       "svgId" : "15",
@@ -160,7 +163,8 @@
       "directionA" : "OUT",
       "directionB" : "OUT",
       "labelA" : "50",
-      "labelB" : "100"
+      "labelB" : "100",
+      "classes" : [ "nad-vl300to500" ]
     },
     "classes1" : [ "nad-vl300to500" ],
     "classes2" : [ "nad-vl300to500" ]

--- a/network-area-diagram/src/test/resources/nad_double_arrows_metadata.json
+++ b/network-area-diagram/src/test/resources/nad_double_arrows_metadata.json
@@ -123,7 +123,8 @@
       "directionA" : "OUT",
       "directionB" : "OUT",
       "labelA" : "50",
-      "labelB" : "100"
+      "labelB" : "100",
+      "classes" : [ "nad-vl300to500" ]
     },
     "classes1" : [ "nad-vl300to500" ],
     "classes2" : [ "nad-vl300to500" ]
@@ -142,7 +143,8 @@
       "directionA" : "OUT",
       "directionB" : "OUT",
       "labelA" : "50",
-      "labelB" : "100"
+      "labelB" : "100",
+      "classes" : [ "nad-vl300to500" ]
     },
     "edgeInfo2" : {
       "svgId" : "14",
@@ -151,7 +153,8 @@
       "directionA" : "OUT",
       "directionB" : "OUT",
       "labelA" : "75",
-      "labelB" : "300"
+      "labelB" : "300",
+      "classes" : [ "nad-vl300to500" ]
     },
     "classes1" : [ "nad-vl300to500" ],
     "classes2" : [ "nad-vl300to500" ]


### PR DESCRIPTION
## Context

Edge infos (arrows and value labels) live in a flat `nad-edge-infos` group and, unlike voltage level nodes and their labels, do not carry the voltage-level CSS class of the side they belong to. As a result, a consumer (e.g. network-viewer) cannot hide these arrows and labels consistently with their voltage level (voltage-level filtering, zoom-based hiding) without re-deriving the node-to-edge-info mapping client-side.

## Change

Carry the side's voltage-level class(es) directly in the edge info metadata.